### PR TITLE
navigation2: 1.1.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4694,7 +4694,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.1.14-1
+      version: 1.1.15-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.1.15-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.14-1`
