### PR TITLE
rcl_logging: 3.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4732,7 +4732,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.0.0-2
+      version: 3.0.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.0.0-3`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-2`

## rcl_logging_interface

```
* add file_name_prefix parameter to external log configuration. (#109 <https://github.com/ros2/rcl_logging/issues/109>)
* Contributors: Tomoya Fujita
```

## rcl_logging_noop

```
* add file_name_prefix parameter to external log configuration. (#109 <https://github.com/ros2/rcl_logging/issues/109>)
* Contributors: Tomoya Fujita
```

## rcl_logging_spdlog

```
* add file_name_prefix parameter to external log configuration. (#109 <https://github.com/ros2/rcl_logging/issues/109>)
* Contributors: Tomoya Fujita
```
