### PR TITLE
rcutils: 6.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4868,7 +4868,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.5.2-2
+      version: 6.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.6.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.5.2-2`

## rcutils

```
* feat: Add human readable date to logging formats (#441 <https://github.com/ros2/rcutils/issues/441>)
* Updates for uncrustify 0.78. (#454 <https://github.com/ros2/rcutils/issues/454>)
* Set hints to find the python version we actually want. (#451 <https://github.com/ros2/rcutils/issues/451>)
* Bring ament_add_gtest/target_link_libraries back together (#452 <https://github.com/ros2/rcutils/issues/452>)
* Change 'ROS2' to 'ROS 2' in quality declaration (#453 <https://github.com/ros2/rcutils/issues/453>)
* Allow parsing of escape sequence in log format (#443 <https://github.com/ros2/rcutils/issues/443>)
* Contributors: Chris Lalancette, Christophe Bedard, Kaju-Bubanja, Marc Bestmann
```
