### PR TITLE
foxglove_bridge: 0.7.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1731,7 +1731,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.4-1
+      version: 0.7.7-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.7-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.4-1`

## foxglove_bridge

```
* send service call failure operation (#298 <https://github.com/foxglove/ros-foxglove-bridge/issues/298>)
* Fix service definition parsing on ROS rolling (#293 <https://github.com/foxglove/ros-foxglove-bridge/issues/293>)
* Update docs to discourage users from using websocket compression (#297 <https://github.com/foxglove/ros-foxglove-bridge/issues/297>)
* Update README.md to remove '$ ' so that you can copy and run command (#294 <https://github.com/foxglove/ros-foxglove-bridge/issues/294>)
* Fix typo in ROS2 launch file example (#296 <https://github.com/foxglove/ros-foxglove-bridge/issues/296>)
* Contributors: Felipe Galindo, Hans-Joachim Krauch, Jacob Bandes-Storch, Roman Shtylman
```
