### PR TITLE
nao_interfaces: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4367,7 +4367,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
-      version: 0.0.4-3
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4359,7 +4359,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git
-      version: iron
+      version: humble
     release:
       packages:
       - nao_command_msgs
@@ -4371,7 +4371,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git
-      version: iron
+      version: humble
     status: developed
   nao_lola:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_interfaces` to `0.0.5-1`:

- upstream repository: https://github.com/ijnek/nao_interfaces.git
- release repository: https://github.com/ros2-gbp/nao_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-3`

## nao_command_msgs

- No changes

## nao_sensor_msgs

- No changes
