### PR TITLE
fields2cover: 2.0.0-13 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1562,7 +1562,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 2.0.0-12
+      version: 2.0.0-13
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fields2cover` to `2.0.0-13`:

- upstream repository: https://github.com/Fields2Cover/fields2cover.git
- release repository: https://github.com/ros2-gbp/fields2cover-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-12`
