### PR TITLE
add supervision pip dependency to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9297,16 +9297,7 @@ python3-suas-interop-clients-pip:
     pip:
       packages: [suas-interop-clients]
 python3-supervision-pip:
-  debian:
-    pip:
-      packages: [supervision]
-  fedora:
-    pip:
-      packages: [supervision]
-  osx:
-    pip:
-      packages: [supervision]
-  ubuntu:
+  '*':
     pip:
       packages: [supervision]
 python3-svg.path:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9296,6 +9296,19 @@ python3-suas-interop-clients-pip:
   ubuntu:
     pip:
       packages: [suas-interop-clients]
+python3-supervision-pip:
+  debian:
+    pip:
+      packages: [supervision]
+  fedora:
+    pip:
+      packages: [supervision]
+  osx:
+    pip:
+      packages: [supervision]
+  ubuntu:
+    pip:
+      packages: [supervision]
 python3-svg.path:
   alpine: [py3-svgpath]
   debian: [python3-svg.path]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

**python3-supervision-pip**

## Package Upstream Source:

https://github.com/roboflow/supervision

## Purpose of using this:

A project that contains reusable model agnostic computer vision tools. It already contains several connectors for some popular image detection/classification/segmentation libraries (like Ultralytics, Transformers or MMDetection). Furthermore, it hugely simplifies annotating an image with detections made by a NN model. 

## Links to Distribution Packages
 pip: https://pypi.org/project/supervision/
 
 ## pip disclaimer
 
Standard pip disclaimer: ROS packages that depend on pip keys cannot be released into a ROS distribution. They can only be depended on by from-source builds. Because of this, system packages are highly preferred to pip packages.
 
