### PR TITLE
Revert "generate_parameter_library: 0.3.8-1 in 'rolling/distribution.…

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1700,16 +1700,13 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
       - generate_parameter_library
-      - generate_parameter_library_example
       - generate_parameter_library_py
-      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.8-1
+      version: 0.3.7-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
…yaml' [bloom] (#40150)"

This reverts commit 263010a7cde278025342089e49f7a994bef755ac.

Based on https://github.com/ros-planning/moveit2/issues/2758#issuecomment-2014785332 , this won't be fixed in the short-term, so go back to the version that works.

This is the Rolling equivalent of https://github.com/ros/rosdistro/pull/40305 .

@sea-bass FYI.