### PR TITLE
rosbag2: 0.25.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5836,7 +5836,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.24.0-3
+      version: 0.25.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.25.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.24.0-3`

## mcap_vendor

```
* Switch to target_link_libraries everywhere. (#1504 <https://github.com/ros2/rosbag2/issues/1504>)
* Contributors: Chris Lalancette
```

## ros2bag

```
* Overhaul in the rosbag2_transport::TopicFilter class and relevant tests (#1585 <https://github.com/ros2/rosbag2/issues/1585>)
* Filter topic by type  (#1577 <https://github.com/ros2/rosbag2/issues/1577>)
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Add python3-yaml as a dependency (#1490 <https://github.com/ros2/rosbag2/issues/1490>)
* Fix the description of paramter '--topics' for play (#1426 <https://github.com/ros2/rosbag2/issues/1426>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Michael Orlov, Michal Sojka
```

## rosbag2

- No changes

## rosbag2_compression

```
* Use std::filesystem instead of rcpputils::fs (#1576 <https://github.com/ros2/rosbag2/issues/1576>)
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Add default initialization for CompressionOptions (#1539 <https://github.com/ros2/rosbag2/issues/1539>)
* Add option to set compression threads priority (#1457 <https://github.com/ros2/rosbag2/issues/1457>)
* Fixes pointed out by clang. (#1493 <https://github.com/ros2/rosbag2/issues/1493>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* Contributors: Arne B, Chris Lalancette, Michael Orlov, Patrick Roncagliolo, Roman Sokolkov, jmachowinski
```

## rosbag2_compression_zstd

```
* Use std::filesystem instead of rcpputils::fs (#1576 <https://github.com/ros2/rosbag2/issues/1576>)
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Contributors: Chris Lalancette, Roman Sokolkov
```

## rosbag2_cpp

```
* Use std::filesystem instead of rcpputils::fs (#1576 <https://github.com/ros2/rosbag2/issues/1576>)
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* call cv.wait_until only if necessary. (#1521 <https://github.com/ros2/rosbag2/issues/1521>)
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Switch to target_link_libraries everywhere. (#1504 <https://github.com/ros2/rosbag2/issues/1504>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* ros2 bag convert now excludes messages not in [start_time;end_time] (#1455 <https://github.com/ros2/rosbag2/issues/1455>)
* Replace TSAUniqueLock implementation with rcpputils::unique_lock (#1454 <https://github.com/ros2/rosbag2/issues/1454>)
* Add BagSplitInfo service call on bag close (#1422 <https://github.com/ros2/rosbag2/issues/1422>)
* Contributors: Barry Xu, Chris Lalancette, Emerson Knapp, Michael Orlov, Patrick Roncagliolo, Peter Favrholdt, Roman Sokolkov, Tomoya Fujita
```

## rosbag2_examples_cpp

```
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* Contributors: Michael Orlov, Patrick Roncagliolo
```

## rosbag2_examples_py

```
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Contributors: Michael Orlov
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Add option to set compression threads priority (#1457 <https://github.com/ros2/rosbag2/issues/1457>)
* Add per group statistics for rosbag2_performance_benchmarking report (#1306 <https://github.com/ros2/rosbag2/issues/1306>)
* Contributors: Michael Orlov, jmachowinski
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Fix for false negative tests in rosbag2_py (#1592 <https://github.com/ros2/rosbag2/issues/1592>)
* Update rosbag2_py stubs (#1593 <https://github.com/ros2/rosbag2/issues/1593>)
* Add Python stubs for rosbag2_py (#1459 <https://github.com/ros2/rosbag2/issues/1459>) (#1569 <https://github.com/ros2/rosbag2/issues/1569>)
* Filter topic by type  (#1577 <https://github.com/ros2/rosbag2/issues/1577>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Install signal handlers in recorder only inside record method (#1464 <https://github.com/ros2/rosbag2/issues/1464>)
* add missing import otherwise it doesnt compile (#1524 <https://github.com/ros2/rosbag2/issues/1524>)
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Make rosbag2_transport::Player::play() run in a separate thread (#1503 <https://github.com/ros2/rosbag2/issues/1503>)
* Switch to target_link_libraries everywhere. (#1504 <https://github.com/ros2/rosbag2/issues/1504>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* ros2 bag convert now excludes messages not in [start_time;end_time] (#1455 <https://github.com/ros2/rosbag2/issues/1455>)
* Add support for compression to python API (#1425 <https://github.com/ros2/rosbag2/issues/1425>)
* Contributors: Alejandro Hernández Cordero, Andrew Symington, Barry Xu, Chris Lalancette, Michael Orlov, Mikael Arguedas, Patrick Roncagliolo, Peter Favrholdt, Roman Sokolkov
```

## rosbag2_storage

```
* Use std::filesystem instead of rcpputils::fs (#1576 <https://github.com/ros2/rosbag2/issues/1576>)
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Remove rcpputils::fs dependencies from rosbag2_storages (#1558 <https://github.com/ros2/rosbag2/issues/1558>)
* Improve performance in SqliteStorage::get_bagfile_size() (#1516 <https://github.com/ros2/rosbag2/issues/1516>)
* Make Player and Recorder Composable (#902 <https://github.com/ros2/rosbag2/issues/902>) (#1419 <https://github.com/ros2/rosbag2/issues/1419>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* ros2 bag convert now excludes messages not in [start_time;end_time] (#1455 <https://github.com/ros2/rosbag2/issues/1455>)
* Contributors: Chris Lalancette, Michael Orlov, Patrick Roncagliolo, Peter Favrholdt, Roman Sokolkov
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Use rw_lock to protect mcap metadata lists. (#1561 <https://github.com/ros2/rosbag2/issues/1561>)
* Remove rcpputils::fs dependencies from rosbag2_storages (#1558 <https://github.com/ros2/rosbag2/issues/1558>)
* remove unused headers (#1544 <https://github.com/ros2/rosbag2/issues/1544>)
* Link and compile against rosbag2_storage_mcap: Fixed issue 1492 (#1496 <https://github.com/ros2/rosbag2/issues/1496>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* Store serialized metadata in MCAP file (#1423 <https://github.com/ros2/rosbag2/issues/1423>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov, Patrick Roncagliolo, Roman Sokolkov, Tomoya Fujita, uupks
```

## rosbag2_storage_sqlite3

```
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Remove rcpputils::fs dependencies from rosbag2_storages (#1558 <https://github.com/ros2/rosbag2/issues/1558>)
* Change an incorrect TSA annotation. (#1552 <https://github.com/ros2/rosbag2/issues/1552>)
* Improve performance in SqliteStorage::get_bagfile_size() (#1516 <https://github.com/ros2/rosbag2/issues/1516>)
* Update rosbag2_storage_sqlite3 to C++17. (#1501 <https://github.com/ros2/rosbag2/issues/1501>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* Stop inheriting from std::iterator. (#1424 <https://github.com/ros2/rosbag2/issues/1424>)
* Contributors: Chris Lalancette, Michael Orlov, Patrick Roncagliolo, Roman Sokolkov
```

## rosbag2_test_common

```
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Contributors: Barry Xu, Chris Lalancette
```

## rosbag2_test_msgdefs

```
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Contributors: Barry Xu
```

## rosbag2_tests

```
* Use std::filesystem instead of rcpputils::fs (#1576 <https://github.com/ros2/rosbag2/issues/1576>)
* Filter topic by type  (#1577 <https://github.com/ros2/rosbag2/issues/1577>)
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Improve performance in SqliteStorage::get_bagfile_size() (#1516 <https://github.com/ros2/rosbag2/issues/1516>)
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Mark play_end_to_end test as xfail in Windows (#1452 <https://github.com/ros2/rosbag2/issues/1452>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chris Lalancette, Cristóbal Arroyo, Michael Orlov, Roman Sokolkov
```

## rosbag2_transport

```
* Use std::filesystem instead of rcpputils::fs (#1576 <https://github.com/ros2/rosbag2/issues/1576>)
* Add transactional state mutex for RecorderImpl class. (#1547 <https://github.com/ros2/rosbag2/issues/1547>)
* Overhaul in the rosbag2_transport::TopicFilter class and relevant tests (#1585 <https://github.com/ros2/rosbag2/issues/1585>)
* Filter topic by type  (#1577 <https://github.com/ros2/rosbag2/issues/1577>)
* fix: use size_t instead of uint64_t in play_options YAML converter (#1575 <https://github.com/ros2/rosbag2/issues/1575>)
* Make some changes for newer versions of uncrustify. (#1578 <https://github.com/ros2/rosbag2/issues/1578>)
* Add topic_id returned by storage to the TopicMetadata (#1538 <https://github.com/ros2/rosbag2/issues/1538>)
* Workaround for flaky test_play_services running with fastrtps (#1556 <https://github.com/ros2/rosbag2/issues/1556>)
* Add proper message for --start-paused (#1537 <https://github.com/ros2/rosbag2/issues/1537>)
* Recording stopped prints only once. (#1530 <https://github.com/ros2/rosbag2/issues/1530>)
* Cleanup the rosbag2_transport tests (#1518 <https://github.com/ros2/rosbag2/issues/1518>)
* Implement service recording and display info about recorded services (#1480 <https://github.com/ros2/rosbag2/issues/1480>)
* Add option to set compression threads priority (#1457 <https://github.com/ros2/rosbag2/issues/1457>)
* Bugfix for incorrect playback rate changes when pressing buttons (#1513 <https://github.com/ros2/rosbag2/issues/1513>)
* Make Player and Recorder Composable (#902 <https://github.com/ros2/rosbag2/issues/902>) (#1419 <https://github.com/ros2/rosbag2/issues/1419>)
* Clang fixes for the latest PlayerImpl code. (#1507 <https://github.com/ros2/rosbag2/issues/1507>)
* Make rosbag2_transport::Player::play() run in a separate thread (#1503 <https://github.com/ros2/rosbag2/issues/1503>)
* Switch to target_link_libraries everywhere. (#1504 <https://github.com/ros2/rosbag2/issues/1504>)
* Use enum values for offered_qos_profiles in code and string names in serialized metadata (#1476 <https://github.com/ros2/rosbag2/issues/1476>)
* Redesign Player class with PIMPL idiom (#1447 <https://github.com/ros2/rosbag2/issues/1447>)
* Don't warn for unknown types if topics are not selected (#1466 <https://github.com/ros2/rosbag2/issues/1466>)
* Remove unused concurrentqueue implementation. (#1465 <https://github.com/ros2/rosbag2/issues/1465>)
* Fix uninitialized value pointed out by clang static analysis. (#1440 <https://github.com/ros2/rosbag2/issues/1440>)
* Fix the build with rmw_fastrtps_dynamic. (#1416 <https://github.com/ros2/rosbag2/issues/1416>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chris Lalancette, Christoph Fröhlich, Daisuke Nishimatsu, Michael Orlov, Patrick Roncagliolo, Roman Sokolkov, Tomoya Fujita, jmachowinski
```

## shared_queues_vendor

```
* Remove unused concurrentqueue implementation. (#1465 <https://github.com/ros2/rosbag2/issues/1465>)
  rosbag2 only depends on the readerwriter queue.
* Contributors: Chris Lalancette
```

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
