### PR TITLE
rqt_bag: 1.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6174,7 +6174,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.5.1-2
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.5.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.1-2`

## rqt_bag

```
* Add in copyright tests to rqt_bag. (#154 <https://github.com/ros-visualization/rqt_bag/issues/154>)
* Add a test dependency on pytest. (#153 <https://github.com/ros-visualization/rqt_bag/issues/153>)
* Revert "Add a dependency on pytest to rqt_bag and rqt_bag_plugins. (#… (#151 <https://github.com/ros-visualization/rqt_bag/issues/151>)
* Update maintainer to myself. (#150 <https://github.com/ros-visualization/rqt_bag/issues/150>)
* Update maintainer list in package.xml files (#149 <https://github.com/ros-visualization/rqt_bag/issues/149>)
* Contributors: Chris Lalancette, Michael Jeronimo
```

## rqt_bag_plugins

```
* Add a test dependency on pytest. (#153 <https://github.com/ros-visualization/rqt_bag/issues/153>)
* Revert "Add a dependency on pytest to rqt_bag and rqt_bag_plugins. (#… (#151 <https://github.com/ros-visualization/rqt_bag/issues/151>)
* Update maintainer to myself. (#150 <https://github.com/ros-visualization/rqt_bag/issues/150>)
* Update maintainer list in package.xml files (#149 <https://github.com/ros-visualization/rqt_bag/issues/149>)
* Contributors: Chris Lalancette, Michael Jeronimo
```
