### PR TITLE
split off jazzy branch for zbar ros

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8105,7 +8105,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: jazzy
     release:
       packages:
       - zbar_ros
@@ -8117,7 +8117,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: jazzy
     status: maintained
   zenoh_bridge_dds:
     doc:


### PR DESCRIPTION
[Link to jazzy branch](https://github.com/ros-drivers/zbar_ros/tree/jazzy)