### PR TITLE
geometry2: 0.36.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1771,7 +1771,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.0-2
+      version: 0.36.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.36.0-2`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Nacho/minor fixes tf2 cache (#658 <https://github.com/ros2/geometry2/issues/658>)
* Removing console_bridge (#655 <https://github.com/ros2/geometry2/issues/655>)
* Contributors: Ignacio Vizzo, Lucas Wendland
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

```
* Fix installation directory of .dll files in tf2_eigen_kdl (#657 <https://github.com/ros2/geometry2/issues/657>)
* Contributors: Silvio Traversaro
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Adding NodeInterfaces to Buffer (#656 <https://github.com/ros2/geometry2/issues/656>)
* Reformat some code to make uncrustify happier. (#654 <https://github.com/ros2/geometry2/issues/654>)
* Contributors: Chris Lalancette, Lucas Wendland
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
