### PR TITLE
Add missing nixos rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4238,9 +4238,9 @@ liblmdb-dev:
 liblttng-ctl-dev:
   debian: [liblttng-ctl-dev]
   fedora: [lttng-tools-devel]
+  nixos: [lttng-tools]
   openembedded: [lttng-tools@openembedded-core]
   opensuse: [lttng-tools-devel]
-  nixos: [lttng-tools]
   rhel: [lttng-tools-devel]
   ubuntu: [liblttng-ctl-dev]
 liblttng-ust-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -837,6 +837,7 @@ docker.io:
     stretch: null
     wheezy: null
   fedora: [docker]
+  nixos: [docker]
   ubuntu: [docker.io]
 doxygen:
   arch: [doxygen]
@@ -1457,6 +1458,7 @@ glslang-dev:
   debian: [glslang-dev]
   fedora: [glslang-devel]
   gentoo: [dev-util/glslang]
+  nixos: [glslang]
   opensuse: [glslang-devel]
   rhel:
     '*': [glslang-devel]
@@ -1469,6 +1471,7 @@ glslc:
     bullseye: null
   fedora: [glslc]
   gentoo: [media-libs/shaderc]
+  nixos: [shaderc]
   rhel:
     '*': [glslc]
     '8': null
@@ -2560,6 +2563,7 @@ libavahi-core-dev:
 libavdevice-dev:
   debian: [libavdevice-dev]
   fedora: [libavdevice-free-devel]
+  nixos: [ffmpeg]
   rhel:
     '*': [libavdevice-free-devel]
     '8': null
@@ -3268,6 +3272,7 @@ libdraco-dev:
   arch: [draco]
   debian: [libdraco-dev]
   fedora: [draco-devel]
+  nixos: [draco]
   rhel:
     '*': [draco-devel]
     '8': null
@@ -3469,6 +3474,7 @@ libfreeimage-dev:
   arch: [freeimage]
   debian: [libfreeimage-dev]
   fedora: [freeimage-devel]
+  nixos: [freeimage]
   opensuse: [freeimage-devel]
   rhel: [freeimage-devel]
   ubuntu: [libfreeimage-dev]
@@ -4234,6 +4240,7 @@ liblttng-ctl-dev:
   fedora: [lttng-tools-devel]
   openembedded: [lttng-tools@openembedded-core]
   opensuse: [lttng-tools-devel]
+  nixos: [lttng-tools]
   rhel: [lttng-tools-devel]
   ubuntu: [liblttng-ctl-dev]
 liblttng-ust-dev:
@@ -4248,6 +4255,7 @@ liblttng-ust-dev:
 liblz4:
   debian: [liblz4-1]
   fedora: [lz4-libs]
+  nixos: [lz4]
   opensuse:
     '*': [liblz4]
     '15.2': null
@@ -4256,6 +4264,7 @@ liblz4:
 liblz4-dev:
   debian: [liblz4-dev]
   fedora: [lz4-devel]
+  nixos: [lz4]
   opensuse:
     '*': [liblz4-devel]
     '15.2': null
@@ -5811,6 +5820,7 @@ libshaderc-dev:
     bullseye: null
   fedora: [libshaderc-devel]
   gentoo: [media-libs/shaderc]
+  nixos: [shaderc]
   opensuse: [shaderc-devel]
   rhel:
     '*': [libshaderc-devel]
@@ -6436,6 +6446,7 @@ libxinerama-dev:
 libxkbcommon-dev:
   debian: [libxkbcommon-dev]
   fedora: [libxkbcommon-devel]
+  nixos: [libxkbcommon]
   rhel: [libxkbcommon-devel]
   ubuntu: [libxkbcommon-dev]
 libxml++-2.6:
@@ -6563,6 +6574,7 @@ libzip-dev:
   debian: [libzip-dev]
   fedora: [libzip-devel]
   gentoo: [dev-libs/libzip]
+  nixos: [libzip]
   ubuntu: [libzip-dev]
 libzmq3-dev:
   arch: [zeromq]
@@ -7122,6 +7134,7 @@ ocl-icd-opencl-dev:
   debian: [ocl-icd-opencl-dev]
   fedora: [ocl-icd-devel]
   gentoo: [virtual/opencl]
+  nixos: [ocl-icd]
   rhel: [ocl-icd-devel]
   ubuntu: [ocl-icd-opencl-dev]
 octave:
@@ -7583,67 +7596,83 @@ qhull-bin:
   ubuntu: [qhull-bin]
 qml-module-qt-labs-folderlistmodel:
   debian: [qml-module-qt-labs-folderlistmodel]
