### PR TITLE
rclpy: 7.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4801,7 +4801,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.0.1-2
+      version: 7.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.0.1-2`

## rclpy

```
* Allow specifying qos (#1225 <https://github.com/ros2/rclpy/issues/1225>)
* update RCL_RET_TIMEOUT error handling with action service response. (#1258 <https://github.com/ros2/rclpy/issues/1258>)
* Add types to time_source.py (#1259 <https://github.com/ros2/rclpy/issues/1259>)
* Small fixes for modern flake8. (#1264 <https://github.com/ros2/rclpy/issues/1264>)
* Add types to qos_overriding_options.py (#1248 <https://github.com/ros2/rclpy/issues/1248>)
* Add types to context.py (#1240 <https://github.com/ros2/rclpy/issues/1240>)
* Add back Type hash __slots__ and add test cases. (#1245 <https://github.com/ros2/rclpy/issues/1245>)
* Revert "Add types to TypeHash and moved away from __slots__ usage (#1232 <https://github.com/ros2/rclpy/issues/1232>)" (#1243 <https://github.com/ros2/rclpy/issues/1243>)
* Time.py Types (#1237 <https://github.com/ros2/rclpy/issues/1237>)
* Add types to TypeHash and moved away from __slots__ usage (#1232 <https://github.com/ros2/rclpy/issues/1232>)
* Add Static Typing to Validate files (#1230 <https://github.com/ros2/rclpy/issues/1230>)
* Add types to duration.py (#1233 <https://github.com/ros2/rclpy/issues/1233>)
* added python3-yaml (#1242 <https://github.com/ros2/rclpy/issues/1242>)
* Add types to exceptions.py (#1241 <https://github.com/ros2/rclpy/issues/1241>)
* Add types (#1231 <https://github.com/ros2/rclpy/issues/1231>)
* Creates Enum wrapper for ClockType and ClockChange (#1235 <https://github.com/ros2/rclpy/issues/1235>)
* Add types to expand_topic_name (#1238 <https://github.com/ros2/rclpy/issues/1238>)
* Add types to logging_service.py (#1227 <https://github.com/ros2/rclpy/issues/1227>)
* Add types to logging.py (#1226 <https://github.com/ros2/rclpy/issues/1226>)
* forbid parameter to be declared statically without initialization. (#1216 <https://github.com/ros2/rclpy/issues/1216>)
* Contributors: Chris Lalancette, Michael Carlstrom, SnIcK, Tim Clephas, Tomoya Fujita
```
