### PR TITLE
rviz: 13.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6588,7 +6588,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.4.0-2
+      version: 13.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `13.4.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `13.4.0-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Remove regex_filter_property.hpp from the moc lines. (#1172 <https://github.com/ros2/rviz/issues/1172>)
  Since it has no SLOTS or SIGNALS, we don't need to run
  MOC on it.  That will both speed up the compilation and
  remove a warning when building.
* Added regex filter field for TF display (#1032 <https://github.com/ros2/rviz/issues/1032>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## rviz_default_plugins

```
* Added CameraInfo display (#1166 <https://github.com/ros2/rviz/issues/1166>)
* apply origin rotation to inertia box visualization (#1171 <https://github.com/ros2/rviz/issues/1171>)
* Added regex filter field for TF display (#1032 <https://github.com/ros2/rviz/issues/1032>)
* Added point_cloud_transport (#1008 <https://github.com/ros2/rviz/issues/1008>)
* Contributors: Alejandro Hernández Cordero, Jonas Otto
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Added CameraInfo display (#1166 <https://github.com/ros2/rviz/issues/1166>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
