### PR TITLE
leo_simulator: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2844,6 +2844,26 @@ repositories:
       url: https://github.com/LeoRover/leo_robot-ros2.git
       version: rolling
     status: maintained
+  leo_simulator:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: ros2
+    release:
+      packages:
+      - leo_gz_bringup
+      - leo_gz_plugins
+      - leo_gz_worlds
+      - leo_simulator
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_simulator-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: ros2
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `2.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator-ros2.git
- release repository: https://github.com/ros2-gbp/leo_simulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## leo_gz_bringup

```
* Get rid of all the ignition references
* Contributors: Błażej Sowa
```

## leo_gz_plugins

```
* Get rid of all the ignition references
* Use gz vendor packages
* Contributors: Błażej Sowa
```

## leo_gz_worlds

```
* Get rid of all the ignition references
* Contributors: Błażej Sowa
```

## leo_simulator

- No changes
