### PR TITLE
ros2_canopen: 0.2.12-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5549,7 +5549,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.9-1
+      version: 0.2.12-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.12-2`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.9-1`

## canopen

```
* Merge pull request #280 <https://github.com/ros-industrial/ros2_canopen/issues/280> from ipa-vsp/fix/yaml-build-error
  Fix undefined reference to yaml library
* pre-commit update
* Merge pull request #261 <https://github.com/ros-industrial/ros2_canopen/issues/261> from gsalinas/configurable-sdo-timeout
  Configurable SDO timeout
* 0.2.9
* forthcoming
* Merge pull request #272 <https://github.com/ros-industrial/ros2_canopen/issues/272> from ros-industrial/ipa-vsp-patch-1
  Update maintainer list
* Update package.xml
* Merge pull request #220 <https://github.com/ros-industrial/ros2_canopen/issues/220> from ipa-vsp/feature/timeout-config
  Add timeouts
* Add SDO timeout to device config documentation.
* change from 100ms to 2000ms
* timeout for booting slave
* Contributors: Gerry Salinas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_402_driver

```
* 0.2.9
* forthcoming
* Merge pull request #267 <https://github.com/ros-industrial/ros2_canopen/issues/267> from clalancette/clalancette/update-lely-core-hash
  Update the lely_core_libraries hash to the latest.
* fix ci build error
* Contributors: Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_base_driver

```
* Merge pull request #280 <https://github.com/ros-industrial/ros2_canopen/issues/280> from ipa-vsp/fix/yaml-build-error
  Fix undefined reference to yaml library
* pre-commit update
* Merge pull request #261 <https://github.com/ros-industrial/ros2_canopen/issues/261> from gsalinas/configurable-sdo-timeout
  Configurable SDO timeout
* 0.2.9
* forthcoming
* Merge pull request #220 <https://github.com/ros-industrial/ros2_canopen/issues/220> from ipa-vsp/feature/timeout-config
  Add timeouts
* Set SDO timeout from node config.
* Replace two more hardcoded timeouts.
* Include timeout in documentation comment for LelyDriverBridge.
* Make 20ms a default argument of the master & driver bridges.
* change error to warn for testing
* remove build warings
* non transmit time from bus.yml
* Contributors: Gerry Salinas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_core

```
* Merge pull request #270 <https://github.com/ros-industrial/ros2_canopen/issues/270> from gsalinas/can-namespace-pr
  Put components loaded by the device container into its namespace, if any.
* pre-commit update
* Put components loaded by the device container into its namespace, if any.
* Merge pull request #280 <https://github.com/ros-industrial/ros2_canopen/issues/280> from ipa-vsp/fix/yaml-build-error
  Fix undefined reference to yaml library
* fix undefined reference to yaml
* Fix logging in device_container.cpp (#277 <https://github.com/ros-industrial/ros2_canopen/issues/277>)
* 0.2.9
* forthcoming
* Merge pull request #220 <https://github.com/ros-industrial/ros2_canopen/issues/220> from ipa-vsp/feature/timeout-config
  Add timeouts
* change from 100ms to 2000ms
* non transmit time from bus.yml
* timeout for booting slave
* Contributors: Christoph Hellmann Santos, Gerry Salinas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_fake_slaves

```
* Merge pull request #265 <https://github.com/ros-industrial/ros2_canopen/issues/265> from kurtist123/feature/expose-fake-slave-includes
  build: export include directories
* build: export include directories
* 0.2.9
* forthcoming
* Contributors: Kurtis Thrush, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_interfaces

```
* 0.2.9
* forthcoming
* Contributors: ipa-vsp
```

## canopen_master_driver

```
* 0.2.9
* forthcoming
* Merge pull request #220 <https://github.com/ros-industrial/ros2_canopen/issues/220> from ipa-vsp/feature/timeout-config
  Add timeouts
* Revert timeout change to master since I'm not providing a way to set that timeout.
* Make 20ms a default argument of the master & driver bridges.
* timeout for booting slave
* Contributors: Gerry Salinas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_proxy_driver

```
* 0.2.9
* forthcoming
* Contributors: ipa-vsp
```

## canopen_ros2_control

```
* 0.2.9
* forthcoming
* Contributors: ipa-vsp
```

## canopen_ros2_controllers

```
* 0.2.9
* forthcoming
* Contributors: ipa-vsp
```

## canopen_tests

```
* Merge pull request #270 <https://github.com/ros-industrial/ros2_canopen/issues/270> from gsalinas/can-namespace-pr
  Put components loaded by the device container into its namespace, if any.
* pre-commit update
* Add node on namespaces.
* Restore base version of canopen_system example.
* Restore cia402_system launch to original.
* Change cia402_system ros2_controllers back to original.
* Add comment about the use of ReplaceString.
* Push namespace to nodes in a group.
* Separate out example of how to use a namespaced ros2_control/cia402 based system.
* Remove commented-out arg and unneeded logging.
* Update canopen test system launch to use a namespace.
* Output robot_description_content to log during launch.
* WIP adding namespace to cia402_system launch.
* 0.2.9
* forthcoming
* Contributors: Gerry Salinas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_utils

```
* 0.2.9
* forthcoming
* Contributors: ipa-vsp
```

## lely_core_libraries

```
* 0.2.9
* forthcoming
* Merge pull request #267 <https://github.com/ros-industrial/ros2_canopen/issues/267> from clalancette/clalancette/update-lely-core-hash
  Update the lely_core_libraries hash to the latest.
* Update the lely_core_libraries hash to the latest.
  This will fix the building of the lely_core_libraries
  on Ubuntu 24.04.
* Contributors: Chris Lalancette, Vishnuprasad Prachandabhanu, ipa-vsp
```
