### PR TITLE
image_common: 5.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2412,7 +2412,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.2.0-1
+      version: 5.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.2.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.2.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Removed warning (#312 <https://github.com/ros-perception/image_common/issues/312>)
* Support zero-copy intra-process publishing (#306 <https://github.com/ros-perception/image_common/issues/306>)
* Add missing sub and pub options (#308 <https://github.com/ros-perception/image_common/issues/308>)
  Co-authored-by: Angsa Deployment Team <mailto:team@angsa-robotics.com>
* Contributors: Alejandro Hernández Cordero, Błażej Sowa, Tony Najjar
```
