### PR TITLE
add libmysql++3v5 and libmysql++-dev in 'rosdep/base.yml'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4374,16 +4374,16 @@ libmsgsl-dev:
   ubuntu: [libmsgsl-dev]
 libmysql++-dev:
   debian: [libmysql++-dev]
+  fedora: [mysql++-devel]
   ubuntu:
     focal: [libmysql++-dev]
     jammy: [libmysql++-dev]
-  fedora: [mysql++-devel]
 libmysql++3v5:
   debian: [libmysql++3v5]
+  fedora: [mysql++]
   ubuntu:
     focal: [libmysql++3v5]
     jammy: [libmysql++3v5]
-  fedora: [mysql++]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4381,9 +4381,7 @@ libmysql++-dev:
 libmysql++3v5:
   debian: [libmysql++3v5]
   fedora: [mysql++]
-  ubuntu:
-    focal: [libmysql++3v5]
-    jammy: [libmysql++3v5]
+  ubuntu: [libmysql++3v5]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4372,16 +4372,6 @@ libmsgsl-dev:
   fedora: [guidelines-support-library-devel]
   gentoo: [dev-cpp/ms-gsl]
   ubuntu: [libmsgsl-dev]
-libmysql++-dev:
-  debian: [libmysql++-dev]
-  ubuntu:
-    focal: [libmysql++-dev]
-    jammy: [libmysql++-dev]
-libmysql++3v5:
-  debian: [libmysql++3v5]
-  ubuntu:
-    focal: [libmysql++3v5]
-    jammy: [libmysql++3v5]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]
@@ -6960,6 +6950,18 @@ muparser:
   nixos: [muparser]
   opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
+mysql++-dev:
+  debian: [libmysql++-dev]
+  ubuntu:
+    focal: [libmysql++-dev]
+    jammy: [libmysql++-dev]
+  fedora: [mysql++-devel]
+mysql++3v5:
+  debian: [libmysql++3v5]
+  ubuntu:
+    focal: [libmysql++3v5]
+    jammy: [libmysql++3v5]
+  fedora: [mysql++]
 nanoflann:
   debian:
     '*': [libnanoflann-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4372,6 +4372,18 @@ libmsgsl-dev:
   fedora: [guidelines-support-library-devel]
   gentoo: [dev-cpp/ms-gsl]
   ubuntu: [libmsgsl-dev]
+libmysql++3v5:
+  debian: [libmysql++3v5]
+  ubuntu:
+    focal: [libmysql++3v5]
+    jammy: [libmysql++3v5]
+    noble: [libmysql++3v5]
+libmysql++-dev:
+  debian: [libmysql++-dev]
+  ubuntu:
+    focal: [libmysql++-dev]
+    jammy: [libmysql++-dev]
+    noble: [libmysql++-dev]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4372,6 +4372,18 @@ libmsgsl-dev:
   fedora: [guidelines-support-library-devel]
   gentoo: [dev-cpp/ms-gsl]
   ubuntu: [libmsgsl-dev]
+libmysql++-dev:
+  debian: [libmysql++-dev]
+  ubuntu:
+    focal: [libmysql++-dev]
+    jammy: [libmysql++-dev]
+  fedora: [mysql++-devel]
+libmysql++3v5:
+  debian: [libmysql++3v5]
+  ubuntu:
+    focal: [libmysql++3v5]
+    jammy: [libmysql++3v5]
+  fedora: [mysql++]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]
@@ -6950,18 +6962,6 @@ muparser:
   nixos: [muparser]
   opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
