### PR TITLE
flir_camera_driver: 2.2.17-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1641,7 +1641,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.2.16-1
+      version: 2.2.17-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.2.17-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.16-1`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* fix broken composable node by installing in correct location
* Add FLIR-AX5 Camera
* Contributors: Bernd Pfrommer, anonymousarmadillo100
```

## spinnaker_synchronized_camera_driver

- No changes
