### PR TITLE
rosidl_runtime_py: 0.13.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6019,7 +6019,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.13.0-2
+      version: 0.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.13.1-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.13.0-2`

## rosidl_runtime_py

```
* Some fixes for modern flake8. (#25 <https://github.com/ros2/rosidl_runtime_py/issues/25>)
* Contributors: Chris Lalancette
```
