### PR TITLE
launch: 2.0.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2644,7 +2644,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `2.0.3-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## launch

```
* Backport Iron: Let XML executables/nodes be "required" (like in ROS 1) (#764 <https://github.com/ros2/launch/issues/764>)
* Contributors: Matthew Elwin, Tim Clephas
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Backport Iron: Let XML executables/nodes be "required" (like in ROS 1) (#764 <https://github.com/ros2/launch/issues/764>)
* Contributors: Matthew Elwin, Tim Clephas
```

## launch_yaml

```
* Backport Iron: Let XML executables/nodes be "required" (like in ROS 1) (#764 <https://github.com/ros2/launch/issues/764>)
* Contributors: Matthew Elwin, Tim Clephas
```
