### PR TITLE
ros2_controllers: 4.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5660,7 +5660,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.7.0-2
+      version: 4.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.7.0-2`

## ackermann_steering_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>)
* add missing compiler definitions of RCPPUTILS_VERSION (#1089 <https://github.com/ros-controls/ros2_controllers/issues/1089>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>)
* add missing compiler definitions of RCPPUTILS_VERSION (#1089 <https://github.com/ros-controls/ros2_controllers/issues/1089>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## diff_drive_controller

```
* Remove non-existing parameter (#1119 <https://github.com/ros-controls/ros2_controllers/issues/1119>)
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>)
* Deprecate non-stamped twist for tricycle_controller and steering_controllers (#1093 <https://github.com/ros-controls/ros2_controllers/issues/1093>)
* add missing compiler definitions of RCPPUTILS_VERSION (#1089 <https://github.com/ros-controls/ros2_controllers/issues/1089>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* [JTC] Remove unused test code (#1095 <https://github.com/ros-controls/ros2_controllers/issues/1095>)
* Contributors: Bence Magyar
```

## pid_controller

```
* [PID] Add example yaml to docs (#951 <https://github.com/ros-controls/ros2_controllers/issues/951>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Deprecate non-stamped twist for tricycle_controller and steering_controllers (#1093 <https://github.com/ros-controls/ros2_controllers/issues/1093>)
* add missing compiler definitions of RCPPUTILS_VERSION (#1089 <https://github.com/ros-controls/ros2_controllers/issues/1089>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## tricycle_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>)
* Deprecate non-stamped twist for tricycle_controller and steering_controllers (#1093 <https://github.com/ros-controls/ros2_controllers/issues/1093>)
* add missing compiler definitions of RCPPUTILS_VERSION (#1089 <https://github.com/ros-controls/ros2_controllers/issues/1089>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## tricycle_steering_controller

```
* Add parameter check for geometric values (#1120 <https://github.com/ros-controls/ros2_controllers/issues/1120>)
* add missing compiler definitions of RCPPUTILS_VERSION (#1089 <https://github.com/ros-controls/ros2_controllers/issues/1089>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## velocity_controllers

- No changes
