### PR TITLE
trac_ik: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7264,6 +7264,15 @@ repositories:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
       version: rolling-devel
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/trac_ik-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `2.0.0-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik
- release repository: https://github.com/ros2-gbp/trac_ik-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## trac_ik

```
* Update CMakeLists for trac_ik
* Contributors: Ana C. Huaman Quispe, Kenji Brameld, Mike Lanighan
```

## trac_ik_kinematics_plugin

```
* hide parameters header file, as it is implemetation
* remove boost from trac_ik_lib and trac_ik_kinematics_plugin
* Set default solve type to Distance
* Contributors: Ana C. Huaman Quispe, Kenji Brameld
```

## trac_ik_lib

```
* change nanoseconds() to seconds()
* remove boost from trac_ik_lib and trac_ik_kinematics_plugin
* Added support for C++17
* added build_export_depends to tracik_lib for nlopt
* fix issues caused by shared references and thread safety
* hotfix for init of solvers using non-thread-safe KDL::Chain
* Contributors: Ana C. Huaman Quispe, Kenji Brameld, Mike Lanighan, Stephen Hart
```
