### PR TITLE
mola: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3179,7 +3179,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.0.1-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* BridgeROS2: do not quit on temporary /tf timeout
* mola_bridge_ros2: option to publish /tf_static for base_footprint
* mola_bridge_ros2: implement missing MOLA->ROS2 conversion for GNNS observations
* BUGFIX: Inverted value of "use_fixed_sensor_pose" was used
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Clean up yaml files.
* PF localization demo for Mulran dataset
* renamed ros launch files for clear autocompletion with ros2 launch
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* BUGFIX: Inverted value of "use_fixed_sensor_pose" was used
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Remove now-useless build dependencies and includes for mola-kernel
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* code clean up.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

- No changes

## mola_navstate_fuse

- No changes

## mola_pose_list

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
