### PR TITLE
rtabmap_ros: 0.21.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6775,6 +6775,35 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: rolling-devel
     status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: jazzy-devel
+    release:
+      packages:
+      - rtabmap_conversions
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: git@github.com:introlab/rtabmap_ros-release.git
+      version: 0.21.5-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: jazzy-devel
+    status: maintained
   rtcm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.21.5-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: git@github.com:introlab/rtabmap_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
