### PR TITLE
ortools_vendor: 9.9.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7291,8 +7291,8 @@ repositories:
   ortools_vendor:
     doc:
       type: git
-      url: https://github.com/google/or-tools.git
-      version: v9.9
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: main
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -7300,8 +7300,8 @@ repositories:
       version: 9.9.0-5
     source:
       type: git
-      url: https://github.com/google/or-tools.git
-      version: v9.9      
+      url: https://github.com/Fields2Cover/ortools_vendor.git
+      version: main
   osqp_vendor:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7289,11 +7289,19 @@ repositories:
       version: master
     status: developed
   ortools_vendor:
+    doc:
+      type: git
+      url: https://github.com/google/or-tools.git
+      version: v9.9
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-2
+      version: 9.9.0-5
+    source:
+      type: git
+      url: https://github.com/google/or-tools.git
+      version: v9.9      
   osqp_vendor:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7288,6 +7288,12 @@ repositories:
       url: https://github.com/Jmeyer1292/opw_kinematics.git
       version: master
     status: developed
+  ortools_vendor:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/ortools_vendor-release.git
+      version: 9.9.0-2
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.0-2`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/ros2-gbp/ortools_vendor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
