### PR TITLE
zbar_ros: 0.5.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8409,7 +8409,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git
-      version: 0.4.0-3
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zbar_ros` to `0.5.1-1`:

- upstream repository: https://github.com/ros-drivers/zbar_ros.git
- release repository: https://github.com/ros2-gbp/zbar_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-3`

## zbar_ros

```
* Add iron CI (#28 <https://github.com/ros-drivers/zbar_ros/issues/28>)
* Remove usage of deprecated cv_bridge header file (#19 <https://github.com/ros-drivers/zbar_ros/issues/19>)
* Switch to CI from ros-tooling (#27 <https://github.com/ros-drivers/zbar_ros/issues/27>)
* Improve README (#17 <https://github.com/ros-drivers/zbar_ros/issues/17>)
* Update authors and maintainers of package (#13 <https://github.com/ros-drivers/zbar_ros/issues/13>)
* Contributors: Kenji Brameld
```
