### PR TITLE
Add `python3-icecream` as a python dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8143,7 +8143,7 @@ python3-pyparsing:
   ubuntu: [python3-pyparsing]
 python3-pypdf:
   debian:
-    orm: [python3-pypdf]
+    bookworm: [python3-pypdf]
     bullseye:
       pip:
         packages: [pypdf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1951,10 +1951,6 @@ python-hypothesis:
   gentoo: [dev-python/hypothesis]
   ubuntu:
     '*': [python-hypothesis]
-python-icecream:
-  ubuntu:
-    jammy: [python3-icecream]
-    noble: [python3-icecream]
 python-imageio:
   debian:
     buster: [python-imageio]
@@ -6497,6 +6493,12 @@ python3-hypothesis:
   fedora: [python3-hypothesis]
   gentoo: [dev-python/hypothesis]
   ubuntu: [python3-hypothesis]
+python3-icecream:
+  debian:
+    bookworm: [python3-icecream]
+  ubuntu:
+    jammy: [python3-icecream]
+    noble: [python3-icecream]
 python3-ifcfg:
   debian:
     buster: [python3-ifcfg]
@@ -8141,7 +8143,7 @@ python3-pyparsing:
   ubuntu: [python3-pyparsing]
 python3-pypdf:
   debian:
-    bookworm: [python3-pypdf]
+    orm: [python3-pypdf]
     bullseye:
       pip:
         packages: [pypdf]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6494,11 +6494,10 @@ python3-hypothesis:
   gentoo: [dev-python/hypothesis]
   ubuntu: [python3-hypothesis]
 python3-icecream:
-  debian:
-    bookworm: [python3-icecream]
+  debian: [python3-icecream]
   ubuntu:
-    jammy: [python3-icecream]
-    noble: [python3-icecream]
+    '*': [python3-icecream]
+    focal: null
 python3-ifcfg:
   debian:
     buster: [python3-ifcfg]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1951,6 +1951,10 @@ python-hypothesis:
   gentoo: [dev-python/hypothesis]
   ubuntu:
     '*': [python-hypothesis]
+python-icecream:
+  ubuntu:
+    jammy: [python3-icecream]
+    noble: [python3-icecream]
 python-imageio:
   debian:
     buster: [python-imageio]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-icecream`

## Package Upstream Source:

https://github.com/gruns/icecream

## Purpose of using this:

Dependency of [`rmf_charging_schedule`](https://github.com/open-rmf/rmf_ros2/tree/main/rmf_charging_schedule)

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/python3-icecream
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-icecream
