### PR TITLE
Add fast_gicp to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1877,6 +1877,12 @@ repositories:
       url: https://github.com/eurogroep/fadecandy_ros.git
       version: ros2
     status: maintained
+  fast_gicp:
+    source:
+      type: git
+      url: https://github.com/SMRT-AIST/fast_gicp.git
+      version: master
+    status: developed
   fastcdr:
     release:
       tags:
@@ -1903,12 +1909,6 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
     status: maintained
-  fast_gicp:
-    source:
-      type: git
-      url: https://github.com/SMRT-AIST/fast_gicp.git
-      version: master
-    status: developed
   ffmpeg_image_transport:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1903,6 +1903,12 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
     status: maintained
+  fast_gicp:
+    source:
+      type: git
+      url: https://github.com/SMRT-AIST/fast_gicp.git
+      version: master
+    status: developed
   ffmpeg_image_transport:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1471,6 +1471,12 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.10.x
     status: maintained
+  fast_gicp:
+    source:
+      type: git
+      url: https://github.com/SMRT-AIST/fast_gicp.git
+      version: master
+    status: developed
   ffmpeg_image_transport:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1441,6 +1441,12 @@ repositories:
       url: https://github.com/ros2/examples.git
       version: iron
     status: maintained
+  fast_gicp:
+    source:
+      type: git
+      url: https://github.com/SMRT-AIST/fast_gicp.git
+      version: master
+    status: developed
   fastcdr:
     release:
       tags:
@@ -1471,12 +1477,6 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.10.x
     status: maintained
-  fast_gicp:
-    source:
-      type: git
-      url: https://github.com/SMRT-AIST/fast_gicp.git
-      version: master
-    status: developed
   ffmpeg_image_transport:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package names:

  * [fast_gicp](https://github.com/SMRT-AIST/fast_gicp.git)
  
## Package Upstream Source:

https://github.com/SMRT-AIST/fast_gicp.git

## Purpose of using this:

A collection of GICP-based fast point cloud registration algorithms. Required as as dependency in the scan matching based odometry and loop closure modules of [lidar_s_graphs](https://github.com/snt-arg/s_graphs_msgs.git).

PR related to `lidar_s_graphs` ---> https://github.com/ros/rosdistro/pull/40800

# Please Add This Package to be indexed in the rosdistro.

Iron and Humble

# The source is here:

https://github.com/SMRT-AIST/fast_gicp.git

# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
