### PR TITLE
mimick_vendor: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3132,7 +3132,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.6.0-3
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.6.1-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-3`

## mimick_vendor

```
* Bump vendored mimick version for ros2/Mimick#32 <https://github.com/ros2/Mimick/issues/32> (#35 <https://github.com/ros2/mimick_vendor/issues/35>)
* Update to the commit that fixes mmk_noreturn. (#34 <https://github.com/ros2/mimick_vendor/issues/34>)
* Contributors: Chris Lalancette, Michael Carroll
```
