### PR TITLE
[rosdep] Add python3-tcr-roboclaw-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9269,6 +9269,16 @@ python3-tabulate:
   nixos: [python3Packages.tabulate]
   rhel: [python3-tabulate]
   ubuntu: [python3-tabulate]
+python3-tcr-roboclaw-pip:
+  debian:
+    pip:
+      packages: [tcr-roboclaw]
+  fedora:
+    pip:
+      packages: [tcr-roboclaw]
+  ubuntu:
+    pip:
+      packages: [tcr-roboclaw]
 python3-tensorboardX-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`tcr-roboclaw`

## Package Upstream Source:

https://pypi.org/project/tcr-roboclaw

## Purpose of using this:

Allows to use [RoboClaw motor drivers](https://www.basicmicro.com/motor-controller).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip:
  - https://pypi.org/project/tcr-roboclaw
- Debian: https://packages.debian.org/
  - Use `pip` package linked above. Not available in the Debian repositories
- Ubuntu: https://packages.ubuntu.com/
  - Use `pip` package linked above. Not available in the Ubuntu repositories
- Fedora: https://packages.fedoraproject.org/
  - NOT AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE
