### PR TITLE
interactive_markers: 2.5.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2376,7 +2376,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.5.3-2
+      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.5.4-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.3-2`

## interactive_markers

```
* Shorten the length of a lambda. (#106 <https://github.com/ros-visualization/interactive_markers/issues/106>)
* Contributors: Chris Lalancette
```
