### PR TITLE
cob_control: 0.8.24-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1136,7 +1136,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/4am-robotics/cob_control-release.git
-      version: 0.8.23-1
+      version: 0.8.24-2
     source:
       type: git
       url: https://github.com/4am-robotics/cob_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_control` to `0.8.24-2`:

- upstream repository: https://github.com/4am-robotics/cob_control.git
- release repository: https://github.com/4am-robotics/cob_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.23-1`

## cob_base_controller_utils

- No changes

## cob_base_velocity_smoother

- No changes

## cob_cartesian_controller

- No changes

## cob_collision_velocity_filter

- No changes

## cob_control

- No changes

## cob_control_mode_adapter

- No changes

## cob_control_msgs

- No changes

## cob_footprint_observer

- No changes

## cob_frame_tracker

- No changes

## cob_hardware_emulation

- No changes

## cob_mecanum_controller

- No changes

## cob_model_identifier

- No changes

## cob_obstacle_distance

```
* Merge pull request #282 <https://github.com/4am-robotics/cob_control/issues/282> from fmessmer/fix/link_ccd
  fix undefined reference to symbol ccd_vec3_origin
* fix undefined reference to symbol 'ccd_vec3_origin'
* Contributors: Felix Messmer, fmessmer
```

## cob_omni_drive_controller

- No changes

## cob_trajectory_controller

- No changes

## cob_tricycle_controller

- No changes

## cob_twist_controller

- No changes
