### PR TITLE
add create3_examples

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1321,6 +1321,12 @@ repositories:
       url: https://github.com/rt-net/crane_plus.git
       version: humble-devel
     status: maintained
+  create3_examples:
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/create3_examples.git
+      version: humble
+    status: developed
   create3_sim:
     release:
       packages:


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Multiple packages from the `https://github.com/iRobotEducation/create3_examples/tree/humble` repo:
 - `create3_coverage`
 - `create3_examples_msgs`
 - `create3_examples_py`
 - `create3_lidar_slam`
 - `create3_republisher`
 - `create3_teleop`


# The source is here:

https://github.com/iRobotEducation/create3_examples/tree/humble

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro


### NOTES:

It's been a couple years since the last timeI did this process.
I found the [instructions in the docs](https://docs.ros.org/en/rolling/How-To-Guides/Releasing/Release-Team-Repository.html#what-is-a-release-repository) and the PR template extremely confusing.
Is this the right process "to get the name approved" and to have a gbp repository created?
