### PR TITLE
ndt_omp: 0.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4743,6 +4743,15 @@ repositories:
       version: humble
     status: maintained
   ndt_omp:
+    doc:
+      type: git
+      url: https://github.com/koide3/ndt_omp.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ndt_omp-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/koide3/ndt_omp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_omp` to `0.0.0-1`:

- upstream repository: https://github.com/koide3/ndt_omp.git
- release repository: https://github.com/ros2-gbp/ndt_omp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
