### PR TITLE
launch: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2745,7 +2745,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.2-1
+      version: 3.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.5.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.2-1`

## launch

- No changes

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
