### PR TITLE
aruco_ros: 5.0.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -426,6 +426,21 @@ repositories:
       url: https://github.com/fictionlab/ros_aruco_opencv.git
       version: rolling
     status: maintained
+  aruco_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 5.0.5-1
+    status: maintained
   async_web_server_cpp:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -440,6 +440,10 @@ repositories:
         release: release/iron/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
       version: 5.0.5-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
     status: maintained
   async_web_server_cpp:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `5.0.5-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## aruco

- No changes

## aruco_msgs

- No changes

## aruco_ros

```
* Merge pull request #135 from wep21/jazzy-devel
  Update cv_bridge header
* check header exists
* feat: update cv bridge header
* Contributors: Sai Kishor Kothakota, wep21
```
