### PR TITLE
aruco_opencv: 5.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -405,7 +405,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `5.1.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.0.0-1`

## aruco_opencv

```
* Add an option to subscribe to compressed image topics. (#28 <https://github.com/fictionlab/ros_aruco_opencv/issues/28>) (#29 <https://github.com/fictionlab/ros_aruco_opencv/issues/29>)
* Contributors: Ray Ferric
```

## aruco_opencv_msgs

- No changes
