### PR TITLE
Add REP-144 check list to pr template, and split pull request template files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/doc_index_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/doc_index_template.md
@@ -1,0 +1,27 @@
+<!--
+This pull request template is used to request the addition of a "doc" entry in rosdistro for your package.
+
+The addition of a doc entry to rosdistro is one of the first steps in the process of getting a package released. You are not expected to provide documentation for your package at this point in time, but is more about undergoing the naming review process and getting the package indexed in the rosdistro.
+
+Before you submit a pull request, you should have settled on the names of your ROS packages, and ensured that they follow package naming guidelines on REP-144 (https://ros.org/reps/rep-0144.html).
+-->
+
+# Doc Indexing Request (Package Naming Review)
+
+## Package Name
+<!-- Enter the name of for your package here (eg. rclcpp) -->
+
+## Source Code Respository URL:
+<!-- Paste the URL for your source code here (eg. https://github.com/ros2/rclcpp) -->
+
+## License Checks
+<!-- Use the check list below to ensure you have satisfied the license requirements. Replace "[ ]" with "[x]" to check the box. -->
+* [ ] All packages have a declared license in the package.xml
+* [ ] This repository has a LICENSE file
+
+## Package Name REP-144 Mandatory Checks
+<!-- Use the check list below to ensure you have satisfied the mandatory checks. Replace "[ ]" with "[x]" to check the box. -->
+* [ ] Only consists of lowercase alphanumerics and _ separators
+* [ ] Starts with an alphabetic character
+* [ ] Does not use multiple _ separators consecutively
+* [ ] At least two characters long

--- a/.github/PULL_REQUEST_TEMPLATE/rosdep_rule_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rosdep_rule_template.md
@@ -1,0 +1,45 @@
+<!--
+This pull request template is used to add a dependency of a platform to the rosdep databse.
+Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md
+-->
+
+# Adding Dependency to Rosdep Databse
+
+## Package name:
+<!-- Enter the name of for the package here (eg. eigen) -->
+
+## Package Upstream Source:
+<!-- Paste the URL for the source repository here (eg. https://gitlab.com/libeigen/eigen) -->
+
+## Purpose of using this:
+<!--
+Write down purpose of using this package.
+Eg. "This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database."
+-->
+
+## Links to Distribution Packages
+<!--
+Replace the REQUIRED areas with the URL to the package.
+For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
+More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules
+-->
+- Debian: https://packages.debian.org/
+  - REQUIRED
+- Ubuntu: https://packages.ubuntu.com/
+  - REQUIRED
+- Fedora: https://packages.fedoraproject.org/
+  - IF AVAILABLE
+- Arch: https://www.archlinux.org/packages/
+  - IF AVAILABLE
+- Gentoo: https://packages.gentoo.org/
+  - IF AVAILABLE
+- macOS: https://formulae.brew.sh/
+  - IF AVAILABLE
+- Alpine: https://pkgs.alpinelinux.org/packages
+  - IF AVAILABLE
+- NixOS/nixpkgs: https://search.nixos.org/packages
+  - OPTIONAL
+- openSUSE: https://software.opensuse.org/package/
+  - IF AVAILABLE
+- rhel: https://rhel.pkgs.org/
+  - IF AVAILABLE

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,66 +1,16 @@
-<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
-Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE
+<!----------------------------------------------------------------------------------------->
+<!-- PLEASE SWITCH TO THE `Preview` TAB AND SELECT THE APPROPRIATE PULL REQUEST TEMPLATE -->
+<!----------------------------------------------------------------------------------------->
 
-If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
-If you've already run the release bloom has a `--pull-request-only` option you can use.-->
+# Pull Request Template Selection
 
-<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->
+Thank you for looking to contribute a change to the rosdistro. There are two primary types of contributions:
 
-Please add the following dependency to the rosdep database.
+* [**Rosdep Rule Template**](?expand=1&template=rosdep_rule_template.md) - Use this template to add a dependency of a platform to the rosdep database.
+* [**Doc Index Template**](?expand=1&template=doc_index_template.md) - Use this template to request naming review of a package and addition of a "doc" entry in rosdistro.
 
-## Package name:
+**Please click on one of the templates above** and it will redirect you to the appropriate pull request template.
 
-TODO
+---
 
-## Package Upstream Source:
-
-TODO link to source repository
-
-## Purpose of using this:
-
-TODO Replace. This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database.
-
-Distro packaging links:
-
-## Links to Distribution Packages
-
-<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
-More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->
-
-- Debian: https://packages.debian.org/
-  - REQUIRED
-- Ubuntu: https://packages.ubuntu.com/
-  - REQUIRED
-- Fedora: https://packages.fedoraproject.org/
-  - IF AVAILABLE
-- Arch: https://www.archlinux.org/packages/
-  - IF AVAILABLE
-- Gentoo: https://packages.gentoo.org/
-  - IF AVAILABLE
-- macOS: https://formulae.brew.sh/
-  - IF AVAILABLE
-- Alpine: https://pkgs.alpinelinux.org/packages
-  - IF AVAILABLE
-- NixOS/nixpkgs: https://search.nixos.org/packages
-  - OPTIONAL
-- openSUSE: https://software.opensuse.org/package/
-  - IF AVAILABLE
-- rhel: https://rhel.pkgs.org/
-  - IF AVAILABLE
-
-<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
-
-<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->
-
-# Please Add This Package to be indexed in the rosdistro.
-
-ROSDISTRO NAME
-
-# The source is here:
-
-http://sourcecode_url
-
-# Checks
- - [ ] All packages have a declared license in the package.xml
- - [ ] This repository has a LICENSE file
- - [ ] This package is expected to build on the submitted rosdistro
+> **_NOTE:_**  If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually). If you've already run the release bloom has a `--pull-request-only` option you can use.


### PR DESCRIPTION
* Adds REP-144 information and updates the DOC INDEX TEMPLATE
* Since the PR template becomes rather large and readability is reduced, I have also split the pull request templates into mupltiple templates which can be selected from the root pr template.
* Improvements to language and formatting to increase readability of templates.

Supercedes #39987.