### PR TITLE
ros2_controllers: 4.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5482,7 +5482,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.6.0-2
+      version: 4.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.7.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.6.0-2`

## ackermann_steering_controller

```
* Fix pid_controller build on ROS 2 Rolling on Ubuntu 24.04 (#1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>)
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Chris Lalancette, Silvio Traversaro
```

## admittance_controller

```
* Use CMake target for eigen (#1058 <https://github.com/ros-controls/ros2_controllers/issues/1058>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

```
* Fix pid_controller build on ROS 2 Rolling on Ubuntu 24.04 (#1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>)
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Chris Lalancette, Silvio Traversaro
```

## diff_drive_controller

```
* added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Contributors: Sai Kishor Kothakota
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

```
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Silvio Traversaro
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Contributors: Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* Remove action_msg dependency (#1077 <https://github.com/ros-controls/ros2_controllers/issues/1077>)
* Bump version of pre-commit hooks (#1073 <https://github.com/ros-controls/ros2_controllers/issues/1073>)
* Added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Parse URDF for continuous joints (#949 <https://github.com/ros-controls/ros2_controllers/issues/949>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, github-actions[bot]
```

## pid_controller

```
* Fix pid_controller build on ROS 2 Rolling on Ubuntu 24.04 (#1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>)
* Added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Chris Lalancette, Sai Kishor Kothakota, Silvio Traversaro
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Contributors: Sai Kishor Kothakota
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* [CI] Code coverage + pre-commit (#1057 <https://github.com/ros-controls/ros2_controllers/issues/1057>)
* Contributors: Christoph Fröhlich
```

## steering_controllers_library

```
* added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Sai Kishor Kothakota, Silvio Traversaro
```

## tricycle_controller

```
* added conditioning to have rolling tags compilable in older versions (#1071 <https://github.com/ros-controls/ros2_controllers/issues/1071>)
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Sai Kishor Kothakota, Silvio Traversaro
```

## tricycle_steering_controller

```
* Fix pid_controller build on ROS 2 Rolling on Ubuntu 24.04 (#1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>)
* Fix usage of visibility macros (#1039 <https://github.com/ros-controls/ros2_controllers/issues/1039>)
* Contributors: Chris Lalancette, Silvio Traversaro
```

## velocity_controllers

- No changes
