### PR TITLE
Add `yourdfpy` to Python rosdeps

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9947,6 +9947,13 @@ python3-yolov5:
   ubuntu:
     pip:
       packages: [yolov5]
+python3-yourdfpy-pip:
+  debian:
+    pip:
+      packages: [yourdfpy]
+  ubuntu:
+    pip:
+      packages: [yourdfpy]
 python3-zmq:
   arch: [python-pyzmq]
   debian: [python3-zmq]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9951,7 +9951,13 @@ python3-yourdfpy-pip:
   debian:
     pip:
       packages: [yourdfpy]
+  fedora:
+    pip:
+      packages: [yourdfpy]
   ubuntu:
+    pip:
+      packages: [yourdfpy]
+  osx:
     pip:
       packages: [yourdfpy]
 python3-zmq:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9954,10 +9954,10 @@ python3-yourdfpy-pip:
   fedora:
     pip:
       packages: [yourdfpy]
-  ubuntu:
+  osx:
     pip:
       packages: [yourdfpy]
-  osx:
+  ubuntu:
     pip:
       packages: [yourdfpy]
 python3-zmq:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9948,16 +9948,7 @@ python3-yolov5:
     pip:
       packages: [yolov5]
 python3-yourdfpy-pip:
-  debian:
-    pip:
-      packages: [yourdfpy]
-  fedora:
-    pip:
-      packages: [yourdfpy]
-  osx:
-    pip:
-      packages: [yourdfpy]
-  ubuntu:
+  '*':
     pip:
       packages: [yourdfpy]
 python3-zmq:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

[`yourdfpy`](https://github.com/clemense/yourdfpy/) 

## Package Upstream Source:

https://github.com/clemense/yourdfpy/

## Purpose of using this:

[`yourdfpy`](https://github.com/clemense/yourdfpy/) is a currently-maintained package for loading and manipulating URDFs in Python. The other comparable library that is in the rosdep, [`urdfpy`](https://github.com/mmatl/urdfpy) has not been updated for years and is having dependency version issues.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - PyPi: https://pypi.org/project/yourdfpy/#description
- Ubuntu: https://packages.ubuntu.com/
  - PyPi: https://pypi.org/project/yourdfpy/#description
- Fedora: https://packages.fedoraproject.org/
  - Not available
- Arch: https://www.archlinux.org/packages/
  - Not available
- Gentoo: https://packages.gentoo.org/
  - Not available
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Not available
- openSUSE: https://software.opensuse.org/package/
  - Not available
- rhel: https://rhel.pkgs.org/
  - Not available