### PR TITLE
rviz: 1.14.21-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10882,7 +10882,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.20-1
+      version: 1.14.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.21-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.14.20-1`

## rviz

```
* ImageDisplay: publish mouse clicks (#1737 <https://github.com/ros-visualization/rviz/issues/1737>)
* Add maximize button to Image and Camera display (#1803 <https://github.com/ros-visualization/rviz/issues/1803>)
* Gracefully handle loops in TF tree (#1820 <https://github.com/ros-visualization/rviz/issues/1820>)
* Ogre 13 compatibility
* Qt6 compatibility (#1813 <https://github.com/ros-visualization/rviz/issues/1813>)
* Fix Qt 5.15 API deprecation warnings
* ScrewDisplay: Fix initialization of HideSmallValues property (#1810 <https://github.com/ros-visualization/rviz/issues/1810>)
* Fix vanishing "Global Options" when adding a RobotModelDisplay (#1808 <https://github.com/ros-visualization/rviz/issues/1808>)
* Modernize to Qt5 slots (#1790 <https://github.com/ros-visualization/rviz/issues/1790>)
* Optionally deprecate old-style slots via -DRVIZ_DEPRECATE_QT4_SLOTS
* Improve error handling in LaserScanDisplay (#1798 <https://github.com/ros-visualization/rviz/issues/1798>)
* MapDisplay: Fix crash after map update (#1793 <https://github.com/ros-visualization/rviz/issues/1793>)
* Call propertyHiddenChanged synchronously (#1795 <https://github.com/ros-visualization/rviz/issues/1795>)
* Replace obsolete QPixmap::grabWindow() with QScreen::grabWindow() (#1794 <https://github.com/ros-visualization/rviz/issues/1794>)
* Contributors: Miguel Riem de Oliveira, Robert Haschke, Simon Schmeisser, Stefan Fabian, vineet131
```
