### PR TITLE
rviz: 1.14.23-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10882,7 +10882,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.22-1
+      version: 1.14.23-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.23-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.14.22-1`

## rviz

```
* Fix #1825 <https://github.com/ros-visualization/rviz/issues/1825>
  model_ is destroyed between registration of the single-shot timer and its execution
* Contributors: Robert Haschke
```
