### PR TITLE
soccer_vision_3d_rviz_markers: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6992,7 +6992,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
-      version: 0.0.1-3
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soccer_vision_3d_rviz_markers` to `1.0.0-1`:

- upstream repository: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
- release repository: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-3`

## soccer_vision_3d_rviz_markers

```
* Fixed rviz marker indexes having duplicate markers of id zero (#19 <https://github.com/ros-sports/soccer_vision_3d_rviz_markers/issues/19>)
* Rename __init__ file to __init__.py (#14 <https://github.com/ros-sports/soccer_vision_3d_rviz_markers/issues/14>)
* Fix mistake in python3 typehint (#14 <https://github.com/ros-sports/soccer_vision_3d_rviz_markers/issues/14>)
* Add parameter files for different robocup leagues (#9 <https://github.com/ros-sports/soccer_vision_3d_rviz_markers/issues/9>)
* Contributors: Florian Vahl, Jan Gutsche, Kenji Brameld, abayomi, ijnek
```
