### PR TITLE
apriltag_detector: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -363,10 +363,15 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: rolling
     release:
+      packages:
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 1.0.0-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `2.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## apriltag_detector

```
* initial release as base class of pluggable detectors
* Contributors: Bernd Pfrommer
```

## apriltag_detector_mit

```
* initial release as plugin
* Contributors: Bernd Pfrommer
```

## apriltag_detector_umich

```
* initial release as plugin
* Contributors: Bernd Pfrommer
```

## apriltag_draw

```
* initial release as ROS2 package
* Contributors: Bernd Pfrommer
```
