### PR TITLE
mark cob packages as end-of-life and sync doc vs. source version

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -713,7 +713,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/care-o-bot.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - care_o_bot
@@ -1029,7 +1029,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_android.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_android
@@ -1050,7 +1050,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -1065,7 +1065,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_command_tools.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_command_gui
@@ -1091,7 +1091,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_common.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - cob_actions
@@ -1113,7 +1113,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_control.git
-      version: melodic_release_candidate
+      version: melodic_dev
     release:
       packages:
       - cob_base_controller_utils
@@ -1146,7 +1146,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/4am-robotics/cob_driver.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - cob_base_drive_chain
@@ -1182,7 +1182,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_environments.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_default_env_config
@@ -1200,7 +1200,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_extern.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_extern
@@ -1237,7 +1237,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - cob_gazebo_plugins
@@ -1255,7 +1255,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_hand.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_hand
@@ -1273,7 +1273,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - cob_collision_monitor
@@ -1296,7 +1296,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_navigation.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_linear_nav
@@ -1320,7 +1320,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_3d_mapping_msgs
@@ -1345,7 +1345,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_robots.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - cob_bringup
@@ -1367,7 +1367,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_simulation.git
-      version: kinetic_release_candidate
+      version: kinetic_dev
     release:
       packages:
       - cob_bringup_sim
@@ -1389,7 +1389,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_substitute.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       packages:
       - cob_docker_control
@@ -1410,7 +1410,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git
-      version: indigo_release_candidate
+      version: indigo_dev
     release:
       tags:
         release: release/noetic/{package}/{version}

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -728,7 +728,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/care-o-bot.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   carla_msgs:
     doc:
       type: git
@@ -1045,7 +1045,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_android.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_calibration_data:
     doc:
       type: git
@@ -1060,7 +1060,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_calibration_data.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_command_tools:
     doc:
       type: git
@@ -1086,7 +1086,7 @@ repositories:
       type: git
       url: https://github.com/4am-robotics/cob_command_tools.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_common:
     doc:
       type: git
@@ -1108,7 +1108,7 @@ repositories:
       type: git
       url: https://github.com/4am-robotics/cob_common.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   cob_control:
     doc:
       type: git
@@ -1141,7 +1141,7 @@ repositories:
       type: git
       url: https://github.com/4am-robotics/cob_control.git
       version: melodic_dev
-    status: maintained
+    status: end-of-life
   cob_driver:
     doc:
       type: git
@@ -1177,7 +1177,7 @@ repositories:
       type: git
       url: https://github.com/4am-robotics/cob_driver.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   cob_environments:
     doc:
       type: git
@@ -1195,7 +1195,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_environments.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_extern:
     doc:
       type: git
@@ -1217,7 +1217,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_extern.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_fiducials:
     doc:
       type: git
@@ -1232,7 +1232,7 @@ repositories:
       type: git
       url: https://github.com/4am-robotics/cob_fiducials.git
       version: kinetic-devel
-    status: maintained
+    status: end-of-life
   cob_gazebo_plugins:
     doc:
       type: git
@@ -1250,7 +1250,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_gazebo_plugins.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   cob_hand:
     doc:
       type: git
@@ -1268,7 +1268,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_hand.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_manipulation:
     doc:
       type: git
@@ -1291,7 +1291,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_manipulation.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   cob_navigation:
     doc:
       type: git
@@ -1315,7 +1315,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_navigation.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_perception_common:
     doc:
       type: git
@@ -1340,7 +1340,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_perception_common.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_robots:
     doc:
       type: git
@@ -1362,7 +1362,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_robots.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   cob_simulation:
     doc:
       type: git
@@ -1384,7 +1384,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_simulation.git
       version: kinetic_dev
-    status: maintained
+    status: end-of-life
   cob_substitute:
     doc:
       type: git
@@ -1405,7 +1405,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_substitute.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   cob_supported_robots:
     doc:
       type: git
@@ -1420,7 +1420,7 @@ repositories:
       type: git
       url: https://github.com/ipa320/cob_supported_robots.git
       version: indigo_dev
-    status: maintained
+    status: end-of-life
   code_coverage:
     doc:
       type: git


### PR DESCRIPTION
follow-up PR following the discussion in https://github.com/ros/rosdistro/pull/40670

this PR marks all `ipa320`/`cob_*`-related packages as `end-of-life`
it also fixes the discrepancy between `doc/version` and `source/version` - see https://github.com/ros/rosdistro/pull/40670#discussion_r1572731948

@clalancette @sloretz 