### PR TITLE
beluga: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -582,7 +582,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/Ekumen-OS/beluga.git


### PR DESCRIPTION
Increasing version of package(s) in repository `beluga` to `2.0.1-1`:

- upstream repository: https://github.com/Ekumen-OS/beluga.git
- release repository: https://github.com/ros2-gbp/beluga-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## beluga

```
* Support 32-bit hashes (#386 <https://github.com/Ekumen-OS/beluga/issues/386>)
* Rewrite make_from_state as a function object (#384 <https://github.com/Ekumen-OS/beluga/issues/384>)
* Contributors: Alon Druck, Nahuel Espinosa
```

## beluga_amcl

- No changes

## beluga_ros

- No changes
