### PR TITLE
Add ndt_omp to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4576,6 +4576,12 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: humble
     status: maintained
+  ndt_omp:
+    source:
+      type: git
+      url: https://github.com/koide3/ndt_omp.git
+      version: master
+    status: developed
   neo_simulation2:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3740,6 +3740,12 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: iron
     status: maintained
+  ndt_omp:
+    source:
+      type: git
+      url: https://github.com/koide3/ndt_omp.git
+      version: master
+    status: developed
   neo_simulation2:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package names:

  * [ndt_omp](https://github.com/koide3/ndt_omp.git)
  
## Package Upstream Source:

https://github.com/koide3/ndt_omp.git

## Purpose of using this:

Multi-threaded and SSE friendly NDT registration algorithm. Required as as dependency in the scan matching based odometry and loop closure modules of [lidar_s_graphs](https://github.com/snt-arg/s_graphs_msgs.git).

PR related to `lidar_s_graphs` ---> https://github.com/ros/rosdistro/pull/40800

# Please Add This Package to be indexed in the rosdistro.

Iron and Humble

# The source is here:

https://github.com/koide3/ndt_omp.git

# Checks
 - [ x] All packages have a declared license in the package.xml
 - [ x] This repository has a LICENSE file
 - [ x] This package is expected to build on the submitted rosdistro
