### PR TITLE
add source entry for new package conditional_substitution

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -823,6 +823,17 @@ repositories:
       url: https://github.com/ros2/common_interfaces.git
       version: iron
     status: maintained
+  conditional_substitution:
+    doc:
+      type: git
+      url: https://github.com/ottojo/ros_conditional_substitution.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ottojo/ros_conditional_substitution.git
+      version: main
+    status: maintained
   console_bridge_vendor:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

This package provides a single utility function for choosing substitutions in a launch file depending on a condition.

The source is here: https://github.com/ottojo/ros_conditional_substitution

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
