### PR TITLE
aruco_ros: 5.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -422,6 +422,21 @@ repositories:
       url: https://github.com/fictionlab/ros_aruco_opencv.git
       version: jazzy
     status: maintained
+  aruco_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/pal-gbp/aruco_ros-release.git
+      version: 5.0.5-1
+    status: maintained
   astuff_sensor_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -436,6 +436,10 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
       version: 5.0.5-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
     status: maintained
   astuff_sensor_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_ros` to `5.0.5-1`:

- upstream repository: https://github.com/pal-robotics/aruco_ros.git
- release repository: https://github.com/pal-gbp/aruco_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## aruco

- No changes

## aruco_msgs

- No changes

## aruco_ros

```
* Merge pull request #135 from wep21/jazzy-devel
  Update cv_bridge header
* check header exists
* feat: update cv bridge header
* Contributors: Sai Kishor Kothakota, wep21
```
