### PR TITLE
rcutils: 6.5.2-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4868,7 +4868,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.5.2-2
+      version: 6.5.2-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.5.2-3`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.5.2-2`

## rcutils

```
* Clean up unused references to mimick/mocking in tests (#450 <https://github.com/ros2/rcutils/issues/450>)
* Fix if(TARGET ...) condition for test (#447 <https://github.com/ros2/rcutils/issues/447>)
* Zero-initialize rcutils_string_array_t in test_string_array (#446 <https://github.com/ros2/rcutils/issues/446>)
* Use rcutils_string_array_init in rcutils_split & handle alloc fail (#445 <https://github.com/ros2/rcutils/issues/445>)
* Contributors: Christophe Bedard
```
