### PR TITLE
gtsam: 4.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1958,6 +1958,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam` to `4.2.0-1`:

- upstream repository: https://github.com/borglab/gtsam.git
- release repository: https://github.com/ros2-gbp/gtsam-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
