### PR TITLE
point_cloud_transport: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4291,7 +4291,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 3.0.5-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.5-1`

## point_cloud_transport

```
* Rename the republish_node to pc_republish_node. (#75 <https://github.com/ros-perception/point_cloud_transport/issues/75>)
* Fixed flake8 errors (#72 <https://github.com/ros-perception/point_cloud_transport/issues/72>)
* Added documentation (#69 <https://github.com/ros-perception/point_cloud_transport/issues/69>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## point_cloud_transport_py

- No changes
