### PR TITLE
variants: 0.11.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7867,7 +7867,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.10.0-4
+      version: 0.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.11.0-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.0-4`

## desktop

```
* [master] Update maintainers - 2022-11-07 (#38 <https://github.com/ros2/variants/issues/38>)
* Contributors: Audrow Nash
```

## desktop_full

```
* Rename ros_ign to ros_gz (#43 <https://github.com/ros2/variants/issues/43>)
* Use single quotes (#41 <https://github.com/ros2/variants/issues/41>)
* [master] Update maintainers - 2022-11-07 (#38 <https://github.com/ros2/variants/issues/38>)
* Contributors: Addisu Z. Taddese, Audrow Nash, Martin Peris
```

## perception

```
* [master] Update maintainers - 2022-11-07 (#38 <https://github.com/ros2/variants/issues/38>)
* Contributors: Audrow Nash
```

## ros_base

```
* [master] Update maintainers - 2022-11-07 (#38 <https://github.com/ros2/variants/issues/38>)
* Contributors: Audrow Nash
```

## ros_core

```
* [master] Update maintainers - 2022-11-07 (#38 <https://github.com/ros2/variants/issues/38>)
* Contributors: Audrow Nash
```

## simulation

```
* Rename ros_ign to ros_gz (#43 <https://github.com/ros2/variants/issues/43>)
* [master] Update maintainers - 2022-11-07 (#38 <https://github.com/ros2/variants/issues/38>)
* Contributors: Addisu Z. Taddese, Audrow Nash
```
