### PR TITLE
Add OpenTelemetry and Adafruit ServoKit Libraries to Rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,6 +29,16 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+adafruit-servokit-pip:
+  debian:
+    pip:
+      packages: [adafruit-circuitpython-servokit]
+  fedora:
+    pip:
+      packages: [adafruit-circuitpython-servokit]
+  ubuntu:
+    pip:
+      packages: [adafruit-circuitpython-servokit]
 autograd-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -20,13 +20,7 @@ adafruit-mcp3008-pip:
     pip:
       packages: [Adafruit-MCP3008]
 python3-adafruit-circuitpython-motor-pip:
-  debian:
-    pip:
-      packages: [adafruit-circuitpython-motor]
-  fedora:
-    pip:
-      packages: [adafruit-circuitpython-motor]
-  ubuntu:
+  '*':
     pip:
       packages: [adafruit-circuitpython-motor]
 adafruit-pca9685-pip:
@@ -50,13 +44,7 @@ autograd-pip:
     pip:
       packages: [autograd]
 python3-adafruit-servokit-pip:
-  debian:
-    pip:
-      packages: [adafruit-circuitpython-servokit]
-  fedora:
-    pip:
-      packages: [adafruit-circuitpython-servokit]
-  ubuntu:
+  '*':
     pip:
       packages: [adafruit-circuitpython-servokit]
 autolab-core-pip:
@@ -350,53 +338,23 @@ opcua-pip:
     pip:
       packages: [opcua]
 python3-opentelemetry-api-pip:
-  debian:
-    pip:
-      packages: [opentelemetry-api]
-  fedora:
-    pip:
-      packages: [opentelemetry-api]
-  ubuntu:
+  '*':
     pip:
       packages: [opentelemetry-api]
 python3-opentelemetry-exporter-otlp-pip:
-  debian:
-    pip:
-      packages: [opentelemetry-exporter-otlp]
-  fedora:
-    pip:
-      packages: [opentelemetry-exporter-otlp]
-  ubuntu:
+  '*':
     pip:
       packages: [opentelemetry-exporter-otlp]
 python3-opentelemetry-instrumentation-requests-pip:
-  debian:
-    pip:
-      packages: [opentelemetry-instrumentation-requests]
-  fedora:
-    pip:
-      packages: [opentelemetry-instrumentation-requests]
-  ubuntu:
+  '*':
     pip:
       packages: [opentelemetry-instrumentation-requests]
 python3-opentelemetry-instrumentation-sqlalchemy-pip:
-  debian:
-    pip:
-      packages: [opentelemetry-instrumentation-sqlalchemy]
-  fedora:
-    pip:
-      packages: [opentelemetry-instrumentation-sqlalchemy]
-  ubuntu:
+  '*':
     pip:
       packages: [opentelemetry-instrumentation-sqlalchemy]
 python3-opentelemetry-sdk-pip:
-  debian:
-    pip:
-      packages: [opentelemetry-sdk]
-  fedora:
-    pip:
-      packages: [opentelemetry-sdk]
-  ubuntu:
+  '*':
     pip:
       packages: [opentelemetry-sdk]
 paramiko:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -19,10 +19,6 @@ adafruit-mcp3008-pip:
   ubuntu:
     pip:
       packages: [Adafruit-MCP3008]
-python3-adafruit-circuitpython-motor-pip:
-  '*':
-    pip:
-      packages: [adafruit-circuitpython-motor]
 adafruit-pca9685-pip:
   debian:
     pip:
@@ -43,10 +39,6 @@ autograd-pip:
   ubuntu:
     pip:
       packages: [autograd]
-python3-adafruit-servokit-pip:
-  '*':
-    pip:
-      packages: [adafruit-circuitpython-servokit]
 autolab-core-pip:
   ubuntu:
     pip:
@@ -337,26 +329,6 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
-python3-opentelemetry-api-pip:
-  '*':
-    pip:
-      packages: [opentelemetry-api]
-python3-opentelemetry-exporter-otlp-pip:
-  '*':
-    pip:
-      packages: [opentelemetry-exporter-otlp]
-python3-opentelemetry-instrumentation-requests-pip:
-  '*':
-    pip:
-      packages: [opentelemetry-instrumentation-requests]
-python3-opentelemetry-instrumentation-sqlalchemy-pip:
-  '*':
-    pip:
-      packages: [opentelemetry-instrumentation-sqlalchemy]
-python3-opentelemetry-sdk-pip:
-  '*':
-    pip:
-      packages: [opentelemetry-sdk]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]
@@ -4809,6 +4781,10 @@ python3-adafruit-circuitpython-mcp230xx-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-mcp230xx]
+python3-adafruit-circuitpython-motor-pip:
+  '*':
+    pip:
+      packages: [adafruit-circuitpython-motor]
 python3-adafruit-circuitpython-mpu6050-pip:
   debian:
     pip:
