### PR TITLE
r2r_spl: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5766,13 +5766,18 @@ repositories:
       version: humble
     release:
       packages:
+      - r2r_spl
       - r2r_spl_7
+      - r2r_spl_8
+      - r2r_spl_test_interfaces
       - splsm_7
       - splsm_7_conversion
+      - splsm_8
+      - splsm_8_conversion
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `r2r_spl` to `2.1.0-1`:

- upstream repository: https://github.com/ros-sports/r2r_spl.git
- release repository: https://github.com/ros2-gbp/r2r_spl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## r2r_spl

```
* Add r2r_spl package, capable of listening to different msg types (#47 <https://github.com/ros-sports/r2r_spl/issues/47>)
* Contributors: Kenji Brameld
```

## r2r_spl_7

```
* Ensure tests don't communicate with each other, by changing team number, and hence udp port number
* Contributors: Kenji Brameld
```

## r2r_spl_8

```
* Ensure tests don't communicate with each other, by changing team number, and hence udp port number
* Contributors: Kenji Brameld, ijnek
```

## r2r_spl_test_interfaces

- No changes

## splsm_7

- No changes

## splsm_7_conversion

- No changes

## splsm_8

- No changes

## splsm_8_conversion

- No changes
