### PR TITLE
ros_gz: 0.244.14-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7129,10 +7129,11 @@ repositories:
       - ros_ign_gazebo_demos
       - ros_ign_image
       - ros_ign_interfaces
+      - test_ros_gz_bridge
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.13-1
+      version: 0.244.14-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.14-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.244.13-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Added conversion for Detection3D and Detection3DArray (#523 <https://github.com/gazebosim/ros_gz/issues/523>) (#526 <https://github.com/gazebosim/ros_gz/issues/526>)
  Co-authored-by: wittenator <mailto:9154515+wittenator@users.noreply.github.com>
* Add ROS namespaces to GZ topics (#512 <https://github.com/gazebosim/ros_gz/issues/512>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz/issues/503>) (#506 <https://github.com/gazebosim/ros_gz/issues/506>)
* Add a virtual destructor to suppress compiler warning (#502 <https://github.com/gazebosim/ros_gz/issues/502>) (#505 <https://github.com/gazebosim/ros_gz/issues/505>)
  Co-authored-by: Michael Carroll <mailto:mjcarroll@intrinsic.ai>
* Add option to change material color from ROS. (#486 <https://github.com/gazebosim/ros_gz/issues/486>)
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: Alejandro Hernández Cordero, Benjamin Perseghetti, Krzysztof Wojciechowski, Michael Carroll
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Add option to change material color from ROS. (#486 <https://github.com/gazebosim/ros_gz/issues/486>)
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: Benjamin Perseghetti
```

## ros_gz_sim

```
* Support <gazebo_ros> in package.xml exports (#492 <https://github.com/gazebosim/ros_gz/issues/492>)
  This copies the implementation from gazebo_ros_paths.py to provide a
  way for packages to set resource paths from package.xml.
  ```
  e.g.  <export>
  <gazebo_ros gazebo_model_path="${prefix}/models"/>
  <gazebo_ros gazebo_media_path="${prefix}/models"/>
  </export>
  ```
  The value of gazebo_model_path and gazebo_media_path is appended to GZ_SIM_RESOURCE_PATH
  The value of plugin_path appended to GZ_SIM_SYSTEM_PLUGIN_PATH
  ---------
* Contributors: Addisu Z. Taddese
```

## ros_gz_sim_demos

- No changes

## ros_ign

- No changes

## ros_ign_bridge

- No changes

## ros_ign_gazebo

- No changes

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
