### PR TITLE
jackal: 0.8.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4422,7 +4422,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.8.9-1
+      version: 0.8.10-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jackal` to `0.8.10-1`:

- upstream repository: https://github.com/jackal/jackal.git
- release repository: https://github.com/clearpath-gbp/jackal-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.9-1`

## jackal_control

```
* Removed Z position
* Mod: Set 'publish_cmd' param to true in jackal_control/config
  - With this change the diff drive controller will output the final cmd_vel to /jackal_velocity_controller/cmd_vel_out after any filters are applied (e.g., speed/acceleration limits)
* Contributors: Luis Camero, Stephen Phillips
```

## jackal_description

- No changes

## jackal_msgs

- No changes

## jackal_navigation

- No changes

## jackal_tutorials

- No changes
