### PR TITLE
vimbax_ros2_driver: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10073,7 +10073,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vimbax_ros2_driver-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/alliedvision/vimbax_ros2_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vimbax_ros2_driver` to `1.0.2-1`:

- upstream repository: https://github.com/alliedvision/vimbax_ros2_driver.git
- release repository: https://github.com/ros2-gbp/vimbax_ros2_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## vimbax_camera

- No changes

## vimbax_camera_events

```
* Fixed ROS buildfarm build issues.
* Updated maintainers.
* Contributors: Dennis Langenkamp
```

## vimbax_camera_examples

```
* Updated maintainers.
* Contributors: Dennis Langenkamp
```

## vimbax_camera_msgs

- No changes

## vmbc_interface

```
* Fixed ROS buildfarm build issues.
* Updated maintainers.
* Contributors: Dennis Langenkamp
```
