### PR TITLE
fields2cover: 1.2.1-5 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1446,11 +1446,19 @@ repositories:
       version: rolling
     status: developed
   fields2cover:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 1.2.1-3
+      version: 1.2.1-5
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
     status: developed
   filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-5`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/ros2-gbp/fields2cover-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-3`
