### PR TITLE
soccer_interfaces: 0.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7090,14 +7090,16 @@ repositories:
       version: rolling
     release:
       packages:
+      - soccer_geometry_msgs
       - soccer_interfaces
+      - soccer_model_msgs
       - soccer_vision_2d_msgs
       - soccer_vision_3d_msgs
       - soccer_vision_attribute_msgs
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
-      version: 0.2.0-3
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_interfaces` to `0.3.0-1`:

- upstream repository: https://github.com/ros-sports/soccer_interfaces.git
- release repository: https://github.com/ros2-gbp/soccer_interfaces-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-3`

## soccer_geometry_msgs

```
* Fill package descriptions in package.xml
* Contributors: Kenji Brameld
```

## soccer_interfaces

- No changes

## soccer_model_msgs

```
* Add package containing world model related message definitions in the soccer domain.
* Contributors: Kenji Brameld
```

## soccer_vision_2d_msgs

```
* Add comment about FieldBoundary when empty (#59 <https://github.com/ros-sports/soccer_interfaces/issues/59>)
* Contributors: Jan Gutsche, Kenji Brameld
```

## soccer_vision_3d_msgs

```
* Add comment about FieldBoundary when empty (#59 <https://github.com/ros-sports/soccer_interfaces/issues/59>)
* Contributors: Jan Gutsche, Kenji Brameld
```

## soccer_vision_attribute_msgs

- No changes
