### PR TITLE
eigen3_cmake_module: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1263,7 +1263,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-      version: 0.3.0-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen3_cmake_module` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/eigen3_cmake_module.git
- release repository: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.0-2`

## eigen3_cmake_module

- No changes
