### PR TITLE
ros_industrial_cmake_boilerplate: 0.5.4-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5906,6 +5906,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
+      version: 0.5.4-3
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_industrial_cmake_boilerplate` to `0.5.4-3`:

- upstream repository: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
- release repository: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ros_industrial_cmake_boilerplate

```
* Fixed error message when extracting maintainer information
* Contributors: Michael Ripperger
```
