### PR TITLE
diagnostics: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1500,7 +1500,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1023,7 +1023,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-3
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1000,7 +1000,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2
+      version: ros2-jazzy
     release:
       packages:
       - diagnostic_aggregator
@@ -1016,7 +1016,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2
+      version: ros2-jazzy
     status: maintained
   dolly:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1011,7 +1011,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.0.0-1` (jazzy) and `3.2.0-1` (humble, iron):

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.2-2`

## diagnostic_aggregator

```
* Avoid rolling up an ERROR state when empty GenericAnalyzer blocks are marked discard_stale, or when all of their items are STALE. (#315 <https://github.com/ros/diagnostics/issues/315>)
* formatting fixes from PR324 (#327 <https://github.com/ros/diagnostics/issues/327>)
* Debugging instability introduced by #317 <https://github.com/ros/diagnostics/issues/317>  (#323 <https://github.com/ros/diagnostics/issues/323>)
* feat: publish top level msg when error is received (#317 <https://github.com/ros/diagnostics/issues/317>)
* Empty default aggregator base_path (#305 <https://github.com/ros/diagnostics/issues/305>)
* using defined state for stale (#298 <https://github.com/ros/diagnostics/issues/298>)
* Contributors: Andrew Symington, Christian Henkel, outrider-jhulas
```

## diagnostic_common_diagnostics

```
* Port cpu_monitor to ROS2 (#326 <https://github.com/ros/diagnostics/issues/326>)
* Debugging instability introduced by #317 <https://github.com/ros/diagnostics/issues/317>  (#323 <https://github.com/ros/diagnostics/issues/323>)
* not testing on foxy any more (#310 <https://github.com/ros/diagnostics/issues/310>)
* Iron support (#304 <https://github.com/ros/diagnostics/issues/304>)
* Contributors: Christian Henkel, Richard
```

## diagnostic_updater

```
* including depdency (#322 <https://github.com/ros/diagnostics/issues/322>)
* Debugging instability introduced by #317 <https://github.com/ros/diagnostics/issues/317>  (#323 <https://github.com/ros/diagnostics/issues/323>)
* feat: add param to use fqn in updater (#320 <https://github.com/ros/diagnostics/issues/320>)
* fix: method names & verbose logging (#307 <https://github.com/ros/diagnostics/issues/307>)
* Fix diagnostic_updater timestamps (#299 <https://github.com/ros/diagnostics/issues/299>)
* Contributors: Christian Henkel, Kevin Schwarzer, h-wata, outrider-jhulas
```

## diagnostics

- No changes

## self_test

```
* Self test publishes the service under the node name, again (#269 <https://github.com/ros/diagnostics/issues/269>)
* Contributors: Christian Henkel
```
