### PR TITLE
Add python3-asn1tools to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4923,10 +4923,7 @@ python3-argcomplete:
   rhel: ['python%{python3_pkgversion}-argcomplete']
   ubuntu: [python3-argcomplete]
 python3-asn1tools-pip:
-  debian:
-    pip:
-      packages: [asn1tools]
-  ubuntu:
+  '*':
     pip:
       packages: [asn1tools]
 python3-astropy-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4922,6 +4922,13 @@ python3-argcomplete:
   openembedded: [python3-argcomplete@meta-python]
   rhel: ['python%{python3_pkgversion}-argcomplete']
   ubuntu: [python3-argcomplete]
+python3-asn1tools-pip:
+  debian:
+    pip:
+      packages: [asn1tools]
+  ubuntu:
+    pip:
+      packages: [asn1tools]
 python3-astropy-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

asn1tools

## Package Upstream Source:

https://pypi.org/project/asn1tools/

## Purpose of using this:

`ans1tools` is a package for parsing, encoding and decoding ASN.1 (Abstract Syntax Notation One).  
ASN.1 is used in a large number of protocols (e.g. ETSI ITS). Therefore it is useful to encode and decode this protocol.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - PyPi: https://pypi.org/project/asn1tools/
- Ubuntu: https://packages.ubuntu.com/
  - PyPi: https://pypi.org/project/asn1tools/

