### PR TITLE
rviz: 11.2.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7944,7 +7944,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.11-1
+      version: 11.2.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.12-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `11.2.11-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Select QoS reliability policy in DepthCloud Plugin (#1159 <https://github.com/ros2/rviz/issues/1159>) (#1164 <https://github.com/ros2/rviz/issues/1164>)
  (cherry picked from commit a76cf91b1b5a4d21c5b6e2405fae99799318f363)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Fixed crash on DepthCloud plugin (#1161 <https://github.com/ros2/rviz/issues/1161>) (#1162 <https://github.com/ros2/rviz/issues/1162>)
  (cherry picked from commit 92023c966414d4d9a044ad8f609a1c6f3ca402d3)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Fixed crash on DepthCloudPlugin (#1133 <https://github.com/ros2/rviz/issues/1133>) (#1152 <https://github.com/ros2/rviz/issues/1152>)
  (cherry picked from commit 85bd6636c8e1d2e61668ca125f8d05ce25531fff)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Wrench accepth nan values fix (#1141 <https://github.com/ros2/rviz/issues/1141>) (#1149 <https://github.com/ros2/rviz/issues/1149>)
  (cherry picked from commit 82385de6ef21db8b4dde57e397f039803c0b102e)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* DepthCloud plugin: Append measured subscription frequency to topic status (#1137 <https://github.com/ros2/rviz/issues/1137>) (#1145 <https://github.com/ros2/rviz/issues/1145>)
  (cherry picked from commit ad1990bfa180f39b4cf04116438453783bb125f9)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Added Cache to camera display for TimeExact (#1138 <https://github.com/ros2/rviz/issues/1138>) (#1142 <https://github.com/ros2/rviz/issues/1142>)
  (cherry picked from commit fdf195771a948d510768ec2ccb08b0c78fdc2b14)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* [backport Humble] load glb meshes (#1154 <https://github.com/ros2/rviz/issues/1154>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
