### PR TITLE
ament_index: 1.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -210,7 +210,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.9.0-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.0-1`

## ament_index_cpp

```
* Update quality declaration documents (#94 <https://github.com/ament/ament_index/issues/94>)
* Contributors: Christophe Bedard
```

## ament_index_python

```
* Update quality declaration documents (#94 <https://github.com/ament/ament_index/issues/94>)
* Contributors: Christophe Bedard
```
