### PR TITLE
image_common: 5.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2400,7 +2400,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.1-1
+      version: 5.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.2-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `5.1.1-1`

## camera_calibration_parsers

```
* Update to yaml-cpp 0.8.0. (#305 <https://github.com/ros-perception/image_common/issues/305>)
* Contributors: Chris Lalancette
```

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

- No changes
