### PR TITLE
cob_command_tools: 0.6.35-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1084,7 +1084,7 @@ repositories:
     source:
       type: git
       url: https://github.com/4am-robotics/cob_command_tools.git
-      version: indigo_dev
+      version: noetic-devel
     status: maintained
   cob_common:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1086,6 +1086,23 @@ repositories:
       url: https://github.com/4am-robotics/cob_command_tools.git
       version: noetic-devel
     status: maintained
+  cob_command_tools_legacy:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_command_tools.git
+      version: indigo_release_candidate
+    release:
+      packages:
+      - service_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/4am-robotics/cob_command_tools-release.git
+      version: 0.6.34-1
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_command_tools.git
+      version: indigo_dev
+    status: end-of-life
   cob_common:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1065,7 +1065,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_command_tools.git
-      version: indigo_release_candidate
+      version: noetic-release-candidate
     release:
       packages:
       - cob_command_gui

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1077,11 +1077,10 @@ repositories:
       - cob_teleop
       - generic_throttle
       - scenario_test_tools
-      - service_tools
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_command_tools-release.git
-      version: 0.6.34-1
+      version: 0.6.35-1
     source:
       type: git
       url: https://github.com/4am-robotics/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.35-1`:

- upstream repository: https://github.com/4am-robotics/cob_command_tools.git
- release repository: https://github.com/4am-robotics/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.34-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_monitoring

- No changes

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes
