### PR TITLE
rosidl_typesupport: 3.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6038,7 +6038,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 3.2.0-2
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `3.2.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.2.0-2`

## rosidl_typesupport_c

```
* compare string contents but string pointer addresses. (#153 <https://github.com/ros2/rosidl_typesupport/issues/153>)
* Set hints to find the python version we actually want. (#150 <https://github.com/ros2/rosidl_typesupport/issues/150>)
* Contributors: Chris Lalancette, Tomoya Fujita
```

## rosidl_typesupport_cpp

```
* compare string contents but string pointer addresses. (#153 <https://github.com/ros2/rosidl_typesupport/issues/153>)
* Set hints to find the python version we actually want. (#150 <https://github.com/ros2/rosidl_typesupport/issues/150>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
