### PR TITLE
ros2_tracing: 8.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5722,7 +5722,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.2.0-1
+      version: 8.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.3.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.0-1`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
