### PR TITLE
ompl: 1.5.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3987,6 +3987,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
+      version: 1.5.2-2
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.5.2-2`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
