### PR TITLE
keyboard_handler: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2494,7 +2494,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.3.0-2
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.3.1-1`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/ros2-gbp/keyboard_handler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-2`

## keyboard_handler

```
* Shorten lambdas so newer uncrustify is happier. (#42 <https://github.com/ros-tooling/keyboard_handler/issues/42>)
* Fixed C++20 warning implicit capture of this in lambda (#41 <https://github.com/ros-tooling/keyboard_handler/issues/41>)
* Contributors: AiVerisimilitude, Chris Lalancette
```
