### PR TITLE
aruco_opencv: 5.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -420,7 +420,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `5.2.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.0-1`

## aruco_opencv

```
* Use post-set parameters callback (#41 <https://github.com/fictionlab/ros_aruco_opencv/issues/41>) (#42 <https://github.com/fictionlab/ros_aruco_opencv/issues/42>)
* Add missing detection parameters (backport #38 <https://github.com/fictionlab/ros_aruco_opencv/issues/38>) (#40 <https://github.com/fictionlab/ros_aruco_opencv/issues/40>)
  * Populate default aruco parameter values from OpenCV library
  * Add detectInvertedMarker parameter
  * Add descriptions to aruco parameters in yaml file
  * Add option to generate inverted markers
  * Add Aruco3 detection parameters
* Remove boards on node cleanup (#35 <https://github.com/fictionlab/ros_aruco_opencv/issues/35>) (#37 <https://github.com/fictionlab/ros_aruco_opencv/issues/37>)
* Fix compatibility with OpenCV ^4.7.0 (backport #32 <https://github.com/fictionlab/ros_aruco_opencv/issues/32>) (#34 <https://github.com/fictionlab/ros_aruco_opencv/issues/34>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
