### PR TITLE
librealsense2: 2.55.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3474,7 +3474,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.54.1-1
+      version: 2.55.1-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.55.1-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.54.1-1`
