### PR TITLE
mrpt_sensors: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4228,6 +4228,17 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
       version: ros2
+    release:
+      packages:
+      - mrpt_generic_sensor
+      - mrpt_sensor_bumblebee_stereo
+      - mrpt_sensor_gnns_nmea
+      - mrpt_sensorlib
+      - mrpt_sensors
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_sensors-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.1.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mrpt_generic_sensor

```
* publish sensor pose to /tf
* Reformat with clang-format to fix ament_linters
* add missing dep to package.xml
* Port to ROS2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_bumblebee_stereo

```
* publish sensor pose to /tf
* Reformat with clang-format to fix ament_linters
* Add driver for Bumblebee stereo camera
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnns_nmea

```
* publish sensor pose to /tf
* Reformat with clang-format to fix ament_linters
* more conservative uncertainty
* fix covariance term index
* create gnns node
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* publish sensor pose to /tf
* fix missing namespace
* Reformat with clang-format to fix ament_linters
* Comply with ROS2 REP-2003
* Fix usage of obsolete mrpt methods
* delegate conversion to mrpt::ros2bridge
* Port to ROS2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

```
* Add driver for Bumblebee stereo camera
* create gnns node
* Port to ROS2
* Contributors: Jose Luis Blanco-Claraco
```
