### PR TITLE
Bump rmf_api_msgs to 0.3.0

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5229,7 +5229,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.2.1-2
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Opening this PR manually since bloom failed to open the PR at the end. However, release repo was successfully updated https://github.com/ros2-gbp/rmf_api_msgs-release