### PR TITLE
Added customtkinter pip dependency to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5441,6 +5441,10 @@ python3-cryptography:
   opensuse: [python3-cryptography]
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
+python3-customtkinter-pip:
+  '*':
+    pip:
+      packages: [customtkinter]
 python3-cvxopt:
   arch: [python-cvxopt]
   debian: [python3-cvxopt]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-customtkinter-pip

## Package Upstream Source:

https://github.com/TomSchimansky/CustomTkinter 

## Purpose of using this:

CustomTkinter is a python UI-library based on Tkinter, which provides new, modern and fully customizable widgets. They are created and used like normal Tkinter widgets and can also be used in combination with normal Tkinter elements.


## Links to Distribution Packages

- pip: https://pypi.org/project/customtkinter/

## pip disclaimer

Standard pip disclaimer: ROS packages that depend on pip keys cannot be released into a ROS distribution. They can only be depended on by from-source builds. Because of this, system packages are highly preferred to pip packages.


