### PR TITLE
launch: 3.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2778,7 +2778,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.2-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.1-1`

## launch

```
* (launch) fix describe of PathJoinSubstitution (#771 <https://github.com/ros2/launch/issues/771>)
* Contributors: Matthijs van der Burgh
```

## launch_pytest

- No changes

## launch_testing

```
* Fix a warning in modern unittest. (#773 <https://github.com/ros2/launch/issues/773>)
  Newer versions of unittest no longer store an errors
  list; instead, they store a result, which then stores
  an error list.  Update the code here to be able to deal
  with either version.
* Contributors: Chris Lalancette
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
