### PR TITLE
libstatistics_collector: 1.7.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2908,7 +2908,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.7.1-2
+      version: 1.7.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.7.2-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.1-2`

## libstatistics_collector

```
* Bump pascalgn/automerge-action from 0.16.2 to 0.16.3
* Bump codecov/codecov-action from 4.1.1 to 4.2.0
* Contributors: dependabot[bot]
```
