### PR TITLE
nao_lola: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3658,7 +3658,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 1.2.0-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_lola` to `1.3.0-1`:

- upstream repository: https://github.com/ros-sports/nao_lola.git
- release repository: https://github.com/ros2-gbp/nao_lola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-2`

## nao_lola

- No changes

## nao_lola_client

```
* optimize header includes from rclcpp and msgpack that were taking long
* Contributors: Kenji Brameld
```

## nao_lola_command_msgs

- No changes

## nao_lola_sensor_msgs

- No changes
