### PR TITLE
rosbag2: 0.26.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5972,6 +5972,7 @@ repositories:
       version: rolling
     release:
       packages:
+      - liblz4_vendor
       - mcap_vendor
       - ros2bag
       - rosbag2
@@ -5998,7 +5999,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.25.0-1
+      version: 0.26.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.25.0-1`

## liblz4_vendor

```
* Switch to using ament_vendor_package for lz4. (#1583 <https://github.com/ros2/rosbag2/issues/1583>)
* Contributors: Chris Lalancette
```

## mcap_vendor

```
* Switch to using ament_vendor_package for lz4. (#1583 <https://github.com/ros2/rosbag2/issues/1583>)
* Contributors: Chris Lalancette
```

## ros2bag

```
* Add option to disable recorder keyboard controls (#1607 <https://github.com/ros2/rosbag2/issues/1607>)
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Added exclude-topic-types to record (#1582 <https://github.com/ros2/rosbag2/issues/1582>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Bernd Pfrommer, Michael Orlov
```

## rosbag2

- No changes

## rosbag2_compression

```
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Contributors: jmachowinski
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Update to use yaml-cpp version 0.8.0. (#1605 <https://github.com/ros2/rosbag2/issues/1605>)
* Contributors: Barry Xu, Chris Lalancette, jmachowinski, Michael Orlov
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

```
* Add node name to the Read(Write)SplitEvent message (#1609 <https://github.com/ros2/rosbag2/issues/1609>)
* Contributors: Michael Orlov
```

## rosbag2_performance_benchmarking

```
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Update to use yaml-cpp version 0.8.0. (#1605 <https://github.com/ros2/rosbag2/issues/1605>)
* Contributors: Chris Lalancette, jmachowinski
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Add option to disable recorder keyboard controls (#1607 <https://github.com/ros2/rosbag2/issues/1607>)
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Switch rclpy to be an exec_depend here. (#1606 <https://github.com/ros2/rosbag2/issues/1606>)
* Gracefully handle SIGINT and SIGTERM signals for play and burst CLI (#1557 <https://github.com/ros2/rosbag2/issues/1557>)
* Added exclude-topic-types to record (#1582 <https://github.com/ros2/rosbag2/issues/1582>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Bernd Pfrommer, Chris Lalancette, Michael Orlov, jmachowinski
```

## rosbag2_storage

```
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Update to use yaml-cpp version 0.8.0. (#1605 <https://github.com/ros2/rosbag2/issues/1605>)
* Contributors: Barry Xu, Chris Lalancette, jmachowinski
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Update to use yaml-cpp version 0.8.0. (#1605 <https://github.com/ros2/rosbag2/issues/1605>)
* Check existence of a file before passing it to the mcap reader (#1594 <https://github.com/ros2/rosbag2/issues/1594>)
* Contributors: Barry Xu, Chris Lalancette, Christopher Wecht, jmachowinski, Michael Orlov
```

## rosbag2_storage_sqlite3

```
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Update to use yaml-cpp version 0.8.0. (#1605 <https://github.com/ros2/rosbag2/issues/1605>)
* Contributors: Barry Xu, Chris Lalancette, jmachowinski, Michael Orlov
```

## rosbag2_test_common

```
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Contributors: Barry Xu
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Added exclude-topic-types to record (#1582 <https://github.com/ros2/rosbag2/issues/1582>)
* Contributors: Alejandro Hernández Cordero, jmachowinski
```

## rosbag2_transport

```
* Add node name to the Read(Write)SplitEvent message (#1609 <https://github.com/ros2/rosbag2/issues/1609>)
* Add option to disable recorder keyboard controls (#1607 <https://github.com/ros2/rosbag2/issues/1607>)
* Support service 2/2 --- rosbag2 service play (#1481 <https://github.com/ros2/rosbag2/issues/1481>)
* Use middleware send and receive timestamps from message_info during recording (#1531 <https://github.com/ros2/rosbag2/issues/1531>)
* Update to use yaml-cpp version 0.8.0. (#1605 <https://github.com/ros2/rosbag2/issues/1605>)
* Gracefully handle SIGINT and SIGTERM signals for play and burst CLI (#1557 <https://github.com/ros2/rosbag2/issues/1557>)
* Added exclude-topic-types to record (#1582 <https://github.com/ros2/rosbag2/issues/1582>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Bernd Pfrommer, Chris Lalancette, Michael Orlov, jmachowinski
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
