### PR TITLE
lsc_ros_driver: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5362,7 +5362,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/AutonicsLiDAR/lsc_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lsc_ros_driver` to `1.0.4-1`:

- upstream repository: https://github.com/AutonicsLiDAR/lsc_ros_driver.git
- release repository: https://github.com/AutonicsLiDAR-release/lsc_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## lsc_ros_driver

```
* add ip change parameter
* add angle_min, angle_max, angle_offset parameter
* add urdf file
```
