### PR TITLE
point_cloud_transport_plugins: 2.0.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4542,7 +4542,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `2.0.5-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-1`

## draco_point_cloud_transport

```
* Get user specified parameters at startup (#46 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/46>) (#51 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/51>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 46f3d22f3d5660529f4372aeed3fbcb41852a911)
  Co-authored-by: john-maidbot <mailto:78750993+john-maidbot@users.noreply.github.com>
* Contributors: mergify[bot]
```

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

```
* Get user specified parameters at startup (#46 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/46>) (#51 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/51>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 46f3d22f3d5660529f4372aeed3fbcb41852a911)
  Co-authored-by: john-maidbot <mailto:78750993+john-maidbot@users.noreply.github.com>
* Contributors: mergify[bot]
```

## zstd_point_cloud_transport

```
* Get user specified parameters at startup (#46 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/46>) (#51 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/51>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 46f3d22f3d5660529f4372aeed3fbcb41852a911)
  Co-authored-by: john-maidbot <mailto:78750993+john-maidbot@users.noreply.github.com>
* Contributors: mergify[bot]
```
