### PR TITLE
kinematics_interface: 1.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2550,7 +2550,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.1.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## kinematics_interface

```
* Use CMake targets for eigen (#50 <https://github.com/ros-controls/kinematics_interface/issues/50>)
* Contributors: Christoph Fröhlich
```

## kinematics_interface_kdl

```
* Read base parameter in initialize function (#73 <https://github.com/ros-controls/kinematics_interface/issues/73>)
* Use CMake targets for eigen (#50 <https://github.com/ros-controls/kinematics_interface/issues/50>)
* Contributors: Bence Magyar, Christoph Fröhlich
```
