### PR TITLE
unitree_ros: 1.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7834,7 +7834,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/unitree_ros-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/snt-arg/unitree_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `unitree_ros` to `1.1.1-1`:

- upstream repository: https://github.com/snt-arg/unitree_ros
- release repository: https://github.com/ros2-gbp/unitree_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## unitree_ros

```
* Merge pull request #22 <https://github.com/snt-arg/unitree_ros/issues/22> from snt-arg/dev
  fix: import error (#21 <https://github.com/snt-arg/unitree_ros/issues/21>)
* fix: import error (#21 <https://github.com/snt-arg/unitree_ros/issues/21>)
  This commit fixes issue (#21 <https://github.com/snt-arg/unitree_ros/issues/21>) and changes the way we use the launch
  file. Now we only need use wifi:=true instead of passing the robot ip.
* chore: update gitignore to conform ros2 development
* Merge pull request #20 <https://github.com/snt-arg/unitree_ros/issues/20> from snt-arg/PedroS235-patch-1
  docs: update installation with apt
* docs: update installation with apt
* Contributors: Pedro Soares
```
