### PR TITLE
dynamixel_hardware: 0.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1074,7 +1074,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
-      version: 0.3.1-5
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware` to `0.5.0-1`:

- upstream repository: https://github.com/dynamixel-community/dynamixel_hardware.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-5`

## dynamixel_hardware

```
* Adhere to style guide (#73 <https://github.com/dynamixel-community/dynamixel_hardware/issues/73>)
* Revised control mode changes, added set_joint_params (#65 <https://github.com/dynamixel-community/dynamixel_hardware/issues/65>)
  * revised control mode changes, added set_params
  * removed unnecessary comment
* Missing comma for setting Position_D_Gain (#56 <https://github.com/dynamixel-community/dynamixel_hardware/issues/56>)
  * comment out unused paramter
  * A comma is missing for setting the Position_D_Gain
* Contributors: Geoff Sokoll, Kenji Brameld, Lass6230, Yutaka Kondo
```
