### PR TITLE
rosidl: 4.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6059,7 +6059,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.5.2-1
+      version: 4.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.6.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.5.2-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

```
* Adding interfaces to support @key annotation (#796 <https://github.com/ros2/rosidl/issues/796>)
  Co-authored-by: Mario Dominguez <mailto:mariodominguez@eprosima.com>
* Contributors: Miguel Company
```

## rosidl_pycommon

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Adding interfaces to support @key annotation (#796 <https://github.com/ros2/rosidl/issues/796>)
  Co-authored-by: Mario Dominguez <mailto:mariodominguez@eprosima.com>
* Contributors: Miguel Company
```

## rosidl_typesupport_introspection_cpp

```
* Adding interfaces to support @key annotation (#796 <https://github.com/ros2/rosidl/issues/796>)
  Co-authored-by: Mario Dominguez <mailto:mariodominguez@eprosima.com>
* Contributors: Miguel Company
```
