### PR TITLE
rclcpp: 28.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4785,7 +4785,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 27.0.0-2
+      version: 28.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `27.0.0-2`

## rclcpp

```
* fix spin_some_max_duration unit-test for events-executor (#2465 <https://github.com/ros2/rclcpp/issues/2465>)
* refactor and improve the parameterized spin_some tests for executors (#2460 <https://github.com/ros2/rclcpp/issues/2460>)
  * refactor and improve the spin_some parameterized tests for executors
  * disable spin_some_max_duration for the StaticSingleThreadedExecutor and EventsExecutor
  * fixup and clarify the docstring for Executor::spin_some()
  * style
  * review comments
  ---------
* enable simulation clock for timer canceling test. (#2458 <https://github.com/ros2/rclcpp/issues/2458>)
  * enable simulation clock for timer canceling test.
  * move MainExecutorTypes to test_executors_timer_cancel_behavior.cpp.
  ---------
* Revert "relax the test simulation rate for timer canceling tests. (#2453 <https://github.com/ros2/rclcpp/issues/2453>)" (#2456 <https://github.com/ros2/rclcpp/issues/2456>)
  This reverts commit 1c350d0d7fb9c7158e0a39057112486ddbd38e9a.
* relax the test simulation rate for timer canceling tests. (#2453 <https://github.com/ros2/rclcpp/issues/2453>)
* Fix TypeAdapted publishing with large messages. (#2443 <https://github.com/ros2/rclcpp/issues/2443>)
  Mostly by ensuring we aren't attempting to store
  large messages on the stack.  Also add in tests.
  I verified that before these changes, the tests failed,
  while after them they succeed.
* Implement generic client (#2358 <https://github.com/ros2/rclcpp/issues/2358>)
  * Implement generic client
  * Fix the incorrect parameter declaration
  * Deleted copy constructor and assignment for FutureAndRequestId
  * Update codes after rebase
  * Address review comments
  * Address review comments from iuhilnehc-ynos
  * Correct an error in a description
  * Fix window build errors
  * Address review comments from William
  * Add doc strings to create_generic_client
  ---------
* Rule of five: implement move operators (#2425 <https://github.com/ros2/rclcpp/issues/2425>)
* Various cleanups to deal with uncrustify 0.78. (#2439 <https://github.com/ros2/rclcpp/issues/2439>)
  These should also work with uncrustify 0.72.
* Remove the set_deprecated signatures in any_subscription_callback. (#2431 <https://github.com/ros2/rclcpp/issues/2431>)
  These have been deprecated since April 2021, so it is safe
  to remove them now.
* fix doxygen syntax for NodeInterfaces (#2428 <https://github.com/ros2/rclcpp/issues/2428>)
* Set hints to find the python version we actually want. (#2426 <https://github.com/ros2/rclcpp/issues/2426>)
  The comment in the commit explains the reasoning behind it.
* Update quality declaration documents (#2427 <https://github.com/ros2/rclcpp/issues/2427>)
* feat: add/minus for msg::Time and rclcpp::Duration (#2419 <https://github.com/ros2/rclcpp/issues/2419>)
  * feat: add/minus for msg::Time and rclcpp::Duration
* Contributors: Alberto Soragna, Barry Xu, Chris Lalancette, Christophe Bedard, HuaTsai, Jonas Otto, Tim Clephas, Tomoya Fujita, William Woodall
```

## rclcpp_action

```
* Do not generate the exception when action service response timeout. (#2464 <https://github.com/ros2/rclcpp/issues/2464>)
  * Do not generate the exception when action service response timeout.
  * address review comment.
  ---------
* Modify rclcpp_action::GoalUUID hashing algorithm (#2441 <https://github.com/ros2/rclcpp/issues/2441>)
  * Add unit tests for hashing rclcpp_action::GoalUUID's
  * Use the FNV-1a hash algorithm for Goal UUID
* Various cleanups to deal with uncrustify 0.78. (#2439 <https://github.com/ros2/rclcpp/issues/2439>)
  These should also work with uncrustify 0.72.
* Update quality declaration documents (#2427 <https://github.com/ros2/rclcpp/issues/2427>)
* Contributors: Chris Lalancette, Christophe Bedard, Tomoya Fujita, mauropasse
```

## rclcpp_components

```
* Add EXECUTOR docs (#2440 <https://github.com/ros2/rclcpp/issues/2440>)
* Update quality declaration documents (#2427 <https://github.com/ros2/rclcpp/issues/2427>)
* crash on no class found (#2415 <https://github.com/ros2/rclcpp/issues/2415>)
  * crash on no class found
  * error on no class found instead of no callback groups
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Adam Aposhian, Christophe Bedard, Ruddick Lawrence
```

## rclcpp_lifecycle

```
* Update quality declaration documents (#2427 <https://github.com/ros2/rclcpp/issues/2427>)
* Contributors: Christophe Bedard
```
