### PR TITLE
ur_description: 2.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9564,7 +9564,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.4-1
+      version: 2.1.5-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.5-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.4-1`

## ur_description

```
* Fix multi-line strings in DeclareLaunchArgument ( backport of #140 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/140>) (#153 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/153>)
* Fix default calibration file for UR30 (#148 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/148>)
* Contributors: Matthijs van der Burgh, Felix Exner
```
