### PR TITLE
ortools_vendor: 9.9.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4002,6 +4002,12 @@ repositories:
       url: https://github.com/ros2/orocos_kdl_vendor.git
       version: rolling
     status: developed
+  ortools_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/Fields2Cover/ortools_vendor-release.git
+      version: 9.9.0-2
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.0-2`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/Fields2Cover/ortools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
