### PR TITLE
gz_rendering_vendor: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2131,6 +2131,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_rendering_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_rendering_vendor.git
- release repository: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_rendering_vendor

```
* Add support for the <pkg>::<pkg> and <pkg>::all targets, fix sourcing of dsv files
* Update vendored version
* Require calling find_package on the underlying package
* Fix linter (#1 <https://github.com/gazebo-release/gz_rendering_vendor/issues/1>)
* Add patches to fix finding Ogre2
* Fix url
* Initial import
* Contributors: Addisu Z. Taddese
```
