### PR TITLE
gazebo_no_physics_plugin: 0.1.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2189,11 +2189,12 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_no_physics_plugin-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/Boeing/gazebo_no_physics_plugin.git
       version: humble
+    status: maintained
   gazebo_planar_move_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_no_physics_plugin` to `0.1.1-2`:

- upstream repository: git@github.com:Boeing/gazebo_no_physics_plugin.git
- release repository: https://github.com/ros2-gbp/gazebo_no_physics_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## gazebo_no_physics_plugin

```
* OSS release
* Contributors: Beau Colley-Allerton, Iñigo Moreno, Jason Cochrane, Leandro Ruiz, Leandro Ruiz-Lozano, Nathan Hui, RoBeau, leandroruiz
```
