### PR TITLE
rqt_robot_monitor: 1.0.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6678,7 +6678,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
-      version: 1.0.5-3
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_monitor` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_monitor.git
- release repository: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.5-3`

## rqt_robot_monitor

```
* Fix warning for setup.cfg that separation by dash will be removed (#45 <https://github.com/ros-visualization/rqt_robot_monitor/issues/45>)
* Fix for instantiation issue (#43 <https://github.com/ros-visualization/rqt_robot_monitor/issues/43>)
* Fix error on ctrl+c
```
