### PR TITLE
lsc_ros2_driver: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3553,7 +3553,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release.git
-      version: 1.0.0-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros2_driver` to `1.0.2-1`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros2_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros2_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## lsc_ros2_driver

```
* add ip change parameter
* add angle_min, angle_max, angle_offset parameter
* add urdf file
```
