### PR TITLE
kuka_external_control_sdk: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3222,6 +3222,14 @@ repositories:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git
       version: master
+    release:
+      packages:
+      - kuka_external_control_sdk
+      - kuka_external_control_sdk_examples
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_external_control_sdk` to `1.3.0-1`:

- upstream repository: https://github.com/kroshu/kuka-external-control-sdk.git
- release repository: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## kuka_external_control_sdk

```
* Change motion state variables from pointer to reference
* Rework control signal Add methods to accept stl iterators
```

## kuka_external_control_sdk_examples

```
* Add examples package
* Contributors: Mark Szitanics, Gergely Kovacs, Aron Svastits
```
