### PR TITLE
tinyspline_vendor: 0.6.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7520,7 +7520,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
-      version: 0.6.0-4
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyspline_vendor` to `0.6.1-1`:

- upstream repository: https://github.com/wep21/tinyspline_vendor.git
- release repository: https://github.com/ros2-gbp/tinyspline_vendor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-4`

## tinyspline_vendor

```
* feat: use ament vendor (#1 <https://github.com/wep21/tinyspline_vendor/issues/1>)
* Contributors: Daisuke Nishimatsu
```
