### PR TITLE
yp-spur: 1.21.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13128,7 +13128,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.20.2-1
+      version: 1.21.0-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.21.0-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.20.2-1`

## ypspur

```
* Update release-candidate workflow (#189 <https://github.com/openspur/yp-spur/issues/189>)
* Simulate motion on --without-device mode (#185 <https://github.com/openspur/yp-spur/issues/185>)
* Format source files by clang-format (#187 <https://github.com/openspur/yp-spur/issues/187>)
* Update assets to v0.6.1 (#184 <https://github.com/openspur/yp-spur/issues/184>)
* Update assets to v0.6.0 (#183 <https://github.com/openspur/yp-spur/issues/183>)
* Update assets to v0.4.1 (#182 <https://github.com/openspur/yp-spur/issues/182>)
* Update assets to v0.4.0 (#181 <https://github.com/openspur/yp-spur/issues/181>)
* Update assets to v0.3.4 (#178 <https://github.com/openspur/yp-spur/issues/178>)
* Update assets to v0.2.0 (#176 <https://github.com/openspur/yp-spur/issues/176>)
* Add missing readline_include_dirs (#175 <https://github.com/openspur/yp-spur/issues/175>)
* Contributors: Atsushi Watanabe, Tobias Fischer
```
