### PR TITLE
rclcpp: 28.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4962,7 +4962,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.1-1
+      version: 28.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `28.1.1-1`

## rclcpp

```
* add impl pointer for ExecutorOptions (#2523 <https://github.com/ros2/rclcpp/issues/2523>) (#2525 <https://github.com/ros2/rclcpp/issues/2525>)
  * add impl pointer for ExecutorOptions
  (cherry picked from commit 343b29b617b163ad72b9fe3f6441dd4ed3d3af09)
  Co-authored-by: William Woodall <mailto:william@osrfoundation.org>
* Fixup Executor::spin_all() regression fix (#2517 <https://github.com/ros2/rclcpp/issues/2517>) (#2521 <https://github.com/ros2/rclcpp/issues/2521>)
  * test(Executors): Added tests for busy waiting
  Checks if executors are busy waiting while they should block
  in spin_some or spin_all.
  * fix: Reworked spinAll test
  This test was strange. It looked like, it assumed that spin_all did
  not return instantly. Also it was racy, as the thread could terminate
  instantly.
  * fix(Executor): Fixed spin_all not returning instantly is no work was available
  * Update rclcpp/test/rclcpp/executors/test_executors.cpp
  * test(executors): Added test for busy waiting while calling spin
  * fix(executor): Reset wait_result on every call to spin_some_impl
  Before, the method would not recollect available work in case of
  spin_some, spin_all. This would lead to the method behaving differently
  than to what the documentation states.
  * restore previous test logic for now
  * refactor spin_some_impl's logic and improve busy wait tests
  * added some more comments about the implementation
  ---------
  Co-authored-by: Janosch Machowinski <mailto:J.Machowinski@cellumation.com>
  Co-authored-by: jmachowinski <mailto:jmachowinski@users.noreply.github.com>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: William Woodall <mailto:william@osrfoundation.org>
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Revert "call shutdown in LifecycleNode dtor to avoid leaving the device in un… (#2450 <https://github.com/ros2/rclcpp/issues/2450>)" (#2522 <https://github.com/ros2/rclcpp/issues/2522>) (#2524 <https://github.com/ros2/rclcpp/issues/2524>)
  This reverts commit 04ea0bb00293387791522590b7347a2282cda290.
  (cherry picked from commit 42b0b5775b4e68718c5949308c9e1a059930ded7)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
