### PR TITLE
geometry2: 0.36.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1802,7 +1802,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.1-1
+      version: 0.36.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.36.1-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Enable Twist interpolator (#646 <https://github.com/ros2/geometry2/issues/646>)
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
* Warning Message Intervals for canTransform (#663 <https://github.com/ros2/geometry2/issues/663>)
* Contributors: Alejandro Hernández Cordero, Lucas Wendland
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Enable Twist interpolator (#646 <https://github.com/ros2/geometry2/issues/646>)
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
* Contributors: Alejandro Hernández Cordero
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Enable Twist interpolator (#646 <https://github.com/ros2/geometry2/issues/646>)
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
* Contributors: Alejandro Hernández Cordero
```

## tf2_ros

```
* Compile fix for upcomming changes to rclcpp::Executor (#668 <https://github.com/ros2/geometry2/issues/668>)
* Enable Twist interpolator (#646 <https://github.com/ros2/geometry2/issues/646>)
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
* Contributors: Alejandro Hernández Cordero, jmachowinski
```

## tf2_ros_py

```
* Transform Data Callback Python (#664 <https://github.com/ros2/geometry2/issues/664>)
* Contributors: Lucas Wendland
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
