### PR TITLE
yaml_cpp_vendor: 9.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8184,7 +8184,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.3.2-1
+      version: 9.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `9.0.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.3.2-1`

## yaml_cpp_vendor

```
* Upgrade to yaml-cpp 0.8.0 (#48 <https://github.com/ros2/yaml_cpp_vendor/issues/48>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Marco A. Gutierrez
```
