### PR TITLE
rcutils: 6.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5030,7 +5030,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.6.0-1
+      version: 6.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.7.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.6.0-1`

## rcutils

```
* validate the allocator before use. (#455 <https://github.com/ros2/rcutils/issues/455>)
  * validate the allocator before use.
  * address review comments.
  - validate allocator only if the function specifically uses.
  - argument null check comes before validation of value.
  ---------
* Contributors: Tomoya Fujita
```
