### PR TITLE
ur_robot_driver: 2.2.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9722,7 +9722,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.11-1
+      version: 2.2.12-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.12-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.11-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Use latched publishing for robot_mode and safety_mode (#991 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/991>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Define default maximum accelerations for MoveIt (backport of #645 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/645>)
* Fix multi-line strings in DeclareLaunchArgument (#948 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/948>)
* Contributors: Robert Wilbrandt, Matthijs van der Burgh
```

## ur_robot_driver

```
* Remove dependency to docker.io (backport #985 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/985>)
* Simplify tests (backport of #849 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/849>)
* Update installation instructions for source build (backport #967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/967>)
* Move installation instructions to subpage (backport #870 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/870>)
* Reduce number of controller_spawners to 3 (#928 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/928>)
* Fix multi-line strings in DeclareLaunchArgument (backport #948 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/948>)
* "use_fake_hardware" for UR20 (#950 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/950>)
* Contributors: Vincenzo Di Pentima, Felix Exner, Robert Wilbrandt, Matthijs van der Burgh
```
