### PR TITLE
ypspur_ros: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13143,7 +13143,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/ypspur_ros-release.git
-      version: 0.3.6-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/openspur/ypspur_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ypspur_ros` to `0.4.0-1`:

- upstream repository: https://github.com/openspur/ypspur_ros.git
- release repository: https://github.com/openspur/ypspur_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.6-1`

## ypspur_ros

```
* Add option to wait convergence of joint trajectory angle and velocity (#122 <https://github.com/openspur/ypspur_ros/issues/122>)
* Use control simulation in yp-spur instead of ypspur_ros (#120 <https://github.com/openspur/ypspur_ros/issues/120>)
* Fix code format (#121 <https://github.com/openspur/ypspur_ros/issues/121>)
* Update assets to v0.6.4 (#119 <https://github.com/openspur/ypspur_ros/issues/119>)
* Update assets to v0.6.3 (#118 <https://github.com/openspur/ypspur_ros/issues/118>)
* Contributors: Atsushi Watanabe, Kazuki Takahashi
```
