### PR TITLE
mp2p_icp: 1.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4362,7 +4362,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.4.1-1
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.4.2-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.1-1`

## mp2p_icp

```
* mm-viewer: add check-all, check-none to layer filters
* Add new filter: FilterRemoveByVoxelOccupancy
* mm-viewer: camera travelling keyframes-based animations
* mm-viewer: navigate the map with keyboard arrows; add a load button
* mm-viewer: can now also draws a TUM trajectory overlaid with the map
* UI apps: smoother rendering
* icp-log-viewer and mm-viewer: the UI now has a XYZ corner overlay
* sm-cli: command "export-kfs" now has an optional flag '--output-twist'
* FilterDeskew: ignore empty input maps
* More debug-level traces
* deskew filter: Fix case of variable names in docs
* sm-cli app: Add new command 'trim' to cut simplemaps by bounding box
* mm-viewer: show mouse pointing coordinates
* Contributors: Jose Luis Blanco-Claraco
```
