### PR TITLE
Fix graphicsmagick dep in gentoo

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1595,7 +1595,7 @@ graphicsmagick:
   arch: [graphicsmagick]
   debian: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
   fedora: [GraphicsMagick-c++-devel]
-  gentoo: [virtual/imagemagick-tools]
+  gentoo: [media-gfx/graphicsmagick]
   macports: [GraphicsMagick]
   nixos: [graphicsmagick]
   openembedded: [graphicsmagick@meta-ros2]


### PR DESCRIPTION
If the virtual pulls `imagemagick` then build of [`nav2_map_server`](https://index.ros.org/p/nav2_map_server/#humble) fails