### PR TITLE
ortools_vendor: 9.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7288,6 +7288,12 @@ repositories:
       url: https://github.com/Jmeyer1292/opw_kinematics.git
       version: master
     status: developed
+  ortools_vendor:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Fields2Cover/ortools_vendor-release.git
+      version: 9.9.0-1
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.0-1`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/Fields2Cover/ortools_vendor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
