### PR TITLE
rmw: 7.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5358,7 +5358,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.3.0-2
+      version: 7.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.4.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.3.0-2`

## rmw

```
* Removed warnings - strict-prototypes (#365 <https://github.com/ros2/rmw/issues/365>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_implementation_cmake

- No changes
