### PR TITLE
rmf_task: 2.2.5-1 in 'iron/distribution.yaml' 

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5282,7 +5282,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.2.4-1
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Manually opening this PR after bloom succeeded but rosdistro PR generation failed.
See https://github.com/ros2-gbp/rmf_task-release/tree/master

Changelog

rmf_task
```
2.2.5 (2024-03-28)
------------------
* Add labels to booking (`#113 <https://github.com/open-rmf/rmf_task/pull/113>`_)
* Contributors: Aaron Chong, Grey
```