### PR TITLE
autoware_internal_msgs: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -553,6 +553,11 @@ repositories:
       version: rolling
     status: developed
   autoware_internal_msgs:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## autoware_internal_msgs

```
* add maintainer (#11 <https://github.com/youtalk/autoware_internal_msgs/issues/11>)
* feat(remaining_dist_eta): add msg definition for mission remaining distance and time (#10 <https://github.com/youtalk/autoware_internal_msgs/issues/10>)
  * feat(remaining_dist_eta): add msg definition for mission remaining distance and time
  feat(remaining_dist_eta): add msg definition for mission remaining distance and time"
  * feat(remaining_dist_eta): fix review comment - remove remaining hours, remaining minutes, and remaining seconds
  ---------
* feat(autoware_internal_msgs): add PublishedTime debug info message (#1 <https://github.com/youtalk/autoware_internal_msgs/issues/1>)
* chore: sync files (#7 <https://github.com/youtalk/autoware_internal_msgs/issues/7>)
  * chore: sync files
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* ci(sync-files): add .pre-commit-config.yaml (#6 <https://github.com/youtalk/autoware_internal_msgs/issues/6>)
* chore: sync files (#4 <https://github.com/youtalk/autoware_internal_msgs/issues/4>)
  Co-authored-by: github-actions <mailto:github-actions@github.com>
* ci(sync-files): add workflow (#3 <https://github.com/youtalk/autoware_internal_msgs/issues/3>)
* ci: initialize (#2 <https://github.com/youtalk/autoware_internal_msgs/issues/2>)
* Initial commit
* Contributors: Ahmed Ebrahim, Berkay Karaman, M. Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo, awf-autoware-bot[bot]
```
