### PR TITLE
rename gc_spl to game_controller_spl in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1711,7 +1711,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
-      version: 4.0.0-2
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/ros-sports/game_controller_spl.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1692,6 +1692,31 @@ repositories:
       url: https://github.com/locusrobotics/fuse.git
       version: rolling
     status: maintained
+  game_controller_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: rolling
+    release:
+      packages:
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
+      - gc_spl_2022
+      - gc_spl_interfaces
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/game_controller_spl-release.git
+      version: 4.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: rolling
+    status: developed
   gazebo_ros2_control:
     doc:
       type: git
@@ -1709,31 +1734,6 @@ repositories:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
       version: master
-    status: developed
-  gc_spl:
-    doc:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: rolling
-    release:
-      packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gc_spl-release.git
-      version: 4.0.0-2
-    source:
-      type: git
-      url: https://github.com/ros-sports/gc_spl.git
-      version: rolling
     status: developed
   generate_parameter_library:
     doc:


### PR DESCRIPTION
As requested in #40578, splitting up the changes into PR per distro.

> Repository was renamed recently from gc_spl to game_controller_spl. Instead of updating the name just for rolling's distribution.yaml, for consistency, I updated the names in humble and iron's distribution files too. I'm hoping there are no issues with this manual change.
>
> * [Source repo](https://github.com/ros-sports/game_controller_spl)
> * [Releas repo](https://github.com/ros2-gbp/game_controller_spl-release)
>
> [Related issue in ros2-gbp](https://github.com/ros2-gbp/ros2-gbp-github-org/issues/430)