### PR TITLE
launch_ros: 0.26.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2670,7 +2670,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.4-2
+      version: 0.26.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.5-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.26.4-2`

## launch_ros

```
* Fix: typing. Iterable doesn't have __getitem__ (#393 <https://github.com/ros2/launch_ros/issues/393>)
* Cleanup some type annotations. (#392 <https://github.com/ros2/launch_ros/issues/392>)
* Contributors: Chris Lalancette, Matthijs van der Burgh
```

## launch_testing_ros

```
* Make launch_testing_ros examples more robust. (#394 <https://github.com/ros2/launch_ros/issues/394>)
* Contributors: Chris Lalancette
```

## ros2launch

- No changes
