### PR TITLE
catch_ros2: 0.2.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -709,7 +709,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/catch_ros2-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ngmor/catch_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros2` to `0.2.1-1`:

- upstream repository: https://github.com/ngmor/catch_ros2.git
- release repository: https://github.com/ros2-gbp/catch_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## catch_ros2

```
* Updated to Catch2 v3.5.4
* Contributors: Nick Morales
```
