### PR TITLE
gz_ros2_control: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2201,7 +2201,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2201,10 +2201,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.2-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.3.0-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.2-1`

## gz_ros2_control

```
* Use Gazebo ROS vendor packages (#277 <https://github.com/ros-controls/gz_ros2_control/issues/277>)
* fixed target of ament_export_libraries (#295 <https://github.com/ros-controls/gz_ros2_control/issues/295>)
* fixed install include (#294 <https://github.com/ros-controls/gz_ros2_control/issues/294>)
* Added parameters robot_param and robot_param_node (#275 <https://github.com/ros-controls/gz_ros2_control/issues/275>) (#280 <https://github.com/ros-controls/gz_ros2_control/issues/280>)
  (cherry picked from commit 53b6c74b02bf85860854a37f429b6e2ecf22a4be)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Rewrite mimic joints (#276 <https://github.com/ros-controls/gz_ros2_control/issues/276>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fixed linter (#264 <https://github.com/ros-controls/gz_ros2_control/issues/264>)
* Fix #259 <https://github.com/ros-controls/gz_ros2_control/issues/259> - ParameterAlreadyDeclaredException for parameter position_proportional_gain (#261 <https://github.com/ros-controls/gz_ros2_control/issues/261>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Christoph Fröhlich, Patrick Roncagliolo, Takashi Sato, mergify[bot]
```

## gz_ros2_control_demos

```
* Update pendulum-example  (#301 <https://github.com/ros-controls/gz_ros2_control/issues/301>)
  * Change initial pose of pendulum
  * Make position and effort version of pendulum equal
* Use Gazebo ROS vendor packages (#277 <https://github.com/ros-controls/gz_ros2_control/issues/277>)
* Add cart-pole demo (#289 <https://github.com/ros-controls/gz_ros2_control/issues/289>)
* Rewrite mimic joints (#276 <https://github.com/ros-controls/gz_ros2_control/issues/276>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fix flake8 (#269 <https://github.com/ros-controls/gz_ros2_control/issues/269>)
* Cleanup launch files and add example for .xml launch file. (#266 <https://github.com/ros-controls/gz_ros2_control/issues/266>)
* Contributors: Addisu Z. Taddese, Christoph Fröhlich, Dr. Denis
```

## gz_ros2_control_tests

```
* Use Gazebo ROS vendor packages (#277 <https://github.com/ros-controls/gz_ros2_control/issues/277>)
* Contributors: Addisu Z. Taddese
```
