### PR TITLE
cob_common: 0.7.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1096,14 +1096,12 @@ repositories:
       packages:
       - cob_actions
       - cob_common
-      - cob_description
       - cob_msgs
       - cob_srvs
-      - raw_description
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_common-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/4am-robotics/cob_common.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1105,7 +1105,7 @@ repositories:
     source:
       type: git
       url: https://github.com/4am-robotics/cob_common.git
-      version: kinetic_dev
+      version: noetic-devel
     status: maintained
   cob_control:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1091,7 +1091,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_common.git
-      version: kinetic_release_candidate
+      version: noetic-release-candidate
     release:
       packages:
       - cob_actions

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1107,6 +1107,24 @@ repositories:
       url: https://github.com/4am-robotics/cob_common.git
       version: noetic-devel
     status: maintained
+  cob_common_legacy:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_description
+      - raw_description
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/4am-robotics/cob_common-release.git
+      version: 0.7.10-1
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: kinetic_dev
+    status: end-of-life
   cob_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.11-1`:

- upstream repository: https://github.com/4am-robotics/cob_common.git
- release repository: https://github.com/4am-robotics/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.10-1`

## cob_actions

- No changes

## cob_common

```
* Merge pull request #308 <https://github.com/4am-robotics/cob_common/issues/308> from fmessmer/noetic-devel
  [ROS1] cob4 eol cleanup
* remove cob_description
* remove raw_description
* Contributors: Felix Messmer, fmessmer
```

## cob_msgs

- No changes

## cob_srvs

- No changes
