### PR TITLE
rviz: 14.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6735,7 +6735,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.0-1
+      version: 14.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.2.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `14.1.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Removed assimp warnings (#1191 <https://github.com/ros2/rviz/issues/1191>)
* Don't treat warnings as errors when building Assimp (#1174 <https://github.com/ros2/rviz/issues/1174>)
* Contributors: Alejandro Hernández Cordero, Scott K Logan
```

## rviz_common

- No changes

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
