### PR TITLE
pcl_type_adapter: 0.0.1-8 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4149,6 +4149,21 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: ros2
     status: maintained
+  pcl_type_adapter:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/pcl_type_adapter.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/OUXT-Polaris/pcl_type_adapter-release.git
+      version: 0.0.1-8
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/pcl_type_adapter.git
+      version: master
+    status: developed
   perception_open3d:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_type_adapter` to `0.0.1-8`:

- upstream repository: https://github.com/OUXT-Polaris/pcl_type_adapter.git
- release repository: https://github.com/OUXT-Polaris/pcl_type_adapter-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
