### PR TITLE
flir_camera_driver: 2.0.16-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1578,7 +1578,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
-      version: 2.0.15-1
+      version: 2.0.16-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.16-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros2-gbp/flir_camera_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.15-1`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* add option to disable external control (default!)
* updated docs for sync driver, switch to RST
* widened the ExposureController interface
* fix build errors on rolling/noble
* added blacklevel and whitebalance support for blackfly
* use proper name for camerainfo when using sync driver
* Contributors: Bernd Pfrommer
```

## spinnaker_synchronized_camera_driver

```
* updated docs for sync driver, switch to RST
* added follower exposure controller renamed individual -> master
* Contributors: Bernd Pfrommer
```
