### PR TITLE
situational_graphs_msgs: 0.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8676,6 +8676,11 @@ repositories:
       version: humble
     status: developed
   situational_graphs_msgs:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/situational_graphs_msgs-release.git
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `situational_graphs_msgs` to `0.0.1-2`:

- upstream repository: https://github.com/snt-arg/situational_graphs_msgs.git
- release repository: https://github.com/ros2-gbp/situational_graphs_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
