### PR TITLE
mp2p_icp: 1.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4331,7 +4331,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.4.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-1`

## mp2p_icp

```
* Fix build for older mrpt versions
* ICP pipelines: Implement loading ``quality_checkpoints`` parameter from YAML config file
* Quality evaluators: add the option for 'hard discard'
* Update QualityEvaluator_Voxels to use prebuilt voxel layers from input maps. Add unit tests.
* BUGFIX: Fix deserializing georeferenced .mm files stored in <1.4.0 format
* ICP: quality evaluators can now have formulas in their parameters too
* mm-viewer and icp-log-viewer: extend zoom range so maps of tens of kms can be viewed at once
* Contributors: Jose Luis Blanco-Claraco
```
