### PR TITLE
ur_robot_driver: 2.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7729,7 +7729,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.4-1
+      version: 2.4.5-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.5-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.4-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Use latched publishing for robot_mode and safety_mode
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Fix multi-line strings in DeclareLaunchArgument (#948 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/948>)
* Contributors: Matthijs van der Burgh
```

## ur_robot_driver

```
* Remove dependency to docker.io (#985 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/985>)
* Move starting the robot_state_publisher to an own launch file (#977 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/977>)
  Co-authored-by: Vincenzo Di Pentima <mailto:DiPentima@fzi.de>
* Update installation instructions for source build (#967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/967>)
* Fix multi-line strings in DeclareLaunchArgument (#948 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/948>)
* Contributors: Christoph Fröhlich, Felix Exner (fexner), Matthijs van der Burgh
```
