### PR TITLE
ros2_ouster_drivers: 0.5.1-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5650,7 +5650,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
-      version: 0.5.1-3
+      version: 0.5.1-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_ouster_drivers` to `0.5.1-4`:

- upstream repository: https://github.com/SteveMacenski/ros2_ouster_drivers.git
- release repository: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.1-3`
