### PR TITLE
rmw: 6.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6798,7 +6798,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 6.1.1-1
+      version: 6.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `6.1.2-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.1.1-1`

## rmw

```
* rmw_send_reqponse returns RMW_RET_TIMEOUT. (#350 <https://github.com/ros2/rmw/issues/350>) (#367 <https://github.com/ros2/rmw/issues/367>)
* Contributors: mergify[bot]
```

## rmw_implementation_cmake

- No changes
