### PR TITLE
microstrain_inertial: 4.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3854,6 +3854,7 @@ repositories:
       version: ros2
     release:
       packages:
+      - microstrain_inertial_description
       - microstrain_inertial_driver
       - microstrain_inertial_examples
       - microstrain_inertial_msgs
@@ -3861,7 +3862,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.2.1-1
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.1.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.1-1`

## microstrain_inertial_description

```
* Moves meshes and urdf files to seperate package (#313 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/313>)
* Contributors: Rob
```

## microstrain_inertial_driver

```
* ROS updates microstrain_inertial_driver_common submodule (#315 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/315>)
* Moves meshes and urdf files to seperate package (#313 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/313>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* ROS puts all messages into single dir (#311 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/311>)
* Contributors: Rob
```

## microstrain_inertial_rqt

- No changes
