### PR TITLE
rqt_publisher: 1.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6357,7 +6357,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.7.1-2
+      version: 1.7.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.7.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.1-2`

## rqt_publisher

```
* Use raw strings for regular expressions. (#44 <https://github.com/ros-visualization/rqt_publisher/issues/44>)
* Switch maintainer to me. (#43 <https://github.com/ros-visualization/rqt_publisher/issues/43>)
* Update maintainer list in package.xml files (#42 <https://github.com/ros-visualization/rqt_publisher/issues/42>)
* Contributors: Chris Lalancette, Michael Jeronimo
```
