### PR TITLE
add libcaer_vendor to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3507,6 +3507,16 @@ repositories:
       url: https://github.com/ros-event-camera/libcaer_driver.git
       version: humble
     status: developed
+  libcaer_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: humble
+    status: developed
   libcamera:
     release:
       tags:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2814,6 +2814,16 @@ repositories:
       url: https://github.com/ros-event-camera/libcaer_driver.git
       version: iron
     status: developed
+  libcaer_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: iron
+    status: developed
   libcreate:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2921,6 +2921,16 @@ repositories:
       url: https://github.com/ros-event-camera/libcaer_driver.git
       version: rolling
     status: developed
+  libcaer_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: jazzy
+    status: developed
   libg2o:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2943,6 +2943,16 @@ repositories:
       url: https://github.com/ros-event-camera/libcaer_driver.git
       version: rolling
     status: developed
+  libcaer_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: rolling
+    status: developed
   libg2o:
     release:
       tags:


### PR DESCRIPTION
# Please Add libcaer_vendor to be indexed in the rosdistro.

ROSDISTRO NAMES:  humble, iron, jazzy, rolling

# The source is here: https://github.com/ros-event-camera/libcaer_vendor

NOTE: this repo replaces "libcaer" with a properly vendored package using ament_cmake_vendor_package.
Once this package has been released I will remove the "libcaer" repo/package.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
