### PR TITLE
gz_utils_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2215,7 +2215,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.0.3-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_utils_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_utils_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_utils_vendor.git
- release repository: https://github.com/ros2-gbp/gz_utils_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-1`

## gz_utils_vendor

```
* Use an alias target for the root library (#3 <https://github.com/gazebo-release/gz_utils_vendor/issues/3>)
  Without this patch, doing find_package(gz-utils) (or any vendor
  package) multiple times in a single CMakeLists file fails with an
  error indicating that cmake cannot create the imported target
  because another target with the same name already exists.
* Contributors: Addisu Z. Taddese
```
