### PR TITLE
rcss3d_nao: 1.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4993,7 +4993,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_nao-release.git
-      version: 1.1.0-2
+      version: 1.2.0-2
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_nao.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcss3d_nao` to `1.2.0-2`:

- upstream repository: https://github.com/ros-sports/rcss3d_nao.git
- release repository: https://github.com/ros2-gbp/rcss3d_nao-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-2`

## rcss3d_nao

```
* Publish imu and joint states (#22 <https://github.com/ros-sports/rcss3d_nao/issues/22>)
* Contributors: Kenji Brameld
```
