### PR TITLE
zbar_ros: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8201,7 +8201,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git
-      version: 0.4.0-3
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.5.0-1`:

- upstream repository: https://github.com/ros-drivers/zbar_ros.git
- release repository: https://github.com/ros2-gbp/zbar_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-3`

## zbar_ros

```
* Bump ros-tooling/setup-ros from 0.6 to 0.7 (#26 <https://github.com/ros-drivers/zbar_ros/issues/26>)
* updating CI for iron (#25 <https://github.com/ros-drivers/zbar_ros/issues/25>)
* Add iron ci and badges for CI (#23 <https://github.com/ros-drivers/zbar_ros/issues/23>)
* fix deprecated cv_bridge header file (#19 <https://github.com/ros-drivers/zbar_ros/issues/19>)
* adapt to split branches in CI (#22 <https://github.com/ros-drivers/zbar_ros/issues/22>)
* Remove galactic CI as it has reached EOL (#20 <https://github.com/ros-drivers/zbar_ros/issues/20>)
* add gif to readme, and minor improvements (#17 <https://github.com/ros-drivers/zbar_ros/issues/17>)
* Update tooling-ci.yaml (#15 <https://github.com/ros-drivers/zbar_ros/issues/15>)
* Add Paul as an author in package.xml (#13 <https://github.com/ros-drivers/zbar_ros/issues/13>)
* Revert "Update package.xml"
* Update package.xml
* Contributors: Kenji Brameld, dependabot[bot]
```
