### PR TITLE
psdk_ros2: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5915,7 +5915,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 1.2.1-3
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.3.0-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.2.1-3`

## psdk_interfaces

```
* Separate each module with an individual thread
* Contributors: Rafael Perez-Segui, biancabnd
```

## psdk_wrapper

```
* Merge pull request #108 <https://github.com/umdlife/psdk_ros2/issues/108> from umdlife/feat/multi-thread-all
  Separate PSDK modules in different nodes and threads
* Merge pull request #62 <https://github.com/umdlife/psdk_ros2/issues/62> from RPS98/gimbal_base_frame
  Add gimbal base frame
* Contributors: Rafael Perez-Segui, Victor Massagué Respall, biancabnd
```
