### PR TITLE
flir_camera_driver: 2.1.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2025,7 +2025,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.1.14-1
+      version: 2.1.15-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.1.15-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.14-1`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* fixes to compile on focal/galactic
* Oryx parameter file
* support for command nodes
* remove more spinnaker imports, make spinnaker private
* added blackfly GigE configuration file
* track incomplete frames
* fixed licensing documentation
* Contributors: Bernd Pfrommer, Sir-Photch
```

## spinnaker_synchronized_camera_driver

```
* fixes to compile on focal/galactic
* Contributors: Bernd Pfrommer
```
