### PR TITLE
Fedora 38 is EOL, long live Fedora 40

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -67,8 +67,8 @@ supported_versions:
   debian:
   - bookworm
   fedora:
-  - '38'
   - '39'
+  - '40'
   opensuse:
   - '15.2'
   openembedded:


### PR DESCRIPTION
https://lists.fedoraproject.org/archives/list/announce@lists.fedoraproject.org/thread/3QE22ILC7EBM6EISHD3HR2S4DFRO7AJL/

In total, there are 57 invalid rules for Fedora 40, up 4 from Fedora 39:
- Package mrpt-devel for rosdep key mrpt
- Package opencv-contrib for rosdep key libopencv-contrib-dev
- Package python-mysql for rosdep key python-mysqldb
- Package python-twitter for rosdep key python-twitter