### PR TITLE
ffmpeg_image_transport_tools: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1923,6 +1923,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_tools` to `1.1.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## ffmpeg_image_transport_tools

```
* initial release
* Contributors: Bernd Pfrommer
```
