### PR TITLE
libstatistics_collector: 1.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2950,7 +2950,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.7.1-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.8.0-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.1-1`

## libstatistics_collector

```
* Switch to Noble for Rolling. (#193 <https://github.com/ros-tooling/libstatistics_collector/issues/193>)
* Lower dependabot update frequency (#192 <https://github.com/ros-tooling/libstatistics_collector/issues/192>)
* Bump pascalgn/automerge-action from 0.16.2 to 0.16.3
* Bump codecov/codecov-action from 4.2.0 to 4.3.0
* Bump codecov/codecov-action from 4.1.1 to 4.2.0
* Contributors: Chris Lalancette, Christophe Bedard, dependabot[bot]
```
