### PR TITLE
flir_camera_driver: 2.0.15-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1498,6 +1498,16 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
       version: rolling-release
+    release:
+      packages:
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
+      version: 2.0.15-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.15-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* fixes to compile on focal/galactic
* Oryx parameter file
* support for command nodes
* remove more spinnaker imports, make spinnaker private
* added blackfly GigE configuration file
* track incomplete frames
* fixed licensing documentation
* Contributors: Bernd Pfrommer, Sir-Photch
```

## spinnaker_synchronized_camera_driver

```
* fixes to compile on focal/galactic
* track incomplete frames
* fixed licensing documentation
* Contributors: Bernd Pfrommer
```
