### PR TITLE
libpointmatcher: 1.4.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2941,6 +2941,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/libpointmatcher-release.git
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/norlab-ulaval/libpointmatcher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libpointmatcher` to `1.4.2-1`:

- upstream repository: https://github.com/norlab-ulaval/libpointmatcher.git
- release repository: https://github.com/ros2-gbp/libpointmatcher-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## libpointmatcher

```
* Add dockerhub release logic and improve main readme by @RedLeader962 in https://github.com/norlab-ulaval/libpointmatcher/pull/550
* Update .gitingore with auto-generated patterns for C++, Python, JetBrains IDEs ,and VSCode by @boxanm in https://github.com/norlab-ulaval/libpointmatcher/pull/555
* build: add ubuntu jammy to the repository suported version by @RedLeader962 in https://github.com/norlab-ulaval/libpointmatcher/pull/557
* fix: Change unit tests floating point type to double and add a precision argument to output streams by @boxanm in https://github.com/norlab-ulaval/libpointmatcher/pull/558
* Update the minimum required Cmake version to 3.10.2 by @boxanm in https://github.com/norlab-ulaval/libpointmatcher/pull/560
* fix: Issue 534 transformation tests failing on some platforms by @boxanm in https://github.com/norlab-ulaval/libpointmatcher/pull/559
* Added orientation descriptor in RigidTransformation and SimilarityTransformation compute functions. by @simonpierredeschenes in https://github.com/norlab-ulaval/libpointmatcher/pull/553
```
