### PR TITLE
proxsuite: 0.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4506,6 +4506,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `proxsuite` to `0.6.1-1`:

- upstream repository: https://github.com/Simple-Robotics/proxsuite.git
- release repository: https://github.com/ros2-gbp/proxsuite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
