### PR TITLE
rqt_graph: 1.5.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6424,7 +6424,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.5.3-2
+      version: 1.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.5.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.3-2`

## rqt_graph

```
* Fixed fit_in_view icon button (backport #95 <https://github.com/ros-visualization/rqt_graph/issues/95>) (#96 <https://github.com/ros-visualization/rqt_graph/issues/96>)
* Contributors: mergify[bot]
```
