### PR TITLE
vision_opencv: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8031,7 +8031,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_opencv` to `4.1.0-1`:

- upstream repository: https://github.com/ros-perception/vision_opencv.git
- release repository: https://github.com/ros2-gbp/vision_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.0-1`

## cv_bridge

- No changes

## image_geometry

```
* Handle upstream deprecation of numpy.matrix, by deprecating methods that return numpy.matrix (#527 <https://github.com/ros-perception/vision_opencv/issues/527>)
* Introduce new methods which return numpy.ndarray, that follow python coding style (snake_case) (#527 <https://github.com/ros-perception/vision_opencv/issues/527>)
* Add tests for deprecated members, fix a few discovered bugs (#527 <https://github.com/ros-perception/vision_opencv/issues/527>)
* Enable tests that were disabled during ros 2 port (#527 <https://github.com/ros-perception/vision_opencv/issues/527>)
* Add python3-deprecated dependency (#527 <https://github.com/ros-perception/vision_opencv/issues/527>)
* Add rectify_image test (#527 <https://github.com/ros-perception/vision_opencv/issues/527>)
* Contributors: Kenji Brameld, Scott Monaghan
```

## vision_opencv

- No changes
