### PR TITLE
fields2cover: 2.0.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2910,7 +2910,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/Fields2Cover/fields2cover-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `2.0.0-2`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/Fields2Cover/fields2cover-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`
