### PR TITLE
Add lidar_s_graphs to humble and iron distributions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3542,6 +3542,12 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: humble
     status: maintained
+  lidar_s_graphs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/lidar_s_graphs.git
+      version: feature/ros2
+    status: maintained
   lms1xx:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3695,10 +3695,10 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: humble
     status: maintained
-  lidar_s_graphs:
+  lidar_situational_graphs:
     source:
       type: git
-      url: https://github.com/snt-arg/lidar_s_graphs.git
+      url: https://github.com/snt-arg/lidar_situational_graphs.git
       version: feature/ros2
     status: maintained
   lms1xx:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2882,6 +2882,12 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: iron
     status: maintained
+  lidar_s_graphs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/lidar_s_graphs.git
+      version: feature/ros2
+    status: maintained
   locator_ros_bridge:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2975,10 +2975,10 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: iron
     status: maintained
-  lidar_s_graphs:
+  lidar_situational_graphs:
     source:
       type: git
-      url: https://github.com/snt-arg/lidar_s_graphs.git
+      url: https://github.com/snt-arg/lidar_situational_graphs.git
       version: feature/ros2
     status: maintained
   locator_ros_bridge:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package names:

  * [lidar_s_graphs](https://github.com/snt-arg/lidar_s_graphs.git)
  
## Package Upstream Source:

https://github.com/snt-arg/lidar_s_graphs.git

## Purpose of using this:

Repository to generate in real-time situational graphs for robot pose and high-Level map Optimization using 3D LiDAR data. Apart from the main package there also dependencies of `lidar_s_graphs` in the which will be uploaded to `distribution.yaml` in seperate PRs. The scientific paper can be found [here](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=10168233).

# Please Add This Package to be indexed in the rosdistro.

Iron and Humble

# The source is here:

https://github.com/snt-arg/lidar_s_graphs.git

# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
