### PR TITLE
ur_robot_driver: 2.3.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8001,7 +8001,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.6-1
+      version: 2.3.7-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.7-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.6-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Use latched publishing for robot_mode and safety_mode (#992 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/992>)
  Co-authored-by: Felix Exner <mailto:exner@fzi.de>
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Fix multi-line strings in DeclareLaunchArgument (#948 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/948>) (#969 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/969>)
  Co-authored-by: Matthijs van der Burgh <mailto:matthijs.vander.burgh@live.nl>
* Contributors: Matthijs van der Burgh
```

## ur_robot_driver

```
* Remove dependency to docker.io (backport of #985 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/985>)
* Simplify tests (backport #849 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/849>)
* Reduce number of controller_spawners to 3 (backport #919 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/919>)
* Update installation instructions for source build (backport #967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/967>)
* Fix multi-line strings in DeclareLaunchArgument (backport #948 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/948>)
* "use_fake_hardware" for UR20 (backport #950 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/950>)
* Contributors: Christoph Fröhlich, Matthijs van der Burgh, Vincenzo Di Pentima
```
