### PR TITLE
rqt_graph: 1.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7874,7 +7874,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.3.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## rqt_graph

```
* Fixed fit_in_view icon button (backport #95 <https://github.com/ros-visualization/rqt_graph/issues/95>) (#97 <https://github.com/ros-visualization/rqt_graph/issues/97>)
* Contributors: mergify[bot]
```
