### PR TITLE
aruco_opencv: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -526,7 +526,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `2.3.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## aruco_opencv

```
* Retrieve new aruco parameters on next image callback (#43 <https://github.com/fictionlab/ros_aruco_opencv/issues/43>)
* Add missing detection parameters (backport #38 <https://github.com/fictionlab/ros_aruco_opencv/issues/38>) (#39 <https://github.com/fictionlab/ros_aruco_opencv/issues/39>)
  * Populate default aruco parameter values from OpenCV library
  * Add detectInvertedMarker parameter
  * Add descriptions to aruco parameters in yaml file
  * Add option to generate inverted markers
  * Add Aruco3 detection parameters
* Remove boards on node cleanup (#35 <https://github.com/fictionlab/ros_aruco_opencv/issues/35>) (#36 <https://github.com/fictionlab/ros_aruco_opencv/issues/36>)
* Fix compatibility with OpenCV ^4.7.0 (backport #32 <https://github.com/fictionlab/ros_aruco_opencv/issues/32>) (#33 <https://github.com/fictionlab/ros_aruco_opencv/issues/33>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
