### PR TITLE
common_interfaces: 4.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1207,7 +1207,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 4.2.3-1
+      version: 4.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `4.2.4-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.3-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Create new messages with all fields needed to define a velocity and transform it  (#240 <https://github.com/ros2/common_interfaces/issues/240>) (#249 <https://github.com/ros2/common_interfaces/issues/249>)
  Co-authored-by: Dr. Denis <mailto:denis@stoglrobotics.de>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
  (cherry picked from commit 74137fc6971ac7d6420248b4394cca977fb5a887)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## nav_msgs

- No changes

## sensor_msgs

- No changes

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
