### PR TITLE
rcl: 9.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4847,7 +4847,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.2.0-1
+      version: 9.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.2.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.2.0-1`

## rcl

```
* chore: Minor style improvements (#1147 <https://github.com/ros2/rcl/issues/1147>)
  Co-authored-by: Janosch Machowinski <mailto:J.Machowinski@cellumation.com>
* improved rcl_wait in the area of timeout computation and spurious wakeups (#1146 <https://github.com/ros2/rcl/issues/1146>)
  Added special handling for timers with a clock that has time override
  enabled. For these timer we should not compute a timeout, as the waitset
  is waken up by the associated guard condition.
  Before this change, the waitset could wait up, because of an expected ready
  timer, that was acutally not ready, as the time update to the ROS_TIME had
  not yet arrived.
* Add tracepoint for publish_serialized_publish (#1136 <https://github.com/ros2/rcl/issues/1136>)
  * Add tracepoint for publish_serialized_publish
  * Add: tracepoint for rcl_take_serialized_message
  ---------
* Revert "improved rcl_wait in the area of timeout computation and spurious wakeups (#1135 <https://github.com/ros2/rcl/issues/1135>)" (#1142 <https://github.com/ros2/rcl/issues/1142>)
  This reverts commit 3c6c5dc47dac23d70722a60b2c0a387d2e71b71d.
* improved rcl_wait in the area of timeout computation and spurious wakeups (#1135 <https://github.com/ros2/rcl/issues/1135>)
  * feat: Allow usage of rcl_timer_clock with const rcl_timer_t*
  * fix: Fixed purious wake-ups on ROS_TIME timers with ROS_TIME enabled
  Added special handling for timers with a clock that has time override
  enabled. For theses timer we should not compute a timeout, as the waitset
  is waken up by the associated guard condition.
  Before this change, the waitset could wait up, because of an expected ready
  timer, that was acutally not ready, as the time update to the ROS_TIME had
  not yet arrived.
  * feat: Added rcl_timer_get_next_call_time
  * fix(rcl_wait): Improved timeout computation in case of many timers
  This commit changes the computation of the timer timeout, to be more
  precise, in the case, of many registered timers.
  ---------
  Co-authored-by: Janosch Machowinski <mailto:j.machowinski@nospam.org>
* Generate version header using ament_generate_version_header(..) (#1141 <https://github.com/ros2/rcl/issues/1141>)
* Contributors: Chris Lalancette, G.A. vd. Hoorn, h-suzuki-isp, jmachowinski
```

## rcl_action

```
* Generate version header using ament_generate_version_header(..) (#1141 <https://github.com/ros2/rcl/issues/1141>)
* Contributors: G.A. vd. Hoorn
```

## rcl_lifecycle

```
* Generate version header using ament_generate_version_header(..) (#1141 <https://github.com/ros2/rcl/issues/1141>)
* Contributors: G.A. vd. Hoorn
```

## rcl_yaml_param_parser

```
* Generate version header using ament_generate_version_header(..) (#1141 <https://github.com/ros2/rcl/issues/1141>)
* Contributors: G.A. vd. Hoorn
```
