### PR TITLE
librealsense2: 2.55.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2844,7 +2844,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.54.1-2
+      version: 2.55.1-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.55.1-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/IntelRealSense/librealsense2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.54.1-2`
