### PR TITLE
vision_opencv: 3.5.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8177,7 +8177,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 3.4.0-3
+      version: 3.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `3.5.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-3`

## cv_bridge

```
* Fixed converstion for 32FC1 (#514 <https://github.com/ros-perception/vision_opencv/issues/514>)
* Allow users to override encoding string in ROSCvMatContainer (#505 <https://github.com/ros-perception/vision_opencv/issues/505>)
* Ensure dynamic scaling works when given matrix with inf, -inf and nan values. (#498 <https://github.com/ros-perception/vision_opencv/issues/498>)
* Add new CMake option CV_BRIDGE_DISABLE_PYTHON to cv_bridge to disable building Python support if desired (#494 <https://github.com/ros-perception/vision_opencv/issues/494>)
* Contributors: Alejandro Hernández Cordero, Kenji Brameld, Lightech, Yadunund, ijnek
```

## image_geometry

```
* Use c++17 (#515 <https://github.com/ros-perception/vision_opencv/issues/515>)
* Remove unused travis file
* Contributors: Kenji Brameld, andrea
```

## vision_opencv

- No changes
