### PR TITLE
libpointmatcher: 1.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2799,7 +2799,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libpointmatcher-release.git
-      version: 1.3.1-5
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/norlab-ulaval/libpointmatcher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.4.1-1`:

- upstream repository: https://github.com/norlab-ulaval/libpointmatcher.git
- release repository: https://github.com/ros2-gbp/libpointmatcher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-5`

## libpointmatcher

```
* Update package.xml version properly
```
