### PR TITLE
rqt_bag: 1.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7803,7 +7803,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.1.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.4-1`

## rqt_bag

```
* Fixed button icons (backport #159 <https://github.com/ros-visualization/rqt_bag/issues/159>) (#161 <https://github.com/ros-visualization/rqt_bag/issues/161>)
* Contributors: mergify[bot]
```

## rqt_bag_plugins

- No changes
