### PR TITLE
pybind11_vendor: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4606,7 +4606,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.1.1-2
+      version: 3.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `3.1.2-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.1-2`

## pybind11_vendor

```
* Update to pybind11 2.11.1 (#28 <https://github.com/ros2/pybind11_vendor/issues/28>)
* Add Apache 2.0 LICENSE file (#27 <https://github.com/ros2/pybind11_vendor/issues/27>)
* Contributors: Chris Lalancette, Michael Carroll
```
