### PR TITLE
ign_ros2_control: 0.7.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2771,12 +2771,13 @@ repositories:
       version: humble
     release:
       packages:
+      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2771,7 +2771,6 @@ repositories:
       version: humble
     release:
       packages:
-      - gz_ros2_control_tests
       - ign_ros2_control
       - ign_ros2_control_demos
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.7-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.6-1`

## ign_ros2_control

```
* Fix #259 <https://github.com/ros-controls/gz_ros2_control/issues/259> - ParameterAlreadyDeclaredException for parameter position_proportional_gain (backport #261 <https://github.com/ros-controls/gz_ros2_control/issues/261>) (#262 <https://github.com/ros-controls/gz_ros2_control/issues/262>)
  Co-authored-by: Patrick Roncagliolo <mailto:ronca.pat@gmail.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## ign_ros2_control_demos

- No changes
