### PR TITLE
rclpy: 7.0.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4801,7 +4801,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.0.1-2
+      version: 7.0.1-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.0.1-3`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.0.1-2`

## rclpy

```
* Remove parentheses from assert statements. (#1213 <https://github.com/ros2/rclpy/issues/1213>)
* Contributors: Chris Lalancette
```
