### PR TITLE
rosbag2: 0.26.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6034,7 +6034,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.2-1
+      version: 0.26.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.3-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.26.2-1`

## liblz4_vendor

- No changes

## mcap_vendor

```
* Update mcap-releases-cpp- into CMakeLists.txt (#1612 <https://github.com/ros2/rosbag2/issues/1612>) (#1631 <https://github.com/ros2/rosbag2/issues/1631>)
  Co-authored-by: mosfet80 <mailto:realeandrea@yahoo.it>
* Contributors: mergify[bot]
```

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Bugfix for writer not being able to open again after closing (#1599 <https://github.com/ros2/rosbag2/issues/1599>) (#1639 <https://github.com/ros2/rosbag2/issues/1639>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: yschulz <mailto:yschulz854@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Bugfix for writer not being able to open again after closing (#1599 <https://github.com/ros2/rosbag2/issues/1599>) (#1639 <https://github.com/ros2/rosbag2/issues/1639>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: yschulz <mailto:yschulz854@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Included to_rclcpp_qos_vector to Python wrappers (#1642 <https://github.com/ros2/rosbag2/issues/1642>) (#1650 <https://github.com/ros2/rosbag2/issues/1650>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Bugfix for writer not being able to open again after closing (#1599 <https://github.com/ros2/rosbag2/issues/1599>) (#1639 <https://github.com/ros2/rosbag2/issues/1639>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: yschulz <mailto:yschulz854@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_transport

- No changes

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* Fixed warnings on RHEL (#1627 <https://github.com/ros2/rosbag2/issues/1627>) (#1630 <https://github.com/ros2/rosbag2/issues/1630>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
