### PR TITLE
rviz: 12.4.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6800,7 +6800,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.6-1
+      version: 12.4.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.7-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `12.4.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix camera display overlay (#1151 <https://github.com/ros2/rviz/issues/1151>) (#1158 <https://github.com/ros2/rviz/issues/1158>)
  (cherry picked from commit c7bf4c99b5f888d2dc200041994ed5c8fe16d3ce)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Select QoS reliability policy in DepthCloud Plugin (#1159 <https://github.com/ros2/rviz/issues/1159>) (#1165 <https://github.com/ros2/rviz/issues/1165>)
  (cherry picked from commit a76cf91b1b5a4d21c5b6e2405fae99799318f363)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Fixed crash on DepthCloud plugin (#1161 <https://github.com/ros2/rviz/issues/1161>) (#1163 <https://github.com/ros2/rviz/issues/1163>)
  (cherry picked from commit 92023c966414d4d9a044ad8f609a1c6f3ca402d3)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Fixed crash on DepthCloudPlugin (#1133 <https://github.com/ros2/rviz/issues/1133>) (#1153 <https://github.com/ros2/rviz/issues/1153>)
  (cherry picked from commit 85bd6636c8e1d2e61668ca125f8d05ce25531fff)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Wrench accepth nan values fix (#1141 <https://github.com/ros2/rviz/issues/1141>) (#1150 <https://github.com/ros2/rviz/issues/1150>)
  (cherry picked from commit 82385de6ef21db8b4dde57e397f039803c0b102e)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* DepthCloud plugin: Append measured subscription frequency to topic status (#1137 <https://github.com/ros2/rviz/issues/1137>) (#1146 <https://github.com/ros2/rviz/issues/1146>)
  (cherry picked from commit ad1990bfa180f39b4cf04116438453783bb125f9)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Added Cache to camera display for TimeExact (#1138 <https://github.com/ros2/rviz/issues/1138>) (#1143 <https://github.com/ros2/rviz/issues/1143>)
  (cherry picked from commit fdf195771a948d510768ec2ccb08b0c78fdc2b14)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Fixed transport name in DepthCloud plugin (#1134 <https://github.com/ros2/rviz/issues/1134>) (#1136 <https://github.com/ros2/rviz/issues/1136>)
  (cherry picked from commit b30838530c1aee8f6ddcbd11db258fbd24e57935)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix camera display overlay (#1151 <https://github.com/ros2/rviz/issues/1151>) (#1158 <https://github.com/ros2/rviz/issues/1158>)
  (cherry picked from commit c7bf4c99b5f888d2dc200041994ed5c8fe16d3ce)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* [backport Humble] load glb meshes (#1154 <https://github.com/ros2/rviz/issues/1154>) (#1157 <https://github.com/ros2/rviz/issues/1157>)
  (cherry picked from commit 0722bd0dc1e8d7948a8fa0a15364a48fb9c5afc9)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
