### PR TITLE
rcutils: 5.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6405,7 +6405,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 5.1.5-1
+      version: 5.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `5.1.6-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.5-1`

## rcutils

```
* update cast to modern style (#418 <https://github.com/ros2/rcutils/issues/418>) (#462 <https://github.com/ros2/rcutils/issues/462>)
* Contributors: mergify[bot]
```
