### PR TITLE
plotjuggler: 3.9.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4349,7 +4349,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.9.1-1
+      version: 3.9.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.9.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.9.1-1`

## plotjuggler

```
* Save NlohmannParser (JSON) settings (#971 <https://github.com/facontidavide/PlotJuggler/issues/971>)
* Fix infinite streaming buffer regression (#953 <https://github.com/facontidavide/PlotJuggler/issues/953>)
  Co-authored-by: paul <mailto:paul@WorkLaptop>
* fix warning and includes
* updated fastcdr
* Added support for empty messages (#960 <https://github.com/facontidavide/PlotJuggler/issues/960>)
* add a parser for the Line Protocol (InfluxDB)
* Fixed the value dereference for ULog information messages (#946 <https://github.com/facontidavide/PlotJuggler/issues/946>)
* adding pre-commit check in CI
* fmt updated to 10.2.1
* apply clang format and move PlotJuggler/fmt
* moved KissFFT
* pre-commit
* Contributors: Davide Faconti, Declan Mullen, Jonathan, Michel Jansson, Paul, ubaldot
```
