### PR TITLE
rospy_message_converter: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6208,7 +6208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
-      version: 2.0.1-3
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rospy_message_converter` to `2.0.2-1`:

- upstream repository: https://github.com/uos/rospy_message_converter.git
- release repository: https://github.com/ros2-gbp/rospy_message_converter-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-3`

## rclpy_message_converter

```
* tests: Adapt to renamed exception message
* Move repo to DFKI-NI
* Modifies the use of slots for get_fields_and_field_types method (#64 <https://github.com/DFKI-NI/rospy_message_converter/issues/64>)
* Contributors: Eloy Briceno, Martin Günther
```

## rclpy_message_converter_msgs

```
* Move repo to DFKI-NI
* Contributors: Martin Günther
```
