### PR TITLE
event_camera_msgs: 1.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1843,7 +1843,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_msgs-release.git
-      version: 1.1.5-1
+      version: 1.1.6-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_msgs` to `1.1.6-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_msgs.git
- release repository: https://github.com/ros2-gbp/event_camera_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.5-1`

## event_camera_msgs

```
* bumped cmake required
* updated documentation
* Contributors: Bernd Pfrommer
```
