### PR TITLE
openrtm_aist: 1.1.2-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7226,7 +7226,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist-release.git
-      version: 1.1.2-4
+      version: 1.1.2-5
     source:
       type: git
       url: https://github.com/tork-a/openrtm_aist-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist` to `1.1.2-5`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist.git
- release repository: https://github.com/tork-a/openrtm_aist-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.2-4`
