### PR TITLE
vision_opencv: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8011,7 +8011,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.4.0-3
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `4.0.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-3`

## cv_bridge

```
* Decode images in mode IMREAD_UNCHANGED (#520 <https://github.com/ros-perception/vision_opencv/issues/520>)
* Remove header files that were deprecated in I-turtle (#517 <https://github.com/ros-perception/vision_opencv/issues/517>)
* Fixed converstion for 32FC1 (#514 <https://github.com/ros-perception/vision_opencv/issues/514>)
* Allow users to override encoding string in ROSCvMatContainer (#505 <https://github.com/ros-perception/vision_opencv/issues/505>)
* Ensure dynamic scaling works when given matrix with inf, -inf and nan values. (#498 <https://github.com/ros-perception/vision_opencv/issues/498>)
* Add new CMake option CV_BRIDGE_DISABLE_PYTHON to cv_bridge to disable building Python support if desired (#494 <https://github.com/ros-perception/vision_opencv/issues/494>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Kenji Brameld, Lightech, Yadunund, ijnek
```

## image_geometry

```
* Add unit tests for all public members (#526 <https://github.com/ros-perception/vision_opencv/pull/526>)
* Remove header files that were deprecated in I-turtle (#517 <https://github.com/ros-perception/vision_opencv/issues/517>)
* Use c++17 (#515 <https://github.com/ros-perception/vision_opencv/issues/515>)
* Remove unused travis file
* Contributors: Kenji Brameld, Scott Monaghan, andrea, ijnek
```

## vision_opencv

- No changes
