### PR TITLE
launch: 3.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2635,7 +2635,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.0-2
+      version: 3.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.0-2`

## launch

```
* Small fixes for modern flake8. (#772 <https://github.com/ros2/launch/issues/772>)
* Cleanup some type annotations.
* Contributors: Chris Lalancette
```

## launch_pytest

```
* Switch tryfirst/trylast to hookimpl.
* Contributors: Chris Lalancette
```

## launch_testing

```
* Add consider_namespace_packages=False (#766 <https://github.com/ros2/launch/issues/766>)
* Contributors: Tony Najjar
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* launch_xml: fix xml syntax in README (#770 <https://github.com/ros2/launch/issues/770>)
* Contributors: Steve Peters
```

## launch_yaml

- No changes
