### PR TITLE
orocos_kdl_vendor: 0.5.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4049,7 +4049,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.5.0-3
+      version: 0.5.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.5.1-2`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.0-3`

## orocos_kdl_vendor

```
* Ensure that orocos_kdl_vendor doesn't accidentally find itself. (#27 <https://github.com/ros2/orocos_kdl_vendor/issues/27>) (#28 <https://github.com/ros2/orocos_kdl_vendor/issues/28>)
  When initially building the orocos_kdl_vendor package (on platforms
  where it actually builds), it turns out that it places a
  valid cmake configuration in the build directory.  In turn,
  that means that a subsequent rebuild will find this configuration
  in the build directory, and throw the rest of the logic off.
  This only seems to be a problem with CMake 3.29 and later, though
  I can't say exactly why at the moment.
  Workaround this problem by writing the configuration out to a
  temporary file, and then moving it into the final place with
  the final name.
  (cherry picked from commit 7aad6d1ad9fa54f3a48f1f194a85127e362c8ade)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```

## python_orocos_kdl_vendor

- No changes
