### PR TITLE
ur_description: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7615,7 +7615,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.2.5-2
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.5-2`

## ur_description

```
* Fix multi-line strings in DeclareLaunchArgument (#140 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/140>)
* Add mergify rule for iron branch (#120 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/120>)
* Fix default calibration file for UR30
* Contributors: Felix Exner, Matthijs van der Burgh, RobertWilbrandt
```
