### PR TITLE
Add PyQt6

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -468,7 +468,10 @@ pyqt5-dev-tools:
 pyqt6-dev-tools:
   debian: [pyqt6-dev-tools]
   fedora: [python3-pyqt6-base]
-  ubuntu: [pyqt6-dev-tools]
+  ubuntu:
+    '*': [pyqt6-dev-tools]
+    focal: null
+    jammy: null
 pyrebase-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -465,6 +465,10 @@ pyqt5-dev-tools:
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   rhel: [python3-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
+pyqt6-dev-tools:
+  debian: [pyqt6-dev-tools]
+  fedora: [python3-pyqt6-base]
+  ubuntu: [pyqt6-dev-tools]
 pyrebase-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

PyQt6

## Package Upstream Source:

[PyPI](https://pypi.org/project/PyQt6/#description)

## Purpose of using this:

For building GUI applications within the ROS 2 ecosystem.