### PR TITLE
vrpn: 7.35.0-20 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8096,7 +8096,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn-release.git
-      version: 7.35.0-15
+      version: 7.35.0-20
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.35.0-20`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros2-gbp/vrpn-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.35.0-15`
