### PR TITLE
Add reasoning_msgs to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6375,6 +6375,12 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: humble
     status: maintained
+  reasoning_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/reasoning_msgs.git
+      version: main
+    status: maintained
   rig_reconfigure:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6506,12 +6506,6 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: humble
     status: maintained
-  reasoning_msgs:
-    source:
-      type: git
-      url: https://github.com/snt-arg/reasoning_msgs.git
-      version: main
-    status: maintained
   rig_reconfigure:
     release:
       tags:
@@ -8560,6 +8554,12 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
+  situational_graphs_reasoning_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
+      version: main
+    status: maintained
   slam_toolbox:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8639,16 +8639,16 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
-  situational_graphs_reasoning_msgs:
-    source:
-      type: git
-      url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
-      version: main
-    status: maintained
   situational_graphs_msgs:
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_msgs.git
+      version: main
+    status: maintained
+  situational_graphs_reasoning_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
       version: main
     status: maintained
   slam_toolbox:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5145,6 +5145,12 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: iron
     status: maintained
+  reasoning_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/reasoning_msgs.git
+      version: main
+    status: maintained
   rig_reconfigure:
     release:
       tags:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7181,16 +7181,16 @@ repositories:
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
     status: maintained
-  situational_graphs_reasoning_msgs:
-    source:
-      type: git
-      url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
-      version: main
-    status: maintained
   situational_graphs_msgs:
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_msgs.git
+      version: main
+    status: maintained
+  situational_graphs_reasoning_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
       version: main
     status: maintained
   slam_toolbox:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5208,12 +5208,6 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: iron
     status: maintained
-  reasoning_msgs:
-    source:
-      type: git
-      url: https://github.com/snt-arg/reasoning_msgs.git
-      version: main
-    status: maintained
   rig_reconfigure:
     release:
       tags:
@@ -7116,6 +7110,12 @@ repositories:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
+    status: maintained
+  situational_graphs_reasoning_msgs:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
+      version: main
     status: maintained
   slam_toolbox:
     doc:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package names:

  * [reasoning_msgs](https://github.com/snt-arg/reasoning_msgs.git)
  
## Package Upstream Source:

https://github.com/snt-arg/reasoning_msgs.git

## Purpose of using this:

Repository to contains custom ros2 msgs for [lidar_s_graphs](https://github.com/snt-arg/s_graphs_msgs.git), required for exchanging high-level reasoning information to and from the `lidar_s_graphs` node.  

PR related to `lidar_s_graphs` ---> https://github.com/ros/rosdistro/pull/40800

# Please Add This Package to be indexed in the rosdistro.

Iron and Humble

# The source is here:

https://github.com/snt-arg/reasoning_msgs.git

# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
