### PR TITLE
ros2_tracing: 8.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5750,7 +5750,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.1.0-1
+      version: 8.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.1.0-1`

## lttngpy

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Fixes for newer uncrustify (#101 <https://github.com/ros2/ros2_tracing/issues/101>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## ros2trace

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Contributors: Chris Lalancette
```

## tracetools

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Switch to ament_generate_version_header for tracetools (#112 <https://github.com/ros2/ros2_tracing/issues/112>)
* Fixes for newer uncrustify (#101 <https://github.com/ros2/ros2_tracing/issues/101>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## tracetools_launch

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Contributors: Chris Lalancette
```

## tracetools_read

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Improve tracetools_test and simplify test_tracetools code (#109 <https://github.com/ros2/ros2_tracing/issues/109>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## tracetools_test

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Improve tracetools_test and simplify test_tracetools code (#109 <https://github.com/ros2/ros2_tracing/issues/109>)
* Improve assertEventOrder failure output (#106 <https://github.com/ros2/ros2_tracing/issues/106>)
* Contributors: Chris Lalancette, Christophe Bedard
```

## tracetools_trace

```
* Replace all occurences of index.ros.org (#114 <https://github.com/ros2/ros2_tracing/issues/114>)
* Contributors: Chris Lalancette
```
