### PR TITLE
Rename zbar_ros dev branch from ros2 to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8133,7 +8133,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - zbar_ros
@@ -8145,7 +8145,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
-      version: ros2
+      version: rolling
     status: maintained
   zenoh_bridge_dds:
     doc:


### PR DESCRIPTION
[Link to rolling branch](https://github.com/ros-drivers/zbar_ros/tree/rolling)