### PR TITLE
rqt_bag: 1.5.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6372,7 +6372,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.5.2-2
+      version: 1.5.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.5.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.2-2`

## rqt_bag

```
* Adapted to rosbag2_py (backport #156 <https://github.com/ros-visualization/rqt_bag/issues/156>) (#165 <https://github.com/ros-visualization/rqt_bag/issues/165>)
  Adapted to rosbag2_py (#156 <https://github.com/ros-visualization/rqt_bag/issues/156>)
  * Switch to an in-built ImageQt class.
  That's because in newer versions of PIL, they skip over
  PyQt5 support even though it works.
  * Update for new rosbag2_py API.
  * Fix TopicMetadata call
  * Avoid freeze the gui
  * Fixed checkboes
  * Update with the license from PIL.
  Note that this is an OSI-approved license, even though
  it is technically deprecated by
  OSI: https://opensource.org/license/historical-php
  * Only change the checkbox when needed.
  Otherwise, we end up with endless paint() calls which
  hammer the CPU.
  * A few small fixes for PIL.
  (cherry picked from commit e7879325f075c9d6749a4324618691933727574c)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fixed button icons (backport #159 <https://github.com/ros-visualization/rqt_bag/issues/159>) (#160 <https://github.com/ros-visualization/rqt_bag/issues/160>)
  Fixed button icons (#159 <https://github.com/ros-visualization/rqt_bag/issues/159>)
  (cherry picked from commit 0d386692f63e35a8ec3c61dee0d70c389f89bf2d)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rqt_bag_plugins

```
* Adapted to rosbag2_py (backport #156 <https://github.com/ros-visualization/rqt_bag/issues/156>) (#165 <https://github.com/ros-visualization/rqt_bag/issues/165>)
  Adapted to rosbag2_py (#156 <https://github.com/ros-visualization/rqt_bag/issues/156>)
  * Switch to an in-built ImageQt class.
  That's because in newer versions of PIL, they skip over
  PyQt5 support even though it works.
  * Update for new rosbag2_py API.
  * Fix TopicMetadata call
  * Avoid freeze the gui
  * Fixed checkboes
  * Update with the license from PIL.
  Note that this is an OSI-approved license, even though
  it is technically deprecated by
  OSI: https://opensource.org/license/historical-php
  * Only change the checkbox when needed.
  Otherwise, we end up with endless paint() calls which
  hammer the CPU.
  * A few small fixes for PIL.
  (cherry picked from commit e7879325f075c9d6749a4324618691933727574c)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fixed image timeline renderer (backport #158 <https://github.com/ros-visualization/rqt_bag/issues/158>) (#163 <https://github.com/ros-visualization/rqt_bag/issues/163>)
  Fixed image timeline renderer (#158 <https://github.com/ros-visualization/rqt_bag/issues/158>)
  (cherry picked from commit a939f27f6323ba1117edaafcdc498fc982743d4f)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
