### PR TITLE
fields2cover: 1.2.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2902,11 +2902,19 @@ repositories:
       version: noetic-devel
     status: maintained
   fields2cover:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Fields2Cover/fields2cover-release.git
-      version: 1.2.1-2
+      version: 1.2.1-3
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
     status: developed
   fields2cover_ros:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2905,7 +2905,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git
-      version: master
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-3`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/Fields2Cover/fields2cover-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-2`
