### PR TITLE
Add doc and source entries for rmw_zenoh into rolling/distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5504,6 +5504,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: rolling
     status: developed
+  rmw_zenoh:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_zenoh.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_zenoh.git
+      version: rolling
+    status: developed
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

# Please Add This Package to be indexed in the rosdistro.

`rmw_zenoh`

# The source is here:

https://github.com/ros2/rmw_zenoh

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
