### PR TITLE
ur_description: 2.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7609,7 +7609,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.2.4-2
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.2.5-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.4-2`

## ur_description

```
* Auto-update pre-commit hooks (#130 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/130>)
* Bump pre-commit/action from 3.0.0 to 3.0.1 (#134 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/134>)
* Bump peter-evans/create-pull-request from 5 to 6 (#133 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/133>)
* Update Graphical Documentation license to version 1.01
* Make sure the UR5 models are actually standing on the ground
* Contributors: Felix Exner, dependabot[bot], github-actions[bot]
```
