### PR TITLE
rtshell: 3.0.1-5 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10827,7 +10827,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/rtshell-release.git
-      version: 3.0.1-3
+      version: 3.0.1-5
     source:
       type: git
       url: https://github.com/gbiggs/rtshell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtshell` to `3.0.1-5`:

- upstream repository: https://github.com/gbiggs/rtshell.git
- release repository: https://github.com/tork-a/rtshell-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-3`
