### PR TITLE
vrpn: 7.35.0-18 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8069,7 +8069,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn-release.git
-      version: 7.35.0-16
+      version: 7.35.0-18
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `vrpn` to `7.35.0-18`:

- upstream repository: https://github.com/vrpn/vrpn.git
- release repository: https://github.com/ros2-gbp/vrpn-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.35.0-16`
