### PR TITLE
azure-iot-sdk-c: 1.13.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -541,6 +541,21 @@ repositories:
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git
       version: main
     status: maintained
+  azure-iot-sdk-c:
+    doc:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/nobleo/azure-iot-sdk-c-release.git
+      version: 1.13.0-2
+    source:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: main
+    status: maintained
   backward_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `azure-iot-sdk-c` to `1.13.0-2`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/nobleo/azure-iot-sdk-c-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
