### PR TITLE
Add graph_datasets to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2517,6 +2517,12 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: ros2
     status: maintained
+  graph_datasets:
+    source:
+      type: git
+      url: https://github.com/snt-arg/graph_datasets.git
+      version: develop
+    status: maintained
   grbl_msgs:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2583,12 +2583,6 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: ros2
     status: maintained
-  graph_datasets:
-    source:
-      type: git
-      url: https://github.com/snt-arg/graph_datasets.git
-      version: develop
-    status: maintained
   grbl_msgs:
     doc:
       type: git
@@ -8560,6 +8554,12 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
+  situational_graph_datasets:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_datasets.git
+      version: develop
+    status: maintained
   slam_toolbox:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8554,7 +8554,7 @@ repositories:
       url: https://github.com/clearpathrobotics/simple-term-menu.git
       version: humble
     status: developed
-  situational_graph_datasets:
+  situational_graphs_datasets:
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_datasets.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2006,6 +2006,12 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: ros2
     status: maintained
+  graph_datasets:
+    source:
+      type: git
+      url: https://github.com/snt-arg/graph_datasets.git
+      version: develop
+    status: maintained
   grbl_msgs:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7111,7 +7111,7 @@ repositories:
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
     status: maintained
-  situational_graph_datasets:
+  situational_graphs_datasets:
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_datasets.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2027,12 +2027,6 @@ repositories:
       url: https://github.com/mikeferguson/grasping_msgs.git
       version: ros2
     status: maintained
-  graph_datasets:
-    source:
-      type: git
-      url: https://github.com/snt-arg/graph_datasets.git
-      version: develop
-    status: maintained
   grbl_msgs:
     doc:
       type: git
@@ -7116,6 +7110,12 @@ repositories:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
+    status: maintained
+  situational_graph_datasets:
+    source:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_datasets.git
+      version: develop
     status: maintained
   slam_toolbox:
     doc:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package names:

  * [graph_datasets](https://github.com/snt-arg/graph_datasets.git)
  
## Package Upstream Source:

https://github.com/snt-arg/graph_datasets.git

## Purpose of using this:

Structured indoors synthetic dataset in the form of graphs as a tool for [lidar_s_graphs](https://github.com/snt-arg/s_graphs_msgs.git). 

PR related to `lidar_s_graphs` ---> https://github.com/ros/rosdistro/pull/40800

# Please Add This Package to be indexed in the rosdistro.

Iron and Humble

# The source is here:

https://github.com/snt-arg/graph_datasets.git

# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
