### PR TITLE
ros2_control: 4.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5585,7 +5585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.8.0-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.9.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.8.0-1`

## controller_interface

```
* return the proper const object of the pointer in the const method (#1494 <https://github.com/ros-controls/ros2_control/issues/1494>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* Deactivate the controllers when they return error similar to hardware (#1499 <https://github.com/ros-controls/ros2_control/issues/1499>)
* Component parser: Get mimic information from URDF (#1256 <https://github.com/ros-controls/ros2_control/issues/1256>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add missing calculate_dynamics (#1498 <https://github.com/ros-controls/ros2_control/issues/1498>)
* Component parser: Get mimic information from URDF (#1256 <https://github.com/ros-controls/ros2_control/issues/1256>)
* Contributors: Christoph Fröhlich
```

## hardware_interface_testing

```
* Component parser: Get mimic information from URDF (#1256 <https://github.com/ros-controls/ros2_control/issues/1256>)
* Contributors: Christoph Fröhlich
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Component parser: Get mimic information from URDF (#1256 <https://github.com/ros-controls/ros2_control/issues/1256>)
* Contributors: Christoph Fröhlich
```

## ros2controlcli

```
* [CI] Specify runner/container images and codecov for joint_limits  (#1504 <https://github.com/ros-controls/ros2_control/issues/1504>)
* [CLI] Add set_hardware_component_state verb (#1248 <https://github.com/ros-controls/ros2_control/issues/1248>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* rosdoc2 for transmission_interface (#1496 <https://github.com/ros-controls/ros2_control/issues/1496>)
* Component parser: Get mimic information from URDF (#1256 <https://github.com/ros-controls/ros2_control/issues/1256>)
* Contributors: Christoph Fröhlich
```
