### PR TITLE
rclcpp: 28.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4914,7 +4914,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.0-1
+      version: 28.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.2.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `28.1.0-1`

## rclcpp

```
* Check for negative time in rclcpp::Time(int64_t nanoseconds, ...) constructor (#2510 <https://github.com/ros2/rclcpp/issues/2510>)
* Revise the description of service configure_introspection() (#2511 <https://github.com/ros2/rclcpp/issues/2511>)
* Contributors: Barry Xu, Sharmin Ramli
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
