### PR TITLE
gz_tools_vendor: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2155,7 +2155,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_tools_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_tools_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_tools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## gz_tools_vendor

```
* Add support for the <pkg>::<pkg> and <pkg>::all targets, fix sourcing of dsv files
* Contributors: Addisu Z. Taddese
```
