### PR TITLE
rcl: 9.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4792,7 +4792,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.2.1-2
+      version: 9.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.2.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.2.1-2`

## rcl

```
* Fixed warnings - strict-prototypes (#1148 <https://github.com/ros2/rcl/issues/1148>) (#1150 <https://github.com/ros2/rcl/issues/1150>)
* Contributors: mergify[bot]
```

## rcl_action

- No changes

## rcl_lifecycle

```
* Fixed warnings - strict-prototypes (#1148 <https://github.com/ros2/rcl/issues/1148>) (#1150 <https://github.com/ros2/rcl/issues/1150>)
* Contributors: mergify[bot]
```

## rcl_yaml_param_parser

- No changes
