### PR TITLE
gz_ogre_next_vendor: 0.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2087,6 +2087,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_ogre_next_vendor

```
* Add additional dependencies, fix vulkan build
* Sort dependencies
* Contributors: Addisu Z. Taddese
```
