### PR TITLE
added apriltag_mit repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -477,6 +477,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: humble
     status: developed
+  apriltag_mit:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: humble
+    status: developed
   apriltag_msgs:
     release:
       tags:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -371,6 +371,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: iron
     status: developed
+  apriltag_mit:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: iron
+    status: developed
   apriltag_msgs:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -372,6 +372,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: rolling
     status: developed
+  apriltag_mit:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: rolling
+    status: developed
   apriltag_msgs:
     release:
       tags:


### PR DESCRIPTION
# Please add apriltag_mit to be indexed in the rosdistro.

ROSDISTRO NAMES: humble, iron, rolling

This repo holds a ROS2-buildable package of the MIT implementation (courtesy of mostly Michael Kaess) of the AprilTag library. While the UMich implementation outperforms the MIT implementation in many respects, only the MIT version can handle the case where black markers encroach on the perimeter of the tag. The UMich detector does *not* work with any of the Kalibr calibration boards, only the MIT detector does. Hence the need to add this detector.


# The source is here:

https://github.com/ros-misc-utilities/apriltag_mit

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
