### PR TITLE
rosidl_python: 0.21.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6003,7 +6003,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.21.1-2
+      version: 0.21.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.21.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.21.1-2`

## rosidl_generator_py

```
* Prototype code for seeing if FindPython3 is usable for rosidl_python (#140 <https://github.com/ros2/rosidl_python/issues/140>)
* Contributors: Shane Loretz
```
