### PR TITLE
apriltag: 3.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -351,7 +351,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag` to `3.4.2-1`:

- upstream repository: https://github.com/AprilRobotics/apriltag.git
- release repository: https://github.com/ros2-gbp/apriltag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.1-1`
