### PR TITLE
ur_robot_driver: 2.2.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9431,7 +9431,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.10-1
+      version: 2.2.11-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.11-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.10-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add UR30 support (#930 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/930>)
* Contributors: Felix Exner, Vincenzo Di Pentima
```

## ur_robot_driver

```
* Add UR30 support (#930 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/930>)
* Move communication setup to on_configure instead of on_activate (#936 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/936>)
* Contributors: Felix Exner, Vincenzo Di Pentima
```
