### PR TITLE
Add support for lzma/xz URLs to rosdep_repo_check

### DIFF
--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -26,6 +26,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from gzip import GzipFile
+from lzma import LZMAFile
 import socket
 import sys
 import time
@@ -56,9 +57,23 @@ def is_probably_gzip(response):
             response.getheader('Content-Type') == 'application/x-gzip')
 
 
-def open_gz_url(url, retry=2, retry_period=1, timeout=10):
+def is_probably_lzma(response):
     """
-    Open a URL to a possibly gzip'd file.
+    Determine if a urllib response is likely lzma'd.
+
+    :param response: the urllib response
+    """
+    return (response.url.endswith('.xz') or
+            response.getheader('Content-Encoding') == 'xz' or
+            response.getheader('Content-Type') == 'application/x-xz')
+
+
+def open_gz_url(url, retry=2, retry_period=1, timeout=10):
+    return open_compressed_url(url, retry, retry_period, timeout)
+
+def open_compressed_url(url, retry=2, retry_period=1, timeout=10):
+    """
+    Open a URL to a possibly compressed file.
 
     :param url: URL to the file.
     :param retry: number of times to re-attempt the download.
@@ -85,7 +100,11 @@ def open_gz_url(url, retry=2, retry_period=1, timeout=10):
                 url, retry=retry - 1, retry_period=retry_period,
                 timeout=timeout)
         raise URLError(str(e) + ' (%s)' % url)
-    return GzipFile(fileobj=f, mode='rb') if is_probably_gzip(f) else f
+    if is_probably_gzip(f):
+        return GzipFile(fileobj=f, mode='rb')
+    elif is_probably_lzma(f):
+        return LZMAFile(f, mode='rb')
+    return f
 
 
 class PackageEntry(str):

--- a/test/rosdep_repo_check/apk.py
+++ b/test/rosdep_repo_check/apk.py
@@ -28,7 +28,7 @@
 import os
 import tarfile
 
-from . import open_gz_url
+from . import open_compressed_url
 from . import PackageEntry
 from . import RepositoryCacheCollection
 
@@ -117,7 +117,7 @@ def enumerate_apk_packages(base_url, os_name, os_code_name, os_arch):
     apkindex_url = os.path.join(base_url, os_arch, 'APKINDEX.tar.gz')
     print('Reading apk package metadata from ' + apkindex_url)
 
-    with open_gz_url(apkindex_url) as f:
+    with open_compressed_url(apkindex_url) as f:
         with tarfile.open(mode='r|', fileobj=f) as tf:
             index = None
             for ti in tf:

--- a/test/rosdep_repo_check/layer_index.py
+++ b/test/rosdep_repo_check/layer_index.py
@@ -28,7 +28,7 @@
 import json
 import os
 
-from . import open_gz_url
+from . import open_compressed_url
 from . import PackageEntry
 from . import RepositoryCacheCollection
 
@@ -37,7 +37,7 @@ def enumerate_recipes(base_url, branch_name):
     recipes_url = os.path.join(base_url, 'recipes')
     recipes_url += f'?filter=layerbranch__branch__name:{branch_name}'
     print('Reading OpenEmbedded recipe metadata from ' + recipes_url)
-    with open_gz_url(recipes_url) as f:
+    with open_compressed_url(recipes_url) as f:
         yield from json.load(f)
 
 
@@ -46,7 +46,7 @@ def enumerate_layers_by_layer_branch_id(base_url, branch_name):
     layer_branches_url = os.path.join(base_url, 'layerBranches')
     layer_branches_url += f'?filter=branch__name:{branch_name}'
     print('Reading OpenEmbedded layer branches from ' + layer_branches_url)
-    with open_gz_url(layer_branches_url) as f:
+    with open_compressed_url(layer_branches_url) as f:
         for layer_branch in json.load(f):
             layer_branch_id = str(layer_branch.get('id', ''))
             layer_id = str(layer_branch.get('layer', ''))
@@ -63,7 +63,7 @@ def enumerate_layers_by_layer_branch_id(base_url, branch_name):
 def enumerate_layers(base_url):
     layers_url = os.path.join(base_url, 'layerItems')
     print('Reading OpenEmbedded layers from ' + layers_url)
-    with open_gz_url(layers_url) as f:
+    with open_compressed_url(layers_url) as f:
         for layer in json.load(f):
             layer_id = str(layer.get('id', ''))
             layer_name = layer.get('name')

--- a/test/rosdep_repo_check/pacman.py
+++ b/test/rosdep_repo_check/pacman.py
@@ -28,7 +28,7 @@
 import os
 import tarfile
 
-from . import open_gz_url
+from . import open_compressed_url
 from . import PackageEntry
 from . import RepositoryCacheCollection
 
@@ -51,7 +51,7 @@ def enumerate_descs(url):
 
     :returns: an enumeration of desc file contents.
     """
-    with open_gz_url(url) as f:
+    with open_compressed_url(url) as f:
         with tarfile.open(mode='r|', fileobj=f) as tf:
             for ti in tf:
                 if ti.name.endswith('/desc'):

--- a/test/rosdep_repo_check/rpm.py
+++ b/test/rosdep_repo_check/rpm.py
@@ -28,7 +28,7 @@
 import os
 from xml.etree import ElementTree
 
-from . import open_gz_url
+from . import open_compressed_url
 from . import PackageEntry
 from . import RepositoryCacheCollection
 from . import URLError
@@ -48,7 +48,7 @@ def replace_tokens(string, os_name, os_code_name, os_arch):
 def get_primary_name(repomd_url):
     """Get the URL of the 'primary' metadata from the 'repo' metadata."""
     print('Reading RPM repository metadata from ' + repomd_url)
-    with open_gz_url(repomd_url) as f:
+    with open_compressed_url(repomd_url) as f:
         tree = iter(ElementTree.iterparse(f, events=('start', 'end')))
         event, root = next(tree)
         if root.tag != '{http://linux.duke.edu/metadata/repo}repomd':
@@ -74,7 +74,7 @@ def get_primary_name(repomd_url):
 
 def enumerate_base_urls(mirrorlist_url):
     """Get candidate RPM repository base URLs from a mirrorlist file."""
-    with open_gz_url(mirrorlist_url) as f:
+    with open_compressed_url(mirrorlist_url) as f:
         while True:
             line = f.readline().decode('utf-8')
             if not len(line):
@@ -101,7 +101,7 @@ def enumerate_rpm_packages(base_url, os_name, os_code_name, os_arch):
     primary_xml_name = get_primary_name(repomd_url)
     primary_xml_url = os.path.join(base_url, primary_xml_name)
     print('Reading RPM primary metadata from ' + primary_xml_url)
-    with open_gz_url(primary_xml_url) as f:
+    with open_compressed_url(primary_xml_url) as f:
         tree = ElementTree.iterparse(f)
         for event, element in tree:
             if (


### PR DESCRIPTION
It seems that some RPM repositories are hosting xz-compressed metadata these days.

I was hitting this locally and I'm pretty surprised we aren't seeing it from GitHub Actions yet.