### PR TITLE
image_pipeline: 5.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2278,7 +2278,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.0-2
+      version: 5.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-2`

## camera_calibration

```
* Fix spelling error for cv2.aruco.DICT from 6x6_50 to 7x7_1000 (#961 <https://github.com/ros-perception/image_pipeline/issues/961>)
  There was mismatch of capitalisation of "X" for OpenCV
  cv2.aruco.DICT_n**X**n_ in camera_calibration package for dicts 6x6_50
  to 7x7_1000
  Co-authored-by: Vishal Balaji <mailto:vishal.balaji@schanzer-racing.de>
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* migrate camera_calibration documentation (#937 <https://github.com/ros-perception/image_pipeline/issues/937>)
* install tarfile_calibration (#923 <https://github.com/ros-perception/image_pipeline/issues/923>)
  otherwise, it can't be run easily
* calibration: better warnings around board configuration #713 <https://github.com/ros-perception/image_pipeline/issues/713> (#724 <https://github.com/ros-perception/image_pipeline/issues/724>)
* Contributors: Michael Ferguson, Vishal Balaji, jonathanTIE
```

## depth_image_proc

```
* Update depth_image_proc::RegisterNode documentation (#957 <https://github.com/ros-perception/image_pipeline/issues/957>)
  Adding missing parameters from register node of depth_image_proc
  package.
  Related to Issue #956 <https://github.com/ros-perception/image_pipeline/issues/956>
* add invalid_depth param (#943 <https://github.com/ros-perception/image_pipeline/issues/943>)
  Add option to set all invalid depth pixels to a specified value, typically the maximum range.
  * Updates convertDepth parameter name and optimizes use of the parameter.
  * Updates PointCloudXYZ, PointCloudXYZI, and PointCloudXYZRGB with new invalid_depth parameter
* fix image publisher remapping (#941 <https://github.com/ros-perception/image_pipeline/issues/941>)
  Addresses #940 <https://github.com/ros-perception/image_pipeline/issues/940> - fixes the compressed/etc topic remapping for publishers
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* migrate image_pipeline docs (#929 <https://github.com/ros-perception/image_pipeline/issues/929>)
  * Migrates image_pipeline overview page
  * Migrates CameraInfo wiki page
  * Adds links to the other packages in this stack
  * Updates depth_image_proc and image_proc to have the overview page properly named and in the TOC
* migrate depth_image_proc docs (#926 <https://github.com/ros-perception/image_pipeline/issues/926>)
* Fixed image types in depth_image_proc
* Contributors: Alejandro Hernández Cordero, Alessio Parmeggiani, Michael Ferguson, philipp.polterauer
```

## image_pipeline

```
* DisparityNode: replace full_dp parameter with sgbm_mode (#945 <https://github.com/ros-perception/image_pipeline/issues/945>)
  Previously, only the SGBM and HH modes were allowed
* add missing tutorial page (#939 <https://github.com/ros-perception/image_pipeline/issues/939>)
  This was supposed to be part of #938 <https://github.com/ros-perception/image_pipeline/issues/938>
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* fix documentation links (#933 <https://github.com/ros-perception/image_pipeline/issues/933>)
* migrate image_pipeline docs (#929 <https://github.com/ros-perception/image_pipeline/issues/929>)
  * Migrates image_pipeline overview page
  * Migrates CameraInfo wiki page
  * Adds links to the other packages in this stack
  * Updates depth_image_proc and image_proc to have the overview page properly named and in the TOC
* Contributors: Michael Ferguson, Pablo David Aranda Rodríguez
```

## image_proc

```
* Fix parameter names in components.rst (#959 <https://github.com/ros-perception/image_pipeline/issues/959>)
  In the docs for image_proc::CropDecimateNode , change the parameter
  names x_offset and y_offset to offset_x and offset_y, matching
  the actual names of parameters defined in crop_decimate.cpp
* fix image publisher remapping (#941 <https://github.com/ros-perception/image_pipeline/issues/941>)
  Addresses #940 <https://github.com/ros-perception/image_pipeline/issues/940> - fixes the compressed/etc topic remapping for publishers
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* Add TrackMarkerNode to image_proc (#930 <https://github.com/ros-perception/image_pipeline/issues/930>)
  Converts sensors_msgs/Image into geometry_msg/PoseStamped using OpenCV Aruco marker detection.
* migrate image_pipeline docs (#929 <https://github.com/ros-perception/image_pipeline/issues/929>)
  * Migrates image_pipeline overview page
  * Migrates CameraInfo wiki page
  * Adds links to the other packages in this stack
  * Updates depth_image_proc and image_proc to have the overview page properly named and in the TOC
* migrate depth_image_proc docs (#926 <https://github.com/ros-perception/image_pipeline/issues/926>)
* fixup bash command rendering (#927 <https://github.com/ros-perception/image_pipeline/issues/927>)
  I didn't actually rebuild with the suggestions in #925 <https://github.com/ros-perception/image_pipeline/issues/925> - but this is
  actually proper rendering (even my three-ticks version wasn't quite
  pretty)
* migrate and update image_proc docs (#925 <https://github.com/ros-perception/image_pipeline/issues/925>)
  * move component documentation from ros wiki, update for various changes
  * add tutorial on how to run components
  * update tutorial on debayer/rectify to use launch file
  * remove image_proc node, it has always been completely broken and the
  launch file has the same (but working) functionality
  * update launch file to support namespace parameter for tutorial
* QoS improvements for image_proc and stereo_image_proc (#922 <https://github.com/ros-perception/image_pipeline/issues/922>)
  First part of #847 <https://github.com/ros-perception/image_pipeline/issues/847>
  * Add QoS overrides for all publishers (in the new, standard way)
  * stereo_image_proc: Default subscriber QoS to SensorDataQoS
  * Clean up some of the comments around lazy subscribers, make them more
  consistent across nodes
* Contributors: Michael Ferguson, Noah Mollerstuen
```

## image_publisher

```
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* add docs for image_rotate/publisher (#936 <https://github.com/ros-perception/image_pipeline/issues/936>)
* Contributors: Michael Ferguson
```

## image_rotate

```
* fix image publisher remapping (#941 <https://github.com/ros-perception/image_pipeline/issues/941>)
  Addresses #940 <https://github.com/ros-perception/image_pipeline/issues/940> - fixes the compressed/etc topic remapping for publishers
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* add docs for image_rotate/publisher (#936 <https://github.com/ros-perception/image_pipeline/issues/936>)
* Contributors: Michael Ferguson
```

## image_view

```
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* add docs for image_rotate/publisher (#936 <https://github.com/ros-perception/image_pipeline/issues/936>)
* migrate image_view docs (#934 <https://github.com/ros-perception/image_pipeline/issues/934>)
  * migrate docs from ROS wiki
  * FIX: video recorder start/end services should only be advertised when
  feature is enabled
  * FIX: image remapping didn't work as expected/documented in
  stereo_image_proc
* default to encoding in the image message (#921 <https://github.com/ros-perception/image_pipeline/issues/921>)
  My camera is publishing rgb8 encoding - the existing code throws an
  error that 8UC3 is not a valid encoding, but if we pass rgb8 from the
  message then things work fine. The encoding in the image should always
  be more descriptive than just the bit and channel size.
  If encoding is not filled in, the existing behavior is used as a
  fallback
* Update extract_images_sync to add sec_per_frame parameter (#920 <https://github.com/ros-perception/image_pipeline/issues/920>)
  Added sec_per_frame parameter to allow decimation of frames being
  synchronized and captured.
  fixes #726 <https://github.com/ros-perception/image_pipeline/issues/726>
  ---------
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Port extract_images_sync script to ROS 2 (#919 <https://github.com/ros-perception/image_pipeline/issues/919>)
  Change Description: The extract_images_sync python script was upgraded
  to ROS 2.
  Testing: Upgraded node tested against Iron on Ubuntu 22.04.3 LTS
  Issue: fixes #860 <https://github.com/ros-perception/image_pipeline/issues/860>
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Contributors: Michael Ferguson, Siddharth Vaghela
```

## stereo_image_proc

```
* DisparityNode: replace full_dp parameter with sgbm_mode (#945 <https://github.com/ros-perception/image_pipeline/issues/945>)
  Previously, only the SGBM and HH modes were allowed
* unified changelog, add missing image, deduplicate tutorials (#938 <https://github.com/ros-perception/image_pipeline/issues/938>)
  Last bit of documentation updates - putting together a single changelog
  summary for the whole release (rather than scattering among packages).
  Unified the camera_info tutorial so it isn't duplicated. Added a missing
  image from image_rotate (was on local disk, but hadn't committed it)
* migrate stereo_image_proc docs (#928 <https://github.com/ros-perception/image_pipeline/issues/928>)
* QoS improvements for image_proc and stereo_image_proc (#922 <https://github.com/ros-perception/image_pipeline/issues/922>)
  First part of #847 <https://github.com/ros-perception/image_pipeline/issues/847>
  * Add QoS overrides for all publishers (in the new, standard way)
  * stereo_image_proc: Default subscriber QoS to SensorDataQoS
  * Clean up some of the comments around lazy subscribers, make them more
  consistent across nodes
* Contributors: Michael Ferguson, Pablo David Aranda Rodríguez
```

## tracetools_image_pipeline

- No changes
