### PR TITLE
ros2_control: 4.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5451,7 +5451,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.7.0-1
+      version: 4.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.7.0-1`

## controller_interface

```
* generate version.h file per package using the ament_generate_version_header  (#1449 <https://github.com/ros-controls/ros2_control/issues/1449>)
* Use ament_cmake generated rclcpp version header (#1448 <https://github.com/ros-controls/ros2_control/issues/1448>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* generate version.h file per package using the ament_generate_version_header  (#1449 <https://github.com/ros-controls/ros2_control/issues/1449>)
* Use ament_cmake generated rclcpp version header (#1448 <https://github.com/ros-controls/ros2_control/issues/1448>)
* Replace random_shuffle with shuffle. (#1446 <https://github.com/ros-controls/ros2_control/issues/1446>)
* Contributors: Chris Lalancette, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* generate version.h file per package using the ament_generate_version_header  (#1449 <https://github.com/ros-controls/ros2_control/issues/1449>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

```
* generate version.h file per package using the ament_generate_version_header  (#1449 <https://github.com/ros-controls/ros2_control/issues/1449>)
* Contributors: Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* Fix rqt_controller_manager for non-humble (#1454 <https://github.com/ros-controls/ros2_control/issues/1454>)
* Add cm as dependency to rqt_cm (#1447 <https://github.com/ros-controls/ros2_control/issues/1447>)
* Contributors: Christoph Fröhlich
```

## transmission_interface

```
* generate version.h file per package using the ament_generate_version_header  (#1449 <https://github.com/ros-controls/ros2_control/issues/1449>)
* Contributors: Sai Kishor Kothakota
```