-mysql++-dev:
-  debian: [libmysql++-dev]
-  ubuntu:
-    focal: [libmysql++-dev]
-    jammy: [libmysql++-dev]
-  fedora: [mysql++-devel]
-mysql++3v5:
-  debian: [libmysql++3v5]
-  ubuntu:
-    focal: [libmysql++3v5]
-    jammy: [libmysql++3v5]
-  fedora: [mysql++]
 nanoflann:
   debian:
     '*': [libnanoflann-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4372,16 +4372,16 @@ libmsgsl-dev:
   fedora: [guidelines-support-library-devel]
   gentoo: [dev-cpp/ms-gsl]
   ubuntu: [libmsgsl-dev]
-libmysql++3v5:
-  debian: [libmysql++3v5]
-  ubuntu:
-    focal: [libmysql++3v5]
-    jammy: [libmysql++3v5]
 libmysql++-dev:
   debian: [libmysql++-dev]
   ubuntu:
     focal: [libmysql++-dev]
     jammy: [libmysql++-dev]
+libmysql++3v5:
+  debian: [libmysql++3v5]
+  ubuntu:
+    focal: [libmysql++3v5]
+    jammy: [libmysql++3v5]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4375,13 +4375,13 @@ libmsgsl-dev:
 libmysql++-dev:
   debian: [libmysql++-dev]
   fedora: [mysql++-devel]
-  ubuntu:
-    focal: [libmysql++-dev]
-    jammy: [libmysql++-dev]
+  ubuntu: [libmysql++-dev]
 libmysql++3v5:
   debian: [libmysql++3v5]
   fedora: [mysql++]
-  ubuntu: [libmysql++3v5]
+  ubuntu:
+    focal: [libmysql++3v5]
+    jammy: [libmysql++3v5]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4377,13 +4377,11 @@ libmysql++3v5:
   ubuntu:
     focal: [libmysql++3v5]
     jammy: [libmysql++3v5]
-    noble: [libmysql++3v5]
 libmysql++-dev:
   debian: [libmysql++-dev]
   ubuntu:
     focal: [libmysql++-dev]
     jammy: [libmysql++-dev]
-    noble: [libmysql++-dev]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4375,15 +4375,11 @@ libmsgsl-dev:
 libmysql++-dev:
   debian: [libmysql++-dev]
   fedora: [mysql++-devel]
-  ubuntu:
-    focal: [libmysql++-dev]
-    jammy: [libmysql++-dev]
+  ubuntu: [libmysql++-dev]
 libmysql++3v5:
   debian: [libmysql++3v5]
   fedora: [mysql++]
-  ubuntu:
-    focal: [libmysql++3v5]
-    jammy: [libmysql++3v5]
+  ubuntu: [libmysql++3v5]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4375,11 +4375,15 @@ libmsgsl-dev:
 libmysql++-dev:
   debian: [libmysql++-dev]
   fedora: [mysql++-devel]
-  ubuntu: [libmysql++-dev]
+  ubuntu:
+    focal: [libmysql++-dev]
+    jammy: [libmysql++-dev]
 libmysql++3v5:
   debian: [libmysql++3v5]
   fedora: [mysql++]
-  ubuntu: [libmysql++3v5]
+  ubuntu:
+    focal: [libmysql++3v5]
+    jammy: [libmysql++3v5]
 libmysqlclient-dev:
   arch: [mariadb]
   debian: [libmysqlclient-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- `libmysql++3v5`
- `libmysql++-dev`

## Package Upstream Source:

[https://tangentsoft.com/mysqlpp](https://tangentsoft.com/mysqlpp)

## Purpose of using this:

Useful package to connect with mariadb or mysql with c++ nodes.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [https://packages.debian.org/sid/libmysql++3v5](https://packages.debian.org/sid/libmysql++3v5)
  - [https://packages.debian.org/trixie/libmysql++3v5](https://packages.debian.org/trixie/libmysql++3v5)
  - [https://packages.debian.org/bookworm/libmysql++3v5](https://packages.debian.org/bookworm/libmysql++3v5)
  - [https://packages.debian.org/bullseye/libmysql++3v5](https://packages.debian.org/bullseye/libmysql++3v5)
  - [https://packages.debian.org/sid/libmysql++-dev](https://packages.debian.org/sid/libmysql++-dev)
  - [https://packages.debian.org/trixie/libmysql++-dev](https://packages.debian.org/trixie/libmysql++-dev)
  - [https://packages.debian.org/bookworm/libmysql++-dev](https://packages.debian.org/bookworm/libmysql++-dev)
  - [https://packages.debian.org/bullseye/libmysql++-dev](https://packages.debian.org/bullseye/libmysql++-dev)
- Ubuntu: https://packages.ubuntu.com/
  - [https://packages.ubuntu.com/focal/libs/libmysql++3v5](https://packages.ubuntu.com/focal/libs/libmysql++3v5)
  - [https://packages.ubuntu.com/jammy/libs/libmysql++3v5](https://packages.ubuntu.com/jammy/libs/libmysql++3v5)
  - [https://packages.ubuntu.com/noble/libs/libmysql++3v5](https://packages.ubuntu.com/noble/libs/libmysql++3v5)
  - [https://packages.ubuntu.com/focal/libs/libmysql++-dev](https://packages.ubuntu.com/focal/libs/libmysql++-dev)
  - [https://packages.ubuntu.com/jammy/libs/libmysql++-dev](https://packages.ubuntu.com/jammy/libs/libmysql++-dev)
  - [https://packages.ubuntu.com/noble/libs/libmysql++-dev](https://packages.ubuntu.com/noble/libs/libmysql++-dev)