### PR TITLE
wireless: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9946,7 +9946,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 1.0.1-3
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-3`

## wireless_msgs

- No changes

## wireless_watcher

```
* License
* Reimplemented in C++
* Use time.sleep instead of rate.sleep to properly exit loop on external shutdown
  Default 'dev' parameter to empty string rather than None
* Contributors: Roni Kreinin
```
