### PR TITLE
add openeb_vendor to humble,iron,rolling,jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5083,6 +5083,16 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.6.0-1
+  openeb_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: humble
+    status: developed
   openni2_camera:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4121,6 +4121,16 @@ repositories:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-4
+  openeb_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: iron
+    status: developed
   openni2_camera:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4023,6 +4023,16 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-2
+  openeb_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: jazzy
+    status: developed
   openni2_camera:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4040,6 +4040,16 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.5.2-4
+  openeb_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: rolling
+    status: developed
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
# Please Add openeb_vendor to be indexed in the rosdistro.

ROSDISTRO NAMES: humble, iron, jazzy, rolling

# The source is here:
https://github.com/ros-event-camera/openeb_vendor

Changed my mind and decided to vendor this library after all, so this PR's purpose is to finish up what was started with PR #40764
# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
