### PR TITLE
openeb_vendor: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5188,6 +5188,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/openeb_vendor-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openeb_vendor` to `1.1.0-1`:

- upstream repository: https://github.com/ros-event-camera/openeb_vendor.git
- release repository: https://github.com/ros2-gbp/openeb_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## openeb_vendor

```
* initial release on humble
* Contributors: Bernd Pfrommer
```
