### PR TITLE
yp-spur: 1.22.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13136,7 +13136,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.21.0-1
+      version: 1.22.0-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.22.0-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.21.0-1`

## ypspur

```
* Add option to stop control on system time jump (#191 <https://github.com/openspur/yp-spur/issues/191>)
* Fix clock_nanosleep existence checks (#193 <https://github.com/openspur/yp-spur/issues/193>)
* Contributors: Atsushi Watanabe
```
