### PR TITLE
Use iron/rolling branches for tracetools_analysis

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9039,7 +9039,7 @@ repositories:
   tracetools_analysis:
     doc:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
+      url: https://github.com/ros-tracing/tracetools_analysis.git
       version: humble
     release:
       packages:
@@ -9051,7 +9051,7 @@ repositories:
       version: 3.0.0-4
     source:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
+      url: https://github.com/ros-tracing/tracetools_analysis.git
       version: humble
     status: developed
   transport_drivers:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7576,8 +7576,8 @@ repositories:
   tracetools_analysis:
     doc:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: iron
     release:
       packages:
       - ros2trace_analysis
@@ -7588,8 +7588,8 @@ repositories:
       version: 3.0.0-5
     source:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: iron
     status: developed
   transport_drivers:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7378,8 +7378,8 @@ repositories:
   tracetools_analysis:
     doc:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: jazzy
     release:
       packages:
       - ros2trace_analysis
@@ -7390,8 +7390,8 @@ repositories:
       version: 3.0.0-6
     source:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: jazzy
     status: developed
   transport_drivers:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7380,8 +7380,8 @@ repositories:
   tracetools_analysis:
     doc:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: rolling
     release:
       packages:
       - ros2trace_analysis
@@ -7392,8 +7392,8 @@ repositories:
       version: 3.0.0-5
     source:
       type: git
-      url: https://gitlab.com/ros-tracing/tracetools_analysis.git
-      version: master
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: rolling
     status: developed
   transport_drivers:
     doc:


### PR DESCRIPTION
* `rolling` is now used instead of `master`
* I created `iron`, which points to the same commit as `rolling`/`master` since there has been no new release anyway
* Same for `jazzy`
* Update repo link to GitHub

See the corresponding changes to the release repo: https://github.com/ros2-gbp/tracetools_analysis-release/pull/1