### PR TITLE
mp2p_icp: 1.3.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3396,7 +3396,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.3.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## mp2p_icp

```
* mm-viewer and icp-log-viewer: saves UI state in persistent user config file
* FIX: missing UI refresh when clicking showPairings checkbox
* renamed apps for less verbose names: icp-run, icp-log-viewer
* ICP core now defines a variable ICP_ITERATION for use in programmable formulas in pipelines
* icp-log-viewer: much faster rendering of ICP iteration details
* mm-viewer: fix bug in calculation of bounding box
* Merge docs with main MOLA repo
* Contributors: Jose Luis Blanco-Claraco
```
