### PR TITLE
[noetic] Update octomap_mapping to 0.6.8

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6937,7 +6937,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/octomap_mapping-release.git
-      version: 0.6.7-1
+      version: 0.6.8-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Updating octomap_mapping in Noetic from 0.6.7 to 0.6.8 (apologies - bloom-release failed to create the PR, hence no automatic PR with all the details)

Difference: https://github.com/OctoMap/octomap_mapping/compare/0.6.7...0.6.8