### PR TITLE
examples: 0.20.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1408,7 +1408,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.19.3-1
+      version: 0.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.20.0-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.19.3-1`

## examples_rclcpp_async_client

- No changes

## examples_rclcpp_cbg_executor

- No changes

## examples_rclcpp_minimal_action_client

- No changes

## examples_rclcpp_minimal_action_server

- No changes

## examples_rclcpp_minimal_client

- No changes

## examples_rclcpp_minimal_composition

- No changes

## examples_rclcpp_minimal_publisher

- No changes

## examples_rclcpp_minimal_service

- No changes

## examples_rclcpp_minimal_subscriber

- No changes

## examples_rclcpp_minimal_timer

- No changes

## examples_rclcpp_multithreaded_executor

- No changes

## examples_rclcpp_wait_set

- No changes

## examples_rclpy_executors

- No changes

## examples_rclpy_guard_conditions

- No changes

## examples_rclpy_minimal_action_client

- No changes

## examples_rclpy_minimal_action_server

- No changes

## examples_rclpy_minimal_client

- No changes

## examples_rclpy_minimal_publisher

- No changes

## examples_rclpy_minimal_service

- No changes

## examples_rclpy_minimal_subscriber

- No changes

## examples_rclpy_pointcloud_publisher

- No changes

## launch_testing_examples

- No changes
