### PR TITLE
Add more libboost and libxtensor keys for noble

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2627,6 +2627,7 @@ libboost-atomic:
     bionic: [libboost-atomic1.65.1]
     focal: [libboost-atomic1.71.0]
     jammy: [libboost-atomic1.74.0]
+    noble: [libboost-atomic1.83.0]
 libboost-atomic-dev:
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
@@ -2650,6 +2651,7 @@ libboost-chrono:
     bionic: [libboost-chrono1.65.1]
     focal: [libboost-chrono1.71.0]
     jammy: [libboost-chrono1.74.0]
+    noble: [libboost-chrono1.83.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
@@ -2676,6 +2678,7 @@ libboost-coroutine:
     bionic: [libboost-coroutine1.65.1]
     focal: [libboost-coroutine1.71.0]
     jammy: [libboost-coroutine1.74.0]
+    noble: [libboost-coroutine1.83.0]
 libboost-coroutine-dev:
   alpine: [boost-dev]
   debian: [libboost-coroutine-dev]
@@ -2759,6 +2762,7 @@ libboost-iostreams:
     bionic: [libboost-iostreams1.65.1]
     focal: [libboost-iostreams1.71.0]
     jammy: [libboost-iostreams1.74.0]
+    noble: [libboost-iostreams1.83.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
@@ -2781,6 +2785,7 @@ libboost-math:
     bionic: [libboost-math1.65.1]
     focal: [libboost-math1.71.0]
     jammy: [libboost-math1.74.0]
+    noble: [libboost-math1.83.0]
 libboost-math-dev:
   debian: [libboost-math-dev]
   fedora: [boost-devel]
@@ -2811,6 +2816,7 @@ libboost-program-options:
     bionic: [libboost-program-options1.65.1]
     focal: [libboost-program-options1.71.0]
     jammy: [libboost-program-options1.74.0]
+    noble: [libboost-program-options1.83.0]
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
@@ -2890,6 +2896,7 @@ libboost-regex:
     bionic: [libboost-regex1.65.1]
     focal: [libboost-regex1.71.0]
     jammy: [libboost-regex1.74.0]
+    noble: [libboost-regex1.83.0]
 libboost-regex-dev:
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
@@ -2913,6 +2920,7 @@ libboost-serialization:
     bionic: [libboost-serialization1.65.1]
     focal: [libboost-serialization1.71.0]
     jammy: [libboost-serialization1.74.0]
+    noble: [libboost-serialization1.83.0]
 libboost-serialization-dev:
   debian: [libboost-serialization-dev]
   fedora: [boost-devel]
@@ -2936,6 +2944,7 @@ libboost-system:
     bionic: [libboost-system1.65.1]
     focal: [libboost-system1.71.0]
     jammy: [libboost-system1.74.0]
+    noble: [libboost-system1.83.0]
 libboost-system-dev:
   debian: [libboost-system-dev]
   fedora: [boost-devel]
@@ -2983,6 +2992,7 @@ libboost-timer:
     bionic: [libboost-timer1.65.1]
     focal: [libboost-timer1.71.0]
     jammy: [libboost-timer1.74.0]
+    noble: [libboost-timer1.83.0]
 libboost-timer-dev:
   debian: [libboost-timer-dev]
   fedora: [boost-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8854,6 +8854,7 @@ xtensor:
   ubuntu:
     bionic: [xtensor-dev]
     jammy: [libxtensor-dev]
+    noble: [libxtensor-dev]
 xterm:
   arch: [xterm]
   debian: [xterm]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

- libboost-*
- libxtensor-dev

## Package Upstream Source:

- https://www.boost.org/
- https://github.com/xtensor-stack/xtensor

## Purpose of using this:

Update libboost-* to have a noble key. This is needed to release Nav2 into Rolling on Noble.
Similar to previous PRs:
- https://github.com/ros/rosdistro/pull/40089 

## Links to Distribution Packages

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libboost-atomic1.83.0
  - https://packages.ubuntu.com/noble/libboost-chrono1.83.0
  - https://packages.ubuntu.com/noble/libboost-coroutine1.83.0
  - https://packages.ubuntu.com/noble/libboost-iostreams1.83.0
  - https://packages.ubuntu.com/noble/libboost-math1.83.0
  - https://packages.ubuntu.com/noble/libboost-program-options1.83.0
  - https://packages.ubuntu.com/noble/libboost-regex1.83.0
  - https://packages.ubuntu.com/noble/libboost-serialization1.83.0
  - https://packages.ubuntu.com/noble/libboost-system1.83.0
  - https://packages.ubuntu.com/noble/libboost-timer1.83.0
  - https://packages.ubuntu.com/noble/libxtensor-dev

@SteveMacenski @clalancette FYI