### PR TITLE
vimbax_ros2_driver: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10004,6 +10004,17 @@ repositories:
       type: git
       url: https://github.com/alliedvision/vimbax_ros2_driver.git
       version: humble
+    release:
+      packages:
+      - vimbax_camera
+      - vimbax_camera_events
+      - vimbax_camera_examples
+      - vimbax_camera_msgs
+      - vmbc_interface
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/vimbax_ros2_driver-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/alliedvision/vimbax_ros2_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vimbax_ros2_driver` to `1.0.1-1`:

- upstream repository: https://github.com/alliedvision/vimbax_ros2_driver.git
- release repository: https://github.com/ros2-gbp/vimbax_ros2_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## vimbax_camera

- No changes

## vimbax_camera_events

- No changes

## vimbax_camera_examples

- No changes

## vimbax_camera_msgs

- No changes

## vmbc_interface

- No changes
