### PR TITLE
cob_common: 0.7.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1103,7 +1103,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_common-release.git
-      version: 0.7.10-1
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/4am-robotics/cob_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `0.7.11-1`:

- upstream repository: https://github.com/4am-robotics/cob_common.git
- release repository: https://github.com/4am-robotics/cob_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.10-1`

## cob_actions

- No changes

## cob_common

- No changes

## cob_description

- No changes

## cob_msgs

- No changes

## cob_srvs

- No changes

## raw_description

- No changes
