### PR TITLE
Fix `KeyError: 'version'` on TestUrlValidity.test_function

### DIFF
--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -182,7 +182,7 @@ def check_source_repo_entry_for_errors(source, tags_valid=False, commits_valid=F
               % (source['type'], source['__line__']))
         return None
 
-    version = source['version'] if source['version'] else None
+    version = source['version'] if 'version' in source else None
     (remote_exists, error_reason) = check_git_remote_exists(source['url'], version, tags_valid, commits_valid)
     if not remote_exists:
         errors.append(


### PR DESCRIPTION
This PR fixes the test `TestUrlValidity.test_function` not to raise the `KeyError: 'version'` error.
ref. https://github.com/ros/rosdistro/actions/runs/9297859282/job/25588717156?pr=41123#step:6:333