### PR TITLE
rcutils: 6.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4975,7 +4975,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.7.0-2
+      version: 6.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.7.1-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.7.0-2`

## rcutils

```
* Removed warnings - strict-prototypes (#461 <https://github.com/ros2/rcutils/issues/461>) (#465 <https://github.com/ros2/rcutils/issues/465>)
* Increase timeout repl_str test (#463 <https://github.com/ros2/rcutils/issues/463>) (#464 <https://github.com/ros2/rcutils/issues/464>)
* Contributors: mergify[bot]
```
