### PR TITLE
apriltag_mit: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -482,6 +482,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_mit-release.git
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_mit` to `1.1.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_mit.git
- release repository: https://github.com/ros2-gbp/apriltag_mit-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## apriltag_mit

```
* Initial release of ROS2 package
* Contributors:  Michael Kaess, Chao Qu, Bernd Pfrommer
```
