### PR TITLE
ros2_tracing: 8.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5588,7 +5588,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.0.0-2
+      version: 8.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.1.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.0.0-2`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

```
* Update tests and docs after new rmw_publish timestamp field (#90 <https://github.com/ros2/ros2_tracing/issues/90>)
* Contributors: Christophe Bedard
```

## tracetools_launch

```
* Use single underscore for private vars in Python (#92 <https://github.com/ros2/ros2_tracing/issues/92>)
* Improve tracing configuration error reporting (#85 <https://github.com/ros2/ros2_tracing/issues/85>)
* Fix warnings when using mypy 1.8.0. (#89 <https://github.com/ros2/ros2_tracing/issues/89>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## tracetools_read

```
* Allow tracing tests to be run in parallel with other tests (#95 <https://github.com/ros2/ros2_tracing/issues/95>)
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Allow tracing tests to be run in parallel with other tests (#95 <https://github.com/ros2/ros2_tracing/issues/95>)
* Fix interference between test_tracetools and ros2lifecycle tests (#96 <https://github.com/ros2/ros2_tracing/issues/96>)
* Make tracing test assert messages more descriptive (#93 <https://github.com/ros2/ros2_tracing/issues/93>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Improve tracing configuration error reporting (#85 <https://github.com/ros2/ros2_tracing/issues/85>)
* Add a space in between not and parentheses. (#88 <https://github.com/ros2/ros2_tracing/issues/88>)
* Contributors: Chris Lalancette, Christophe Bedard
```
