### PR TITLE
rqt_service_caller: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6576,7 +6576,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.2.1-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `1.3.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.1-2`

## rqt_service_caller

- No changes
