### PR TITLE
Add grid_map_geo source entry to humble distro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2521,6 +2521,16 @@ repositories:
       url: https://github.com/ANYbotics/grid_map.git
       version: humble
     status: developed
+  grid_map_geo:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/grid_map_geo.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/ethz-asl/grid_map_geo.git
+      version: ros2
+    status: developed
   gscam:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.
Package name: grid_map_geo

grid_map_geo is a library for loading elevation maps and color data into a grid_map object.

The source is here:
https://github.com/ethz-asl/grid_map_geo

The ros2-gpb release team is here: 
https://github.com/ros2-gbp/ros2-gbp-github-org/issues/471#issuecomment-2016238119


# Checks
- [ ] All packages have a declared license in the package.xml
- [ ] This repository has a LICENSE file
- [ ] This package is expected to build on the submitted rosdistro