### PR TITLE
sdformat_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6714,10 +6714,16 @@ repositories:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sdformat_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
       version: rolling
+    status: maintained
   septentrio_gnss_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## sdformat_vendor

```
* Update version, disable pybind11
  This also removes BUILD_DOCS since it's not a valid CMake argument in
  libsdformat.
* Require calling find_package on the underlying package
* Fix linter (#1 <https://github.com/gazebo-release/sdformat_vendor/issues/1>)
* Initial import
* Contributors: Addisu Z. Taddese
```
