### PR TITLE
Mark jazzy as active.

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -84,7 +84,7 @@ distributions:
   jazzy:
     distribution: [jazzy/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/jazzy-cache.yaml.gz
-    distribution_status: pre-release
+    distribution_status: active
     distribution_type: ros2
     python_version: 3
   kinetic:


### PR DESCRIPTION
Move Jazzy's distribution status from `pre-release` to `active`.
