### PR TITLE
Update control_msgs to use humble-devel branch for humble and newer

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1205,7 +1205,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: foxy-devel
+      version: humble
     status: maintained
   control_toolbox:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1196,7 +1196,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: humble-devel
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1196,7 +1196,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: foxy-devel
+      version: humble-devel
     release:
       tags:
         release: release/humble/{package}/{version}

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -859,7 +859,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: foxy-devel
+      version: humble-devel
     release:
       tags:
         release: release/iron/{package}/{version}

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -859,7 +859,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: humble-devel
+      version: humble
     release:
       tags:
         release: release/iron/{package}/{version}

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -859,7 +859,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: humble
+      version: master
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -868,7 +868,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: foxy-devel
+      version: master
     status: maintained
   control_toolbox:
     doc:


### PR DESCRIPTION
@bmagyar @christophfroehlich 

I was looking at a compliance process and found that https://github.com/ros-controls/control_msgs/pull/114 wasn't available in the devel branch and saw that it was pointing all the way back to foxy.  When there was a humble backport here: https://github.com/ros-controls/control_msgs/pull/116

Based on this humble backport I'm assuming that `humble` is the appropriate development branch for humble and also iron, where rolling is on master. 
