### PR TITLE
libcaer_vendor: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2938,6 +2938,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer_vendor-release.git
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_vendor` to `1.3.0-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_vendor.git
- release repository: https://github.com/ros2-gbp/libcaer_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## libcaer_vendor

```
* initial commit
* Contributors: Bernd Pfrommer
```
