### PR TITLE
rmw_fastrtps: 8.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5382,7 +5382,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 8.3.0-1
+      version: 8.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `8.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.3.0-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Allow pkcs11 when calling rmw_dds_common::get_security_files. (#565 <https://github.com/ros2/rmw_fastrtps/issues/565>)
  Co-authored-by: Miguel Company <mailto:MiguelCompany@eprosima.com>
* Add tracepoint for publish/subscribe serialized_message (#748 <https://github.com/ros2/rmw_fastrtps/issues/748>)
  * Add: tracepoint for generic pub/sub
  * Fix: correspond to PR 454
  * Fix: change write to write_to_timestamp
  ---------
* Contributors: IkerLuengo, h-suzuki-isp
```
