### PR TITLE
rviz_satellite: 4.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8429,7 +8429,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
-      version: ros2
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -8438,7 +8438,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
-      version: ros2
+      version: main
     status: maintained
   rviz_visual_tools:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7028,7 +7028,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
-      version: ros2
+      version: main
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -7037,7 +7037,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
-      version: ros2
+      version: main
     status: maintained
   rviz_visual_tools:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6897,6 +6897,21 @@ repositories:
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
       version: main
     status: maintained
+  rviz_satellite:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/nobleo/rviz_satellite-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: main
+    status: maintained
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.0.0-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rviz_satellite

```
* ROS2 support!
* Contributors: Lee Hicks, Marcel Zeilinger, Tim Clephas, Vitaliy Bondar, ceranit
```
