### PR TITLE
gnsstk: 14.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3577,7 +3577,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/gnsstk-release.git
-      version: 14.0.0-8
+      version: 14.3.0-1
     source:
       type: git
       url: https://github.com/SGL-UT/gnsstk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gnsstk` to `14.3.0-1`:

- upstream repository: https://github.com/SGL-UT/gnsstk.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/gnsstk-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.0.0-8`
