### PR TITLE
nao_button_sim: 0.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3550,7 +3550,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/nao_button_sim-release.git
-      version: 0.1.1-5
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_button_sim` to `0.2.0-1`:

- upstream repository: https://github.com/ijnek/nao_button_sim.git
- release repository: https://github.com/ros2-gbp/nao_button_sim-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-5`

## nao_button_sim

```
* Update ci
* Contributors: Kenji Brameld
```
