### PR TITLE
image_common: 5.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2252,7 +2252,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.0-2
+      version: 5.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.1.0-2`

## camera_calibration_parsers

```
* Switch from rcpputils::fs to std::filesystem (#300 <https://github.com/ros-perception/image_common/issues/300>)
* Contributors: Christophe Bedard
```

## camera_info_manager

```
* Switch from rcpputils::fs to std::filesystem (#300 <https://github.com/ros-perception/image_common/issues/300>)
* Contributors: Christophe Bedard
```

## image_common

- No changes

## image_transport

```
* Added rclcpp component to Republish (#275 <https://github.com/ros-perception/image_common/issues/275>)
* Contributors: Alejandro Hernández Cordero
```
