### PR TITLE
apriltag: 3.4.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.2.0-7
+      version: 3.4.1-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.4.1-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/ros2-gbp/apriltag-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.0-7`
