### PR TITLE
fast_gicp: 0.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1485,6 +1485,15 @@ repositories:
       version: iron
     status: maintained
   fast_gicp:
+    doc:
+      type: git
+      url: https://github.com/SMRT-AIST/fast_gicp.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ndt_omp-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/SMRT-AIST/fast_gicp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fast_gicp` to `0.0.0-1`:

- upstream repository: https://github.com/SMRT-AIST/fast_gicp.git
- release repository: https://github.com/ros2-gbp/ndt_omp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
