### PR TITLE
image_pipeline: 4.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2268,7 +2268,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `4.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.0-1`

## camera_calibration

- No changes

## depth_image_proc

```
* [backport iron] Fixed image types in depth_image_proc (#917 <https://github.com/ros-perception/image_pipeline/issues/917>)
  backport iron
  https://github.com/ros-perception/image_pipeline/pull/915#event-11585393591
* Contributors: Alejandro Hernández Cordero
```

## image_pipeline

- No changes

## image_proc

```
* [backport iron] Node namespace parameter (#953 <https://github.com/ros-perception/image_pipeline/issues/953>)
  Backport pull request #925 <https://github.com/ros-perception/image_pipeline/issues/925> which solves issue #952 <https://github.com/ros-perception/image_pipeline/issues/952> by adding the
  namespace parameter to the image_proc launch file
* Contributors: Lucas Wendland
```

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
