### PR TITLE
robot_localization: 3.5.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6770,7 +6770,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.5.2-1
+      version: 3.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.5.3-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.2-1`

## robot_localization

```
* TF Prefix Bug (#876 <https://github.com/cra-ros-pkg/robot_localization/issues/876>)
* Fixing angle clamping for humble (#854 <https://github.com/cra-ros-pkg/robot_localization/issues/854>)
* Contributors: Tom Moore, rafal-gorecki
```
