### PR TITLE
rosbag2: 0.15.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7504,7 +7504,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.9-1
+      version: 0.15.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.10-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.9-1`

## mcap_vendor

- No changes

## ros2bag

```
* [humble] Add --log-level to ros2 bag play and record (#1655 <https://github.com/ros2/rosbag2/issues/1655>)
* [Humble] Resolve recording option problem (backport #1649 <https://github.com/ros2/rosbag2/issues/1649>) (#1651 <https://github.com/ros2/rosbag2/issues/1651>)
* Contributors: Roman, mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* [humble] Bugfix for writer not being able to open again after closing (backport #1599 <https://github.com/ros2/rosbag2/issues/1599>) (#1653 <https://github.com/ros2/rosbag2/issues/1653>)
* [humble] Add default initialization for CompressionOptions (backport #1539 <https://github.com/ros2/rosbag2/issues/1539>) (#1546 <https://github.com/ros2/rosbag2/issues/1546>)
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* [humble] Bugfix for writer not being able to open again after closing (backport #1599 <https://github.com/ros2/rosbag2/issues/1599>) (#1653 <https://github.com/ros2/rosbag2/issues/1653>)
* [humble] Add BagSplitInfo service call on bag close (backport #1422 <https://github.com/ros2/rosbag2/issues/1422>) (#1637 <https://github.com/ros2/rosbag2/issues/1637>)
* Fix split by time. (backport #1022 <https://github.com/ros2/rosbag2/issues/1022>) (#1616 <https://github.com/ros2/rosbag2/issues/1616>)
* Contributors: Tomoya Fujita, mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* [humble] Add --log-level to ros2 bag play and record (#1655 <https://github.com/ros2/rosbag2/issues/1655>)
* Contributors: Roman
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* [humble] Use rw_lock to protect mcap metadata lists. (backport #1561 <https://github.com/ros2/rosbag2/issues/1561>) (#1567 <https://github.com/ros2/rosbag2/issues/1567>)
* Contributors: mergify[bot]
```

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

```
* [humble] Bugfix for writer not being able to open again after closing (backport #1599 <https://github.com/ros2/rosbag2/issues/1599>) (#1653 <https://github.com/ros2/rosbag2/issues/1653>)
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* Add /bigobj to MSVC compiles. (#1571 <https://github.com/ros2/rosbag2/issues/1571>)
* Contributors: Chris Lalancette
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

```
* Fix/zstd vendor does not find system zstd (#1111 <https://github.com/ros2/rosbag2/issues/1111>) (#1560 <https://github.com/ros2/rosbag2/issues/1560>)
* Contributors: mergify[bot]
```
