### PR TITLE
cob_control: 0.8.24-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1130,6 +1130,34 @@ repositories:
       url: https://github.com/4am-robotics/cob_control.git
       version: noetic-devel
     status: maintained
+  cob_control_legacy:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_control.git
+      version: melodic_release_candidate
+    release:
+      packages:
+      - cob_base_controller_utils
+      - cob_cartesian_controller
+      - cob_control_mode_adapter
+      - cob_control_msgs
+      - cob_frame_tracker
+      - cob_mecanum_controller
+      - cob_model_identifier
+      - cob_obstacle_distance
+      - cob_omni_drive_controller
+      - cob_trajectory_controller
+      - cob_tricycle_controller
+      - cob_twist_controller
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/4am-robotics/cob_control-release.git
+      version: 0.8.23-1
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_control.git
+      version: melodic_dev
+    status: end-of-life
   cob_driver:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1116,27 +1116,15 @@ repositories:
       version: melodic_release_candidate
     release:
       packages:
-      - cob_base_controller_utils
       - cob_base_velocity_smoother
-      - cob_cartesian_controller
       - cob_collision_velocity_filter
       - cob_control
-      - cob_control_mode_adapter
-      - cob_control_msgs
       - cob_footprint_observer
-      - cob_frame_tracker
       - cob_hardware_emulation
-      - cob_mecanum_controller
-      - cob_model_identifier
-      - cob_obstacle_distance
-      - cob_omni_drive_controller
-      - cob_trajectory_controller
-      - cob_tricycle_controller
-      - cob_twist_controller
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_control-release.git
-      version: 0.8.23-1
+      version: 0.8.24-1
     source:
       type: git
       url: https://github.com/4am-robotics/cob_control.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1128,7 +1128,7 @@ repositories:
     source:
       type: git
       url: https://github.com/4am-robotics/cob_control.git
-      version: melodic_dev
+      version: noetic-devel
     status: maintained
   cob_driver:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1113,7 +1113,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_control.git
-      version: melodic_release_candidate
+      version: noetic-release-candidate
     release:
       packages:
       - cob_base_velocity_smoother


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.24-1`:

- upstream repository: https://github.com/4am-robotics/cob_control.git
- release repository: https://github.com/4am-robotics/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.23-1`

## cob_base_velocity_smoother

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

```
* Merge pull request #283 <https://github.com/4am-robotics/cob_control/issues/283> from fmessmer/noetic-devel
  cob4 eol cleanup
* remove cob_control_msgs
* remove cob_frame_tracker
* remove cob_twist_controller
* remove cob_obstacle_distance
* remove cob_cartesian_controller
* remove cob_control_mode_adapter
* remove cob_base_controller_utils
* remove cob_omni_drive_controller
* remove cob_tricycle_controller
* remove cob_trajectory_controller
* remove cob_model_identifier
* remove cob_mecanum_controller
* Contributors: Felix Messmer, fmessmer
```

## cob_footprint_observer

- No changes

## cob_hardware_emulation

- No changes
