### PR TITLE
moveit: 1.1.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6076,7 +6076,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 1.1.13-2
+      version: 1.1.14-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `1.1.14-1`:

- upstream repository: https://github.com/ros-planning/moveit.git
- release repository: https://github.com/ros-gbp/moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.13-2`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_commander

```
* Fixed order of return values in doc string of compute_cartesian_path() (#3574 <https://github.com/ros-planning/moveit/issues/3574>)
* Augment Python PlanningSceneInterface API (#3534 <https://github.com/ros-planning/moveit/issues/3534>)
* Add PlanningSceneInterface::clear() (#3512 <https://github.com/ros-planning/moveit/issues/3512>)
* Contributors: Aaryan Murgunde, IrvingF7, Robert Haschke
```

## moveit_core

```
* Allow moving of all shapes of an object in one go (#3599 <https://github.com/ros-planning/moveit/issues/3599>)
* Add benchmark dependency in moveit_core's package.xml
* Benchmarking with Google benchmark (#3565 <https://github.com/ros-planning/moveit/issues/3565>)
* Cleanup const-ref arguments to double+int (#3560 <https://github.com/ros-planning/moveit/issues/3560>)
* Use min instead of multiplication to combine relative and absolute check (#3556 <https://github.com/ros-planning/moveit/issues/3556>)
* Find pybind11_catkin early (#3552 <https://github.com/ros-planning/moveit/issues/3552>)
* Allow links with slashes again (#3539 <https://github.com/ros-planning/moveit/issues/3539>)
* Support ompl::ompl cmake target (#3549 <https://github.com/ros-planning/moveit/issues/3549>)
* RobotState: Initialize joint transforms of fixed joints (#3541 <https://github.com/ros-planning/moveit/issues/3541>)
* Pass more distance information out from FCL collision check (#3531 <https://github.com/ros-planning/moveit/issues/3531>)
* Fix segfault when planning with differential drive planar joints (#3457 <https://github.com/ros-planning/moveit/issues/3457>)
* Consider distance field padding for spheres (#3506 <https://github.com/ros-planning/moveit/issues/3506>)
* Remove unused variables (#3507 <https://github.com/ros-planning/moveit/issues/3507>)
* Gracefully handle zero-size bodies in determineCollisionSpheres() (#3504 <https://github.com/ros-planning/moveit/issues/3504>)
* Use new API for providing RNG to make some test results more consistant (#3501 <https://github.com/ros-planning/moveit/issues/3501>)
* More URDF validation (#3499 <https://github.com/ros-planning/moveit/issues/3499>)
* PlanningRequestAdapterChain: Fix added_path_index vector (#3464 <https://github.com/ros-planning/moveit/issues/3464>)
* Constrain orocos_kdl to ROS melodic
* moveit_core: make angles a build_depend rather than a test_depend (#3483 <https://github.com/ros-planning/moveit/issues/3483>)
* Contributors: Ben Wolsieffer, Captain Yoshi, Hugal31, Lucas Walter, Michael Görner, Robert Haschke, SchneiderC1, Scott Chow, Simon Schmeisser, Stephanie Eng
```

## moveit_fake_controller_manager

- No changes

## moveit_kinematics

```
* Addressing discrepancies in angle parameter definition between IKFast solvers and the plugin template (#3489 <https://github.com/ros-planning/moveit/issues/3489>)
* Constrain orocos_kdl to ROS Melodic
* Contributors: Michael Görner, Robert Haschke, nothingstopsme
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Support ompl::ompl cmake target (#3549 <https://github.com/ros-planning/moveit/issues/3549>)
* Install generate_state_database.launch (#3510 <https://github.com/ros-planning/moveit/issues/3510>)
* Contributors: Michael Görner
```

