### PR TITLE
rcutils: 6.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4997,7 +4997,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.7.0-1
+      version: 6.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.8.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `6.7.0-1`

## rcutils

```
* Removed warnings - strict-prototypes (#461 <https://github.com/ros2/rcutils/issues/461>)
* Increase timeout repl_str test (#463 <https://github.com/ros2/rcutils/issues/463>)
* Contributors: Alejandro Hernández Cordero
```
