### PR TITLE
gz_sim_vendor: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2177,6 +2177,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sim_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_sim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sim_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gz_sim_vendor

```
* Remove python3-distutils dependency
  This dependency is only needed in the vendored package for CMake
  versions less than 3.12. It is also failing to install on Noble
  currently preventing the whole vendor package from building.
* Update vendored version, add support for the <pkg>::<pkg> and <pkg>::all targets, fix sourcing of dsv files
* Require calling find_package on the underlying package
* Fix linter (#1 <https://github.com/gazebo-release/gz_sim_vendor/issues/1>)
* Initial import
* Contributors: Addisu Z. Taddese
```
