### PR TITLE
resource_retriever: 3.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5093,7 +5093,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.4.0-2
+      version: 3.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.4.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.0-2`

## libcurl_vendor

- No changes

## resource_retriever

```
* Update resource retreiver to use rule of five (#95 <https://github.com/ros/resource_retriever/issues/95>)
* Use default ament_lint_auto (#92 <https://github.com/ros/resource_retriever/issues/92>)
* Contributors: Chris Lalancette, Michael Carroll
```
