### PR TITLE
libcaer_vendor: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2954,6 +2954,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer_vendor-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_vendor.git
- release repository: https://github.com/ros2-gbp/libcaer_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## libcaer_vendor

```
* initial commit
* Contributors: Bernd Pfrommer
```
