### PR TITLE
robot_controllers: 0.7.1-4 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9104,7 +9104,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
-      version: 0.7.0-1
+      version: 0.7.1-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_controllers` to `0.7.1-4`:

- upstream repository: https://github.com/fetchrobotics/robot_controllers.git
- release repository: https://github.com/fetchrobotics-gbp/robot_controllers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-1`

## robot_controllers

```
* Update maintainers
* Zero out base controller update delta time when negative (#82 <https://github.com/ZebraDevs/robot_controllers/issues/82>)
* Contributors: Eric Relson, Jeff Wilson
```

## robot_controllers_interface

```
* Update maintainers
* Contributors: Eric Relson
```

## robot_controllers_msgs

```
* Update maintainers
* Contributors: Eric Relson
```