## moveit_plugins

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Use boost::timer::progress_display if available (#3547 <https://github.com/ros-planning/moveit/issues/3547>)
* Contributors: Michael Görner
```

## moveit_ros_control_interface

- No changes

## moveit_ros_manipulation

- No changes

## moveit_ros_move_group

```
* Gracefully handle exceptions thrown by planning pipelines (#3481 <https://github.com/ros-planning/moveit/issues/3481>)
* Contributors: Robert Haschke
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Allow waiting for joint model group states and retrieval of group-specific timestamps (#3580 <https://github.com/ros-planning/moveit/issues/3580>)
* Add joints_allowed_start_tolerance parameter for joint-specific start tolerances for TrajectoryExecutionManager (#3287 <https://github.com/ros-planning/moveit/issues/3287>)
* PSM: keep references to scene_ valid upon receiving full scenes (#3538 <https://github.com/ros-planning/moveit/issues/3538>)
* Warn if trajectory becomes invalid during execution (#3536 <https://github.com/ros-planning/moveit/issues/3536>)
* Consider distance field padding for spheres (#3506 <https://github.com/ros-planning/moveit/issues/3506>)
* Inform planning pipeline about waypoints added by AddIterativeSplineParameterization (#3466 <https://github.com/ros-planning/moveit/issues/3466>)
* Add missing RUNTIME DESTINATION for moveit_cpp (#3494 <https://github.com/ros-planning/moveit/issues/3494>)
* Gracefully handle exceptions thrown by planning pipelines (#3481 <https://github.com/ros-planning/moveit/issues/3481>)
* Contributors: Hugal31, Michael Görner, Robert Haschke, Silvio Traversaro
```

## moveit_ros_planning_interface

```
* MoveGroupInterface: allow RobotState diffs as start state (#3592 <https://github.com/ros-planning/moveit/issues/3592>)
* Augment Python PlanningSceneInterface API (#3534 <https://github.com/ros-planning/moveit/issues/3534>)
* Add PlanningSceneInterface::clear() (#3512 <https://github.com/ros-planning/moveit/issues/3512>)
* PSI::getKnownObjectNamesInROI: consider collision object's pose (#3477 <https://github.com/ros-planning/moveit/issues/3477>)
* Contributors: Aaryan Murgunde, Jorge Santos Simón, Robert Haschke, Tom Noble
```

## moveit_ros_robot_interaction

```
* Consider distance field padding for spheres (#3506 <https://github.com/ros-planning/moveit/issues/3506>)
* Contributors: Robert Haschke
```

## moveit_ros_visualization

```
* Radian/Degree joint value edits in RViz (#3542 <https://github.com/ros-planning/moveit/issues/3542>)
* Add radio buttons to switch degrees/radians in MotionPlanning's Joints tab (#3516 <https://github.com/ros-planning/moveit/issues/3516>)
* Fix tab order of widgets in MotionPlanning plugin
* Remove unused variables (#3507 <https://github.com/ros-planning/moveit/issues/3507>)
* Contributors: Aaryan Murgunde, Michael Görner, Robert Haschke
```

## moveit_ros_warehouse

```
* Fix warehouse database destruction (#3581 <https://github.com/ros-planning/moveit/issues/3581>)
* Contributors: Robert Haschke
```

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_assistant

```
* MSA: Add missing filename attribute to gazebo plugin tag (#3572 <https://github.com/ros-planning/moveit/issues/3572>)
* [ROS-O] update Boost API (melodic compatible) (#3564 <https://github.com/ros-planning/moveit/issues/3564>)
* Cleanup const-ref arguments to double+int (#3560 <https://github.com/ros-planning/moveit/issues/3560>)
* Support ompl::ompl cmake target (#3549 <https://github.com/ros-planning/moveit/issues/3549>)
* Enable higher number of self-collision checking samples (#3529 <https://github.com/ros-planning/moveit/issues/3529>)
* MSA ControllerWidget: allow digits in controller names (#3528 <https://github.com/ros-planning/moveit/issues/3528>)
* Remove unused variables (#3507 <https://github.com/ros-planning/moveit/issues/3507>)
* Contributors: Abe Maclean, Michael Görner, Robert Haschke, Salih Marangoz
```

## moveit_simple_controller_manager

```
* Simplify code waiting for ActionBasedController, fix timeout to 5s
* Contributors: Robert Haschke
```

## pilz_industrial_motion_planner

```
* Don't copy attached collision objects in CommandListManager::setStartState (#3590 <https://github.com/ros-planning/moveit/issues/3590>)
* [ROS-O] Fix Pilz unit tests (#3561 <https://github.com/ros-planning/moveit/issues/3561>)
* Add Pilz unit tests, defining goal poses w.r.t. frame_id != planning frame (#3525 <https://github.com/ros-planning/moveit/issues/3525>)
* Fix Pilz planner: consider link_name's offset during IK computation (#3523 <https://github.com/ros-planning/moveit/issues/3523>)
* Pilz: Tranform goal pose and center point w.r.t. planning frame (#3522 <https://github.com/ros-planning/moveit/issues/3522>)
* Silent error msg: Found empty JointState message
* Replace Eigen::Affine3D -> Eigen::Isometry3D
* Fix Pilz planners to consider and plan Cartesian motions w.r.t. subframes (#3519 <https://github.com/ros-planning/moveit/issues/3519>)
* Constrain orocos_kdl to ROS Melodic
* Contributors: Captain Yoshi, Robert Haschke, Tom Noble
```

## pilz_industrial_motion_planner_testutils

- No changes
