### PR TITLE
gazebo_planar_move_plugin: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2199,10 +2199,16 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_planar_move_plugin.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_planar_move_plugin-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/Boeing/gazebo_planar_move_plugin.git
       version: humble
+    status: maintained
   gazebo_ros2_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_planar_move_plugin` to `1.0.2-1`:

- upstream repository: https://github.com/Boeing/gazebo_planar_move_plugin.git
- release repository: https://github.com/ros2-gbp/gazebo_planar_move_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
