### PR TITLE
py_trees_js: 0.6.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4538,6 +4538,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
+      version: 0.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.4-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/ros2-gbp/py_trees_js-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## py_trees_js

```
* [actions] pre-merge and update-cache, #146 <https://github.com/splintered-reality/py_trees_js/pull/146>
* [actions] push containers, #144 <https://github.com/splintered-reality/py_trees_js/pull/144>
* [poetry] update project to use poetry, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
* [vscode] devcontainer workflows, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
* [tests] basic tests, formatting, linting, #143 <https://github.com/splintered-reality/py_trees_js/pull/143>
```
