### PR TITLE
ros2_controllers: 2.34.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6808,7 +6808,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.33.0-1
+      version: 2.34.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.34.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.33.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Use CMake target for eigen (#1058 <https://github.com/ros-controls/ros2_controllers/issues/1058>) (#1066 <https://github.com/ros-controls/ros2_controllers/issues/1066>)
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## forward_command_controller

- No changes

## gripper_controllers

```
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Remove action_msg dependency (#1077 <https://github.com/ros-controls/ros2_controllers/issues/1077>) (#1080 <https://github.com/ros-controls/ros2_controllers/issues/1080>)
* [JTC] Angle wraparound for first segment of trajectory (#796 <https://github.com/ros-controls/ros2_controllers/issues/796>) (#1033 <https://github.com/ros-controls/ros2_controllers/issues/1033>)
* Bump version of pre-commit hooks (#1073 <https://github.com/ros-controls/ros2_controllers/issues/1073>) (#1074 <https://github.com/ros-controls/ros2_controllers/issues/1074>)
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Let sphinx add parameter description with nested structures to documentation (backport #652 <https://github.com/ros-controls/ros2_controllers/issues/652>) (#1005 <https://github.com/ros-controls/ros2_controllers/issues/1005>)
* Contributors: mergify[bot]
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* [CI] Code coverage + pre-commit (backport #1057 <https://github.com/ros-controls/ros2_controllers/issues/1057>) (#1064 <https://github.com/ros-controls/ros2_controllers/issues/1064>)
* Contributors: mergify[bot]
```

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
