### PR TITLE
[rosdep] [catkin-lint] [debian/ubuntu] Use catkin-lint instead of python3-catkin-lint package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5178,7 +5178,7 @@ python3-catkin-lint:
   openembedded: [python3-catkin-lint@meta-ros-common]
   rhel: [python3-catkin_lint]
   ubuntu:
-    '*': [python3-catkin-lint]
+    '*': [catkin-lint]
     bionic: null
 python3-catkin-pkg:
   alpine: [py3-catkin-pkg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5172,7 +5172,7 @@ python3-cantools-pip:
       packages: [cantools]
 python3-catkin-lint:
   debian:
-    '*': [python3-catkin-lint]
+    '*': [catkin-lint]
     stretch: null
   fedora: [python3-catkin_lint]
   openembedded: [python3-catkin-lint@meta-ros-common]


### PR DESCRIPTION
It looks like python3-catkin-tools was a name used in the past but not used anymore, and catkin-lint is used intead on all currently active distros.

## Ubuntu
$ rmadison python3-catkin-lint
 python3-catkin-lint | 1.6.6-1 | focal/universe | all

$ rmadison catkin-lint
 catkin-lint | 1.6.6-1  | focal/universe  | all
 catkin-lint | 1.6.16-1 | jammy/universe  | all
 catkin-lint | 1.6.22-1 | mantic/universe | all
 catkin-lint | 1.6.22-1 | noble/universe  | all

## Debian

$ rmadison python3-catkin-lint --url debian
python3-catkin-lint | 1.6.0-1       | oldoldstable | all
python3-catkin-lint | 1.6.12-1      | oldstable    | all

$ rmadison catkin-lint --url debian
catkin-lint | 1.6.12-1      | oldstable  | all
catkin-lint | 1.6.22-1      | stable     | all
catkin-lint | 1.6.22-1      | testing    | all
catkin-lint | 1.6.22-1      | unstable   | all