### PR TITLE
rclcpp: 21.0.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4978,7 +4978,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 21.0.5-1
+      version: 21.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `21.0.6-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `21.0.5-1`

## rclcpp

```
* address ambiguous auto variable. (#2486 <https://github.com/ros2/rclcpp/issues/2486>)
* Contributors: Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* call shutdown in LifecycleNode dtor to avoid leaving the device in un… (#2490 <https://github.com/ros2/rclcpp/issues/2490>)
* Contributors: Tomoya Fujita
```
