### PR TITLE
Refresh our github workflows.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,12 +14,10 @@ pull_request_rules:
   - and:
     - label=end-of-life
     # Active ROS 1 distros
-    - label!=melodic
     - label!=noetic
     # Active ROS 2 distros
-    - label!=foxy
-    - label!=galactic
     - label!=humble
+    - label!=iron
     - label!=rolling
     # Other labels
     - label!=rosdep

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,6 +18,7 @@ pull_request_rules:
     # Active ROS 2 distros
     - label!=humble
     - label!=iron
+    - label!=jazzy
     - label!=rolling
     # Other labels
     - label!=rosdep

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -12,14 +12,14 @@ permissions:
 jobs:
   checks:
     name: rosdistro / rosdep checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Fetch upstream (to enable diff)
@@ -35,14 +35,14 @@ jobs:
       run: pytest -s test
   yamllint:
     name: Yaml Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4  # b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5  # 82c7e631bb3cdc910f68e0081d67478d79c6982d
       with:
         python-version: ${{ matrix.python-version }}
     - name: Fetch upstream (to enable diff)
@@ -40,9 +40,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4  # b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5  # 82c7e631bb3cdc910f68e0081d67478d79c6982d
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -12,9 +12,9 @@ jobs:
     permissions:
       contents: read  # for actions/labeler to determine modified files
       pull-requests: write  # for actions/labeler to add labels to PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: ".github/labeler-config.yaml"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v5  # 8558fd74291d67161a8a78ce36a881fa63b766a9
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: ".github/labeler-config.yaml"

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -8,9 +8,9 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/stale@v8  # https://github.com/marketplace/actions/close-stale-issues
+    - uses: actions/stale@v9  # https://github.com/marketplace/actions/close-stale-issues
       with:
         stale-pr-label: 'stale'
         stale-pr-message: >

--- a/.github/workflows/stale_labeler.yaml
+++ b/.github/workflows/stale_labeler.yaml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/stale@v9  # https://github.com/marketplace/actions/close-stale-issues
+    - uses: actions/stale@v9  # 28ca1036281a5e5922ead5184a1bbf96e5fc984e
       with:
         stale-pr-label: 'stale'
         stale-pr-message: >


### PR DESCRIPTION
1.  Use "runs-on: ubuntu-22.04" in all workflows, so we are completely consistent.
2.  Update the versions of actions that we depend on, to get the latest bugfixes.
3.  Update the version of Python to 3.10, which matches what is in Ubuntu 22.04.
4.  Update our list of EOL distros so we aren't incorrectly leaving things open.

@nuclearsandwich FYI