### PR TITLE
Revert "fields2cover: 2.0.0-1 in 'iron/distribution.yaml' [bloom]"

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1520,7 +1520,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 2.0.0-1
+      version: 1.2.1-3
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git


### PR DESCRIPTION
Reverts ros/rosdistro#40490

As per https://github.com/ros/rosdistro/pull/40490#issuecomment-2068718007
cc @Gonzalo-Mier 