### PR TITLE
googletest: 1.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1851,7 +1851,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.14.9000-1
+      version: 1.15.0-1
     source:
       type: git
       url: https://github.com/ament/googletest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.15.0-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.14.9000-1`

## gmock_vendor

- No changes

## gtest_vendor

- No changes
