### PR TITLE
robot_localization: 3.7.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5570,7 +5570,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.5.0-3
+      version: 3.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.7.0-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.0-3`

## robot_localization

```
* TF Prefix Bug (#876 <https://github.com/cra-ros-pkg/robot_localization/issues/876>)
* Update ukf.yaml to match ekf.yaml (#867 <https://github.com/cra-ros-pkg/robot_localization/issues/867>)
  Add missing *_pose_use_child_frame parameter.
* Fix throttle duration (#866 <https://github.com/cra-ros-pkg/robot_localization/issues/866>)
  * Fix throttle duration
* Migrate static tfs to ros2 format. (#864 <https://github.com/cra-ros-pkg/robot_localization/issues/864>)
* Update issue templates
* Feature/set utm service (#856 <https://github.com/cra-ros-pkg/robot_localization/issues/856>)
  * Forward port Fix/set utm map frame change
  ---------
* fix: modify dual_ekf_navsat_example.launch file to remap the correct imu topic (#857 <https://github.com/cra-ros-pkg/robot_localization/issues/857>)
* fix header timestamp (#852 <https://github.com/cra-ros-pkg/robot_localization/issues/852>)
  Co-authored-by: Luke Chang <mailto:luke@boxfish.nz>
* Wait for odometry message before setting manual datum so that the base and world frame names can be set. (#836 <https://github.com/cra-ros-pkg/robot_localization/issues/836>)
  * wait for odom msg before setting manual datum
* Test navsat transform functionality (#838 <https://github.com/cra-ros-pkg/robot_localization/issues/838>)
* Utm using geographiclib ros2 branch (#833 <https://github.com/cra-ros-pkg/robot_localization/issues/833>)
  * Add single test for navsat_conversions
  * Add a southern point to the navsat_transform test
  * LLtoUTM using GeographicLib
  * Use GeographicLib for UTMtoLL conversions
  * Linting
  * Forgot include
  * Fix compilation
  * Calculate gamma because it's a function output and was supplied before
  * Also test for gamma conversion
  * Align naming and install
* bugfix (#809 <https://github.com/cra-ros-pkg/robot_localization/issues/809>): check if covariance values are specified or not (#810 <https://github.com/cra-ros-pkg/robot_localization/issues/810>)
* Contributors: Daisuke Sato, Luke Chang, Mukunda Bharatheesha, Tim Clephas, Tom Greier, Tom Moore, joeldushouyu, rafal-gorecki, thandal
```
