### PR TITLE
static_transform_mux: 1.1.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11627,7 +11627,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/static_transform_mux-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/tradr-project/static_transform_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `static_transform_mux` to `1.1.2-1`:

- upstream repository: https://github.com/tradr-project/static_transform_mux.git
- release repository: https://github.com/peci1/static_transform_mux-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## static_transform_mux

```
* Fixed Python 3 compatibility
* Contributors: Martin Pecka
```
