### PR TITLE
ortools_vendor: 9.9.0-6 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7297,7 +7297,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-5
+      version: 9.9.0-6
     source:
       type: git
       url: https://github.com/Fields2Cover/ortools_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ortools_vendor` to `9.9.0-6`:

- upstream repository: https://github.com/Fields2Cover/ortools_vendor
- release repository: https://github.com/ros2-gbp/ortools_vendor-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `9.9.0-5`
