### PR TITLE
Rename gc_spl to game_controller_spl

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2161,6 +2161,31 @@ repositories:
       url: https://github.com/foxglove/schemas.git
       version: main
     status: developed
+  game_controller_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: humble
+    release:
+      packages:
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
+      - gc_spl_2022
+      - gc_spl_interfaces
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/game_controller_spl-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: humble
+    status: developed
   gazebo_model_attachment_plugin:
     doc:
       type: git
@@ -2284,31 +2309,6 @@ repositories:
       url: https://github.com/nlamprian/gazebo_video_monitors.git
       version: ros2
     status: maintained
-  gc_spl:
-    doc:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: humble
-    release:
-      packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 2.1.0-1
-    source:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: humble
-    status: developed
   generate_parameter_library:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1713,6 +1713,31 @@ repositories:
       url: https://github.com/locusrobotics/fuse.git
       version: rolling
     status: maintained
+  game_controller_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: iron
+    release:
+      packages:
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
+      - gc_spl_2022
+      - gc_spl_interfaces
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/game_controller_spl-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: iron
+    status: developed
   gazebo_ros2_control:
     doc:
       type: git
@@ -1773,31 +1798,6 @@ repositories:
       url: https://github.com/nlamprian/gazebo_video_monitors.git
       version: ros2
     status: maintained
-  gc_spl:
-    doc:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: iron
-    release:
-      packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 3.1.0-1
-    source:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: iron
-    status: developed
   generate_parameter_library:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1657,6 +1657,31 @@ repositories:
       url: https://github.com/locusrobotics/fuse.git
       version: rolling
     status: maintained
+  game_controller_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: rolling
+    release:
+      packages:
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
+      - gc_spl_2022
+      - gc_spl_interfaces
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/game_controller_spl-release.git
+      version: 4.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: rolling
+    status: developed
   gazebo_ros2_control:
     doc:
       type: git
@@ -1696,31 +1721,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
     status: maintained
-  gc_spl:
-    doc:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: rolling
-    release:
-      packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 4.0.0-2
-    source:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: rolling
-    status: developed
   generate_parameter_library:
     doc:
       type: git


### PR DESCRIPTION
Repository was renamed recently from gc_spl to game_controller_spl. Instead of updating the name just for rolling's distribution.yaml, for consistency, I updated the names in humble and iron's distribution files too. I'm hoping there are no issues with this manual change.

* [Source repo](https://github.com/ros-sports/game_controller_spl)
* [Releas repo](https://github.com/ros2-gbp/game_controller_spl-release)

[Related issue in ros2-gbp](https://github.com/ros2-gbp/ros2-gbp-github-org/issues/430)