### PR TITLE
ur_description: 2.1.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7826,7 +7826,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.3-1`

## ur_description

```
* Update Graphical Documentation license to version 1.01 (#143 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/143>)
* Add UR30 model (#142 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/142>)
* Make sure the UR5 models are actually standing on the ground (#136 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/136>)
* Contributors: Felix Exner, RobertWilbrandt, Vincenzo Di Pentima
```
