### PR TITLE
rtshell: 3.0.1-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10827,7 +10827,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-2
+      version: 3.0.1-3
     source:
       type: git
       url: https://github.com/gbiggs/rtshell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-3`:

- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-2`
