### PR TITLE
gps_umd: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1904,7 +1904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `2.0.4-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## gps_msgs

```
* Updating CI process (#85 <https://github.com/swri-robotics/gps_umd/issues/85>)
* Contributors: David Anthony
```

## gps_tools

```
* Updating CI process (#85 <https://github.com/swri-robotics/gps_umd/issues/85>)
* Contributors: David Anthony
```

## gps_umd

```
* Updating CI process (#85 <https://github.com/swri-robotics/gps_umd/issues/85>)
* Contributors: David Anthony
```

## gpsd_client

```
* Fix queue build up issue in gpsd_client (#89 <https://github.com/swri-robotics/gps_umd/issues/89>)
* Updating CI process (#85 <https://github.com/swri-robotics/gps_umd/issues/85>)
* Contributors: David Anthony, Erik Botö
```
