### PR TITLE
zbar_ros: 0.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8160,10 +8160,13 @@ repositories:
       url: https://github.com/ros-drivers/zbar_ros.git
       version: ros2
     release:
+      packages:
+      - zbar_ros
+      - zbar_ros_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git
-      version: 0.5.0-2
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.6.0-1`:

- upstream repository: https://github.com/ros-drivers/zbar_ros.git
- release repository: https://github.com/ros2-gbp/zbar_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.5.0-2`

## zbar_ros

```
* Add new Symbol.msg, with more polygon Info obtained from zbar (#11 <https://github.com/ros-drivers/zbar_ros/issues/11>)
* Deprecate barcode topic (#11 <https://github.com/ros-drivers/zbar_ros/issues/11>)
* Contributors: Kenji Brameld
```

## zbar_ros_interfaces

```
* Add Polygon Info obtained from zbar (#11 <https://github.com/ros-drivers/zbar_ros/issues/11>)
* Contributors: Kenji Brameld
```
