### PR TITLE
gazebo_ros2_control: 0.6.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1791,7 +1791,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.6.6-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.5-1`

## gazebo_ros2_control

```
* Add PID controller to control joint using effort (#294 <https://github.com/ros-controls/gazebo_ros2_control//issues/294>) (#311 <https://github.com/ros-controls/gazebo_ros2_control//issues/311>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  (cherry picked from commit f769c6c1684eb2ccb3e4988ad4611b32b4beabf6)
  Co-authored-by: chameau5050 <mailto:54971185+chameau5050@users.noreply.github.com>
* Update precommit config (#298 <https://github.com/ros-controls/gazebo_ros2_control//issues/298>) (#302 <https://github.com/ros-controls/gazebo_ros2_control//issues/302>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 105c0ba5b786a43e1e9266399ab027a12011c643)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Fix incorrect force-torque sensor vec population (#296 <https://github.com/ros-controls/gazebo_ros2_control//issues/296>) (#300 <https://github.com/ros-controls/gazebo_ros2_control//issues/300>)
  (cherry picked from commit fdcd7aa8c67ea57f44bbf2f8fba90a28d7f04b5d)
  Co-authored-by: Mateus Menezes <mailto:mateusmenezes95@gmail.com>
* Contributors: mergify[bot]
```

## gazebo_ros2_control_demos

```
* Change initial pose of pendulum (#313 <https://github.com/ros-controls/gazebo_ros2_control//issues/313>) (#316 <https://github.com/ros-controls/gazebo_ros2_control//issues/316>)
  (cherry picked from commit 40ee42da16af9f1bc78886dbaec8082fd3fdea26)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Add PID controller to control joint using effort (#294 <https://github.com/ros-controls/gazebo_ros2_control//issues/294>) (#311 <https://github.com/ros-controls/gazebo_ros2_control//issues/311>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  (cherry picked from commit f769c6c1684eb2ccb3e4988ad4611b32b4beabf6)
  Co-authored-by: chameau5050 <mailto:54971185+chameau5050@users.noreply.github.com>
* Add an example with a passive joint (backport #172 <https://github.com/ros-controls/gazebo_ros2_control//issues/172>) (#307 <https://github.com/ros-controls/gazebo_ros2_control//issues/307>)
  * Add an example with a passive joint (#172 <https://github.com/ros-controls/gazebo_ros2_control//issues/172>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 7d5ec5dbad710d628bc14a82195c196f088621b8)
  # Conflicts:
  #     doc/index.rst
  * Fixed docs
  ---------
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
