### PR TITLE
imu_tools: 2.1.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2954,7 +2954,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.1.4-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.3-1`

## imu_complementary_filter

```
* Set read-only parameters as read_only (#185 <https://github.com/CCNYRoboticsLab/imu_tools/issues/185>)
* Contributors: Christoph Fröhlich
```

## imu_filter_madgwick

```
* Show remapped topic names (#196 <https://github.com/CCNYRoboticsLab/imu_tools/issues/196>)
* Set read-only parameters as read_only (#185 <https://github.com/CCNYRoboticsLab/imu_tools/issues/185>)
* Contributors: Christoph Fröhlich, Tamaki Nishino
```

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
