### PR TITLE
Revert "mola: 1.0.2-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4008,14 +4008,13 @@ repositories:
       - mola_metric_maps
       - mola_navstate_fuse
       - mola_pose_list
-      - mola_relocalization
       - mola_traj_tools
       - mola_viz
       - mola_yaml
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.2-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Reverts ros/rosdistro#40458

It seems that some of the dependencies could not be installed. You can see the logs [here](https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__mola__ubuntu_jammy_amd64__binary/3/console).

```
08:46:23 The command '/bin/sh -c echo "apt-src: 0.25.3" && echo "debhelper: 13.6ubuntu1" && echo "ros-humble-ament-cmake: 1.3.8-1jammy.20240217.030113" && echo "ros-humble-ament-lint-auto: 0.12.10-1jammy.20240217.024701" && echo "ros-humble-ament-lint-common: 0.12.10-1jammy.20240217.035005" && echo "ros-humble-kitti-metrics-eval: 1.0.2-1jammy.20240404.132419" && echo "ros-humble-mola-bridge-ros2: 1.0.2-1jammy.20240404.133547" && echo "ros-humble-mola-demos: 1.0.2-1jammy.20240404.132433" && echo "ros-humble-mola-imu-preintegration: 1.0.2-1jammy.20240404.132445" && echo "ros-humble-mola-input-euroc-dataset: 1.0.2-1jammy.20240404.133544" && echo "ros-humble-mola-input-kitti-dataset: 1.0.2-1jammy.20240404.133542" && echo "ros-humble-mola-input-kitti360-dataset: 1.0.2-1jammy.20240404.133542" && echo "ros-humble-mola-input-mulran-dataset: 1.0.2-1jammy.20240404.133547" && echo "ros-humble-mola-input-paris-luco-dataset: 1.0.2-1jammy.20240404.133542" && echo "ros-humble-mola-input-rawlog: 1.0.2-1jammy.20240404.133542" && echo "ros-humble-mola-input-rosbag2: 1.0.2-1jammy.20240404.133542" && echo "ros-humble-mola-kernel: 1.0.2-1jammy.20240404.132927" && echo "ros-humble-mola-launcher: 1.0.2-1jammy.20240404.133544" && echo "ros-humble-mola-metric-maps: 1.0.2-1jammy.20240404.132444" && echo "ros-humble-mola-navstate-fuse: 1.0.2-1jammy.20240404.132830" && echo "ros-humble-mola-pose-list: 1.0.2-1jammy.20240404.132500" && echo "ros-humble-mola-relocalization: 1.0.2-1jammy.20240404.132505" && echo "ros-humble-mola-traj-tools: 1.0.2-1jammy.20240404.132442" && echo "ros-humble-mola-viz: 1.0.2-1jammy.20240404.133543" && echo "ros-humble-mola-yaml: 1.0.2-1jammy.20240404.132409" && echo "ros-humble-ros-workspace: 1.0.2-2jammy.20240217.023146" && python3 -u /tmp/wrapper_scripts/apt.py update-install-clean -q -y -o Debug::pkgProblemResolver=yes apt-src debhelper ros-humble-ament-cmake ros-humble-ament-lint-auto ros-humble-ament-lint-common ros-humble-kitti-metrics-eval ros-humble-mola-bridge-ros2 ros-humble-mola-demos ros-humble-mola-imu-preintegration ros-humble-mola-input-euroc-dataset ros-humble-mola-input-kitti-dataset ros-humble-mola-input-kitti360-dataset ros-humble-mola-input-mulran-dataset ros-humble-mola-input-paris-luco-dataset ros-humble-mola-input-rawlog ros-humble-mola-input-rosbag2 ros-humble-mola-kernel ros-humble-mola-launcher ros-humble-mola-metric-maps ros-humble-mola-navstate-fuse ros-humble-mola-pose-list ros-humble-mola-relocalization ros-humble-mola-traj-tools ros-humble-mola-viz ros-humble-mola-yaml ros-humble-ros-workspace' returned a non-zero code: 100
```