### PR TITLE
nao_button_sim: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4344,7 +4344,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git
-      version: iron
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4353,7 +4353,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git
-      version: iron
+      version: humble
     status: developed
   nao_interfaces:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4349,7 +4349,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nao_button_sim-release.git
-      version: 0.1.1-4
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_button_sim` to `0.1.2-1`:

- upstream repository: https://github.com/ijnek/nao_button_sim.git
- release repository: https://github.com/ros2-gbp/nao_button_sim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-4`

## nao_button_sim

```
* Update ci
* Contributors: Kenji Brameld
```
