### PR TITLE
fuse: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1670,7 +1670,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.0.1-3
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.1.0-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-3`

## fuse

- No changes

## fuse_constraints

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_core

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_doc

- No changes

## fuse_graphs

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_loss

- No changes

## fuse_models

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_publishers

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_tutorials

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_variables

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```

## fuse_viz

```
* Port support for Ceres 2.1.0 Manifold class into ROS 2 Rolling (#366 <https://github.com/locusrobotics/fuse/issues/366>)
  * Support gcc12 and ceres 2.1.0
  * Add support for the Manifold class when using Ceres Solver version 2.1.0 and above
  * General clean up for Ceres 2.2.0 support
  * Updated serialization support to be backwards compatible with previously serialized files
  * Formatting changes required for ROS 2 Rolling / Ubuntu Noble
* Contributors: Stephen Williams
```
