### PR TITLE
Add python3-typeshed

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9519,9 +9519,16 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
-python3-typeshed:
+python3-types-pyyaml:
   debian: [python3-typeshed]
-  ubuntu: [python3-typeshed]
+  ubuntu: 
+    '*': [python3-typeshed]
+    focal:
+      pip:
+        packages: [types-pyyaml]
+  rhel:
+    pip:
+      packages: [types-pyyaml]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9514,8 +9514,10 @@ python3-types-pyyaml:
       pip:
         packages: [types-pyyaml]
   rhel:
-    pip:
-      packages: [types-pyyaml]
+    '*': [python3-types-pyyaml]
+    '8':
+      pip:
+        packages: [types-pyyaml]
 python3-typing-extensions:
   arch: [python-typing_extensions]
   debian: [python3-typing-extensions]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9505,6 +9505,19 @@ python3-typeguard-pip:
   ubuntu:
     pip:
       packages: [typeguard]
+python3-types-pyyaml:
+  debian: [python3-typeshed]
+  fedora:
+    pip:
+      packages: [types-pyyaml]
+  ubuntu: 
+    '*': [python3-typeshed]
+    focal:
+      pip:
+        packages: [types-pyyaml]
+  rhel:
+    pip:
+      packages: [types-pyyaml]
 python3-typing-extensions:
   arch: [python-typing_extensions]
   debian: [python3-typing-extensions]
@@ -9519,16 +9532,6 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
-python3-types-pyyaml:
-  debian: [python3-typeshed]
-  ubuntu: 
-    '*': [python3-typeshed]
-    focal:
-      pip:
-        packages: [types-pyyaml]
-  rhel:
-    pip:
-      packages: [types-pyyaml]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9508,7 +9508,7 @@ python3-typeguard-pip:
 python3-types-pyyaml:
   debian: [python3-typeshed]
   fedora: [python3-types-pyyaml]
-  ubuntu: 
+  ubuntu:
     '*': [python3-typeshed]
     focal:
       pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9519,13 +9519,9 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
-python3-types-pyyaml-pip:
-  debian:
-    pip:
-      packages: [types-pyyaml]
-  ubuntu:
-    pip:
-      packages: [types-pyyaml]
+python3-typeshed:
+  debian: [python3-typeshed]
+  ubuntu: [python3-typeshed]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9508,14 +9508,14 @@ python3-typeguard-pip:
 python3-types-pyyaml:
   debian: [python3-typeshed]
   fedora: [python3-types-pyyaml]
-  ubuntu:
-    '*': [python3-typeshed]
-    focal:
-      pip:
-        packages: [types-pyyaml]
   rhel:
     '*': [python3-types-pyyaml]
     '8':
+      pip:
+        packages: [types-pyyaml]
+  ubuntu:
+    '*': [python3-typeshed]
+    focal:
       pip:
         packages: [types-pyyaml]
 python3-typing-extensions:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9519,7 +9519,10 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
-python3-types-pyyaml:
+python3-types-pyyaml-pip:
+  debian:
+    pip:
+      packages: [types-pyyaml]
   ubuntu:
     pip:
       packages: [types-pyyaml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9507,9 +9507,7 @@ python3-typeguard-pip:
       packages: [typeguard]
 python3-types-pyyaml:
   debian: [python3-typeshed]
-  fedora:
-    pip:
-      packages: [types-pyyaml]
+  fedora: [python3-types-pyyaml]
   ubuntu: 
     '*': [python3-typeshed]
     focal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9519,6 +9519,10 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
+python3-types-pyyaml:
+  ubuntu:
+    pip:
+      packages: [types-pyyaml]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-typeshed

## Package Upstream Source:

https://github.com/python/typeshed

## Purpose of using this:

In the process of accomplishing https://github.com/ros2/rclpy/issues/1257 we need the types for pyyaml being used for mypy support.

# The source is here:

https://packages.ubuntu.com/jammy/amd64/python/python3-typeshed
https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=python3-typeshed
