### PR TITLE
ur_robot_driver: 2.1.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12318,7 +12318,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.1.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.3-1`

## ur_calibration

- No changes

## ur_dashboard_msgs

- No changes

## ur_robot_driver

```
* Added support for UR30 (#688 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/688>)
* Added arg to enable/disable launch of ursim (#679 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/679>)
* Contributors: Vincenzo Di Pentima, mahp
```
