### PR TITLE
ros2_canopen: 0.2.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5586,7 +5586,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.8-2
+      version: 0.2.9-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.9-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.8-2`

## canopen

```
* Update maintainer list
* Update package.xml
* Add timeouts
* Contributors: Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_402_driver

```
* Update the lely_core_libraries hash to the latest.
* fix ci build error
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_base_driver

```
* Add timeouts
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_core

```
* Add timeouts
* Contributors: Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_fake_slaves

- No changes

## canopen_interfaces

- No changes

## canopen_master_driver

```
* Add timeouts
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_proxy_driver

- No changes

## canopen_ros2_control

- No changes

## canopen_ros2_controllers

- No changes

## canopen_tests

- No changes

## canopen_utils

- No changes

## lely_core_libraries

```
* Update the lely_core_libraries hash to the latest.
* Contributors: Chris Lalancette, Vishnuprasad Prachandabhanu
```
