### PR TITLE
Add autoware_cmake to humble, jazzy, and rolling indices

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -624,6 +624,12 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  autoware_cmake:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_cmake.git
+      version: rolling
+    status: developed
   avt_vimba_camera:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -505,6 +505,12 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  autoware_cmake:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_cmake.git
+      version: rolling
+    status: developed
   avt_vimba_camera:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -510,6 +510,12 @@ repositories:
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
+  autoware_cmake:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_cmake.git
+      version: rolling
+    status: developed
   avt_vimba_camera:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble, jazzy, and rolling

# The source is here:

https://github.com/autowarefoundation/autoware_cmake.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
