### PR TITLE
Use triple-dot diff YAML in CI

### DIFF
--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -70,7 +70,7 @@ def get_changed_line_numbers():
         # Check url
         assert remote_url == DIFF_REPO, \
             '%s remote url [%s] is different than %s' % (UPSTREAM_NAME, remote_url, DIFF_REPO)
-        base_ref = '%s/%s' % (UPSTREAM_NAME, DIFF_BRANCH)
+        base_ref = '%s/%s...' % (UPSTREAM_NAME, DIFF_BRANCH)
     except subprocess.CalledProcessError:
         # No remote so fall back to origin/master
         print('WARNING: No remote %s detected, falling back to origin master. Make sure it is up to date.' % UPSTREAM_NAME, file=sys.stderr)


### PR DESCRIPTION
The current diff mechanism in rosdep_repo_check uses a 'bare' diff with the configured upstream ref. If the upstream ref contains additional commits which are not present in the PR's HEAD which remove lines of YAML, this bare diff will report those lines as 'added' when comparing the PR to the target, which is certainly not what we want to do.

We can use the git triple-dot notation to compare only commits which are present in HEAD but not in target, effectively comparing between the PR's HEAD and the merge base with the target branch, instead of the target branch directly.

One disadvantage of this approach is that uncommitted changes are no longer considered part of the diff. For this reason, I'm only adding the triple dot during diffs with the specifically-configured upstream branch and not the 'fallback' comparison with origin/master. This way, you can still invoke the test locally without the need to commit the changes first.

Fixes part of #31439