### PR TITLE
apriltag_detector: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -468,10 +468,15 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: humble
     release:
+      packages:
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 1.1.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `2.1.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## apriltag_detector

```
* switched to plugins, added MIT detector, split off apriltag_draw
* Contributors: Bernd Pfrommer
```

## apriltag_detector_mit

```
* initial release of detector plugin
* Contributors: Bernd Pfrommer
```

## apriltag_detector_umich

```
* initial release as plugin ROS2 package
* Contributors: Bernd Pfrommer
```

## apriltag_draw

```
* initial release as ROS2 package
* Contributors: Bernd Pfrommer
```
