### PR TITLE
aruco_opencv: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -406,7 +406,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 4.1.1-2
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `4.2.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.1-2`

## aruco_opencv

```
* Add an option to subscribe to compressed image topics. (#28 <https://github.com/fictionlab/ros_aruco_opencv/issues/28>) (#30 <https://github.com/fictionlab/ros_aruco_opencv/issues/30>)
* Contributors: Ray Ferric
```

## aruco_opencv_msgs

- No changes
