### PR TITLE
ortools_vendor: 9.9.0-4 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4085,19 +4085,11 @@ repositories:
       version: iron
     status: developed
   ortools_vendor:
-    doc:
-      type: git
-      url: https://github.com/google/or-tools.git
-      version: v9.9
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
       version: 9.9.0-4
-    source:
-      type: git
-      url: https://github.com/google/or-tools.git
-      version: v9.9
   osqp_vendor:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4085,11 +4085,19 @@ repositories:
       version: iron
     status: developed
   ortools_vendor:
+    doc:
+      type: git
+      url: https://github.com/google/or-tools.git
+      version: v9.9
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-3
+      version: 9.9.0-4
+    source:
+      type: git
+      url: https://github.com/google/or-tools.git
+      version: v9.9
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.0-4`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/ros2-gbp/ortools_vendor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `9.9.0-3`
