### PR TITLE
gz_fuel_tools_vendor: 0.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2001,7 +2001,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_fuel_tools_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## gz_fuel_tools_vendor

```
* Use an alias target for root library
* Contributors: Addisu Z. Taddese
```
