### PR TITLE
add openeb package to humble, iron, rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4937,6 +4937,16 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.6.0-1
+  openeb:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb.git
+      version: ros2-latest
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb.git
+      version: ros2-latest
+    status: maintained
   openni2_camera:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4034,6 +4034,16 @@ repositories:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-4
+  openeb:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb.git
+      version: ros2-latest
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb.git
+      version: ros2-latest
+    status: maintained
   openni2_camera:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3939,6 +3939,16 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-4
+  openeb:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb.git
+      version: ros2-latest
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb.git
+      version: ros2-latest
+    status: maintained
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
# Please add openeb package to be indexed in the rosdistro.

rosdistros: humble, iron, rolling

# The source is here:

https://github.com/ros-event-camera/openeb

# Comment

The OpenEB library is the SDK for event based cameras based on Prophesee chips.

The metavision_driver package depends on this library. Currently I'm downloading, building and installing it in the metavision_driver package using FetchContent, but something is broken now on rolling/noble and I find it really hard to debug FetchContent. A separate package is also the cleaner solution.

Please add this package to rosdistro, thanks!



# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
