### PR TITLE
add ffmpeg_image_transport_tools to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1445,6 +1445,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: rolling
     status: developed
+  ffmpeg_image_transport_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: rolling
+    status: developed
   fields2cover:
     doc:
       type: git


### PR DESCRIPTION
# Please add ffmpeg_image_transport_tools to be indexed in the rosdistro for rolling

Note: this package is already in humble + iron

ROSDISTRO NAME: rolling

# The source is here:

https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools/


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
