### PR TITLE
gz_ros2_control: 1.1.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2086,10 +2086,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2086,7 +2086,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.1.6-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.5-1`

## gz_ros2_control

```
* Fix #259 <https://github.com/ros-controls/gz_ros2_control/issues/259> - ParameterAlreadyDeclaredException for parameter position_proportional_gain (backport #261 <https://github.com/ros-controls/gz_ros2_control/issues/261>) (#263 <https://github.com/ros-controls/gz_ros2_control/issues/263>)
  Co-authored-by: Patrick Roncagliolo <mailto:ronca.pat@gmail.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes

## gz_ros2_control_tests

- No changes
