### PR TITLE
rosidl: 4.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5897,7 +5897,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.5.1-2
+      version: 4.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.5.2-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.5.1-2`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

```
* Improve deprecation notice of rosidl_target_interface to give a hint on how to update the code (#788 <https://github.com/ros2/rosidl/issues/788>)
* Contributors: Alexis Paques
```

## rosidl_generator_c

```
* Set hints to find the python version we actually want. (#785 <https://github.com/ros2/rosidl/issues/785>)
* Contributors: Chris Lalancette
```

## rosidl_generator_cpp

```
* Set hints to find the python version we actually want. (#785 <https://github.com/ros2/rosidl/issues/785>)
* Contributors: Chris Lalancette
```

## rosidl_generator_type_description

```
* Set hints to find the python version we actually want. (#785 <https://github.com/ros2/rosidl/issues/785>)
* Contributors: Chris Lalancette
```

## rosidl_parser

```
* Small fix for newer flake8 compatibility. (#792 <https://github.com/ros2/rosidl/issues/792>)
* Contributors: Chris Lalancette
```

## rosidl_pycommon

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Set hints to find the python version we actually want. (#785 <https://github.com/ros2/rosidl/issues/785>)
* Contributors: Chris Lalancette
```

## rosidl_typesupport_introspection_cpp

```
* Set hints to find the python version we actually want. (#785 <https://github.com/ros2/rosidl/issues/785>)
* Contributors: Chris Lalancette
```
