### PR TITLE
microstrain_inertial: 4.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3132,6 +3132,7 @@ repositories:
       version: ros2
     release:
       packages:
+      - microstrain_inertial_description
       - microstrain_inertial_driver
       - microstrain_inertial_examples
       - microstrain_inertial_msgs
@@ -3139,7 +3140,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.2.1-1
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.1.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.2.1-1`

## microstrain_inertial_description

```
* Moves meshes and urdf files to seperate package (#313 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/313>)
* Contributors: Rob
```

## microstrain_inertial_driver

```
* ROS updates microstrain_inertial_driver_common submodule (#315 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/315>)
* Moves meshes and urdf files to seperate package (#313 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/313>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* ROS puts all messages into single dir (#311 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/311>)
* Contributors: Rob
```

## microstrain_inertial_rqt

- No changes
