### PR TITLE
webots_ros2: 2023.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8061,7 +8061,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2023.1.1-3
+      version: 2023.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `webots_ros2` to `2023.1.2-1`:

- upstream repository: https://github.com/cyberbotics/webots_ros2.git
- release repository: https://github.com/ros2-gbp/webots_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2023.1.1-3`

## webots_ros2

```
* Fixed errors showing up when launching moveit for ur5e.
* Fixed nav2 turtlebot test failing very often.
* Fixed build and tests for rolling.
* Fixed deprecated ros_controls command: cmd_vel_unstamped.
* Remove usage of deprecated resource manager method: activate_all_components().
* Set is_urdf_loaded__ of the resource manager to true.
```

## webots_ros2_universal_robot

```
* Fixed errors showing up when launching moveit for ur5e.
```
