### PR TITLE
psdk_ros2: 1.2.0-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5805,7 +5805,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 1.1.1-1
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.2.0-4`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.1.1-1`

## psdk_interfaces

```
* Merge pull request #81 <https://github.com/umdlife/psdk_ros2/issues/81> from umdlife/feat/sd_images
  SD card functions
* Merge pull request #76 <https://github.com/umdlife/psdk_ros2/issues/76> from umdlife/feat/psdk-3.8.1
  Upgrade to Payload-SDK v3.8.1
* Contributors: DominikWawak, Victor Massagué Respall, biancabnd
```

## psdk_wrapper

```
* Merge pull request #81 <https://github.com/umdlife/psdk_ros2/issues/81> from umdlife/feat/sd_images
  SD card functions
* Merge pull request #76 <https://github.com/umdlife/psdk_ros2/issues/76> from umdlife/feat/psdk-3.8.1
  Upgrade to Payload-SDK v3.8.1
* Merge pull request #77 <https://github.com/umdlife/psdk_ros2/issues/77> from RPS98/dji_core_deinit
  Clean up node on destructor
* Merge pull request #64 <https://github.com/umdlife/psdk_ros2/issues/64> from RPS98/json_fails
  Add include dependencies for Json utils
* Contributors: DominikWawak, Rafael Perez-Segui, Victor Massagué Respall, amoramar, biancabnd
```
