### PR TITLE
Remove ignition_cmake2_vendor and ignition_math6_vendor from Rolling/Jazzy.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2337,38 +2337,6 @@ repositories:
       url: https://github.com/ignitionrobotics/ign-rviz.git
       version: main
     status: developed
-  ignition_cmake2_vendor:
-    doc:
-      type: git
-      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-      version: rolling
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
-      version: 0.3.0-2
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-      version: rolling
-    status: maintained
-  ignition_math6_vendor:
-    doc:
-      type: git
-      url: https://github.com/ignition-release/ignition_math6_vendor.git
-      version: rolling
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
-      version: 0.3.0-2
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ignition-release/ignition_math6_vendor.git
-      version: rolling
-    status: maintained
   image_common:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2354,38 +2354,6 @@ repositories:
       url: https://github.com/ignitionrobotics/ign-rviz.git
       version: main
     status: developed
-  ignition_cmake2_vendor:
-    doc:
-      type: git
-      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ignition_cmake2_vendor-release.git
-      version: 0.3.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ignition-release/ignition_cmake2_vendor.git
-      version: rolling
-    status: maintained
-  ignition_math6_vendor:
-    doc:
-      type: git
-      url: https://github.com/ignition-release/ignition_math6_vendor.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ignition_math6_vendor-release.git
-      version: 0.3.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ignition-release/ignition_math6_vendor.git
-      version: rolling
-    status: maintained
   image_common:
     doc:
       type: git


### PR DESCRIPTION

We have now changed to using gz_cmake_vendor and gz_math_vendor, and nothing in these distributions depends on them.