### PR TITLE
cob_driver: 0.7.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1164,7 +1164,7 @@ repositories:
     source:
       type: git
       url: https://github.com/4am-robotics/cob_driver.git
-      version: kinetic_dev
+      version: noetic-devel
     status: maintained
   cob_environments:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1149,30 +1149,18 @@ repositories:
       version: kinetic_release_candidate
     release:
       packages:
-      - cob_base_drive_chain
-      - cob_bms_driver
-      - cob_canopen_motor
       - cob_driver
-      - cob_elmo_homing
-      - cob_generic_can
       - cob_light
       - cob_mimic
-      - cob_phidget_em_state
-      - cob_phidget_power_state
       - cob_phidgets
-      - cob_relayboard
       - cob_scan_unifier
-      - cob_sick_lms1xx
       - cob_sick_s300
       - cob_sound
-      - cob_undercarriage_ctrl
-      - cob_utilities
-      - cob_voltage_control
       - laser_scan_densifier
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_driver-release.git
-      version: 0.7.16-2
+      version: 0.7.17-1
     source:
       type: git
       url: https://github.com/4am-robotics/cob_driver.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1146,7 +1146,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_driver.git
-      version: kinetic_release_candidate
+      version: noetic-release-candidate
     release:
       packages:
       - cob_driver

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1166,6 +1166,34 @@ repositories:
       url: https://github.com/4am-robotics/cob_driver.git
       version: noetic-devel
     status: maintained
+  cob_driver_legacy:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_driver.git
+      version: kinetic_release_candidate
+    release:
+      packages:
+      - cob_base_drive_chain
+      - cob_bms_driver
+      - cob_canopen_motor
+      - cob_elmo_homing
+      - cob_generic_can
+      - cob_phidget_em_state
+      - cob_phidget_power_state
+      - cob_relayboard
+      - cob_sick_lms1xx
+      - cob_undercarriage_ctrl
+      - cob_utilities
+      - cob_voltage_control
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/4am-robotics/cob_driver-release.git
+      version: 0.7.16-2
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_driver.git
+      version: kinetic_dev
+    status: end-of-life
   cob_environments:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_driver` to `0.7.17-1`:

- upstream repository: https://github.com/4am-robotics/cob_driver.git
- release repository: https://github.com/4am-robotics/cob_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.16-2`

## cob_driver

```
* Merge pull request #445 <https://github.com/4am-robotics/cob_driver/issues/445> from fmessmer/noetic-devel
  cob4 eol cleanup
* remove cob_bms_driver
* add laser_scan_densifier to cob_driver meta-package
* remove cob_relayboard
* remove cob_utilities
* remove cob_generic_can
* remove cob_canopen_motor
* remove cob_base_drive_chain
* remove cob_undercarriage_ctrl
* remove cob_elmo_homing
* remove cob_voltage_control
* remove cob_sick_lms1xx
* Contributors: Felix Messmer, fmessmer
```

## cob_light

- No changes

## cob_mimic

- No changes

## cob_phidgets

- No changes

## cob_scan_unifier

- No changes

## cob_sick_s300

- No changes

## cob_sound

- No changes

## laser_scan_densifier

- No changes
