### PR TITLE
rcl_logging: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4750,7 +4750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.0.0-3
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.1.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.0-3`

## rcl_logging_interface

```
* Check allocator validity in some rcl_logging functions (#116 <https://github.com/ros2/rcl_logging/issues/116>)
  If the allocator is zero-initialized, it may cause a segfault when it is
  used later in the functions.
* Use (void) in declaration of param-less function (#114 <https://github.com/ros2/rcl_logging/issues/114>)
* Contributors: Christophe Bedard, Scott K Logan
```

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* Check allocator validity in some rcl_logging functions (#116 <https://github.com/ros2/rcl_logging/issues/116>)
  If the allocator is zero-initialized, it may cause a segfault when it is
  used later in the functions.
* Cleanup the tests. (#115 <https://github.com/ros2/rcl_logging/issues/115>)
  * Cleanup the tests.
  There are a few different fixes in here:
  1.  Move away from using "popen" to get the list of files
  in a directory.  Instead, switch to using the C++ std::filesystem
  directory iterator and doing the work ourselves, which is portable
  and much less error-prone.
  2.  Set the ROS_LOG_DIR for all of the tests in here.  This should
  make the test resistant to being run in parallel with other tests.
  3.  Consistently use rcpputils::set_env_var, rather than a mix
  of rcpputils and rcutils.
* Update quality declaration document (#112 <https://github.com/ros2/rcl_logging/issues/112>)
* Re-order rcl_logging_interface include (#111 <https://github.com/ros2/rcl_logging/issues/111>)
* Contributors: Chris Lalancette, Christophe Bedard, Scott K Logan
```
