### PR TITLE
libcaer_driver: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2949,7 +2949,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.0.0-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.0.2-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## libcaer_driver

```
* use libcaer_vendor
* support sync with additional options for launch files
* introduced time_reset_delay to make sync work
* fix SEGV bug: check for nullptr in rosparam declaration
* catch runtime exception for DvXplorer Mini
* Contributors: Bernd Pfrommer, Thies Lennart Alff
```
