### PR TITLE
mqtt_client: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6291,7 +6291,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/mqtt_client-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.3.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ika-rwth-aachen/mqtt_client-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`

## mqtt_client

```
* Merge pull request #61 <https://github.com/ika-rwth-aachen/mqtt_client/issues/61> from Chance-Maritime-Technologies/dev-explicitTypes
  Added the ability to explicitly set type names and some QoS settings
* Merge remote-tracking branch 'upstream/main' into dev-explicitTypes
* Merge pull request #63 <https://github.com/ika-rwth-aachen/mqtt_client/issues/63> from tecnalia-medical-robotics/system-fmt
  Use system version of libfmt instead of rosfmt vendored one on ROS 1
* Merge pull request #60 <https://github.com/ika-rwth-aachen/mqtt_client/issues/60> from ika-rwth-aachen/feature/nodename_in_params_file
  Modify ROS2 node name in params files
* Merge pull request #58 <https://github.com/ika-rwth-aachen/mqtt_client/issues/58> from ika-rwth-aachen/feature/configure_node_name
  Make ROS/ROS2 node name configurable via launch file
* Contributors: JayHerpin, Lennart Reiher
```

## mqtt_client_interfaces

- No changes
