### PR TITLE
point_cloud_transport: 2.0.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4407,7 +4407,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `2.0.5-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.4-1`

## point_cloud_transport

```
* Cleanup republisher (#58 <https://github.com/ros-perception/point_cloud_transport/issues/58>) (#71 <https://github.com/ros-perception/point_cloud_transport/issues/71>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Improve Windows support (#50 <https://github.com/ros-perception/point_cloud_transport/issues/50>) (#62 <https://github.com/ros-perception/point_cloud_transport/issues/62>)
* Fixed MacOS M1 build (#57 <https://github.com/ros-perception/point_cloud_transport/issues/57>) (#60 <https://github.com/ros-perception/point_cloud_transport/issues/60>)
* Contributors: Alejandro Hernández Cordero, john-maidbot
```

## point_cloud_transport_py

- No changes
