### PR TITLE
omni_base_simulation: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4907,6 +4907,24 @@ repositories:
       url: https://github.com/pal-robotics/omni_base_robot.git
       version: humble-devel
     status: developed
+  omni_base_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/omni_base_simulation.git
+      version: humble-devel
+    release:
+      packages:
+      - omni_base_gazebo
+      - omni_base_simulation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/omni_base_simulation-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/omni_base_simulation.git
+      version: humble-devel
+    status: developed
   ompl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_simulation` to `2.0.3-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_simulation.git
- release repository: https://github.com/pal-gbp/omni_base_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## omni_base_gazebo

```
* Merge branch 'omm/feat/public_sim_control' into 'humble-devel'
  is_public_sim check
  See merge request robots/omni_base_simulation!15
* Using new launch action
* Contributors: Oscar, davidterkuile
```

## omni_base_simulation

- No changes
