### PR TITLE
bcr_bot: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -697,7 +697,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
-      version: 1.0.1-3
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_bot` to `1.0.2-1`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_bot.git
- release repository: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-3`

## bcr_bot

```
* Setting Gazebo resource paths through launch files
* Modified launch files to dynamically spawn bcr_bot
```
