### PR TITLE
cob_command_tools: 0.6.35-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1081,7 +1081,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_command_tools-release.git
-      version: 0.6.34-1
+      version: 0.6.35-2
     source:
       type: git
       url: https://github.com/4am-robotics/cob_command_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_command_tools` to `0.6.35-2`:

- upstream repository: https://github.com/4am-robotics/cob_command_tools.git
- release repository: https://github.com/4am-robotics/cob_command_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.34-1`

## cob_command_gui

- No changes

## cob_command_tools

- No changes

## cob_dashboard

- No changes

## cob_helper_tools

- No changes

## cob_monitoring

- No changes

## cob_script_server

- No changes

## cob_teleop

- No changes

## generic_throttle

- No changes

## scenario_test_tools

- No changes

## service_tools

- No changes
