### PR TITLE
Add xvfb entry for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8974,6 +8974,7 @@ xvfb:
   fedora: [xorg-x11-server-Xvfb]
   gentoo: [x11-misc/xvfb-run]
   nixos: [xorg.xorgserver]
+  rhel: [xorg-x11-server-Xvfb]
   ubuntu: [xvfb]
 xz-utils:
   arch: [xz]


### PR DESCRIPTION
xvfb is available for RHEL8 and 9  as xorg-x11-server-Xvfb according to https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/package_manifest/index and  https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/package_manifest/index