### PR TITLE
Add packages for ROS2 kuka drivers

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3121,6 +3121,46 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
+  kuka_controllers:
+    doc:
+      type: git
+      url: https://github.com/kroshu/kuka_controllers.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/kroshu/kuka_controllers.git
+      version: humble
+    status: developed
+  kuka_drivers:
+    doc:
+      type: git
+      url: https://github.com/kroshu/kuka_drivers.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/kroshu/kuka_drivers.git
+      version: humble
+    status: developed
+  kuka_external_control_sdk:
+    doc:
+      type: git
+      url: https://github.com/kroshu/kuka-external-control-sdk.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/kroshu/kuka-external-control-sdk.git
+      version: humble
+    status: developed
+  kuka_robot_descriptions:
+    doc:
+      type: git
+      url: https://github.com/kroshu/kuka_robot_descriptions.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/kroshu/kuka_robot_descriptions.git
+      version: humble
+    status: developed
   lanelet2:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3121,16 +3121,6 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
-  kuka_controllers:
-    doc:
-      type: git
-      url: https://github.com/kroshu/kuka_controllers.git
-      version: master
-    source:
-      type: git
-      url: https://github.com/kroshu/kuka_controllers.git
-      version: master
-    status: developed
   kuka_drivers:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3125,41 +3125,41 @@ repositories:
     doc:
       type: git
       url: https://github.com/kroshu/kuka_controllers.git
-      version: humble
+      version: master
     source:
       type: git
       url: https://github.com/kroshu/kuka_controllers.git
-      version: humble
+      version: master
     status: developed
   kuka_drivers:
     doc:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git
-      version: humble
+      version: master
     source:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git
-      version: humble
+      version: master
     status: developed
   kuka_external_control_sdk:
     doc:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git
-      version: humble
+      version: master
     source:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git
-      version: humble
+      version: master
     status: developed
   kuka_robot_descriptions:
     doc:
       type: git
       url: https://github.com/kroshu/kuka_robot_descriptions.git
-      version: humble
+      version: master
     source:
       type: git
       url: https://github.com/kroshu/kuka_robot_descriptions.git
-      version: humble
+      version: master
     status: developed
   lanelet2:
     doc:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3512,10 +3512,6 @@ libgps:
   opensuse: [gpsd-devel]
   rhel: [gpsd-devel]
   ubuntu: [libgps-dev]
-libgrpc++-dev:
-  debian: [libgrpc++-dev]
-  fedora: [grpc]
-  ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3512,6 +3512,9 @@ libgps:
   opensuse: [gpsd-devel]
   rhel: [gpsd-devel]
   ubuntu: [libgps-dev]
+libgrpc++-dev:
+  debian: [libgrpc++-dev]
+  ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]
   debian:
@@ -4060,6 +4063,8 @@ libnanoflann-dev:
     '*': [libnanoflann-dev]
     bionic: null
     focal: null
+libnanopb-dev:
+  ubuntu: [libnanopb-dev]
 libncurses:
   arch: [ncurses]
   debian: [libncurses5]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3514,6 +3514,7 @@ libgps:
   ubuntu: [libgps-dev]
 libgrpc++-dev:
   debian: [libgrpc++-dev]
+  fedora: [grpc]
   ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4095,8 +4095,7 @@ libnanoflann-dev:
     bionic: null
     focal: null
 libnanopb-dev:
-  debian:
-    bullseye: [libnanopb-dev]
+  debian: [libnanopb-dev]
   ubuntu:
     '*': [libnanopb-dev]
     bionic: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4095,7 +4095,11 @@ libnanoflann-dev:
     bionic: null
     focal: null
 libnanopb-dev:
-  ubuntu: [libnanopb-dev]
+  debian:
+    bullseye: [libnanopb-dev]
+  ubuntu:
+    '*': [libnanopb-dev]
+    bionic: null
 libncurses:
   arch: [ncurses]
   debian: [libncurses5]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.
rosdistro: humble
package names:
- `kuka_drivers`
- `kuka_external_control_sdk`
- `kuka_robot_descriptions`

These packages add real-time capable drivers for different KUKA robots, including hardware interfaces of the `ros2_control` framework, robot models and KUKA-specific controllers.

Package dependencies: `kuka_drivers` depends on `kuka_external_control_sdk` and `kuka_robot_descriptions`. Aside of these depencencies, all of them build on humble.

What is the process in this case? I would like to create a ROS2 release from all packages. Should I at first only include `kuka_external_control_sdk` in this PR, do the relesase and then add the other packages one by one?

# The source is here:
- https://github.com/kroshu/kuka_drivers
- https://github.com/kroshu/kuka-external-control-sdk
- https://github.com/kroshu/kuka_robot_descriptions

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
