### PR TITLE
gz_cmake_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1928,10 +1928,16 @@ repositories:
       type: git
       url: https://github.com/gazebo-release/gz_cmake_vendor.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_cmake_vendor.git
       version: rolling
+    status: maintained
   gz_common_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gz_cmake_vendor

```
* Require calling find_package on the underlying package (#3 <https://github.com/gazebo-release/gz_cmake_vendor/issues/3>)
  This also changes the version of the vendor package to 0.0.1
  and adds the version of the vendored package in the description
* Fix linter (#2 <https://github.com/gazebo-release/gz_cmake_vendor/issues/2>)
* Use <depend> on upstream package so that dependency is exported
* Update maintainer
* Add package.xml and CMakeLists (#1 <https://github.com/gazebo-release/gz_cmake_vendor/issues/1>)
* Initial import
* Contributors: Addisu Z. Taddese
```