+  nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qt-labs-folderlistmodel]
 qml-module-qt-labs-platform:
   arch: [qt5-quickcontrols2]
   debian: [qml-module-qt-labs-platform]
   fedora: [qt5-qtquickcontrols2]
   gentoo: [dev-qt/qtquickcontrols2]
+  nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qt-labs-platform]
 qml-module-qt-labs-settings:
   debian: [qml-module-qt-labs-settings]
+  nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qt-labs-settings]
 qml-module-qtcharts:
   arch: [qt5-charts]
   debian: [qml-module-qtcharts]
   fedora: [qt5-qtcharts]
   gentoo: [dev-qt/qtcharts]
+  nixos: [qt5.qtcharts]
   ubuntu: [qml-module-qtcharts]
 qml-module-qtgraphicaleffects:
   debian: [qml-module-qtgraphicaleffects]
+  nixos: [qt5.qtgraphicaleffects]
   ubuntu: [qml-module-qtgraphicaleffects]
 qml-module-qtlocation:
   arch: [qt5-location]
   debian: [qml-module-qtlocation]
   fedora: [qt5-qtlocation]
   gentoo: [dev-qt/qtlocation]
+  nixos: [qt5.qtlocation]
   ubuntu: [qml-module-qtlocation]
 qml-module-qtmultimedia:
   debian: [qml-module-qtmultimedia]
+  nixos: [qt5.qtmultimedia]
   ubuntu: [qml-module-qtmultimedia]
 qml-module-qtpositioning:
   arch: [qt5-location]
   debian: [qml-module-qtpositioning]
   fedora: [qt5-qtlocation]
   gentoo: [dev-qt/qtpositioning]
+  nixos: [qt5.qtpositioning]
   ubuntu: [qml-module-qtpositioning]
 qml-module-qtquick-controls:
   debian: [qml-module-qtquick-controls]
   gentoo: [dev-qt/qtquickcontrols]
+  nixos: [qt5.qtquickcontrols]
   ubuntu: [qml-module-qtquick-controls]
 qml-module-qtquick-controls2:
   debian: [qml-module-qtquick-controls2]
+  nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qtquick-controls2]
 qml-module-qtquick-dialogs:
   debian: [qml-module-qtquick-dialogs]
+  nixos: [qt5.qtquickcontrols]
   ubuntu: [qml-module-qtquick-dialogs]
 qml-module-qtquick-extras:
   debian: [qml-module-qtquick-extras]
   fedora: [qt5-qtquickcontrols]
   gentoo: [dev-qt/qtquickcontrols]
+  nixos: [qt5.qtquickcontrols]
   rhel: [qt5-qtquickcontrols]
   ubuntu: [qml-module-qtquick-extras]
 qml-module-qtquick-layouts:
   debian: [qml-module-qtquick-layouts]
+  nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qtquick-layouts]
 qml-module-qtquick-templates2:
   debian: [qml-module-qtquick-templates2]
+  nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qtquick-templates2]
 qml-module-qtquick-window2:
   debian: [qml-module-qtquick-window2]
+  nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qtquick-window2]
 qml-module-qtquick2:
   debian: [qml-module-qtquick2]
+  nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qtquick2]
 qrencode:
   arch: [qrencode]
@@ -7741,12 +7770,14 @@ qtmultimedia5-dev:
   ubuntu: [qtmultimedia5-dev]
 qtpositioning5-dev:
   debian: [qtpositioning5-dev]
+  nixos: [qt5.qtpositioning]
   ubuntu: [qtpositioning5-dev]
 qtquickcontrols2-5-dev:
   arch: [qt5-quickcontrols2]
   debian: [qtquickcontrols2-5-dev]
   fedora: [qt5-qtquickcontrols2]
   gentoo: [dev-qt/qtquickcontrols2]
+  nixos: [qt5.qtquickcontrols]
   ubuntu: [qtquickcontrols2-5-dev]
 qttools5-dev:
   debian: [qttools5-dev]
@@ -8039,6 +8070,7 @@ simde:
     '*': [libsimde-dev]
     buster: null
   fedora: [simde-devel]
+  nixos: [simde]
   rhel:
     '*': [simde-devel]
     '9': null
@@ -8682,6 +8714,7 @@ wayland:
   arch: [wayland]
   debian: [libwayland-client0, libwayland-cursor0, libwayland-egl1]
   fedora: [libwayland-client, libwayland-cursor, libwayland-egl]
