### PR TITLE
unitree_ros: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9294,10 +9294,16 @@ repositories:
       version: humble
     status: maintained
   unitree_ros:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/unitree_ros-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/snt-arg/unitree_ros.git
       version: main
+    status: developed
   ur_client_library:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unitree_ros` to `1.1.0-1`:

- upstream repository: https://github.com/snt-arg/unitree_ros
- release repository: https://github.com/ros2-gbp/unitree_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## unitree_ros

```
* fix: only make foxy CI run on the foxy branch
* chore: merge changes made in foxy branch
* build: fix deprecation warning
* build: add boost build dependency
* build: add missing depdendencies for tf2 in package.xml
* chore: change submodule url to https
* Merge pull request #19 <https://github.com/snt-arg/unitree_ros/issues/19> from snt-arg/PedroS235-patch-3
  docs: fix some miscellaneous typos
* docs: fix some miscellaneous typos
* Update README.md
* Merge pull request #18 <https://github.com/snt-arg/unitree_ros/issues/18> from snt-arg/PedroS235-patch-2
  chore: update license to GPL
* chore: update license to GPL
* Merge pull request #17 <https://github.com/snt-arg/unitree_ros/issues/17> from snt-arg/feature/license
  [Misc] Update license to GPLv3
* [Misc] Update license to GPLv3
* Merge pull request #16 <https://github.com/snt-arg/unitree_ros/issues/16> from snt-arg/PedroS235-patch-1
  docs(fix): specify the unitree go1 edu version
* docs(fix): specify the unitree go1 edu version
* Update README.md
* Contributors: Hriday Bavle, Pedro Soares
```
