### PR TITLE
image_common: 5.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2405,7 +2405,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.2-2
+      version: 5.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.3-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.2-2`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Add missing sub and pub options (#308 <https://github.com/ros-perception/image_common/issues/308>) (#309 <https://github.com/ros-perception/image_common/issues/309>)
  Co-authored-by: Angsa Deployment Team <mailto:team@angsa-robotics.com>
  (cherry picked from commit 74d9e8edb02eaf13771ee4d12a558d68279cbf44)
  Co-authored-by: Tony Najjar <mailto:tony.najjar.1997@gmail.com>
* Support zero-copy intra-process publishing (#306 <https://github.com/ros-perception/image_common/issues/306>) (#310 <https://github.com/ros-perception/image_common/issues/310>)
  (cherry picked from commit fd51363e2b8f8cd99e9a77970c1d49eb86c1480f)
  Co-authored-by: Błażej Sowa <mailto:bsowa123@gmail.com>
* Contributors: mergify[bot]
```
