### PR TITLE
zbar_ros: 0.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10174,7 +10174,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git
-      version: 0.4.0-2
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.4.1-1`:

- upstream repository: https://github.com/ros-drivers/zbar_ros.git
- release repository: https://github.com/ros2-gbp/zbar_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-2`

## zbar_ros

```
* Switch to CI from ros-tooling (#27 <https://github.com/ros-drivers/zbar_ros/issues/27>)
* Improve README (#17 <https://github.com/ros-drivers/zbar_ros/issues/17>)
* Update authors and maintainers of package (#13 <https://github.com/ros-drivers/zbar_ros/issues/13>)
* Contributors: Kenji Brameld
```
