### PR TITLE
qb_device: 4.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5912,6 +5912,24 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: humble
     status: maintained
+  qb_device:
+    release:
+      packages:
+      - qb_device
+      - qb_device_bringup
+      - qb_device_driver
+      - qb_device_msgs
+      - qb_device_ros2_control
+      - qb_device_test_controllers
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros2-release.git
+      version: 4.1.3-1
+    source:
+      type: git
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros
+      version: production-humble
+    status: developed
   qb_softhand_industry:
     release:
       packages:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5927,7 +5927,7 @@ repositories:
       version: 4.1.3-1
     source:
       type: git
-      url: https://bitbucket.org/qbrobotics/qbdevice-ros
+      url: https://bitbucket.org/qbrobotics/qbdevice-ros.git
       version: production-humble
     status: developed
   qb_softhand_industry:


### PR DESCRIPTION
Increasing version of package(s) in repository `qb_device` to `4.1.3-1`:

- upstream repository: https://bitbucket.org/qbrobotics/qbdevice-ros
- release repository: https://bitbucket.org/qbrobotics/qbdevice-ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## qb_device

```
* Fixing my mess with releases...
```

## qb_device_bringup

```
* Fixing my mess with releases...
```

## qb_device_driver

```
* Fixing my mess with releases...
```

## qb_device_msgs

```
* Fixing my mess with releases...
```

## qb_device_ros2_control

```
* Fixing my mess with releases...
```

## qb_device_test_controllers

```
* Fixing my mess with releases...
```
