### PR TITLE
rcl_logging: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4861,7 +4861,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.2.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.0-1`

## rcl_logging_interface

- No changes

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

- No changes
