### PR TITLE
rclcpp: 28.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4947,7 +4947,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.0.0-1
+      version: 28.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `28.0.0-1`

## rclcpp

```
* Remove references to index.ros.org. (#2504 <https://github.com/ros2/rclcpp/issues/2504>)
* Reduce overhead for inheriting from rclcpp::Executor when base functionality is not reused (#2506 <https://github.com/ros2/rclcpp/issues/2506>)
* Contributors: Chris Lalancette, William Woodall, jmachowinski
```

## rclcpp_action

```
* Remove references to index.ros.org. (#2504 <https://github.com/ros2/rclcpp/issues/2504>)
* Contributors: Chris Lalancette
```

## rclcpp_components

```
* Remove references to index.ros.org. (#2504 <https://github.com/ros2/rclcpp/issues/2504>)
* Contributors: Chris Lalancette
```

## rclcpp_lifecycle

```
* Remove references to index.ros.org. (#2504 <https://github.com/ros2/rclcpp/issues/2504>)
* Contributors: Chris Lalancette
```
