### PR TITLE
rmw_connextdds: 0.22.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5401,10 +5401,12 @@ repositories:
       packages:
       - rmw_connextdds
       - rmw_connextdds_common
+      - rmw_connextddsmicro
       - rti_connext_dds_cmake_module
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
+      version: 0.22.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.22.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Revert "Mitigate discovery race condition between clients and services (#132 <https://github.com/ros2/rmw_connextdds/issues/132>)" (#146 <https://github.com/ros2/rmw_connextdds/issues/146>)
  This reverts commit 7c95abbfc4559b293ebf5e94e20250bdd99d3ac6.
* Mitigate discovery race condition between clients and services (#132 <https://github.com/ros2/rmw_connextdds/issues/132>)
  * Mitigate discovery race condition between clients and services.
* Add: tracepoint for subscribe serialized_message (#145 <https://github.com/ros2/rmw_connextdds/issues/145>)
  * Add: tracepoint for take_serialized_message
  * Fix: TRACETOOLS_TRACEPOINT args
  * Update rmw_connextdds_common/src/common/rmw_subscription.cpp
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: Andrea Sorbini, Chris Lalancette, h-suzuki-isp
```

## rmw_connextddsmicro

- No changes

## rti_connext_dds_cmake_module

- No changes
