### PR TITLE
microstrain_inertial: 4.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3320,7 +3320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.3.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.2.0-1`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* Updates CV7 INS example yaml (https://github.com/LORD-MicroStrain/microstrain_inertial/pull/330 _)
* Update udev to specify manufacturer (https://github.com/LORD-MicroStrain/microstrain_inertial/pull/327 _)
* Rename gx5_15 config file to match folder name (https://github.com/LORD-MicroStrain/microstrain_inertial/pull/321 _)
* Updates submodule (#328 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/329>)
  * Adds ability for ROS2 implementation to be a non-lifecycle node microstrain_inertial_driver_common#68
  * Remove dongle version check microstrain_inertial_driver_common#72
  * Updates MIP SDK to fully support CV7-INS microstrain_inertial_driver_common#73
  * Waits for GNSS antenna transforms instead of erroring if they cannot be found microstrain_inertial_driver_common#74
  * Fixes the gnss_state in human readable status microstrain_inertial_driver_common#75
* Contributors: hilary-luo, GreatAlexander, robbiefish
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

- No changes

## microstrain_inertial_rqt

- No changes
