### PR TITLE
fields2cover: 2.0.0-5 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1525,7 +1525,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 2.0.0-3
+      version: 2.0.0-5
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `2.0.0-5`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/ros2-gbp/fields2cover-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-3`
