### PR TITLE
uncrustify_vendor: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7659,7 +7659,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
-      version: 2.2.1-2
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `uncrustify_vendor` to `3.0.0-1`:

- upstream repository: https://github.com/ament/uncrustify_vendor.git
- release repository: https://github.com/ros2-gbp/uncrustify_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-2`

## uncrustify_vendor

```
* Update to uncrustify 0.78.1 (#37 <https://github.com/ament/uncrustify_vendor/issues/37>)
  * Update to uncrustify 0.78.1
  * Fix the uncrustify version detection logic.
  And make sure we are at least 0.78.
* Contributors: Chris Lalancette
```
