### PR TITLE
kinematics_interface: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2650,7 +2650,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.0.0-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.1.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## kinematics_interface

```
* Use CMake targets for eigen (#50 <https://github.com/ros-controls/kinematics_interface/issues/50>)
* Contributors: Christoph Fröhlich
```

## kinematics_interface_kdl

```
* Read base parameter in initialize function (#73 <https://github.com/ros-controls/kinematics_interface/issues/73>)
* Use CMake targets for eigen (#50 <https://github.com/ros-controls/kinematics_interface/issues/50>)
* Contributors: Bence Magyar, Christoph Fröhlich
```
