### PR TITLE
ros_gz: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5838,15 +5838,11 @@ repositories:
       - ros_gz_interfaces
       - ros_gz_sim
       - ros_gz_sim_demos
-      - ros_ign
-      - ros_ign_bridge
-      - ros_ign_gazebo
-      - ros_ign_gazebo_demos
-      - ros_ign_image
-      - ros_ign_interfaces
+      - test_ros_gz_bridge
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ros_gz

- No changes

## ros_gz_bridge

```
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz/issues/531>)
* Added conversion for Detection3D and Detection3DArray (#523 <https://github.com/gazebosim/ros_gz/issues/523>) (#525 <https://github.com/gazebosim/ros_gz/issues/525>)
  Co-authored-by: wittenator <mailto:9154515+wittenator@users.noreply.github.com>
* [Backport rolling] Add ROS namespaces to GZ topics (#517 <https://github.com/gazebosim/ros_gz/issues/517>)
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
* ign to gz (#519 <https://github.com/gazebosim/ros_gz/issues/519>)
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz/issues/503>)
* Add a virtual destructor to suppress compiler warning (#502 <https://github.com/gazebosim/ros_gz/issues/502>)
* Add conversion for geometry_msgs/msg/TwistStamped <-> gz.msgs.Twist (#468 <https://github.com/gazebosim/ros_gz/issues/468>)
* Added messages for 2D Bounding Boxes to ros_gz_bridge (#458 <https://github.com/gazebosim/ros_gz/issues/458>) (#466 <https://github.com/gazebosim/ros_gz/issues/466>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* populate imu covariances when converting (#375 <https://github.com/gazebosim/ros_gz/issues/375>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, El Jawad Alaa, Michael Carroll
```

## ros_gz_image

```
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz/issues/531>)
* ign to gz (#519 <https://github.com/gazebosim/ros_gz/issues/519>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz/issues/531>)
* ign to gz (#519 <https://github.com/gazebosim/ros_gz/issues/519>)
* Undeprecate use of commandline flags (#491 <https://github.com/gazebosim/ros_gz/issues/491>)
* Remove deprecations using ros_gz_sim_create (#476 <https://github.com/gazebosim/ros_gz/issues/476>)
* Added support for using ROS 2 parameters to spawn entities in Gazebo using ros_gz_sim::create (#475 <https://github.com/gazebosim/ros_gz/issues/475>)
* Fix bug in create where command line arguments were truncated (#472 <https://github.com/gazebosim/ros_gz/issues/472>)
* Filter ROS arguments before gflags parsing (#453 <https://github.com/gazebosim/ros_gz/issues/453>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Ayush Singh, Michael Carroll
```

## ros_gz_sim_demos

```
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz/issues/531>)
* Remove deprecations using ros_gz_sim_create (#476 <https://github.com/gazebosim/ros_gz/issues/476>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## test_ros_gz_bridge

```
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz/issues/503>)
* Contributors: Michael Carroll
```
