### PR TITLE
ffmpeg_image_transport: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1907,7 +1907,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `1.1.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## ffmpeg_image_transport

```
* use appropriate header for cv_bridge
* Contributors: Bernd Pfrommer
```
