### PR TITLE
fuse: 1.0.1-4 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1721,7 +1721,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.0.1-3
+      version: 1.0.1-4
     source:
       test_pull_requests: true
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1702,7 +1702,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/locusrobotics/fuse.git
-      version: rolling
+      version: iron
     release:
       packages:
       - fuse
@@ -1726,7 +1726,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/fuse.git
-      version: rolling
+      version: iron
     status: maintained
   gazebo_ros2_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.0.1-4`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-3`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

- No changes

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

- No changes

## fuse_tutorials

```
* Fixing rviz2 dependency (#320 <https://github.com/locusrobotics/fuse/issues/320>)
* Contributors: Tom Moore
```

## fuse_variables

- No changes

## fuse_viz

- No changes
