### PR TITLE
aruco_ros: 5.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -545,7 +545,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
-      version: 5.0.4-1
+      version: 5.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `5.0.5-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `5.0.4-1`

## aruco

- No changes

## aruco_msgs

- No changes

## aruco_ros

```
* Merge pull request #135 from wep21/jazzy-devel
  Update cv_bridge header
* check header exists
* feat: update cv bridge header
* Contributors: Sai Kishor Kothakota, wep21
```
