### PR TITLE
rmw_cyclonedds: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5346,7 +5346,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-1`

## rmw_cyclonedds_cpp

```
* Add tracepoint for publish/subscribe serialized message (#485 <https://github.com/ros2/rmw_cyclonedds/issues/485>)
  Co-authored-by: eboasson <mailto:eb@ilities.com>
* Contributors: h-suzuki-isp
```
