### PR TITLE
gz_cmake_vendor: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1950,7 +1950,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_cmake_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.2-1`

## gz_cmake_vendor

```
* Patch the pkg-config directory in the gz-cmake code. (#4 <https://github.com/gazebo-release/gz_cmake_vendor/issues/4>)
  * Patch the pkg-config directory in the gz-cmake code.
  When building on the ROS 2 buildfarm, we aren't setting
  some of the CMAKE_PREFIX variables.  This means that
  using CMAKE_INSTALL_FULL_LIBDIR actually creates a path
  like /opt/ros/rolling/... , which makes debuild upset.
  However, we actually need the FULL_LIBDIR in order to
  calculate the relative path between it and the INSTALL_PREFIX.
  Work around this by having two variables; the
  pkgconfig_install_dir (relative), used to install the files,
  and pkgconfig_abs_install_dir (absolute), used to calculate
  the relative path between them.
  This should fix the build on the buildfarm.  I'll note that
  we are doing it here and not in gz-cmake proper because of
  knock-on effects to downstream gazebo.  If this is successful
  we may end up merging it there, at which point we can drop
  this patch.
  * Update GzPackage as well.
  ---------
* Contributors: Chris Lalancette
```
