### PR TITLE
autoware_utils: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -534,6 +534,11 @@ repositories:
       version: rolling
     status: developed
   autoware_utils:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_utils-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_utils` to `1.0.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_utils.git
- release repository: https://github.com/ros2-gbp/autoware_utils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## autoware_utils

```
* Merge pull request #2 <https://github.com/youtalk/autoware_utils/issues/2> from youtalk/import-from-autoware-common
  feat: import from autoware_common
* add maintainer
* move to autoware_utils
* Contributors: Yutaka Kondo
```
