### PR TITLE
behaviortree_cpp_v4: 4.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -690,7 +690,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.6.0-1
+      version: 4.6.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.6.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.6.0-1`

## behaviortree_cpp

```
* remove flatbuffers from public API and old file_logger
* fix issue #824 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/824>: use global in Blackboard::set
* Add test for setting a global blackboard entry using a node's output port #823 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/823>
* examples renamed
* Contributors: Davide Faconti, Robin Müller
```
