### PR TITLE
Added the Jetson GPIO python pkg

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2058,6 +2058,10 @@ python-jasmine-pip:
   ubuntu:
     pip:
       packages: [jasmine]
+python-jetson-gpio-pip:
+  ubuntu:
+    pip:
+      packages: [Jetson.GPIO]
 python-jetson-stats-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
Jetson.GPIO
LINK: https://pypi.org/project/Jetson.GPIO/

## Package Upstream Source:
LINK: https://github.com/NVIDIA/jetson-gpio

## Purpose of using this:
This is used for the Nvidia Jetson development boards, to control the digital input and output. 


