### PR TITLE
franka_description: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2242,6 +2242,15 @@ repositories:
       version: main
     status: developed
   franka_description:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/franka_description.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/franka_description-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_description` to `0.2.0-1`:

- upstream repository: https://github.com/frankaemika/franka_description.git
- release repository: https://github.com/ros2-gbp/franka_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## franka_description

```
* feat: end-effector can be deactivated with an argument
* feat: add dedicated folder for end-effectors
* fix: license name in readme
* Contributors: Guillermo Gomez Pena
```
