### PR TITLE
psdk_ros2: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5506,7 +5506,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.1.1-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.0-1`

## psdk_interfaces

```
* Merge pull request #68 <https://github.com/umdlife/psdk_ros2/issues/68> from umdlife/hotfix/motors-stop
  Add ESC data
* Merge remote-tracking branch 'origin/main' into add_namespace_to_tf
* Contributors: DominikWawak, Rafael Perez-Segui, biancabnd
```

## psdk_wrapper

```
* Merge pull request #68 <https://github.com/umdlife/psdk_ros2/issues/68> from umdlife/hotfix/motors-stop
  Add ESC data
* Merge pull request #60 <https://github.com/umdlife/psdk_ros2/issues/60> from RPS98/add_namespace_to_tf
  Add prefix to TF frames
* Merge pull request #65 <https://github.com/umdlife/psdk_ros2/issues/65> from umdlife/feat/add-linters-workflow
  Add clang and super linter to workflows
* Merge pull request #61 <https://github.com/umdlife/psdk_ros2/issues/61> from umdlife/hotfix/set-home-from-gps
  Convert coordinates to radians before setting home position
* Contributors: DominikWawak, Rafael Perez-Segui, UMLDev Clang Robot, Victor Massagué Respall, biancabnd, vicmassy
```
