### PR TITLE
libevent

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3379,6 +3379,14 @@ libevdev-dev:
   gentoo: [dev-libs/libevdev]
   nixos: [libevdev]
   ubuntu: [libevdev-dev]
+libevent-dev:
+  alpine: [libevent-dev]
+  arch: [libevent]
+  debian: [libevent-dev]
+  fedora: [libevent-devel]
+  opensuse: [libevent-devel]
+  rhel: [libevent-devel]
+  ubuntu: [libevent-dev]
 libexpat1-dev:
   arch: [expat]
   debian: [libexpat1-dev]


### PR DESCRIPTION
## Purpose of using this:

From https://libevent.org:

The libevent API provides a mechanism to execute a callback function when a specific event occurs on a file descriptor or after a timeout has been reached. Furthermore, libevent also support callbacks due to signals or regular timeouts.
Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libevent-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libevent-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libevent/libevent-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/core/x86_64/libevent/
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/libevent-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libevent
- rhel: https://rhel.pkgs.org/
  - https://centos.pkgs.org/9-stream/centos-appstream-x86_64/libevent-devel-2.1.12-6.el9.x86_64.rpm.html
