### PR TITLE
Add robin-map-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7791,6 +7791,19 @@ redis-server:
   gentoo: [dev-db/redis]
   nixos: [redis]
   ubuntu: [redis-server]
+robin-map:
+  alpine: [robin-map]
+  arch: [robin-map]
+  debian: [robin-map-dev]
+  fedora: [robin-map-devel]
+  gentoo: [robin-map]
+  nixos: [robin-map]
+  opensuse: [robin-map]
+  osx:
+    homebrew:
+      packages: [robin-map]
+  rhel: [robin-map-devel]
+  ubuntu: [robin-map-dev]
 robotino-api2:
   ubuntu: [robotino-api2]
 rsync:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7791,7 +7791,7 @@ redis-server:
   gentoo: [dev-db/redis]
   nixos: [redis]
   ubuntu: [redis-server]
-robin-map:
+robin-map-dev:
   alpine: [robin-map]
   arch: [robin-map]
   debian: [robin-map-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7798,7 +7798,7 @@ robin-map:
   fedora: [robin-map-devel]
   gentoo: [robin-map]
   nixos: [robin-map]
-  opensuse: [robin-map]
+  opensuse: [robin-map-devel]
   osx:
     homebrew:
       packages: [robin-map]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

robin-map

## Package Upstream Source:

https://github.com/Tessil/robin-map

## Purpose of using this:

Dependency used in projects like [KISS-ICP](https://github.com/PRBonn/kiss-icp) and not present in the rosdep index

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/robin-map-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/robin-map-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/robin-map/robin-map-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/robin-map/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/robin-map
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/robin-map#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://alpine.pkgs.org/3.19/alpine-community-aarch64/robin-map-1.2.1-r0.apk.html
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.11&show=robin-map&from=0&size=50&sort=relevance&type=packages&query=robin
- openSUSE: https://software.opensuse.org/package/
  -  https://software.opensuse.org/package/robin-map
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/robin-map-devel-1.2.2-1.el9.noarch.rpm.html