### PR TITLE
ur_client_library: 1.3.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12284,7 +12284,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.3.5-1
+      version: 1.3.6-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.6-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.5-1`

## ur_client_library

```
* Changed spline interpolation to use the last commanded joint velocity… (#195 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/195>)
* Contributors: Mads Holm Peters, Rune Søe-Knudsen
```
