### PR TITLE
openrtm_aist_python: 1.1.0-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7232,6 +7232,17 @@ repositories:
       url: https://github.com/tork-a/openrtm_aist-release.git
       version: release/melodic/openrtm_aist
     status: maintained
+  openrtm_aist_python:
+    doc:
+      type: git
+      url: https://github.com/tork-a/openrtm_aist_python-release.git
+      version: release/noetic/openrtm_aist_python
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/openrtm_aist_python-release.git
+      version: 1.1.0-5
+    status: maintained
   openslam_gmapping:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-5`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist-Python.git
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
