### PR TITLE
Add cppzmq-dev to the libzmq3-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6602,14 +6602,21 @@ libzip-dev:
   ubuntu: [libzip-dev]
 libzmq3-dev:
   arch: [zeromq]
-  debian: [libzmq3-dev]
+  debian:
+    '*': [libzmq3-dev, cppzmq-dev]
+    bullseye: [libzmq3-dev]
+    buster: [libzmq3-dev]
   fedora: [cppzmq-devel]
   gentoo: [net-libs/cppzmq]
   nixos: [cppzmq]
   openembedded: [zeromq@meta-oe]
   opensuse: [zeromq-devel]
   rhel: [cppzmq-devel]
-  ubuntu: [libzmq3-dev]
+  ubuntu:
+    '*': [libzmq3-dev, cppzmq-dev]
+    bionic: [libzmq3-dev]
+    focal: [libzmq3-dev]
+    jammy: [libzmq3-dev]
 libzmqpp-dev:
   ubuntu: [libzmqpp-dev]
 libzmqpp3:


### PR DESCRIPTION
Starting in Debian Bookworm and Ubuntu Noble, the cppzmq headers have been extracted out of `libzmq3-dev` and placed in their own package, `cppzmq-dev`. This updates the `libzmq3-dev` key to include `cppzmq-dev` for Debian and Ubuntu to maintain parity with the other platforms.
