### PR TITLE
mp2p_icp: 1.3.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4236,7 +4236,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.3.3-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.2-1`

## mp2p_icp

```
* Add minimum_input_points_to_filter option to FilterDecimateVoxels
* FIX: QualityEvaluator_PairedRatio throws when one of the reference maps is empty
* FIX BUG: Won't try to match 2D pointclouds if their height is different
* Clarify comments in metricmap.h about geodetic references
* Fix printing metric_map_t contents when it only has a gridmap
* Fix potential dangling references (g++ 13 warning)
* Fix potential use of uninitialized point index
* Bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```
