### PR TITLE
Add python3-pil-imagetk in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7606,6 +7606,10 @@ python3-pil:
     slackpkg:
       packages: [python3-pillow]
   ubuntu: [python3-pil]
+python3-pil-imagetk:
+  debian: [python3-pil.imagetk]
+  fedora: [python3-pillow-tk]
+  ubuntu: [python3-pil.imagetk]
 python3-pip:
   alpine: [py3-pip]
   debian: [python3-pip]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7609,6 +7609,7 @@ python3-pil:
 python3-pil-imagetk:
   debian: [python3-pil.imagetk]
   fedora: [python3-pillow-tk]
+  rhel: [python3-pillow-tk]
   ubuntu: [python3-pil.imagetk]
 python3-pip:
   alpine: [py3-pip]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pil-imagetk

## Package Upstream Source:

https://github.com/python-pillow/Pillow

## Purpose of using this:

The [ImageTk](https://pillow.readthedocs.io/en/stable/reference/ImageTk.html#module-PIL.ImageTk) module contains support to create and modify Tkinter BitmapImage and PhotoImage objects from PIL images. `Python-imaging-imagetk` was available up to Python2 on Ubuntu 18.04, but the Python3 version was not registered, so I submitted a PR.

Distro packaging links: https://pillow.readthedocs.io/en/stable/installation/platform-support.html

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/python3-pil.imagetk
- Ubuntu: https://packages.ubuntu.com/focal/riscv64/python3-pil.imagetk
- Fedora: https://packages.fedoraproject.org/pkgs/python-pillow/python3-pillow-tk/
