### PR TITLE
libcaer_vendor: 1.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3527,6 +3527,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer_vendor-release.git
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_vendor` to `1.1.0-2`:

- upstream repository: https://github.com/ros-event-camera/libcaer_vendor.git
- release repository: https://github.com/ros2-gbp/libcaer_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## libcaer_vendor

```
* initial commit
* Contributors: Bernd Pfrommer
```
