### PR TITLE
septentrio_gnss_driver: 1.4.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6895,7 +6895,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
-      version: ros2
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -6905,7 +6905,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
-      version: ros2
+      version: master
     status: maintained
   sick_safevisionary_base:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6900,6 +6900,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
+      version: 1.4.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.0-4`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## septentrio_gnss_driver

```
* New features
  * Send custom commands via ASCII file on startup
  * Save config to boot after setup
  * NTP and PTP server options (BREAKING: NTP is not setup automatically for use_gnss_time: true anymore)
  * Receiver status on /diagnostics
  * Option to publish only valid SBF block messages
  * Option to auto publish available messages for configure_rx: false
* Changes
  * Change floating point do-not-use-values to NaN (BREAKING in case these values ae used for validity checks downstream)
  * VSM now uses separate TCP device specified IP server
* Improvements
  * Rework some sections of the README
  * Combine ROS 1 and ROS 2 in one branch
  * Change GPSFix publishing policy to allow for high update rates
```
