### PR TITLE
clearpath_common: 0.2.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -965,6 +965,7 @@ repositories:
       packages:
       - clearpath_common
       - clearpath_control
+      - clearpath_customization
       - clearpath_description
       - clearpath_generator_common
       - clearpath_mounts_description
@@ -974,7 +975,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `0.2.7-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.6-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

```
* Removed author tag
* Fixed mismatched tag
* Updated package.xml to match
* Extra namespace to device launch
* Fixed URDF issues
* Fixed package and executable name
* Added customization package
* Contributors: Luis Camero
* Removed author tag
* Fixed mismatched tag
* Updated package.xml to match
* Extra namespace to device launch
* Fixed URDF issues
* Fixed package and executable name
* Added customization package
* Contributors: Luis Camero
```

## clearpath_description

- No changes

## clearpath_generator_common

```
* ARM_MOUNT to ARM_PLATE
* Added simple package writer to copy package from template
* Check terminal to set ROS_SUPER_CLIENT
* Generate script to start the discovery server
* Updated setup.bash generation for discovery server
* Contributors: Hilary Luo, Luis Camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform

- No changes

## clearpath_platform_description

```
* All Warthog attachments default to 0
* Aligned attachment links
* Contributors: Luis Camero
```

## clearpath_sensors_description

- No changes
