### PR TITLE
add multiple_topic_monitor to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4321,6 +4321,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  multiple_topic_monitor:
+    doc:
+      type: git
+      url: https://github.com/yukkysaito/multiple_topic_monitor.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/yukkysaito/multiple_topic_monitor.git
+      version: humble
+    status: developed
   mvsim:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

multiple_topic_monitor

## Package Upstream Source:

https://github.com/yukkysaito/multiple_topic_monitor

## Purpose of using this:

This is a ROS 2 package for monitoring the frequency and delay of multiple topics.

Distro packaging links: https://github.com/yukkysaito/multiple_topic_monitor/blob/humble/README.md

Background : https://github.com/ros2-gbp/ros2-gbp-github-org/issues/502#issuecomment-2072398855

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
