### PR TITLE
gz_common_vendor: 0.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1987,6 +1987,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_common_vendor

```
* Add support for the <pkg>::<pkg> and <pkg>::all targets, fix sourcing of dsv files
* Contributors: Addisu Z. Taddese
```
