### PR TITLE
fastcdr: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1390,7 +1390,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastcdr-release.git
-      version: 1.1.0-3
+      version: 2.2.1-1
     source:
       test_commits: false
       test_pull_requests: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1396,7 +1396,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: 1.1.x
+      version: 2.2.x
     status: maintained
   fastrtps:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fastcdr` to `2.2.1-1`:

- upstream repository: https://github.com/eProsima/Fast-CDR.git
- release repository: https://github.com/ros2-gbp/fastcdr-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-3`
