### PR TITLE
Add pyFirmata to Rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -389,6 +389,13 @@ pydrive-pip:
   ubuntu:
     pip:
       packages: [PyDrive]
+pyfirmata-pip:
+  debian:
+    pip:
+      packages: [pyfirmata]
+  ubuntu:
+    pip:
+      packages: [pyfirmata]
 pyflakes3:
   alpine: [py3-pyflakes]
   arch: [python-pyflakes]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -390,10 +390,7 @@ pydrive-pip:
     pip:
       packages: [PyDrive]
 pyfirmata-pip:
-  debian:
-    pip:
-      packages: [pyfirmata]
-  ubuntu:
+  '*':
     pip:
       packages: [pyfirmata]
 pyflakes3:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7919,10 +7919,10 @@ python3-pyee:
   fedora: [python3-ee]
   opensuse: [python3-pyee]
   ubuntu: [python3-pyee]
-python3-pyfirmata-pip:
+python3-pyfirmata2-pip:
   '*':
     pip:
-      packages: [pyfirmata]
+      packages: [pyfirmata2]
 python3-pyftdi-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -389,10 +389,6 @@ pydrive-pip:
   ubuntu:
     pip:
       packages: [PyDrive]
-pyfirmata-pip:
-  '*':
-    pip:
-      packages: [pyfirmata]
 pyflakes3:
   alpine: [py3-pyflakes]
   arch: [python-pyflakes]
@@ -7923,6 +7919,10 @@ python3-pyee:
   fedora: [python3-ee]
   opensuse: [python3-pyee]
   ubuntu: [python3-pyee]
+python3-pyfirmata-pip:
+  '*':
+    pip:
+      packages: [pyfirmata]
 python3-pyftdi-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pyfirmata2-pip

## Package Upstream Source:

https://github.com/berndporr/pyFirmata2

## Purpose of using this:

A library for communicating with micro controllers over the Firmata protocol. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Python: https://pypi.org/project/pyFirmata2/
