### PR TITLE
rosidl_python: 0.22.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6165,7 +6165,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.21.2-1
+      version: 0.22.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.21.2-1`

## rosidl_generator_py

```
* Revert install of .so files into python path (#211 <https://github.com/ros2/rosidl_python/issues/211>)
  There seems that some regression might have happened after #195 <https://github.com/ros2/rosidl_python/issues/195>.
  When removing those 2 lines, we avoid to install the .so files
  in lib *and* python path.
* Contributors: Matthias Schoepfer
```
