### PR TITLE
rviz: 14.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6766,7 +6766,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.0.0-1
+      version: 14.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Update the vendored package path. (#1184 <https://github.com/ros2/rviz/issues/1184>)
  Since we just updated to assimp 5.3, we also need to
  update the path we look for it.
  This should fix the build with clang which is currently
  failing.
* Update assimp vendor to 5.3.1 (#1182 <https://github.com/ros2/rviz/issues/1182>)
  This matches what is in Ubuntu 24.04.
* Contributors: Chris Lalancette
```

## rviz_common

```
* Update to yaml-cpp 0.8.0 (#1183 <https://github.com/ros2/rviz/issues/1183>)
  yaml-cpp 0.8.0 has a proper CMake target, i.e. yaml-cpp::yaml-cpp.
  Use that here.
* Contributors: Chris Lalancette
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
