### PR TITLE
ros2_control: 4.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5645,7 +5645,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.9.0-1
+      version: 4.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.10.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.9.0-1`

## controller_interface

```
* Working async controllers and components [not synchronized] (#1041 <https://github.com/ros-controls/ros2_control/issues/1041>)
* Contributors: Márk Szitanics
```

## controller_manager

```
* allow extra spawner arguments to not declare every argument in launch utils (#1505 <https://github.com/ros-controls/ros2_control/issues/1505>)
* Working async controllers and components [not synchronized] (#1041 <https://github.com/ros-controls/ros2_control/issues/1041>)
* Add fallback controllers list to the ControllerInfo (#1503 <https://github.com/ros-controls/ros2_control/issues/1503>)
* Add a functionality to look for the controller type in the params file when not parsed (#1502 <https://github.com/ros-controls/ros2_control/issues/1502>)
* Add controller exception handling in controller manager (#1507 <https://github.com/ros-controls/ros2_control/issues/1507>)
* Contributors: Márk Szitanics, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add hardware components exception handling in resource manager (#1508 <https://github.com/ros-controls/ros2_control/issues/1508>)
* Working async controllers and components [not synchronized] (#1041 <https://github.com/ros-controls/ros2_control/issues/1041>)
* Parse URDF joint hard limits into the HardwareInfo structure (#1472 <https://github.com/ros-controls/ros2_control/issues/1472>)
* Add fallback controllers list to the ControllerInfo (#1503 <https://github.com/ros-controls/ros2_control/issues/1503>)
* Add more common hardware interface type constants (#1500 <https://github.com/ros-controls/ros2_control/issues/1500>)
* Contributors: Márk Szitanics, Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Parse URDF joint hard limits into the HardwareInfo structure (#1472 <https://github.com/ros-controls/ros2_control/issues/1472>)
* Contributors: Sai Kishor Kothakota
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
