### PR TITLE
remove soccer_object_msgs package that was deprecated in I-turtle

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6958,21 +6958,6 @@ repositories:
       url: https://github.com/ros-sports/soccer_interfaces.git
       version: rolling
     status: developed
-  soccer_object_msgs:
-    doc:
-      type: git
-      url: https://github.com/ijnek/soccer_object_msgs.git
-      version: rolling
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/soccer_object_msgs-release.git
-      version: 1.1.0-4
-    source:
-      type: git
-      url: https://github.com/ijnek/soccer_object_msgs.git
-      version: rolling
-    status: developed
   soccer_vision_3d_rviz_markers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6988,21 +6988,6 @@ repositories:
       url: https://github.com/ros-sports/soccer_interfaces.git
       version: rolling
     status: developed
-  soccer_object_msgs:
-    doc:
-      type: git
-      url: https://github.com/ijnek/soccer_object_msgs.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/soccer_object_msgs-release.git
-      version: 1.1.0-3
-    source:
-      type: git
-      url: https://github.com/ijnek/soccer_object_msgs.git
-      version: rolling
-    status: developed
   soccer_vision_3d_rviz_markers:
     doc:
       type: git


### PR DESCRIPTION
Please remove soccer_object_msgs from rolling and j-turtle. The package was deprecated in I-turtle, and was intended to be removed in J-turtle.

Resolves: https://github.com/ijnek/soccer_object_msgs/issues/12