### PR TITLE
mvsim: 0.9.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3672,7 +3672,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.9.2-2
+      version: 0.9.4-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.9.4-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.9.2-2`

## mvsim

```
* Better detection of "in collision" flag.
* Update to clang-format-14
* Upgrade Joystick API so it works correctly with an arbitrary number of axes
* ROS nodes: add collision state publishers for each vehicle
* remove dead code
* Contributors: Jose Luis Blanco-Claraco
```
