### PR TITLE
image_transport_plugins: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2429,10 +2429,11 @@ repositories:
       - compressed_image_transport
       - image_transport_plugins
       - theora_image_transport
+      - zstd_image_transport
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 3.2.0-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `4.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.0-2`

## compressed_depth_image_transport

```
* Added RVL Codec support to compressed_depth_image_transport (#159 <https://github.com/ros-perception/image_transport_plugins/issues/159>)
* Contributors: Kenji Brameld, anilsripadarao, ijnek
```

## compressed_image_transport

- No changes

## image_transport_plugins

```
* Added ZSTD plugin to metapackage (#162 <https://github.com/ros-perception/image_transport_plugins/issues/162>)
* Contributors: Alejandro Hernández Cordero, Kenji Brameld
```

## theora_image_transport

- No changes

## zstd_image_transport

```
* Added zstd image transport plugin (#154 <https://github.com/ros-perception/image_transport_plugins/issues/154>)
* Contributors: Alejandro Hernández Cordero, Kenji Brameld
```
