### PR TITLE
point_cloud_transport: 2.0.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4502,7 +4502,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `2.0.6-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.5-1`

## point_cloud_transport

```
* [rolling] Get user specified parameters at startup (#80 <https://github.com/ros-perception/point_cloud_transport/issues/80>) (#84 <https://github.com/ros-perception/point_cloud_transport/issues/84>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 90c603a1e8fb56c3203ff6870e4f2205c37e59b4)
  Co-authored-by: john-maidbot <mailto:78750993+john-maidbot@users.noreply.github.com>
* Rename the republish_node to pc_republish_node. (#75 <https://github.com/ros-perception/point_cloud_transport/issues/75>) (#76 <https://github.com/ros-perception/point_cloud_transport/issues/76>)
  The major reason for this is that image_transport already
  has a republish_node, and when we are building for distribution
  we can't have two files named /opt/ros/rolling/lib/librepublish_node.so
  Rename this one to libpc_republish_node, which should remove
  the conflict.
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## point_cloud_transport_py

- No changes
