### PR TITLE
gz_plugin_vendor: 0.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
-      version: 0.0.3-2
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_plugin_vendor` to `0.0.4-1`:

- upstream repository: https://github.com/gazebo-release/gz_plugin_vendor.git
- release repository: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-2`

## gz_plugin_vendor

```
* Use an alias target for root library
* Contributors: Addisu Z. Taddese
```
