### PR TITLE
Removing euslime

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2647,17 +2647,6 @@ repositories:
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
       version: main
     status: developed
-  euslime:
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/jsk-ros-pkg/euslime-release.git
-      version: 1.1.4-4
-    source:
-      type: git
-      url: https://github.com/jsk-ros-pkg/euslime.git
-      version: master
-    status: developed
   euslisp:
     doc:
       type: git


### PR DESCRIPTION
Binary builds for the euslime package have been failing for some time, so I'm taking them down until I (or someone else) can figure out a fix.

https://build.ros.org/job/Nbin_ufv8_uFv8__euslime__ubuntu_focal_arm64__binary/
https://build.ros.org/job/Nbin_ufhf_uFhf__euslime__ubuntu_focal_armhf__binary/


On a related note, any info on how to replicate the buildfarm results locally?
I've been trying the prerelease tests, but I can't quite get the arm ones running.
(do I really need an arm machine to run the arm tests?)
https://wiki.ros.org/regression_tests

@k-okada