### PR TITLE
Add tochka_ai_shared_cpp_libs repo

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9296,6 +9296,21 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: humble
     status: maintained
+  tochka_ai_shared_cpp_libs:
+    doc:
+      type: git
+      url: https://github.com/TochkaAI/tochka-ai-shared-cpp-libs
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/TochkaAI/tochka-ai-shared-cpp-libs-release
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/TochkaAI/tochka-ai-shared-cpp-libs
+      version: master
+    status: maintained
   topic_based_ros2_control:
     release:
       tags:


### PR DESCRIPTION
## Package name:

* tochka-ai-shared-cpp-libs

## Package Upstream Source:

https://github.com/TochkaAI/tochka-ai-shared-cpp-libs

## Purpose of using this:

Auxiliary and service modules for the framework to work

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/TochkaAI/tochka-ai-shared-cpp-libs

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
