### PR TITLE
Add `urchin` and `pyrender` pip dependencies to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8200,6 +8200,10 @@ python3-pyqtgraph:
   gentoo: [dev-python/pyqtgraph]
   nixos: [python3Packages.pyqtgraph]
   ubuntu: [python3-pyqtgraph]
+python3-pyrender-pip:
+  '*':
+    pip:
+      packages: [pyrender]
 python3-pyro-ppl-pip:
   debian:
     pip:
@@ -9683,6 +9687,10 @@ python3-unidiff:
   opensuse: [python-unidiff]
   rhel: [python3-unidiff]
   ubuntu: [python3-unidiff]
+python3-urchin-pip:
+  '*':
+    pip:
+      packages: [urchin]
 python3-urdfpy-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

`python3-urchin-pip` and `python3-pyrender-pip`

## Package Upstream Source:

[https://github.com/fishbotics/urchin/](https://github.com/fishbotics/urchin/)
[https://github.com/mmatl/pyrender/](https://github.com/mmatl/pyrender/)

## Purpose of using this:

The `urchin` package is useful for simple URDF manipulation and visualization. The `pyrender` package is added since it is a dependency of `urchin`.

## Links to Distribution Packages

- pip: https://pypi.org/
  - [https://pypi.org/project/urchin/](https://pypi.org/project/urchin/)
  - [https://pypi.org/project/pyrender/](https://pypi.org/project/pyrender/)
