### PR TITLE
rqt_plot: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6342,7 +6342,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.3.2-2
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.4.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.2-2`

## rqt_plot

```
* Add in copyright tests to rqt_bag. (#95 <https://github.com/ros-visualization/rqt_plot/issues/95>)
* Add a test dependency on pytest. (#94 <https://github.com/ros-visualization/rqt_plot/issues/94>)
* Contributors: Chris Lalancette
```
