### PR TITLE
control_msgs: 4.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1240,7 +1240,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `4.5.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.4.0-1`

## control_msgs

```
* Add velocity to gripper command (#99 <https://github.com/ros-controls/control_msgs/issues/99>) (#129 <https://github.com/ros-controls/control_msgs/issues/129>)
* Add custom rosdoc2 config (#132 <https://github.com/ros-controls/control_msgs/issues/132>) (#135 <https://github.com/ros-controls/control_msgs/issues/135>)
* Specify BSD as BSD-3-Clause (#114 <https://github.com/ros-controls/control_msgs/issues/114>) (#116 <https://github.com/ros-controls/control_msgs/issues/116>)
* Contributors: Christoph Fröhlich, Paul Gesel
```
