### PR TITLE
rosidl: 4.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6028,7 +6028,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.6.0-1
+      version: 4.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.7.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.6.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Fixed warnings - strict-prototypes (#800 <https://github.com/ros2/rosidl/issues/800>)
* Contributors: Alejandro Hernández Cordero
```

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

```
* Global use of nodiscard (#801 <https://github.com/ros2/rosidl/issues/801>)
  * Global use of nodiscard
* Suppress a warning around BoundedVector. (#803 <https://github.com/ros2/rosidl/issues/803>)
  The comment has more explanation, but in short GCC 13
  has false positives around some warnings, so we suppress
  it for BoundedVector.
* Contributors: Chris Lalancette, Lucas Wendland
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Fixed warnings - strict-prototypes (#800 <https://github.com/ros2/rosidl/issues/800>)
* Contributors: Alejandro Hernández Cordero
```

## rosidl_typesupport_introspection_cpp

```
* Global use of nodiscard (#801 <https://github.com/ros2/rosidl/issues/801>)
  * Global use of nodiscard
* Contributors: Lucas Wendland
```
