### PR TITLE
bcr_bot: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -531,7 +531,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/blackcoffeerobotics/bcr_bot-release.git
-      version: 0.0.1-4
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_bot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_bot` to `0.0.2-1`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_bot.git
- release repository: https://github.com/blackcoffeerobotics/bcr_bot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-4`

## bcr_bot

```
* Setting Gazebo resource paths through launch files
* Modified launch files to dynamically spawn bcr_bot
```
