### PR TITLE
Add autoware_lanelet2_extension to humble, jazzy, and rolling indices

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -652,6 +652,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: rolling
     status: developed
+  autoware_lanelet2_extension:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+      version: rolling
+    status: developed
   autoware_utils:
     release:
       tags:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -533,6 +533,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: rolling
     status: developed
+  autoware_lanelet2_extension:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+      version: rolling
+    status: developed
   autoware_utils:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -538,6 +538,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: rolling
     status: developed
+  autoware_lanelet2_extension:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+      version: rolling
+    status: developed
   autoware_utils:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble, jazzy, and rolling

# The source is here:

https://github.com/autowarefoundation/autoware_lanelet2_extension.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
