### PR TITLE
omni_base_robot: 2.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4853,6 +4853,26 @@ repositories:
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
       version: humble-devel
     status: maintained
+  omni_base_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/omni_base_robot.git
+      version: humble-devel
+    release:
+      packages:
+      - omni_base_bringup
+      - omni_base_controller_configuration
+      - omni_base_description
+      - omni_base_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/omni_base_robot-release.git
+      version: 2.0.9-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/omni_base_robot.git
+      version: humble-devel
+    status: developed
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.0.9-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## omni_base_bringup

- No changes

## omni_base_controller_configuration

```
* Merge branch 'dtk/fix/update-module-numbers' into 'humble-devel'
  Dtk/fix/update module numbers
  See merge request robots/omni_base_robot!25
* Change module number to 00
* Contributors: David ter Kuile, Noel Jimenez
```

## omni_base_description

```
* Merge branch 'omm/feat/planar_move_plugin' into 'humble-devel'
  Restored old plugin with is_public_sim checks
  See merge request robots/omni_base_robot!24
* Removing hector plugin dep
* Restored old gazebo plugin
* Merge branch 'dtk/fix/update-module-numbers' into 'humble-devel'
  Dtk/fix/update module numbers
  See merge request robots/omni_base_robot!25
* Change module number to 00
* Merge branch 'dtk/fix/remove-pmb2-dependency' into 'humble-devel'
  Remove pmb2-description dependency
  See merge request robots/omni_base_robot!22
* Remove dependency of pmb2
* Remove pmb2-description dependency
* Contributors: David ter Kuile, Noel Jimenez, Oscar, andreacapodacqua, davidterkuile
```

## omni_base_robot

- No changes
