### PR TITLE
v4l2_camera: 0.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7863,7 +7863,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.7.0-3
+      version: 0.7.1-1
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4l2_camera` to `0.7.1-1`:

- upstream repository: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
- release repository: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-3`

## v4l2_camera

```
* Fix deprecated cv_bridge header
* Avoid unnecessary memory operations by using std::vector::assign()
* Add camera frame id to camera info message
* Contributors: Błażej Sowa, Martin Fraunhofer, Muzhyk Belarus, Sander G. van Dijk
```
