### PR TITLE
control_msgs: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -862,7 +862,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.0.0-2
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.1.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.0-2`

## control_msgs

```
* Add ParallelGripperCommand (#99 <https://github.com/ros-controls/control_msgs/issues/99>)
* Specify BSD as BSD-3-Clause (#114 <https://github.com/ros-controls/control_msgs/issues/114>)
* Contributors: Christoph Fröhlich, Paul Gesel
```
