### PR TITLE
Remove gazebo_ros_pkgs from Rolling and Jazzy.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1689,27 +1689,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
       version: master
     status: developed
-  gazebo_ros_pkgs:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    release:
-      packages:
-      - gazebo_dev
-      - gazebo_msgs
-      - gazebo_plugins
-      - gazebo_ros
-      - gazebo_ros_pkgs
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    status: maintained
   gc_spl:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1690,27 +1690,6 @@ repositories:
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
       version: master
     status: developed
-  gazebo_ros_pkgs:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    release:
-      packages:
-      - gazebo_dev
-      - gazebo_msgs
-      - gazebo_plugins
-      - gazebo_ros
-      - gazebo_ros_pkgs
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-      version: ros2
-    status: maintained
   gc_spl:
     doc:
       type: git


### PR DESCRIPTION
This is a Gazebo classic plugin, and thus isn't supported on Rolling and Jazzy anymore.

@azeey FYI