### PR TITLE
Index Beluga documentation and sources

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -787,6 +787,16 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  beluga:
+    doc:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    status: developed
   bno055:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -609,6 +609,16 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  beluga:
+    doc:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    status: developed
   bno055:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -652,6 +652,16 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  beluga:
+    doc:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    status: developed
   bno055:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -569,6 +569,16 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  beluga:
+    doc:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

`beluga`

# The source is here:

https://github.com/Ekumen-OS/beluga

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
