### PR TITLE
gz_ogre_next_vendor: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2131,7 +2131,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
-      version: 0.0.4-1
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-1`

## gz_ogre_next_vendor

```
* Fix build on arm64  (#3 <https://github.com/gazebo-release/gazebo_ogre_next_vendor/issues/3>)
  Co-authored-by: Jose Luis Rivero <mailto:jrivero@osrfoundation.org>
* Contributors: Addisu Z. Taddese
```