@@ -4819,6 +4795,10 @@ python3-adafruit-circuitpython-mpu6050-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-mpu6050]
+python3-adafruit-servokit-pip:
+  '*':
+    pip:
+      packages: [adafruit-circuitpython-servokit]
 python3-adapt-parser-pip:
   debian:
     pip:
@@ -7406,6 +7386,26 @@ python3-openhsi-pip:
   ubuntu:
     pip:
       packages: [openhsi]
+python3-opentelemetry-api-pip:
+  '*':
+    pip:
+      packages: [opentelemetry-api]
+python3-opentelemetry-exporter-otlp-pip:
+  '*':
+    pip:
+      packages: [opentelemetry-exporter-otlp]
+python3-opentelemetry-instrumentation-requests-pip:
+  '*':
+    pip:
+      packages: [opentelemetry-instrumentation-requests]
+python3-opentelemetry-instrumentation-sqlalchemy-pip:
+  '*':
+    pip:
+      packages: [opentelemetry-instrumentation-sqlalchemy]
+python3-opentelemetry-sdk-pip:
+  '*':
+    pip:
+      packages: [opentelemetry-sdk]
 python3-orjson:
   # Replace pip packages with native packages when this bug is resolved:
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1002996

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -19,7 +19,7 @@ adafruit-mcp3008-pip:
   ubuntu:
     pip:
       packages: [Adafruit-MCP3008]
-adafruit-circuitpython-motor-pip:
+python3-adafruit-circuitpython-motor-pip:
   debian:
     pip:
       packages: [adafruit-circuitpython-motor]
@@ -29,7 +29,7 @@ adafruit-circuitpython-motor-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-motor]
-adafruit-pca9685-pip:
+python3-adafruit-pca9685-pip:
   debian:
     pip:
       packages: [adafruit-pca9685]
@@ -49,7 +49,7 @@ autograd-pip:
   ubuntu:
     pip:
       packages: [autograd]
-adafruit-servokit-pip:
+python3-adafruit-servokit-pip:
   debian:
     pip:
       packages: [adafruit-circuitpython-servokit]
@@ -349,7 +349,7 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
-opentelemetry-api-pip:
+python3-opentelemetry-api-pip:
   debian:
     pip:
       packages: [opentelemetry-api]
@@ -359,7 +359,7 @@ opentelemetry-api-pip:
   ubuntu:
     pip:
       packages: [opentelemetry-api]
-opentelemetry-exporter-otlp-pip:
+python3-opentelemetry-exporter-otlp-pip:
   debian:
     pip:
       packages: [opentelemetry-exporter-otlp]
@@ -369,7 +369,7 @@ opentelemetry-exporter-otlp-pip:
   ubuntu:
     pip:
       packages: [opentelemetry-exporter-otlp]
-opentelemetry-instrumentation-requests-pip:
+python3-opentelemetry-instrumentation-requests-pip:
   debian:
     pip:
       packages: [opentelemetry-instrumentation-requests]
@@ -379,7 +379,7 @@ opentelemetry-instrumentation-requests-pip:
   ubuntu:
     pip:
       packages: [opentelemetry-instrumentation-requests]
-opentelemetry-instrumentation-sqlalchemy-pip:
+python3-opentelemetry-instrumentation-sqlalchemy-pip:
   debian:
     pip:
       packages: [opentelemetry-instrumentation-sqlalchemy]
@@ -389,7 +389,7 @@ opentelemetry-instrumentation-sqlalchemy-pip:
   ubuntu:
     pip:
       packages: [opentelemetry-instrumentation-sqlalchemy]
-opentelemetry-sdk-pip:
+python3-opentelemetry-sdk-pip:
   debian:
     pip:
       packages: [opentelemetry-sdk]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -19,6 +19,16 @@ adafruit-mcp3008-pip:
   ubuntu:
     pip:
       packages: [Adafruit-MCP3008]
+adafruit-circuitpython-motor-pip:
+  debian:
+    pip:
+      packages: [adafruit-circuitpython-motor]
+  fedora:
+    pip:
+      packages: [adafruit-circuitpython-motor]
+  ubuntu:
+    pip:
+      packages: [adafruit-circuitpython-motor]
 adafruit-pca9685-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,7 +29,7 @@ python3-adafruit-circuitpython-motor-pip:
   ubuntu:
     pip:
       packages: [adafruit-circuitpython-motor]
