### PR TITLE
Revert "perception_pcl: 2.4.3-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5215,7 +5215,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.4.3-1
+      version: 2.4.0-6
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#40477

I believe this is causing a regression in some downstream packages.

Here's an error from [`ros2_ouster`](https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__ros2_ouster__ubuntu_jammy_amd64__binary/).

```
-- Found pcl_conversions: 2.4.3 (/opt/ros/humble/share/pcl_conversions/cmake)
CMake Error at /opt/ros/humble/share/pcl_conversions/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  By not providing "FindPCL.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "PCL", but
  CMake did not find one.

  Could not find a package configuration file provided by "PCL" with any of
  the following names:

    PCLConfig.cmake
    pcl-config.cmake

  Add the installation prefix of "PCL" to CMAKE_PREFIX_PATH or set "PCL_DIR"
  to a directory containing one of the above files.  If "PCL" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /opt/ros/humble/share/pcl_conversions/cmake/pcl_conversionsConfig.cmake:41 (include)
  CMakeLists.txt:21 (find_package)
```

Here's some context from @sloretz:
> Probably in pcl_conversions the rosdep key  libpcl-all-dev should also be a build_export_depend at a minimum, https://github.com/ros-perception/perception_pcl/blob/7e3401c96a9f58861693917f479f43ff3521f3c1/pcl_conversions/package.xml#L24C17-L24C31

and 

> The key resolves to libpcl-dev on Ubuntu, and that includes an uppercase PCLConfig.cmake which matches the PCL added to ament_export_dependencies()  https://packages.ubuntu.com/focal/amd64/libpcl-dev/filelist

FYI, @SteveMacenski 