### PR TITLE
pal_statistics: 2.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5316,7 +5316,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.2.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.3-1`

## pal_statistics

```
* Use enabled_.swap instead of std::swap.
  This allows this package to compile on modern g++,
  on Ubuntu 24.04.
* Contributors: Chris Lalancette
```

## pal_statistics_msgs

- No changes

