### PR TITLE
mola: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3365,7 +3365,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.0.4-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.3-1`

## kitti_metrics_eval

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola

- No changes

## mola_bridge_ros2

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* bump cmake_minimum_required to 3.5
* Avoid global static objects
* remove useless #include's
* Define Dataset_UI dtor/ctor in a separate translation unit
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* bump cmake_minimum_required to 3.5
* Avoid global static objects
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Metric maps: load insertion options from field 'insertOpts' instead of 'insertionOptions' for compatibility with all other MRPT maps
* disable clang-format in 3rdparty submodules
* Fix usage of const_cast<> with proper value() method
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fuse

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* bump cmake_minimum_required to 3.5
* Move experimental methods to another branch, and update documentation.
* adjust feature options
* Relocalization: refactor in several .cpp files. Add new method from BEV point density
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Add ncd-csv2tum trajectory file tool
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* bump cmake_minimum_required to 3.5
* MolaViz: BUGFIX: shared_ptr were captured by lambdas, delaying proper dtors. Replaced by weak_ptr's
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* bump cmake_minimum_required to 3.5
* Contributors: Jose Luis Blanco-Claraco
```
