### PR TITLE
yp-spur: 1.22.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13178,7 +13178,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/openspur/yp-spur-release.git
-      version: 1.22.4-1
+      version: 1.22.5-1
     source:
       type: git
       url: https://github.com/openspur/yp-spur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yp-spur` to `1.22.5-1`:

- upstream repository: https://github.com/openspur/yp-spur.git
- release repository: https://github.com/openspur/yp-spur-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.22.4-1`

## ypspur

```
* Detect system time jump back (#208 <https://github.com/openspur/yp-spur/issues/208>)
* Use nanosleep if available (#209 <https://github.com/openspur/yp-spur/issues/209>)
* Output detailed log on time jump exit (#207 <https://github.com/openspur/yp-spur/issues/207>)
* Contributors: Atsushi Watanabe
```
