### PR TITLE
rclcpp: 27.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4785,7 +4785,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 27.0.0-2
+      version: 27.0.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `27.0.0-3`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `27.0.0-2`

## rclcpp

```
* Split test_executors up into smaller chunks. (#2421 <https://github.com/ros2/rclcpp/issues/2421>)
* [events executor] - Fix Behavior with Timer Cancel (#2375 <https://github.com/ros2/rclcpp/issues/2375>)
* Removed deprecated header (#2413 <https://github.com/ros2/rclcpp/issues/2413>)
* Make sure to mark RingBuffer methods as 'override'. (#2410 <https://github.com/ros2/rclcpp/issues/2410>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Matt Condino
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
