### PR TITLE
gz_ogre_next_vendor: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2049,10 +2049,16 @@ repositories:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
       version: rolling
+    status: maintained
   gz_physics_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_ogre_next_vendor

```
* Change version to 0.0.1
* Fix linter (#2 <https://github.com/gazebo-release/gazebo_ogre_next_vendor/issues/2>)
* Add README (#1 <https://github.com/gazebo-release/gazebo_ogre_next_vendor/issues/1>)
* Rename package to gz_ogre_next_vendor
* Remove unused flag
* Add license and contributing files
* Fix rosdep keys in package.xml
* Fix patch to work on Jammy
* Aligned with  build flags from our fork
* Ogre Next Vendor package
* Contributors: Addisu Z. Taddese, Michael Carroll
```
