### PR TITLE
Add in a RHEL key for ruby.

### DIFF
--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -76,8 +76,8 @@ ruby:
   gentoo: [dev-lang/ruby]
   macports: [ruby]
   nixos: [ruby]
-  ubuntu:
-    '*': [ruby]
+  rhel: [ruby]
+  ubuntu: [ruby]
 ruby-backports:
   debian: [ruby-backports]
   gentoo: [dev-ruby/backports]


### PR DESCRIPTION
While we are here, also simplify the ubuntu key.

Please update the following dependency in the rosdep database.

## Package name:

ruby

## Package Upstream Source:

https://www.ruby-lang.org/en/

## Purpose of using this:

This is used in Gazebo

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=ruby