### PR TITLE
add toppra pip dependency to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9323,6 +9323,19 @@ python3-toml:
   gentoo: [dev-python/toml]
   nixos: [python3Packages.toml]
   ubuntu: [python3-toml]
+python3-toppra:
+  debian:
+    pip:
+      packages: [toppra]
+  fedora:
+    pip:
+      packages: [toppra]
+  osx:
+    pip:
+      packages: [toppra]
+  ubuntu:
+    pip:
+      packages: [toppra]
 python3-torch:
   arch: [python-pytorch]
   debian: [python3-torch]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9323,7 +9323,7 @@ python3-toml:
   gentoo: [dev-python/toml]
   nixos: [python3Packages.toml]
   ubuntu: [python3-toml]
-python3-toppra:
+python3-toppra-pip:
   debian:
     pip:
       packages: [toppra]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

**python3-toppra-pip**

## Package Upstream Source:

https://github.com/hungpham2511/toppra

## Purpose of using this:

The library is a **Time-Optimal Path Parameterization** and is a popular library for motion planning.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org/project/toppra/
