### PR TITLE
robot_localization: 2.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9087,7 +9087,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.7.5-1
+      version: 2.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `2.7.6-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/cra-ros-pkg/robot_localization-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.5-1`

## robot_localization

```
* Updating issue templates
* Fixing angle clamping in Noetic (#855 <https://github.com/cra-ros-pkg/robot_localization/issues/855>)
* Contributors: Tom Moore
```
