### PR TITLE
mola: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3216,13 +3216,14 @@ repositories:
       - mola_metric_maps
       - mola_navstate_fuse
       - mola_pose_list
+      - mola_relocalization
       - mola_traj_tools
       - mola_viz
       - mola_yaml
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.0.2-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.1-1`

## kitti_metrics_eval

- No changes

## mola

```
* Add new mola_relocalization as dependency of the metapackage mola
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* update docs
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_imu_preintegration

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

```
* Add docs on expected KITTI dataset layout
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_kernel

- No changes

## mola_launcher

```
* BUGFIX: mola_launcher will not autoregister .so modules if installed via apt
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

- No changes

## mola_navstate_fuse

- No changes

## mola_pose_list

- No changes

## mola_relocalization

```
* Implement SE(2) relocalization grid method
* New package mola_relocalization
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
