### PR TITLE
geometry2: 0.37.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1861,7 +1861,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.37.0-1
+      version: 0.37.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.37.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.37.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* [TimeCache] Improve performance for insertData() and pruneList() (#680 <https://github.com/ros2/geometry2/issues/680>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Removed warning (#682 <https://github.com/ros2/geometry2/issues/682>)
* Add cache_benchmark (#679 <https://github.com/ros2/geometry2/issues/679>)
  * Add cache_benchmark
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* [cache_unittest] Add direct implementation testing on ordering, pruning (#678 <https://github.com/ros2/geometry2/issues/678>)
  * [cache_unittest] Add direct implementation testing on ordering, pruning
  * do getAllItems() approach
  * Return a reference instead.
  * mark getAllItems as internal
  * Fix warning on Windows.
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Alejandro Hernández Cordero, Eric Cousineau
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Cli tools documentation (#653 <https://github.com/ros2/geometry2/issues/653>)
* Contributors: Lucas Wendland
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* [view_frames] log filenames after it's been determined (#674 <https://github.com/ros2/geometry2/issues/674>)
* Contributors: Mikael Arguedas
```
