### PR TITLE
rmf_simulation: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5347,15 +5347,13 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_building_sim_common
-      - rmf_building_sim_gz_classic_plugins
       - rmf_building_sim_gz_plugins
       - rmf_robot_sim_common
-      - rmf_robot_sim_gz_classic_plugins
       - rmf_robot_sim_gz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rmf_building_sim_gz_plugins

```
* Port outdated actions to Noble (#122 <https://github.com/open-rmf/rmf_simulation/pull/122>)
* Refactor plugins in an ECS based way and migrate to Harmonic (#114 <https://github.com/open-rmf/rmf_simulation/pull/114>)
* Contributors: Arjo Chakravarty, Grey, Luca Della Vedova
```

## rmf_robot_sim_common

```
* Port outdated actions to Noble (#122 <https://github.com/open-rmf/rmf_simulation/pull/122>)
* Explicitly specify all qos depth (#116 <https://github.com/open-rmf/rmf_simulation/pull/116>)
* Contributors: Luca Della Vedova, Teo Koon Peng
```

## rmf_robot_sim_gz_plugins

```
* Port outdated actions to Noble (#122 <https://github.com/open-rmf/rmf_simulation/pull/122>)
* Refactor plugins in an ECS based way and migrate to Harmonic (#114 <https://github.com/open-rmf/rmf_simulation/pull/114>)
* Contributors: Arjo Chakravarty, Grey, Luca Della Vedova
```
