### PR TITLE
rclcpp: 16.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6338,7 +6338,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.8-1
+      version: 16.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.9-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `16.0.8-1`

## rclcpp

```
* Fix logging macros to build with msvc and cpp20 (#2063 <https://github.com/ros2/rclcpp/issues/2063>) (#2529 <https://github.com/ros2/rclcpp/issues/2529>)
  (cherry picked from commit 86335dd4acd91d5dd973c4e4e97014e5e8a916bc)
  Co-authored-by: Mateusz Szczygielski <mailto:112629916+msz-rai@users.noreply.github.com>
* address ambiguous auto variable. (#2481 <https://github.com/ros2/rclcpp/issues/2481>) (#2485 <https://github.com/ros2/rclcpp/issues/2485>)
  (cherry picked from commit 3cdb25934ed261c78bdfbcf5ec9f06e0573be81e)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Fix clang warning: bugprone-use-after-move (#2116 <https://github.com/ros2/rclcpp/issues/2116>) (#2459 <https://github.com/ros2/rclcpp/issues/2459>)
  Co-authored-by: mauropasse <mailto:mauropasse@hotmail.com>
  Co-authored-by: Mauro Passerino <mailto:mpasserino@irobot.com>
* Contributors: Tamaki Nishino, mergify[bot]
```

## rclcpp_action

```
* Do not generate the exception when action service response timeout. (#2464 <https://github.com/ros2/rclcpp/issues/2464>) (#2518 <https://github.com/ros2/rclcpp/issues/2518>)
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* call shutdown in LifecycleNode dtor to avoid leaving the device in un… (#2450 <https://github.com/ros2/rclcpp/issues/2450>) (#2491 <https://github.com/ros2/rclcpp/issues/2491>)
* Contributors: mergify[bot]
```
