### PR TITLE
rosidl_typesupport_fastrtps: 3.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6220,7 +6220,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.6.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.0-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Adding interfaces to support @key annotation (#116 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/116>)
  Co-authored-by: Mario Dominguez <mailto:mariodominguez@eprosima.com>
* Contributors: Miguel Company
```

## rosidl_typesupport_fastrtps_cpp

```
* Fix how header template works to prevent double-inclusion (#117 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/117>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Adding interfaces to support @key annotation (#116 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/116>)
  Co-authored-by: Mario Dominguez <mailto:mariodominguez@eprosima.com>
* Contributors: Michael Carroll, Miguel Company
```
