### PR TITLE
leo_simulator: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3391,7 +3391,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_simulator-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator-ros2.git
- release repository: https://github.com/ros2-gbp/leo_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## leo_gz_bringup

```
* Set new GZ variables to work on Gazebo Harmonic
* Contributors: Błażej Sowa
```

## leo_gz_plugins

```
* Update package dependencies
* Fix build for Gazebo Harmonic
* Set new GZ variables to work on Gazebo Harmonic
* Contributors: Błażej Sowa
```

## leo_gz_worlds

```
* Add README to leo_gz_worlds [skip ci]
* Set new GZ variables to work on Gazebo Harmonic
* Revert empty world collision detector to ode
* Contributors: Błażej Sowa, Jan Hernas
```

## leo_simulator

- No changes
