### PR TITLE
ros2_controllers: 3.24.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5734,7 +5734,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.23.0-1
+      version: 3.24.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.24.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.23.0-1`

## ackermann_steering_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>) (#1126 <https://github.com/ros-controls/ros2_controllers/issues/1126>)
* Contributors: mergify[bot]
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>) (#1126 <https://github.com/ros-controls/ros2_controllers/issues/1126>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Remove non-existing parameter (#1119 <https://github.com/ros-controls/ros2_controllers/issues/1119>) (#1127 <https://github.com/ros-controls/ros2_controllers/issues/1127>)
* Deprecate non-stamped twist for tricycle_controller and steering_controllers (#1093 <https://github.com/ros-controls/ros2_controllers/issues/1093>) (#1124 <https://github.com/ros-controls/ros2_controllers/issues/1124>)
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>) (#1126 <https://github.com/ros-controls/ros2_controllers/issues/1126>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Deprecate non-stamped twist for tricycle_controller and steering_controllers (#1093 <https://github.com/ros-controls/ros2_controllers/issues/1093>) (#1124 <https://github.com/ros-controls/ros2_controllers/issues/1124>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Deprecate non-stamped twist for tricycle_controller and steering_controllers (#1093 <https://github.com/ros-controls/ros2_controllers/issues/1093>) (#1124 <https://github.com/ros-controls/ros2_controllers/issues/1124>)
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>) (#1126 <https://github.com/ros-controls/ros2_controllers/issues/1126>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>) (#1126 <https://github.com/ros-controls/ros2_controllers/issues/1126>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
