### PR TITLE
Revert "libcamera: 0.2.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3442,7 +3442,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
-      version: 0.2.0-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git


### PR DESCRIPTION
Reverts ros/rosdistro#39494

I would like to revert this back to version 0.1 as it causes issues with the RHEL build and crashes with some Raspberry Pi cameras.