### PR TITLE
rcpputils: 2.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4979,7 +4979,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.10.0-2
+      version: 2.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.11.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.0-2`

## rcpputils

```
* Generate version header with ament_generate_version_header function (#190 <https://github.com/ros2/rcpputils/issues/190>)
* Update docs for rcpputils::split functions (#188 <https://github.com/ros2/rcpputils/issues/188>)
* Contributors: Christophe Bedard, Sai Kishor Kothakota
```
