### PR TITLE
ur_description: 2.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7864,7 +7864,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.4-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.4-1`

## ur_description

```
* Update CI for iron
* Fix multi-line strings in DeclareLaunchArgument (backport of #140 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/140>) (#154 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/154>)
  Co-authored-by: Matthijs van der Burgh <mailto:matthijs.vander.burgh@live.nl>
* Fix default calibration file for UR30 (#151 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/151>)
* Update description for using gz
  The ign libs don't exist anymore on iron.
* Contributors: Felix Exner, Matthijs van der Burgh
```
