### PR TITLE
rmf_traffic_editor: 1.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5411,6 +5411,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.9.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rmf_building_map_tools

```
* Fix MultiPolygon not iterable (#496 <https://github.com/open-rmf/rmf_traffic_editor/pull/496>)
* Harmonic release and ECS refactor (#483 <https://github.com/open-rmf/rmf_traffic_editor/pull/483>)
* workaround fuel dup (#490 <https://github.com/open-rmf/rmf_traffic_editor/pull/490>)
* Add per_page arg to fuel pagination for pit_crew (#491 <https://github.com/open-rmf/rmf_traffic_editor/pull/491>)
* bugfix: specify coordiate_system when generating yaml for lift. (#488 <https://github.com/open-rmf/rmf_traffic_editor/pull/488>)
* Handle geometry collections (#476 <https://github.com/open-rmf/rmf_traffic_editor/pull/476>)
* Contributors: Arjo Chakravarty, Grey, Luca Della Vedova, Teo Koon Peng, Xiyu, cwrx777, methylDragon, Yadunund
```

## rmf_traffic_editor

```
* Fix buildfarm build of rmf_traffic_editor packages (#495 <https://github.com/open-rmf/rmf_traffic_editor/pull/495>)
* Harmonic release and ECS refactor (#483 <https://github.com/open-rmf/rmf_traffic_editor/pull/483>)
* Fix empty generate_crs in building yaml. (#482 <https://github.com/open-rmf/rmf_traffic_editor/pull/482>)
* Contributors: Luca Della Vedova, Grey, cwrx777
```

## rmf_traffic_editor_assets

```
* Fix buildfarm build of rmf_traffic_editor packages (#495 <https://github.com/open-rmf/rmf_traffic_editor/pull/495>)
* Contributors: Luca Della Vedova
```

## rmf_traffic_editor_test_maps

- No changes
