### PR TITLE
nao_button_sim: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3636,7 +3636,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_button_sim-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_button_sim` to `1.0.1-1`:

- upstream repository: https://github.com/ijnek/nao_button_sim.git
- release repository: https://github.com/ros2-gbp/nao_button_sim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## nao_button_sim

```
* update iron CI to use iron branch
* Contributors: ijnek
```
