### PR TITLE
leo_common: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2801,7 +2801,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 3.0.1-2
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `3.0.2-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-2`

## leo

- No changes

## leo_description

```
* IGN_GAZEBO_RESOURCE_PATH -> GZ_SIM_RESOURCE_PATH
* Contributors: Błażej Sowa
```

## leo_msgs

- No changes

## leo_teleop

- No changes
