### PR TITLE
fast_gicp: 0.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1941,6 +1941,15 @@ repositories:
       version: ros2
     status: maintained
   fast_gicp:
+    doc:
+      type: git
+      url: https://github.com/SMRT-AIST/fast_gicp.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/fast_gicp-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/SMRT-AIST/fast_gicp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fast_gicp` to `0.0.0-1`:

- upstream repository: https://github.com/SMRT-AIST/fast_gicp.git
- release repository: https://github.com/ros2-gbp/fast_gicp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
