### PR TITLE
libcaer_driver: 1.2.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2860,7 +2860,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.2.1-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.2.3-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## libcaer_driver

```
* remove repos file, build only on recent distros
* use libcaer_vendor
* support sync with additional options for launch files
* introduced time_reset_delay to make sync work
* fix SEGV bug: check for nullptr in rosparam declaration
* Contributors: Bernd Pfrommer
```
