### PR TITLE
common_interfaces: 5.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -814,7 +814,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.3.1-1
+      version: 5.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.3.2-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.1-1`

## actionlib_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## common_interfaces

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## diagnostic_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## geometry_msgs

```
* Create new messages with all fields needed to define a velocity and transform it  (#240 <https://github.com/ros2/common_interfaces/issues/240>)
  Co-authored-by: Dr. Denis <mailto:denis@stoglrobotics.de>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## nav_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## sensor_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* [J-Turtle] Fix uninitialized values in NavSatFix and add missing NavSatStatus UNKNOWN (#220 <https://github.com/ros2/common_interfaces/issues/220>)
  * Fix unitialized values in NavSatFix and add missing UNKNOWN
  * Fixes #196 <https://github.com/ros2/common_interfaces/issues/196>
  * Fix default initialization instead of constants
  * Define SERVICE_UNKNOWN
  Co-authored-by: Tully Foote <mailto:tully.foote@gmail.com>
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Contributors: Chris Lalancette, Ryan
```

## sensor_msgs_py

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## shape_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## std_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## std_srvs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## stereo_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## trajectory_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```

## visualization_msgs

```
* Clarify the license. (#241 <https://github.com/ros2/common_interfaces/issues/241>)
  In particular, every package in this repository is Apache 2.0
  licensed except for sensor_msgs_py.  So move the CONTRIBUTING.md
  and LICENSE files down into the individual packages, and
  make sure that sensor_msgs_py has the correct CONTRIBUTING.md
  file (it already had the correct LICENSE file).
* Contributors: Chris Lalancette
```
