### PR TITLE
sdformat_vendor: 0.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6775,7 +6775,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.0.3-2
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.0.4-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-2`

## sdformat_vendor

```
* Use an alias target for root library
* Contributors: Addisu Z. Taddese
```
