### PR TITLE
Revert "perception_pcl: 2.5.1-1 in 'iron/distribution.yaml' [bloom]"

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4225,7 +4225,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.5.1-1
+      version: 2.4.0-5
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#40476 to unblock Iron sync.