### PR TITLE
Add python3-pymongo-pip and python3-motor-pip keys for debian and ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6981,6 +6981,13 @@ python3-moteus-pip:
   ubuntu:
     pip:
       packages: [moteus]
+python3-motor-pip:
+  debian:
+    pip:
+      packages: [motor]
+  ubuntu:
+    pip:
+      packages: [motor]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]
@@ -8003,6 +8010,13 @@ python3-pymongo:
   nixos: [python3Packages.pymongo]
   openembedded: [python3-pymongo@meta-python]
   ubuntu: [python3-pymongo]
+python3-pymongo-pip:
+  debian:
+    pip:
+      packages: [pymongo]
+  ubuntu:
+    pip:
+      packages: [pymongo]
 python3-pynmea2:
   debian: [python3-nmea2]
   fedora:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

* python3-pymongo-pip
* python3-motor-pip

## Package Upstream Source:
* https://github.com/mongodb/mongo-python-driver/
* https://github.com/mongodb/motor

## Purpose of using this:

The pymongo package distributed by apt is a major release behind (v3.11 compared to v4.6) missing a set of critical new features and functionality.

Additionally Motor is an asynchronous driver for MongoDB that allows for data to be accessed asynchronously. 

## Links to Distribution Packages

* pip: https://pypi.org/project/pymongo/
* pip: https://pypi.org/project/motor/
