### PR TITLE
mp2p_icp: 1.3.2-1 in 'iron/distribution.yaml' [bloom]  [fixes regression]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3396,7 +3396,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.3.2-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.1-1`

## mp2p_icp

```
* tsl::robin_map library is no longer exposed neither in the public API nor as public headers (PIMPL pattern)
  This is to prevent Debian-level collisions with other packages also exposing it.
* add first icp-log-viewer docs
* Contributors: Jose Luis Blanco-Claraco
```
