### PR TITLE
gz_dartsim_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1970,10 +1970,16 @@ repositories:
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git
       version: rolling
+    status: maintained
   gz_fuel_tools_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_dartsim_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_dartsim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_dartsim_vendor

```
* Add dependency on fmt, patch pkgconfig installation
* Change version to 0.0.1
* Fix linter (#3 <https://github.com/gazebo-release/gazebo_dartsim_vendor/issues/3>)
* Remove Octomap (#2 <https://github.com/gazebo-release/gazebo_dartsim_vendor/issues/2>)
  Octomap is an optional dependency. There seems to be an issue resolving
  this key on the ROS buildfarm, so disabling it for now.
  This also removes DART_BUILD_OSG cmake flag, which does not exist in 6.13.2
* Add README (#1 <https://github.com/gazebo-release/gazebo_dartsim_vendor/issues/1>)
* Rename to gz_dartsim_vendor
* Add license and contributing files
* Change name and update version
* Remove optional packages
* Initial import
* Contributors: Addisu Z. Taddese
```
