### PR TITLE
ros2_control: 3.25.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5665,7 +5665,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.24.0-1
+      version: 3.25.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.25.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.24.0-1`

## controller_interface

- No changes

## controller_manager

```
* check for state of the controller node before cleanup (backport #1363 <https://github.com/ros-controls/ros2_control/issues/1363>) (#1379 <https://github.com/ros-controls/ros2_control/issues/1379>)
* Bump version of pre-commit hooks (backport #1430 <https://github.com/ros-controls/ros2_control/issues/1430>) (#1435 <https://github.com/ros-controls/ros2_control/issues/1435>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add missing calculate_dynamics (#1498 <https://github.com/ros-controls/ros2_control/issues/1498>) (#1512 <https://github.com/ros-controls/ros2_control/issues/1512>)
* [Doc] Add documentation about initial_value regarding mock_hw (#1352 <https://github.com/ros-controls/ros2_control/issues/1352>) (#1514 <https://github.com/ros-controls/ros2_control/issues/1514>)
* Move migration notes (#1481 <https://github.com/ros-controls/ros2_control/issues/1481>)
* Bump version of pre-commit hooks (backport #1430 <https://github.com/ros-controls/ros2_control/issues/1430>) (#1435 <https://github.com/ros-controls/ros2_control/issues/1435>)
* Contributors: Christoph Fröhlich, Felix Exner
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Bump version of pre-commit hooks (backport #1430 <https://github.com/ros-controls/ros2_control/issues/1430>) (#1435 <https://github.com/ros-controls/ros2_control/issues/1435>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [CI] Specify runner/container images and codecov for joint_limits  (#1504 <https://github.com/ros-controls/ros2_control/issues/1504>) (#1520 <https://github.com/ros-controls/ros2_control/issues/1520>)
* [CLI] Add set_hardware_component_state verb (#1248 <https://github.com/ros-controls/ros2_control/issues/1248>) (#1471 <https://github.com/ros-controls/ros2_control/issues/1471>)
* Contributors: Christoph Fröhlich
```

## rqt_controller_manager

```
* Add cm as dependency to rqt_cm (#1447 <https://github.com/ros-controls/ros2_control/issues/1447>) (#1460 <https://github.com/ros-controls/ros2_control/issues/1460>)
* Contributors: mergify[bot]
```

## transmission_interface

```
* rosdoc2 for transmission_interface (#1496 <https://github.com/ros-controls/ros2_control/issues/1496>) (#1510 <https://github.com/ros-controls/ros2_control/issues/1510>)
* Contributors: Christoph Fröhlich
```
