### PR TITLE
apriltag_detector: 2.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -362,10 +362,15 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: iron
     release:
+      packages:
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 1.2.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `2.2.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## apriltag_detector

```
* initial release as plugin
* Contributors: Bernd Pfrommer
```

## apriltag_detector_mit

```
* initial release as plugin
* Contributors: Bernd Pfrommer
```

## apriltag_detector_umich

```
* initial release as a plugin
* Contributors: Bernd Pfrommer
```

## apriltag_draw

```
* initial release
* Contributors: Bernd Pfrommer
```
