### PR TITLE
generate_parameter_library: 0.3.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2313,7 +2313,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.8-1
+      version: 0.3.8-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.8-2`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.8-1`

## cmake_generate_parameter_module_example

- No changes

## generate_parameter_library

```
* uss python_install_dir (#178 <https://github.com/PickNikRobotics/generate_parameter_library/issues/178>)
* Update CMakeLists.txt (#173 <https://github.com/PickNikRobotics/generate_parameter_library/issues/173>)
* Contributors: Christoph Fröhlich, Paul Gesel
```

## generate_parameter_library_example

```
* Fix newline issue (#176 <https://github.com/PickNikRobotics/generate_parameter_library/issues/176>)
  * fix new line rendering for Python
* Support nested mapped parameters (#166 <https://github.com/PickNikRobotics/generate_parameter_library/issues/166>)
* Contributors: Paul Gesel
```

## generate_parameter_library_py

```
* add # flake8: noqa to template (#177 <https://github.com/PickNikRobotics/generate_parameter_library/issues/177>)
* Fix newline issue (#176 <https://github.com/PickNikRobotics/generate_parameter_library/issues/176>)
  * fix new line rendering for Python
* Support nested mapped parameters (#166 <https://github.com/PickNikRobotics/generate_parameter_library/issues/166>)
* Contributors: Paul Gesel
```

## generate_parameter_module_example

```
* Fix newline issue (#176 <https://github.com/PickNikRobotics/generate_parameter_library/issues/176>)
  * fix new line rendering for Python
* Support nested mapped parameters (#166 <https://github.com/PickNikRobotics/generate_parameter_library/issues/166>)
* Contributors: Paul Gesel
```

## parameter_traits

- No changes
