### PR TITLE
leo_simulator: 1.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2748,6 +2748,26 @@ repositories:
       url: https://github.com/LeoRover/leo_robot-ros2.git
       version: iron
     status: maintained
+  leo_simulator:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: iron
+    release:
+      packages:
+      - leo_gz_bringup
+      - leo_gz_plugins
+      - leo_gz_worlds
+      - leo_simulator
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_simulator-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: iron
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator-ros2.git
- release repository: https://github.com/ros2-gbp/leo_simulator-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## leo_gz_bringup

```
* Set new GZ variables to work on Gazebo Harmonic
* Contributors: Błażej Sowa
```

## leo_gz_plugins

```
* Update package dependencies
* Fix build for Gazebo Harmonic
* Set new GZ variables to work on Gazebo Harmonic
* Contributors: Błażej Sowa
```

## leo_gz_worlds

```
* Add README to leo_gz_worlds [skip ci]
* Set new GZ variables to work on Gazebo Harmonic
* Revert empty world collision detector to ode
* Contributors: Błażej Sowa, Jan Hernas
```

## leo_simulator

- No changes
