### PR TITLE
image_transport_plugins: 2.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2894,7 +2894,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.5.0-2
+      version: 2.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.5.1-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-2`

## compressed_depth_image_transport

```
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld
```

## compressed_image_transport

```
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld
```

## image_transport_plugins

```
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld
```

## theora_image_transport

```
* Update maintainer (#112 <https://github.com/ros-perception/image_transport_plugins/issues/112>)
* Contributors: Kenji Brameld
```
