### PR TITLE
ur_robot_driver: 2.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7646,7 +7646,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.3-2
+      version: 2.4.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.3-2`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Use ros2 control node from controller_manager and description topic (#939 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/939>)
* Move communication setup to on_configure instead of on_activate (#732 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/732>)
* [URDF] Fix initial value of speed scaling factor syntax (#920 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/920>)
* Reduce number of controller_spawners to 3 (#919 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/919>)
* Contributors: Felix Exner
```
