### PR TITLE
sdformat_vendor: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6757,7 +6757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## sdformat_vendor

```
* Add target with <pkg>::<pkg> format (#2 <https://github.com/gazebo-release/sdformat_vendor/issues/2>)
  * gz-lib target aliases to gz-lib::gz-lib
  * Support the '::all' target
  ---------
* Fix issue with sourcing .dsv files
* Contributors: Addisu Z. Taddese
```
