### PR TITLE
omni_base_navigation: 2.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4853,6 +4853,26 @@ repositories:
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
       version: humble-devel
     status: maintained
+  omni_base_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/omni_base_navigation.git
+      version: humble-devel
+    release:
+      packages:
+      - omni_base_2dnav
+      - omni_base_laser_sensors
+      - omni_base_maps
+      - omni_base_navigation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/omni_base_navigation-release.git
+      version: 2.0.7-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/omni_base_navigation.git
+      version: humble-devel
+    status: developed
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_navigation` to `2.0.7-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_navigation.git
- release repository: https://github.com/pal-gbp/omni_base_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## omni_base_2dnav

```
* Merge branch 'feat/ros2-params' into 'humble-devel'
  Feat/ros2 params
  See merge request robots/omni_base_navigation!20
* cosmetic
* launch indipendent nav loc and slam public sim
* linters
* pipelines for navigation
* fix launch private sim
* fix and change params names
* fix dep
* default nav config for omni_base
* splitted navigation and localization pipeline and modules
* added state_lattice
* rviz config
* fine tuning params
* tuning parameters ros2
* Contributors: andreacapodacqua
```

## omni_base_laser_sensors

```
* Merge branch 'feat/ros2-params' into 'humble-devel'
  Feat/ros2 params
  See merge request robots/omni_base_navigation!20
* launch indipendent nav loc and slam public sim
* added dlo dep
* pipelines for navigation
* fix and change params names
* fix laser pipeline
* renamed lifecycle manager
* corrected dep
* Contributors: andreacapodacqua
```

## omni_base_maps

- No changes

## omni_base_navigation

- No changes


