### PR TITLE
rcl: 9.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4685,7 +4685,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.1.0-2
+      version: 9.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.2.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `9.1.0-2`

## rcl

```
* Add rcl_timer_call_with_info function that retrieves the expected and the actual timer trigger times (#1113 <https://github.com/ros2/rcl/issues/1113>)
  Co-authored-by: Alexis Tsogias <mailto:a.tsogias@cellumation.com>
  Co-authored-by: Michael Carroll <mailto:carroll.michael@gmail.com>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* document out parameters for rcl_get_node_names and rcl_get_node_names_with_enclaves (#1137 <https://github.com/ros2/rcl/issues/1137>)
  * document out params for rcl_get_node_names
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Cleanups for uncrustify 0.78. (#1134 <https://github.com/ros2/rcl/issues/1134>)
  Mostly this is expanding macros, as this is just easier
  to read anyway.  But we also mark one section as INDENT-OFF.
* Re-order rcl_logging_interface include (#1133 <https://github.com/ros2/rcl/issues/1133>)
* Remove unnecessary macros. (#1132 <https://github.com/ros2/rcl/issues/1132>)
  These really don't add anything, and allows us to
  avoid some changes in macro formatting between Ubuntu
  22.04 and Ubuntu 24.04.
* Update quality declaration documents (#1131 <https://github.com/ros2/rcl/issues/1131>)
* Contributors: Chris Lalancette, Christophe Bedard, Felix Penzlin, jmachowinski
```

## rcl_action

```
* add RCL_RET_TIMEOUT to action service response. (#1138 <https://github.com/ros2/rcl/issues/1138>)
  * add RCL_RET_TIMEOUT to action service response.
  * address review comment.
  ---------
* Update quality declaration documents (#1131 <https://github.com/ros2/rcl/issues/1131>)
* Contributors: Christophe Bedard, Tomoya Fujita
```

## rcl_lifecycle

```
* Update quality declaration documents (#1131 <https://github.com/ros2/rcl/issues/1131>)
* Contributors: Christophe Bedard
```

## rcl_yaml_param_parser

```
* Update quality declaration documents (#1131 <https://github.com/ros2/rcl/issues/1131>)
* Contributors: Christophe Bedard
```
