### PR TITLE
aruco_ros: 5.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -441,6 +441,10 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
       version: 5.0.5-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
     status: maintained
   astuff_sensor_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -427,6 +427,21 @@ repositories:
       url: https://github.com/fictionlab/ros_aruco_opencv.git
       version: rolling
     status: maintained
+  aruco_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 5.0.5-1
+    status: maintained
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `5.0.5-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## aruco

- No changes

## aruco_msgs

- No changes

## aruco_ros

```
* Merge pull request #135 from wep21/jazzy-devel
  Update cv_bridge header
* check header exists
* feat: update cv bridge header
* Contributors: Sai Kishor Kothakota, wep21
```
