### PR TITLE
gz_tools_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2102,10 +2102,16 @@ repositories:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_tools_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
       version: rolling
+    status: maintained
   gz_transport_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_tools_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_tools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gz_tools_vendor

```
* Update vendored package version
* Require calling find_package on the underlying package
* Fix linter (#1 <https://github.com/gazebo-release/gz_tools_vendor/issues/1>)
* Initial import
* Contributors: Addisu Z. Taddese
```
