### PR TITLE
tinyspline_vendor: 0.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9039,7 +9039,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
-      version: 0.6.0-2
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyspline_vendor` to `0.6.1-1`:

- upstream repository: https://github.com/wep21/tinyspline_vendor.git
- release repository: https://github.com/ros2-gbp/tinyspline_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-2`

## tinyspline_vendor

```
* feat: use ament vendor (#1 <https://github.com/wep21/tinyspline_vendor/issues/1>)
* Contributors: Daisuke Nishimatsu
```
