### PR TITLE
mrpt_navigation: 2.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3544,6 +3544,21 @@ repositories:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
       version: ros2
+    release:
+      packages:
+      - mrpt_map_server
+      - mrpt_msgs_bridge
+      - mrpt_nav_interfaces
+      - mrpt_navigation
+      - mrpt_pf_localization
+      - mrpt_pointcloud_pipeline
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tutorials
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_navigation-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.0.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mrpt_map_server

```
* Implement map getter services
* Define map_server services
* Comply with ROS2 REP-2003
* new param force_republish_period
* map_server: publish voxelmaps as points too
* map_server: Implement publishing from .mm files
* Rename mrpt_map: mrpt_map_server
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* Prepare demo launch files
* Port mrpt localization for ros2 and whole refactor
* Add ament linter for testing builds
* Make marker_msgs an optional dependency.
  Closes #138 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/138>
* Unify and clarify license headers in all files
* ROS2 port: mrpt_msgs_bridge
* Contributors: Jose Luis Blanco-Claraco, SRai22
```

## mrpt_nav_interfaces

```
* Define map_server services
* Add new package mrpt_nav_interfaces with action and msg defintions for navigation
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

```
* Add new package mrpt_nav_interfaces with action and msg defintions for navigation
* Rename mrpt_map: mrpt_map_server
* Renamed pkg mrpt_local_obstacles: mrpt_pointcloud_pipeline to reflect new capabilities
* Fix missing build dep
* Renamed: mrpt_localization: mrpt_pf_localization
* Add ament linter for testing builds
* ROS2 port metapackage
* Contributors: Jose Luis Blanco-Claraco, SRai22
```

## mrpt_pf_localization

```
* unit test executable now accepts many env var arguments for use in batch tests
* More relocalization parameters
* pf-test: fix static not POD warnings, and support env var-based config file too
* Fix for latest mp2p_icp api
* Implement relocalization based on ICP
* fix relocalization with reference pointmaps
* code clean up; check convergence in unit test
* Do not update the PF if there are no usable observations
* use pf/m² to initialize; estimate twist
* Expose gnns topic in the launch file
* GNNS-based initialization
* Comply with ROS2 REP-2003
* use namespaces for launch files
* allow overriding map likelihood options
* Show more debug info on metric map likelihood options
* New param for core-only debug level
* enable running the test from an MM file
* Receive gridmap from ROS topic
* Clearer warn messages
* Reorganize launch and demo files
* Prepare demo launch files
* Port mrpt localization to ROS 2 and whole refactor
* Renamed: mrpt_localization: mrpt_pf_localization
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

```
* use namespaces for launch files
* Use just one pipeline generator+filter definition file
* split filtering into per-observation and final pipelines
* generic launch for pipeline
* Renamed pkg mrpt_local_obstacles: mrpt_pointcloud_pipeline to reflect new capabilities
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_rawlog

```
* rosbag2rawlog: BUGFIX: sensor poses were inverted
* rosbag2rawlog: drop msgs if /tf data did not arrive yet instead of aborting
* rosbag2rawlog: now also can convert from mrpt_msgs/GenericObservation messages
* Import GNNS observations
* Fix build with older versions of cv_bridge
* rosbag2rawlog: Implement automatic detection of sensorPose from /tf, and added option to override poses from config yaml
* rosbag2rawlog: Add support for XYZIRT pointcloud observations
* Add support for CObservationRotatingScan in rosbag2rawlog
* Fix rosbag2rawlog install path should be 'bin'
* rosbag2rawlog: add conversion for LaserScan msgs
* Fix missing build dep
* Add ament linter for testing builds
* mrpt_rawlog: remove all record nodes. The package will only provide a play rawlog node, and offline tool to convert rosbag2 to rawlog
* Fix obsolete tf2_geometry_msgs.h header
* Unify and clarify license headers in all files
* Port to ROS 2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* rnav: add new pure_pursuit mode
* Implement two action servers: NavigateGoal and NavigateWaypoints
* Comply with ROS2 REP 2003
* expose waypoint sequence launch argument
* use namespaces for launch files
* rnav node: publish selected PTG as marker
* FIX: waypoints should also observe frame_id
* Fix obsolete tf2_geometry_msgs.h header
* Unify and clarify license headers in all files
* Merge pull request #134 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/134> from SRai22/ros2
  Merge from SRai22 fork
* Port to ROS 2
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera López, SRai22
```

## mrpt_tutorials

```
* Port to ROS2
* Contributors: Jose Luis Blanco-Claraco
```
