### PR TITLE
mp2p_icp: 1.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3427,7 +3427,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.3.3-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.4.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.3-1`

## mp2p_icp

```
* Update commit for robin-map to latest version (patch contributed upstream)
* icp-log-viewer: UI now has a slider for each map point size
* ICP: Add a new quality_checkpoint parameter to early abort ICP attempts
* georeferenced maps: T_enu_to_map now has a covariance field
* mm-viewer: display ENU frame too
* Contributors: Jose Luis Blanco-Claraco
```
