### PR TITLE
Revert "gz_ros2_control: 1.1.7-1 in 'iron/distribution.yaml' [bloom] …

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2158,7 +2158,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.1.7-1
+      version: 1.1.6-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
…(#41177)"

This reverts commit c72eb3dc9c515d6cb7ae7921db90f6d4d98284ac.

It is currently failing to build: https://build.ros2.org/job/Isrc_uJ__gz_ros2_control__ubuntu_jammy__source/7/console .

@ahcorde @Yadunund FYI