### PR TITLE
rosidl_typesupport: 3.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6141,7 +6141,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 3.2.1-2
+      version: 3.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `3.2.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.1-2`

## rosidl_typesupport_c

```
* Fixed warnings - strict-prototypes (#155 <https://github.com/ros2/rosidl_typesupport/issues/155>) (#156 <https://github.com/ros2/rosidl_typesupport/issues/156>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_cpp

- No changes
