### PR TITLE
fields2cover: 1.2.1-3 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1497,11 +1497,19 @@ repositories:
       version: iron
     status: developed
   fields2cover:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 1.2.1-2
+      version: 1.2.1-3
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
     status: developed
   filters:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `1.2.1-3`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/ros2-gbp/fields2cover-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-2`
