### PR TITLE
launch_pal: 0.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3344,7 +3344,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.1.4-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.1.6-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.4-1`

## launch_pal

```
* added tuck arm parameter
* Contributors: sergiacosta
