### PR TITLE
nao_interfaces: 0.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3568,7 +3568,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
-      version: 0.0.4-4
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `0.1.0-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ros2-gbp/nao_interfaces-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-4`

## nao_command_msgs

- No changes

## nao_sensor_msgs

- No changes
