### PR TITLE
ros2_control: 2.41.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6968,7 +6968,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.40.0-1
+      version: 2.41.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.41.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.40.0-1`

## controller_interface

- No changes

## controller_manager

```
* check for state of the controller node before cleanup (backport #1363 <https://github.com/ros-controls/ros2_control/issues/1363>) (#1378 <https://github.com/ros-controls/ros2_control/issues/1378>)
* Bump version of pre-commit hooks (backport #1430 <https://github.com/ros-controls/ros2_control/issues/1430>) (#1434 <https://github.com/ros-controls/ros2_control/issues/1434>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add missing calculate_dynamics (#1498 <https://github.com/ros-controls/ros2_control/issues/1498>) (#1511 <https://github.com/ros-controls/ros2_control/issues/1511>)
* [Doc] Add documentation about initial_value regarding mock_hw (#1352 <https://github.com/ros-controls/ros2_control/issues/1352>) (#1513 <https://github.com/ros-controls/ros2_control/issues/1513>)
* Move migration notes (#1481 <https://github.com/ros-controls/ros2_control/issues/1481>) (#1515 <https://github.com/ros-controls/ros2_control/issues/1515>)
* Bump version of pre-commit hooks (backport #1430 <https://github.com/ros-controls/ros2_control/issues/1430>) (#1434 <https://github.com/ros-controls/ros2_control/issues/1434>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Bump version of pre-commit hooks (backport #1430 <https://github.com/ros-controls/ros2_control/issues/1430>) (#1434 <https://github.com/ros-controls/ros2_control/issues/1434>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [CI] Specify runner/container images and codecov for joint_limits  (#1504 <https://github.com/ros-controls/ros2_control/issues/1504>) (#1519 <https://github.com/ros-controls/ros2_control/issues/1519>)
* [CLI] Add set_hardware_component_state verb (#1248 <https://github.com/ros-controls/ros2_control/issues/1248>) (#1470 <https://github.com/ros-controls/ros2_control/issues/1470>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* Add cm as dependency to rqt_cm (#1447 <https://github.com/ros-controls/ros2_control/issues/1447>) (#1459 <https://github.com/ros-controls/ros2_control/issues/1459>)
* Contributors: mergify[bot]
```

## transmission_interface

```
* rosdoc2 for transmission_interface (#1496 <https://github.com/ros-controls/ros2_control/issues/1496>) (#1509 <https://github.com/ros-controls/ros2_control/issues/1509>)
* Contributors: mergify[bot]
```
