### PR TITLE
libcamera: 0.3.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2948,6 +2948,17 @@ repositories:
       url: https://github.com/ros-event-camera/libcaer_vendor.git
       version: jazzy
     status: developed
+  libcamera:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/libcamera-release.git
+      version: 0.3.0-2
+    source:
+      type: git
+      url: https://git.libcamera.org/libcamera/libcamera.git
+      version: master
+    status: maintained
   libg2o:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `libcamera` to `0.3.0-2`:

- upstream repository: https://git.libcamera.org/libcamera/libcamera.git
- release repository: https://github.com/ros2-gbp/libcamera-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
