### PR TITLE
Removed gazebo_ros2_control from rolling and Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1764,24 +1764,6 @@ repositories:
       url: https://github.com/ros-sports/game_controller_spl.git
       version: rolling
     status: developed
-  gazebo_ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
-    release:
-      packages:
-      - gazebo_ros2_control
-      - gazebo_ros2_control_demos
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.7.1-3
-    source:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
-    status: developed
   generate_parameter_library:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1780,24 +1780,6 @@ repositories:
       url: https://github.com/ros-sports/game_controller_spl.git
       version: rolling
     status: developed
-  gazebo_ros2_control:
-    doc:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
-    release:
-      packages:
-      - gazebo_ros2_control
-      - gazebo_ros2_control_demos
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.7.1-2
-    source:
-      type: git
-      url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
-    status: developed
   generate_parameter_library:
     doc:
       type: git


### PR DESCRIPTION
Gazebo Classic is not released to Ubuntu Noble. As a consequence, gazebo_ros2_control won't be released for Jazzy and Rolling anymore.

Removing the keys

FYI @azeey 