### PR TITLE
psdk_ros2: 1.2.1-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5864,7 +5864,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 1.2.0-4
+      version: 1.2.1-3
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.2.1-3`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.0-4`

## psdk_interfaces

```
* Merge pull request #101 <https://github.com/umdlife/psdk_ros2/issues/101> from umdlife/hotfix/build-farm
  Add action_msgs as dependency
* Contributors: biancabnd, vicmassy
```

## psdk_wrapper

- No changes
