### PR TITLE
sdformat_urdf: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6764,7 +6764,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/sdformat_urdf.git
-      version: ros2
+      version: jazzy
     status: maintained
   sdformat_vendor:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6759,6 +6759,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6751,7 +6751,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/sdformat_urdf.git
-      version: ros2
+      version: jazzy
     release:
       packages:
       - sdformat_test_files


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `1.0.2-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sdformat_test_files

- No changes

## sdformat_urdf

```
* Explain how Gazebo and RViz can resolve mesh URIs (#26 <https://github.com/ros/sdformat_urdf/issues/26>) (#29 <https://github.com/ros/sdformat_urdf/issues/29>)
  Co-authored-by: Yadu <mailto:yadunund@gmail.com>
* Use gz vendor packages and update to Harmonic (#28 <https://github.com/ros/sdformat_urdf/issues/28>)
* Support Gazebo Harmonic (#23 <https://github.com/ros/sdformat_urdf/issues/23>)
* ign to gz migration (#19 <https://github.com/ros/sdformat_urdf/issues/19>)
  * ign->gz
  * revertingsdf13 changes
  ---------
* Create sdformat_urdf_plugin as SHARED instead of MODULE for macOS compatibility (#22 <https://github.com/ros/sdformat_urdf/issues/22>)
  * Create sdformat_urdf_plugin as SHARED instead of MODULE for macOS compatibility
  * Remove trailing whitespace
* Support Gazebo Garden (#17 <https://github.com/ros/sdformat_urdf/issues/17>)
* updating gtest conditionals (#16 <https://github.com/ros/sdformat_urdf/issues/16>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Dharini Dutia, Louise Poubel, Rhys Mainwaring, Silvio Traversaro
```
