### PR TITLE
gz_gui_vendor: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2029,6 +2029,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_gui_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_gui_vendor.git
- release repository: https://github.com/ros2-gbp/gz_gui_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_gui_vendor

```
* Update vendored version, add support for the <pkg>::<pkg> and <pkg>::all targets, fix sourcing of dsv files
* Require calling find_package on the underlying package
* Fix linter (#1 <https://github.com/gazebo-release/gz_gui_vendor/issues/1>)
* Add missing dep
* Initial import
* Contributors: Addisu Z. Taddese
```
