### PR TITLE
gz_ogre_next_vendor: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2077,7 +2077,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.0.4-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## gz_ogre_next_vendor

```
* Fix build error due to glslang
* Contributors: Addisu Z. Taddese
```
