### PR TITLE
Update rqt_image_overlay branch for iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6439,7 +6439,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: iron
     release:
       packages:
       - rqt_image_overlay
@@ -6451,7 +6451,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: iron
     status: developed
   rqt_image_view:
     doc:


### PR DESCRIPTION
splitting off [iron branch](https://github.com/ros-sports/rqt_image_overlay/tree/iron) in preparation for rolling transition.