### PR TITLE
fuse: 1.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1676,7 +1676,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.0.1-4
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1657,7 +1657,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/locusrobotics/fuse.git
-      version: rolling
+      version: jazzy
     release:
       packages:
       - fuse
@@ -1681,7 +1681,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/locusrobotics/fuse.git
-      version: rolling
+      version: jazzy
     status: maintained
   game_controller_spl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.1.1-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-4`

## fuse

- No changes

## fuse_constraints

```
* Required formatting changes for the lastest version of ROS 2 Rolling (#368 <https://github.com/locusrobotics/fuse/issues/368>)
* Contributors: Stephen Williams
```

## fuse_core

```
* Required formatting changes for the lastest version of ROS 2 Rolling (#368 <https://github.com/locusrobotics/fuse/issues/368>)
* Contributors: Stephen Williams
```

## fuse_doc

- No changes

## fuse_graphs

```
* Required formatting changes for the lastest version of ROS 2 Rolling (#368 <https://github.com/locusrobotics/fuse/issues/368>)
* Contributors: Stephen Williams
```

## fuse_loss

- No changes

## fuse_models

```
* Required formatting changes for the lastest version of ROS 2 Rolling (#368 <https://github.com/locusrobotics/fuse/issues/368>)
* Contributors: Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

```
* Fix fuse optimizer unit test (#369 <https://github.com/locusrobotics/fuse/issues/369>)
  * Fix fuse optimizer unit test. The rclcpp::wait_for_message call was throwing an exception 'subscription already associated with a wait set'. Switched to a standard subscriber instead.
* Required formatting changes for the lastest version of ROS 2 Rolling (#368 <https://github.com/locusrobotics/fuse/issues/368>)
* Contributors: Stephen Williams
```

## fuse_publishers

- No changes

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

- No changes