+  nixos: [wayland]
   openembedded: [wayland@openembedded-core]
   rhel: [libwayland-client, libwayland-cursor, libwayland-egl]
   ubuntu: [libwayland-client0, libwayland-cursor0, libwayland-egl1]
@@ -8689,6 +8722,7 @@ wayland-dev:
   arch: [wayland, wayland-protocols]
   debian: [libwayland-dev, wayland-protocols]
   fedora: [wayland-devel, wayland-protocols-devel]
+  nixos: [wayland]
   openembedded: [wayland@openembedded-core]
   rhel: [wayland-devel, wayland-protocols-devel]
   ubuntu: [libwayland-dev, wayland-protocols]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4949,6 +4949,7 @@ python3-babeltrace:
   debian: [python3-babeltrace]
   fedora: [python3-babeltrace]
   gentoo: [dev-util/babeltrace]
+  nixos: [babeltrace]
   opensuse: [python3-babeltrace]
   rhel:
     '*': [python3-babeltrace]
@@ -5494,6 +5495,7 @@ python3-deprecated:
     '*': [python3-deprecated]
     buster: null
   fedora: [python3-deprecated]
+  nixos: [python3Packages.deprecated]
   rhel:
     '*': [python3-deprecated]
     '7': null
@@ -5950,6 +5952,7 @@ python3-flake8-docstrings:
   arch: [python-flake8-docstrings]
   debian: [python3-flake8-docstrings]
   fedora: [python3-flake8-docstrings]
+  nixos: [python3Packages.flake8-docstrings]
   openembedded: [python3-flake8-docstrings@meta-ros-common]
   opensuse: [python3-flake8-docstrings]
   rhel:
@@ -5967,6 +5970,7 @@ python3-flake8-import-order:
       pip:
         packages: [flake8-import-order]
   fedora: [python3-flake8-import-order]
+  nixos: [python3Packages.flake8-import-order]
   openembedded: [python3-flake8-import-order@meta-ros-common]
   opensuse: [python3-flake8-import-order]
   rhel:
@@ -9002,6 +9006,7 @@ python3-smbus:
   arch: [i2c-tools]
   debian: [python3-smbus]
   fedora: [python3-i2c-tools]
+  nixos: [python3Packages.i2c-tools]
   opensuse: [python3-smbus]
   rhel:
     '*': [python3-i2c-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5335,6 +5335,7 @@ python3-colorcet:
       pip:
         packages: [colorcet]
   fedora: [python3-colorcet]
+  nixos: [python3Packages.colorcet]
   ubuntu:
     '*': [python3-colorcet]
     bionic:
@@ -7836,6 +7837,7 @@ python3-pydantic:
       pip: [pydantic]
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
+  nixos: [python3Packages.pydantic]
   ubuntu:
     '*': [python3-pydantic]
     bionic:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5882,6 +5882,7 @@ python3-flake8-builtins:
       pip:
         packages: [flake8-builtins]
   fedora: [python3-flake8-builtins]
+  nixos: []
   openembedded: [python3-flake8-builtins@meta-ros-common]
   opensuse: [python3-flake8-builtins]
   rhel:
@@ -5919,6 +5920,7 @@ python3-flake8-comprehensions:
       pip:
         packages: [flake8-comprehensions]
   fedora: [python3-flake8-comprehensions]
+  nixos: []
   openembedded: [python3-flake8-comprehensions@meta-ros-common]
   rhel:
     '*': [python3-flake8-comprehensions]
@@ -6008,6 +6010,7 @@ python3-flake8-quotes:
   fedora:
     '*': [python3-flake8-quotes]
     '35': null
+  nixos: []
   openembedded: [python3-flake8-quotes@meta-ros-common]
   opensuse: [python3-flake8-quotes]
   rhel:

--- a/rosdep/ruby.yaml
+++ b/rosdep/ruby.yaml
@@ -66,6 +66,7 @@ rdoc:
 rubocop:
   arch: [rubocop]
   debian: [rubocop]
+  nixos: [rubocop]
   ubuntu: [rubocop]
 ruby:
   arch: [ruby]


### PR DESCRIPTION
Added some nixos rules to fix generating nix derivations for rolling packages.

The `flake8-builtins`, `flake8-comprehensions` and `flake8-quotes` python packages are not available for nixos but they prevent generating derivation for `ament_flake8` package which is a dependency of many essential packages (e.g. rclpy). That's why I decided to ignore them for now. `ament_flake8` works without these packages as they only add more checks to flake8 tool.