### PR TITLE
rclpy: 7.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4963,7 +4963,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.1.0-1
+      version: 7.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.1.0-1`

## rclpy

```
* Clock.py types. (#1244 <https://github.com/ros2/rclpy/issues/1244>)
  * Start typing time.py
  * Testing out Enum wrapper for ClockType
  * convert to rcl_clock_type_t
  * Update create_time_point
  * add types to logging_service
  * Add types to duration.py
  * Add newlines for class definintions
  * update type alias name
  * Update to use Protocols
  * Add types to time.py
  * Add types
  * Fix import order
  * Started typing clock.py
  * Move typealias import
* pybind11 definition doc typo fixes. (#1270 <https://github.com/ros2/rclpy/issues/1270>)
* Fix small flake8 error in rclpy. (#1267 <https://github.com/ros2/rclpy/issues/1267>)
  Newer versions of flake8 complain that using 'str' as a
  variable shadows a builtin.  Just make it 's'.
* Contributors: Chris Lalancette, Michael Carlstrom, Tomoya Fujita
```
