### PR TITLE
play_motion2: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5264,7 +5264,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.1.0-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## play_motion2

```
* Fix comment
* Add test deactivating unused controller while executing a motion
* Fail on controller change only if it's used by the running motion
* Cancel goals on failure
* Change logging level for 'Motion failed' message
* Invert loop to check changing controller properly
* Contributors: Noel Jimenez
```

## play_motion2_msgs

- No changes


