### PR TITLE
ndt_omp: 0.0.0-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3841,6 +3841,15 @@ repositories:
       version: iron
     status: maintained
   ndt_omp:
+    doc:
+      type: git
+      url: https://github.com/koide3/ndt_omp.git
+      version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ndt_omp-release.git
+      version: 0.0.0-2
     source:
       type: git
       url: https://github.com/koide3/ndt_omp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_omp` to `0.0.0-2`:

- upstream repository: https://github.com/koide3/ndt_omp.git
- release repository: https://github.com/ros2-gbp/ndt_omp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
