### PR TITLE
spatio_temporal_voxel_layer: 2.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7295,6 +7295,24 @@ repositories:
       url: https://github.com/clalancette/sophus.git
       version: release/1.3.x
     status: maintained
+  spatio_temporal_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: iron
+    release:
+      packages:
+      - openvdb_vendor
+      - spatio_temporal_voxel_layer
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
+      version: 2.4.0-1
+    source:
+      type: git
+      url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
+      version: iron
+    status: maintained
   spdlog_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `spatio_temporal_voxel_layer` to `2.4.0-1`:

- upstream repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer.git
- release repository: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
