### PR TITLE
gz_sensors_vendor: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2163,6 +2163,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_sensors_vendor

```
* Add support for the <pkg>::<pkg> and <pkg>::all targets, fix sourcing of dsv files
* Require calling find_package on the underlying package
* Fix linter (#1 <https://github.com/gazebo-release/gz_sensors_vendor/issues/1>)
* Fix url
* Initial import
* Contributors: Addisu Z. Taddese
```
