### PR TITLE
Add do-mpc pip package to python.yaml for debian and ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5575,6 +5575,13 @@ python3-dlib-pip:
     pip:
       depends: [cmake, build-essential, python3-dev]
       packages: [dlib]
+python3-do-mpc-pip:
+  debian:
+    pip:
+      packages: [do-mpc]
+  ubuntu:
+    pip:
+      packages: [do-mpc]
 python3-docker:
   arch: [python-docker]
   debian: [python3-docker]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-do-mpc-pip

## Package Upstream Source:

[https://github.com/do-mpc/do-mpc](https://github.com/do-mpc/do-mpc)

## Purpose of using this:

This dependency is useful for quick development of the Model Predictive Control algorithm in the ros environment. 

## Links to Distribution Packages

- Debian: https://pypi.org/project/do-mpc/ 
- Ubuntu: https://pypi.org/project/do-mpc/