### PR TITLE
octomap_mapping: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3951,7 +3951,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.1.0-3
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.2.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-3`

## octomap_mapping

- No changes

## octomap_server

```
* Fix: Include missing tf2 geometry_msgs (#128 <https://github.com/octomap/octomap_mapping/issues/128>)
* Fix: Deprecated PCL APIs (#126 <https://github.com/octomap/octomap_mapping/issues/126>)
* Contributors: Wolfgang Merkt, Daisuke Nishimatsu
```
