### PR TITLE
spdlog_vendor: 1.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7049,7 +7049,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.6.0-2
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.6.1-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-2`

## spdlog_vendor

```
* Removed spdlog_vendor warnings (#36 <https://github.com/ros2/spdlog_vendor/issues/36>) (#37 <https://github.com/ros2/spdlog_vendor/issues/37>)
  (cherry picked from commit 4510d9ab4389f84daac77210f3fdf8aab372b938)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
