### PR TITLE
qbdevice-ros: 4.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5839,6 +5839,20 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbshin-ros.git
       version: production-humble
     status: developed
+  qbdevice-ros:
+    release:
+      packages:
+      - qb_device
+      - qb_device_bringup
+      - qb_device_driver
+      - qb_device_msgs
+      - qb_device_ros2_control
+      - qb_device_test_controllers
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros2-release
+      version: 4.0.2-1
+    status: developed
   qpoases_vendor:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5839,7 +5839,7 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbshin-ros.git
       version: production-humble
     status: developed
-  qbdevice-ros:
+  qb_device:
     release:
       packages:
       - qb_device
@@ -5852,6 +5852,10 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros2-release
       version: 4.0.2-1
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
+      version: production-humble      
     status: developed
   qpoases_vendor:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `qbdevice-ros` to `4.0.2-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros2-release
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## qb_device

- No changes

## qb_device_bringup

- No changes

## qb_device_driver

- No changes

## qb_device_msgs

- No changes

## qb_device_ros2_control

- No changes

## qb_device_test_controllers

- No changes
