### PR TITLE
azure_iot_sdk_c: 1.13.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -615,6 +615,21 @@ repositories:
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git
       version: main
     status: maintained
+  azure_iot_sdk_c:
+    doc:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
+      version: 1.13.0-2
+    source:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: main
+    status: maintained
   backward_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `azure_iot_sdk_c` to `1.13.0-2`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