-python3-adafruit-pca9685-pip:
+adafruit-pca9685-pip:
   debian:
     pip:
       packages: [adafruit-pca9685]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,16 +29,6 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
-adafruit-servokit-pip:
-  debian:
-    pip:
-      packages: [adafruit-circuitpython-servokit]
-  fedora:
-    pip:
-      packages: [adafruit-circuitpython-servokit]
-  ubuntu:
-    pip:
-      packages: [adafruit-circuitpython-servokit]
 autograd-pip:
   debian:
     pip:
@@ -49,6 +39,16 @@ autograd-pip:
   ubuntu:
     pip:
       packages: [autograd]
+adafruit-servokit-pip:
+  debian:
+    pip:
+      packages: [adafruit-circuitpython-servokit]
+  fedora:
+    pip:
+      packages: [adafruit-circuitpython-servokit]
+  ubuntu:
+    pip:
+      packages: [adafruit-circuitpython-servokit]
 autolab-core-pip:
   ubuntu:
     pip:
@@ -339,6 +339,36 @@ opcua-pip:
   ubuntu:
     pip:
       packages: [opcua]
+opentelemetry-api-pip:
+  debian:
+    pip:
+      packages: [opentelemetry-api]
+  fedora:
+    pip:
+      packages: [opentelemetry-api]
+  ubuntu:
+    pip:
+      packages: [opentelemetry-api]
+opentelemetry-exporter-otlp-pip:
+  debian:
+    pip:
+      packages: [opentelemetry-exporter-otlp]
+  fedora:
+    pip:
+      packages: [opentelemetry-exporter-otlp]
+  ubuntu:
+    pip:
+      packages: [opentelemetry-exporter-otlp]
+opentelemetry-sdk-pip:
+  debian:
+    pip:
+      packages: [opentelemetry-sdk]
+  fedora:
+    pip:
+      packages: [opentelemetry-sdk]
+  ubuntu:
+    pip:
+      packages: [opentelemetry-sdk]
 paramiko:
   alpine: [py-paramiko]
   arch: [python2-paramiko]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -359,6 +359,26 @@ opentelemetry-exporter-otlp-pip:
   ubuntu:
     pip:
       packages: [opentelemetry-exporter-otlp]
+opentelemetry-instrumentation-requests-pip:
+  debian:
+    pip:
+      packages: [opentelemetry-instrumentation-requests]
+  fedora:
+    pip:
+      packages: [opentelemetry-instrumentation-requests]
+  ubuntu:
+    pip:
+      packages: [opentelemetry-instrumentation-requests]
+opentelemetry-instrumentation-sqlalchemy-pip:
+  debian:
+    pip:
+      packages: [opentelemetry-instrumentation-sqlalchemy]
+  fedora:
+    pip:
+      packages: [opentelemetry-instrumentation-sqlalchemy]
+  ubuntu:
+    pip:
+      packages: [opentelemetry-instrumentation-sqlalchemy]
 opentelemetry-sdk-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependencies to the rosdep database.

## Package name:

* adafruit-servokit-pip
* opentelemetry-api-pip
* opentelemetry-exporter-otlp-pip
* opentelemetry-sdk-pip

## Package Upstream Source:

* https://github.com/adafruit/Adafruit_CircuitPython_ServoKit
* https://github.com/open-telemetry/opentelemetry-python

## Purpose of using this:

These dependencies are proposed for the following reasons:
1. Adafruit ServoKit allows for control of standard hobby servos via the I2C PCA9685 driver boards, enabling small robot arms to be controlled via ROS easily on a Raspberry Pi or similar device
2. [Open Telemetry](https://www.opentelemetry.io) is rapidly becoming the defacto standard for monitoring software performance across the IT industry.  Adding these libraries enables us to visualise the interactions between ROS components in standard observability tooling such as Grafana, Honeycomb.io, or DataDog

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - N/A - Python Pip Packge
- Ubuntu: https://packages.ubuntu.com/
  - N/A - Python Pip Packge
- Fedora: https://packages.fedoraproject.org/
  - N/A - Python Pip Packge
- Arch: https://www.archlinux.org/packages/
  - N/A - Python Pip Packge
- Gentoo: https://packages.gentoo.org/
  - N/A - Python Pip Packge
- macOS: https://formulae.brew.sh/
  - N/A - Python Pip Packge
- Alpine: https://pkgs.alpinelinux.org/packages
  - N/A - Python Pip Packge
- NixOS/nixpkgs: https://search.nixos.org/packages
  - N/A - Python Pip Packge
- openSUSE: https://software.opensuse.org/package/
  - N/A - Python Pip Packge
- rhel: https://rhel.pkgs.org/
  - N/A - Python Pip Packge