### PR TITLE
mrpt_sensors: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3633,12 +3633,13 @@ repositories:
       - mrpt_generic_sensor
       - mrpt_sensor_bumblebee_stereo
       - mrpt_sensor_gnns_nmea
+      - mrpt_sensor_imu_taobotics
       - mrpt_sensorlib
       - mrpt_sensors
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.2.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.0-1`

## mrpt_generic_sensor

- No changes

## mrpt_sensor_bumblebee_stereo

```
* Add parameter to set the sensorLabel of generated observations
* BUGFIX: Wrong parsing of sensor "roll" angle from ros2 params
* add XSens IMU sensor driver wrapper
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnns_nmea

```
* Add parameter to set the sensorLabel of generated observations
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_imu_taobotics

```
* fix docs typos
* Add parameter to set the sensorLabel of generated observations
* Add new driver for IMU sensors by Taobotics
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* FIX: Implement the missing "saveToRawlog" feature
* Add parameter to set the sensorLabel of generated observations
* Limit publication of /tf sensor poses to a maximum configurable rate
* BUGFIX: tf error if sensor_frame_id==robot_frame_id
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

- No changes
