### PR TITLE
geometry2: 0.31.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1957,7 +1957,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.31.6-1
+      version: 0.31.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.31.7-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.31.6-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* [TimeCache] Improve performance for insertData() and pruneList() (backport #680 <https://github.com/ros2/geometry2/issues/680>) (#694 <https://github.com/ros2/geometry2/issues/694>)
  * Nacho/minor fixes tf2 cache (#658 <https://github.com/ros2/geometry2/issues/658>)
  * Remove unused parameter
  * Make use of API function to improve redability
  ```cpp
  TimePoint TimeCache::getLatestTimestamp()
  {
  return storage\_.front().stamp\_;
  }
  ```
  And std::list<T>::front() is(gcclib):
  ```cpp
  reference
  front() _GLIBCXX_NOEXCEPT
  { return *begin(); }
  ```
  * Same argument as 321bd225afb5c
  ```cpp
  TimePoint TimeCache::getLatestTimestamp()
  {
  // empty list case
  // ...
  return storage\_.front().stamp\_;
  }
  ```
  and std::list<T>::front():
  ```cpp
  reference
  front() _GLIBCXX_NOEXCEPT
  { return *begin(); }
  ```
  * Improve readbility by relying on STL functions
  By now reading to this block I can tell that we are preventing to
  inserting a new element in the list, that has a timestamp that is
  actually older than the max_storage_time_ we allow for
  * Remove hardcoded algorithmg for STL one
  The intent of the code is now more clear, instead of relying on raw
  loops, we "find if" there is any element in the list that has a stamp
  older than the incoming one. With this we find the position in the list
  where we should insert the current timestamp: storage_it
  * Remove to better express what this pointer is represetngin
  * Replace raw loop for STL algorithm
  Remove if any element is older thant the max_storage_time_ allowed,
  relative to the latest(sooner) time seems clear npw
  * [TimeCache] Improve performance for insertData() and pruneList() (#680 <https://github.com/ros2/geometry2/issues/680>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  * Don't break ABI
  ---------
  Co-authored-by: Ignacio Vizzo <mailto:ignacio@dexory.com>
  Co-authored-by: Eric Cousineau <mailto:eric.cousineau@tri.global>
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Add cache_benchmark (backport #679 <https://github.com/ros2/geometry2/issues/679>) (#692 <https://github.com/ros2/geometry2/issues/692>)
  Co-authored-by: Eric Cousineau <mailto:eric.cousineau@tri.global>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* [cache_unittest] Add direct implementation testing on ordering, pruning (backport #678 <https://github.com/ros2/geometry2/issues/678>) (#689 <https://github.com/ros2/geometry2/issues/689>)
  Co-authored-by: Eric Cousineau <mailto:eric.cousineau@tri.global>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
