### PR TITLE
rqt: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6140,7 +6140,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.5.0-2
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.6.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-2`

## rqt

```
* Add a test dependency on pytest. (#306 <https://github.com/ros-visualization/rqt/issues/306>)
* Contributors: Chris Lalancette
```

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

```
* Allow to autocomplete namespaced topics (#299 <https://github.com/ros-visualization/rqt/issues/299>)
* Contributors: Alejandro Hernández Cordero
```
