### PR TITLE
ros2_canopen: 0.2.11-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6872,6 +6872,25 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git
       version: humble
+    release:
+      packages:
+      - canopen
+      - canopen_402_driver
+      - canopen_base_driver
+      - canopen_core
+      - canopen_fake_slaves
+      - canopen_interfaces
+      - canopen_master_driver
+      - canopen_proxy_driver
+      - canopen_ros2_control
+      - canopen_ros2_controllers
+      - canopen_tests
+      - canopen_utils
+      - lely_core_libraries
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_canopen-release.git
+      version: 0.2.11-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.11-2`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canopen

- No changes

## canopen_402_driver

```
* catalogue for first release humble
* Contributors: ipa-vsp
```

## canopen_base_driver

```
* catalogue for first release humble
* Contributors: ipa-vsp
```

## canopen_core

```
* catalogue for first release humble
* Contributors: ipa-vsp
```

## canopen_fake_slaves

- No changes

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_ros2_control

- No changes

## canopen_ros2_controllers

- No changes

## canopen_utils

- No changes

## lely_core_libraries

- No changes
