### PR TITLE
xacro: 1.14.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13068,7 +13068,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.17-2
+      version: 1.14.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.18-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.14.17-2`

## xacro

```
* Add more unit tags for yaml files  (#331 <https://github.com/ros/xacro/issues/331>)
* Mark regexes as raw strings (#336 <https://github.com/ros/xacro/issues/336>)
* Contributors: Adam Heins, Bruno-Pier
```
