### PR TITLE
ros2_control: 4.11.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5623,7 +5623,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.10.0-1
+      version: 4.11.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.11.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.10.0-1`

## controller_interface

```
* Fix dependencies for source build (#1533 <https://github.com/ros-controls/ros2_control/issues/1533>)
* Add find_package for ament_cmake_gen_version_h (#1534 <https://github.com/ros-controls/ros2_control/issues/1534>)
* Contributors: Christoph Fröhlich
```

## controller_manager

```
* Add find_package for ament_cmake_gen_version_h (#1534 <https://github.com/ros-controls/ros2_control/issues/1534>)
* Contributors: Christoph Fröhlich
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add find_package for ament_cmake_gen_version_h (#1534 <https://github.com/ros-controls/ros2_control/issues/1534>)
* Parse URDF soft_limits into the HardwareInfo structure (#1488 <https://github.com/ros-controls/ros2_control/issues/1488>)
* Contributors: Christoph Fröhlich, adriaroig
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix dependencies for source build (#1533 <https://github.com/ros-controls/ros2_control/issues/1533>)
* Add find_package for ament_cmake_gen_version_h (#1534 <https://github.com/ros-controls/ros2_control/issues/1534>)
* Contributors: Christoph Fröhlich
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Parse URDF soft_limits into the HardwareInfo structure (#1488 <https://github.com/ros-controls/ros2_control/issues/1488>)
* Contributors: adriaroig
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Add find_package for ament_cmake_gen_version_h (#1534 <https://github.com/ros-controls/ros2_control/issues/1534>)
* Contributors: Christoph Fröhlich
```
