### PR TITLE
URGENT: Fix broken gtkmm entry

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3908,7 +3908,7 @@ libgtkmm3.0-dev:
   arch: [gtkmm3]
   debian: [libgtkmm-3.0-dev]
   fedora: [gtkmm30-devel]
-  gentoo: [dev-cpp/gtkmm:3.0]
+  gentoo: ["dev-cpp/gtkmm:3.0"]
   rhel: [gtkmm30-devel]
   ubuntu: [libgtkmm-3.0-dev]
 libgts:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3908,7 +3908,7 @@ libgtkmm3.0-dev:
   arch: [gtkmm3]
   debian: [libgtkmm-3.0-dev]
   fedora: [gtkmm30-devel]
-  gentoo: ["dev-cpp/gtkmm:3.0"]
+  gentoo: ['dev-cpp/gtkmm:3.0']
   rhel: [gtkmm30-devel]
   ubuntu: [libgtkmm-3.0-dev]
 libgts:


### PR DESCRIPTION
#40772, merged yesterday, breaks rosdep with the following error:
```
ERROR: unable to process source [https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml]:
  while scanning a plain scalar
  in "<string>", line 3911, column 12:
      gentoo: [dev-cpp/gtkmm:3.0]
               ^
found unexpected ':'
  in "<string>", line 3911, column 25:
      gentoo: [dev-cpp/gtkmm:3.0]
                            ^
```
Obviously, names containing a colon should be quoted, such that they are not interpreted as a map.