### PR TITLE
off_highway_sensor_drivers: 0.6.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5014,6 +5014,23 @@ repositories:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
       version: humble-devel
+    release:
+      packages:
+      - off_highway_can
+      - off_highway_general_purpose_radar
+      - off_highway_general_purpose_radar_msgs
+      - off_highway_premium_radar_sample
+      - off_highway_premium_radar_sample_msgs
+      - off_highway_radar
+      - off_highway_radar_msgs
+      - off_highway_sensor_drivers
+      - off_highway_sensor_drivers_examples
+      - off_highway_uss
+      - off_highway_uss_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `0.6.0-2`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## off_highway_can

```
* Switch from deprecated signature to const shared_ptr reference while still supporting efficient intra-process communication
  See https://github.com/ros2/rclcpp/pull/1598.
* Contributors: Sarah Huber
```

## off_highway_general_purpose_radar

```
* Convert general purpose radar from node to component
* Add launch argument for parameters and unify launch file names
* Contributors: Robin Petereit
```

## off_highway_general_purpose_radar_msgs

- No changes

## off_highway_premium_radar_sample

```
* Rename premium radar driver to sample
  Currently, the delivered Radar Off-Highway Premium and its firmware are just samples.
  Separate package will be created for series firmware.
* Switch from deprecated signature to const shared_ptr reference while still supporting efficient intra-process communication
  See https://github.com/ros2/rclcpp/pull/1598.
* Interpret azimuth and elevation angle of premium radar locations as cone coordinates
* Update executable names for premium radar in launch
* Convert premium radar from node to component
* Remove redundant normal in pcl
* Contributors: Robin Petereit, Sarah Huber
```

## off_highway_premium_radar_sample_msgs

```
* Rename premium radar driver to sample
  Currently, the delivered Radar Off-Highway Premium and its firmware are just samples.
  Separate package will be created for series firmware.
* Add mapping to TCI
* Contributors: Robin Petereit
```

## off_highway_radar

```
* Switch from deprecated signature to const shared_ptr reference while still supporting efficient intra-process communication
  See https://github.com/ros2/rclcpp/pull/1598.
* Convert radar driver from node to component
* Add launch argument for parameters and unify launch file names
* Contributors: Robin Petereit, Sarah Huber
```

## off_highway_radar_msgs

- No changes

## off_highway_sensor_drivers

```
* Rename premium radar driver to sample
  Currently, the delivered Radar Off-Highway Premium and its firmware are just samples.
  Separate package will be created for series firmware.
* Contributors: Robin Petereit
```

## off_highway_sensor_drivers_examples

```
* Restructure README of examples package
* Use single container for driver and filter
* Rename premium radar driver to sample
  Currently, the delivered Radar Off-Highway Premium and its firmware are just samples.
  Separate package will be created for series firmware.
* Add example component to demonstrate extraction of velocity
* Update executable names for premium radar in launch
* Add launch argument for parameters and unify launch file names
* Contributors: Robin Petereit, Sarah Huber
```

## off_highway_uss

```
* Switch from deprecated signature to const shared_ptr reference while still supporting efficient intra-process communication
  See https://github.com/ros2/rclcpp/pull/1598.
* Convert USS driver from node to component
* Add launch argument for parameters and unify launch file names
* Contributors: Robin Petereit, Sarah Huber
```

## off_highway_uss_msgs

- No changes
