### PR TITLE
rmw_cyclonedds: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5266,7 +5266,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 2.1.0-2
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `2.1.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-2`

## rmw_cyclonedds_cpp

```
* Remove a bunch of unnecessary macros. (#482 <https://github.com/ros2/rmw_cyclonedds/issues/482>)
* compare string contents but string pointer addresses. (#481 <https://github.com/ros2/rmw_cyclonedds/issues/481>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
