### PR TITLE
septentrio_gnss_driver: 1.4.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6902,7 +6902,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.0-2
+      version: 1.4.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.0-3`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-2`

## septentrio_gnss_driver

```
* New features
  * Send custom commands via ASCII file on startup
  * Save config to boot after setup
  * NTP and PTP server options (BREAKING: NTP is not setup automatically for use_gnss_time: true anymore)
  * Receiver status on /diagnostics
  * Option to publish only valid SBF block messages
  * Option to auto publish available messages for configure_rx: false
* Changes
  * Change floating point do-not-use-values to NaN (BREAKING in case these values ae used for validity checks downstream)
  * VSM now uses separate TCP device specified IP server
* Improvements
  * Rework some sections of the README
  * Combine ROS 1 and ROS 2 in one branch
  * Change GPSFix publishing policy to allow for high update rates
```
