### PR TITLE
geometric_shapes: 0.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3443,7 +3443,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometric_shapes-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `0.7.6-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros-gbp/geometric_shapes-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.5-1`

## geometric_shapes

```
* Improve padding of meshes using weighted vertex normals (#238 <https://github.com/ros-planning/geometric_shapes/issues/238>)
* Drop obsolete C++ standard definition (#235 <https://github.com/ros-planning/geometric_shapes/issues/235>)
* Contributors: Kenji Brameld (TRACLabs), Michael Görner
```
