### PR TITLE
pcl_type_adapter: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4149,6 +4149,21 @@ repositories:
       url: https://github.com/ros-perception/pcl_msgs.git
       version: ros2
     status: maintained
+  pcl_type_adapter:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/pcl_type_adapter.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/OUXT-Polaris/pcl_type_adapter-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/pcl_type_adapter.git
+      version: master
+    status: developed
   perception_open3d:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_type_adapter` to `0.0.2-1`:

- upstream repository: https://github.com/OUXT-Polaris/pcl_type_adapter.git
- release repository: https://github.com/OUXT-Polaris/pcl_type_adapter-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## pcl_type_adapter

```
* fix README
* Merge pull request #2 <https://github.com/OUXT-Polaris/pcl_type_adapter/issues/2> from OUXT-Polaris/feature/zero_copy
  Feature/zero copy
* change supporting pointer passing
* fix compile error
* fix compile error
* update test code
* Contributors: Masaya Kataoka, hakuturu583
```
