### PR TITLE
usb_cam: 0.8.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7830,7 +7830,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/usb_cam-release.git
-      version: 0.8.0-1
+      version: 0.8.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `usb_cam` to `0.8.1-1`:

- upstream repository: https://github.com/ros-drivers/usb_cam.git
- release repository: https://github.com/ros2-gbp/usb_cam-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.0-1`

## usb_cam

```
* Merge pull request #330 <https://github.com/ros-drivers/usb_cam/issues/330> from ros-drivers/fix-rolling-builds
  Update comment in CI from Jammy to Noble
* Fix linter error in uyvy file
  - Update comment in CI from Jammy to Noble
* Merge pull request #324 <https://github.com/ros-drivers/usb_cam/issues/324> from clalancette/clalancette/const-avcodec
  Switch to a const AVCodec *.
* Switch to a const AVCodec *.
  This is because newer versions of avcodec return a const AVCodec *.
* Merge pull request #313 <https://github.com/ros-drivers/usb_cam/issues/313> from ros-drivers/v4l2-devices-might-not-be-named-video
  V4l2 devices might not be named video
* Use /sys/class/video4linux/ to get list of v4l2 devices
* Merge pull request #311 <https://github.com/ros-drivers/usb_cam/issues/311> from firesurfer/ros2
  Resolve Symlinks
* Update usb_cam_node.cpp
  Fix formatting
* try to fix formatting issue
* resolve symlinks
* Merge pull request #305 <https://github.com/ros-drivers/usb_cam/issues/305> from ros-drivers/fix-docs-deployment
* Remove unnecessary steps from docs CI
* Merge pull request #304 <https://github.com/ros-drivers/usb_cam/issues/304> from ros-drivers/fix-docs-ci
  Fix docs ci
* Trigger docs CI on every push to ros2 branch
* Merge pull request #303 <https://github.com/ros-drivers/usb_cam/issues/303> from ros-drivers/add-mkdocs-documentation
* Standup basic mkdocs documentation site
* Contributors: Chris Lalancette, Evan Flynn, Lennart Nachtigall
```
