### PR TITLE
Add autoware_utils to humble, jazzy, and rolling indices

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -636,6 +636,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: rolling
     status: developed
+  autoware_utils:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_utils.git
+      version: rolling
+    status: developed
   avt_vimba_camera:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -517,6 +517,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: rolling
     status: developed
+  autoware_utils:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_utils.git
+      version: rolling
+    status: developed
   avt_vimba_camera:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -522,6 +522,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: rolling
     status: developed
+  autoware_utils:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_utils.git
+      version: rolling
+    status: developed
   avt_vimba_camera:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble, jazzy, and rolling

# The source is here:

 https://github.com/autowarefoundation/autoware_utils.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
