### PR TITLE
event_camera_codecs: 1.3.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1365,7 +1365,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 1.0.4-3
+      version: 1.3.5-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_codecs` to `1.3.5-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_codecs.git
- release repository: https://github.com/ros2-gbp/event_camera_codecs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.4-3`

## event_camera_codecs

```
* first release for jazzy
* Contributors: Bernd Pfrommer
```
