### PR TITLE
remove soccer_visualization package that was deprecated in I-turtle

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6988,23 +6988,6 @@ repositories:
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
       version: rolling
     status: developed
-  soccer_visualization:
-    doc:
-      type: git
-      url: https://github.com/ijnek/soccer_visualization.git
-      version: rolling
-    release:
-      packages:
-      - soccer_marker_generation
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/soccer_visualization-release.git
-      version: 0.1.0-4
-    source:
-      type: git
-      url: https://github.com/ijnek/soccer_visualization.git
-      version: rolling
-    status: developed
   sol_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7018,23 +7018,6 @@ repositories:
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
       version: rolling
     status: developed
-  soccer_visualization:
-    doc:
-      type: git
-      url: https://github.com/ijnek/soccer_visualization.git
-      version: rolling
-    release:
-      packages:
-      - soccer_marker_generation
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/soccer_visualization-release.git
-      version: 0.1.0-3
-    source:
-      type: git
-      url: https://github.com/ijnek/soccer_visualization.git
-      version: rolling
-    status: developed
   sol_vendor:
     doc:
       type: git


### PR DESCRIPTION
Please remove soccer_visualization from rolling and j-turtle. The package was deprecated in I-turtle, and was intended to be removed in J-turtle.

Resolves: https://github.com/ijnek/soccer_visualization/issues/4