### PR TITLE
aruco_opencv: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -421,7 +421,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 4.2.0-1
+      version: 6.0.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `6.0.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.0-1`

## aruco_opencv

```
* Use post-set parameters callback (#41 <https://github.com/fictionlab/ros_aruco_opencv/issues/41>)
* Add missing detection parameters (#38 <https://github.com/fictionlab/ros_aruco_opencv/issues/38>)
  * Populate default aruco parameter values from OpenCV library
  * Add detectInvertedMarker parameter
  * Add descriptions to aruco parameters in yaml file
  * Add option to generate inverted markers
  * Add Aruco3 detection parameters
* Remove boards on node cleanup (#35 <https://github.com/fictionlab/ros_aruco_opencv/issues/35>)
* Fix compatibility with OpenCV ^4.7.0 (#32 <https://github.com/fictionlab/ros_aruco_opencv/issues/32>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
