### PR TITLE
Revert "apriltag: 3.4.0-1 in 'rolling/distribution.yaml' [bloom] (#40…

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.4.0-1
+      version: 3.2.0-6
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git


### PR DESCRIPTION
…163)"

This reverts commit 62f6019e751d4ec15bd21a2b2874309471ae8f6b.

This version doesn't seem to build on Rolling: https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__apriltag__ubuntu_noble_amd64__binary/13/console .

@christian-rauch FYI