### PR TITLE
rmw_implementation: 2.15.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5443,7 +5443,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.15.1-2
+      version: 2.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.15.2-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.15.1-2`

## rmw_implementation

```
* Update quality declaration document (#225 <https://github.com/ros2/rmw_implementation/issues/225>) (#226 <https://github.com/ros2/rmw_implementation/issues/226>)
* Contributors: mergify[bot]
```
