### PR TITLE
python_qt_binding: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4475,7 +4475,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.1.1-2
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.2.0-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-2`

## python_qt_binding

```
* Switch to C++17 for SIP and Shiboken (#135 <https://github.com/ros-visualization/python_qt_binding/issues/135>)
* Set hints to find the python version we actually want. (#134 <https://github.com/ros-visualization/python_qt_binding/issues/134>)
* Contributors: Chris Lalancette, Christophe Bedard
```
