### PR TITLE
simple_launch: 1.9.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6994,7 +6994,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.9.2-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.9.1-1`

## simple_launch

```
* Gazebo basic example: launch SDF world + spawn from xacro
* remove dead code related to Gazebo.
* sl.arg returns a SimpleSubstitution to allow concatenation
* auto-detect Gazebo world name, allows running the simulation + spawn models in the same launch file
* Type debug on String being Iterable
* better handling of non-string choices in argument declaration
* more robust to various gz/ros combinations
* Contributors: Olivier Kermorgant
```
