### PR TITLE
gazebo_set_joint_positions_plugin: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2248,10 +2248,16 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_set_joint_positions_plugin-release.git
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
       version: humble
+    status: maintained
   gazebo_video_monitors:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_set_joint_positions_plugin` to `1.0.3-1`:

- upstream repository: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
- release repository: https://github.com/ros2-gbp/gazebo_set_joint_positions_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
