### PR TITLE
leo_common: 2.0.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2711,7 +2711,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `2.0.3-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## leo

- No changes

## leo_description

```
* Remove imu system plugin from the robot (#11 <https://github.com/LeoRover/leo_common-ros2/issues/11>) (#12 <https://github.com/LeoRover/leo_common-ros2/issues/12>)
* Contributors: Jan Hernas
```

## leo_msgs

- No changes

## leo_teleop

- No changes
