### PR TITLE
Add s_graphs_msgs to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8272,6 +8272,12 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: ros2
     status: maintained
+  s_graphs_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/s_graphs_msgs.git
+      version: main
+    status: maintained
   sick_safetyscanners2:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8403,12 +8403,6 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: ros2
     status: maintained
-  s_graphs_msgs:
-    source:
-      type: git
-      url: https://github.com/snt-arg/s_graphs_msgs.git
-      version: main
-    status: maintained
   sick_safetyscanners2:
     doc:
       type: git
@@ -8560,6 +8554,12 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
+  situational_graphs_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_msgs.git
+      version: main
+    status: maintained
   slam_toolbox:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6938,6 +6938,12 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: ros2
     status: maintained
+  s_graphs_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/s_graphs_msgs.git
+      version: main
+    status: maintained
   sick_safetyscanners2:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7001,12 +7001,6 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: ros2
     status: maintained
-  s_graphs_msgs:
-    source:
-      type: git
-      url: https://github.com/snt-arg/s_graphs_msgs.git
-      version: main
-    status: maintained
   sick_safetyscanners2:
     doc:
       type: git
@@ -7116,6 +7110,12 @@ repositories:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
+    status: maintained
+  situational_graphs_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_msgs.git
+      version: main
     status: maintained
   slam_toolbox:
     doc:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package names:

  * [s_graphs_msgs](https://github.com/snt-arg/s_graphs_msgs.git)
  
## Package Upstream Source:

https://github.com/snt-arg/s_graphs_msgs.git

## Purpose of using this:

Repository to contains custom ros2 msgs for [lidar_s_graphs](https://github.com/snt-arg/s_graphs_msgs.git), required for exchanging information to and from the `lidar_s_graphs` node.  

PR related to `lidar_s_graphs` ---> https://github.com/ros/rosdistro/pull/40800

# Please Add This Package to be indexed in the rosdistro.

Iron and Humble

# The source is here:

https://github.com/snt-arg/s_graphs_msgs.git

# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
