### PR TITLE
rmw_fastrtps: 8.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5302,7 +5302,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 8.2.0-2
+      version: 8.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `8.3.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.0-2`

## rmw_fastrtps_cpp

```
* Support Fast CDR v2 (#746 <https://github.com/ros2/rmw_fastrtps/issues/746>)
  * Require fastcdr version 2
  * Changes to build rmw_fastrtps_shared_cpp
  * Changes to build rmw_fastrtps_cpp
  * Changes to build rmw_fastrtps_dynamic_cpp
* Contributors: Miguel Company
```

## rmw_fastrtps_dynamic_cpp

```
* Support Fast CDR v2 (#746 <https://github.com/ros2/rmw_fastrtps/issues/746>)
  * Require fastcdr version 2
  * Changes to build rmw_fastrtps_shared_cpp
  * Changes to build rmw_fastrtps_cpp
  * Changes to build rmw_fastrtps_dynamic_cpp
* compare string contents but string pointer addresses. (#744 <https://github.com/ros2/rmw_fastrtps/issues/744>)
* Improve wide string (de)serialization in rwm_dynamic_fastrtps_cpp (#740 <https://github.com/ros2/rmw_fastrtps/issues/740>)
  * Move type support headers to src
  * Fix references to moved headers
  * move macros.hpp to src/serialization_helpers.hpp
  * Move other non-api headers
  * Move common code into serialize_wide_string.
  * Move common code into deserialize_wide_string.
  * Move serialization into serialization_helpers.hpp
  * Move deserialization into serialization_helpers.hpp
  * Fix header guards
  * Linters
  * Do not account for extra character on serialized size calculation
  * Remove dependency on rosidl_typesupport_fastrtps_c(pp)
  ---------
* Contributors: Miguel Company, Tomoya Fujita
```

## rmw_fastrtps_shared_cpp

```
* Support Fast CDR v2 (#746 <https://github.com/ros2/rmw_fastrtps/issues/746>)
  * Require fastcdr version 2
  * Changes to build rmw_fastrtps_shared_cpp
  * Changes to build rmw_fastrtps_cpp
  * Changes to build rmw_fastrtps_dynamic_cpp
* Remove an unnecessary constructor. (#743 <https://github.com/ros2/rmw_fastrtps/issues/743>)
  We can just use brace initialization here, and this
  allows us to side-step an uncrustify issue with the constructor.
* Contributors: Chris Lalancette, Miguel Company
```
