### PR TITLE
Add autoware_adapi_msgs to humble, jazzy, and rolling indices

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -609,6 +609,12 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: maintained
+  autoware_adapi_msgs:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+      version: humble
+    status: developed
   autoware_auto_msgs:
     doc:
       type: git
@@ -623,12 +629,6 @@ repositories:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
-    status: developed
-  autoware_adapi_msgs:
-    source:
-      type: git
-      url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-      version: humble
     status: developed
   avt_vimba_camera:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -613,7 +613,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-      version: humble
+      version: rolling
     status: developed
   autoware_auto_msgs:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -624,6 +624,12 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  autoware_adapi_msgs:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+      version: humble
+    status: developed
   avt_vimba_camera:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -490,6 +490,12 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: maintained
+  autoware_adapi_msgs:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+      version: rolling
+    status: developed
   autoware_auto_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -495,6 +495,12 @@ repositories:
       url: https://github.com/astuff/automotive_autonomy_msgs.git
       version: master
     status: maintained
+  autoware_adapi_msgs:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+      version: rolling
+    status: developed
   autoware_auto_msgs:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble, jazzy, and rolling

# The source is here:

https://github.com/autowarefoundation/autoware_adapi_msgs.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
