### PR TITLE
py_binding_tools: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4580,6 +4580,17 @@ repositories:
       url: https://github.com/Simple-Robotics/proxsuite.git
       version: devel
     status: developed
+  py_binding_tools:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-gbp/py_binding_tools-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/py_binding_tools.git
+      version: ros2
+    status: maintained
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.0.0-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros-gbp/py_binding_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## py_binding_tools

```
* ROS2 migration
* Contributors: Robert Haschke
```
