### PR TITLE
control_msgs: 5.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -849,7 +849,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.1.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.0-1`

## control_msgs

```
* Add ParallelGripperCommand (#99 <https://github.com/ros-controls/control_msgs/issues/99>)
* Specify BSD as BSD-3-Clause (#114 <https://github.com/ros-controls/control_msgs/issues/114>)
* Contributors: Christoph Fröhlich, Paul Gesel
```
