### PR TITLE
pal_maps: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5135,6 +5135,21 @@ repositories:
       url: https://github.com/pal-robotics/pal_hey5.git
       version: humble-devel
     status: maintained
+  pal_maps:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_maps.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_maps-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_maps.git
+      version: humble-devel
+    status: developed
   pal_navigation_cfg_public:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_maps` to `0.0.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_maps.git
- release repository: https://github.com/pal-gbp/pal_maps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## pal_maps

```
* license and contributing
* Contributors: antoniobrandi
