### PR TITLE
[Iron] Removing opennav-coverage

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4003,24 +4003,6 @@ repositories:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-4
-  opennav_coverage:
-    release:
-      packages:
-      - opennav_coverage
-      - opennav_coverage_bt
-      - opennav_coverage_demo
-      - opennav_coverage_msgs
-      - opennav_coverage_navigator
-      - opennav_row_coverage
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/open-navigation/opennav_coverage-release.git
-      version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/open-navigation/opennav_coverage.git
-      version: iron
-    status: developed
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
This is still after months waiting on an update to F2C binaries to fix a build issue. At this point if its not fixed yet, it may not be in any reasonable timeframe so removing from here to save the compute time on the daily builds that are failing (and emails) 

I'll resubmit when I have reason to think its resolved