### PR TITLE
rmf_utils: 1.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5425,7 +5425,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.6.0-2
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.6.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-2`

## rmf_utils

```
* Fix build with apple clang (#27 <https://github.com/open-rmf/rmf_utils/pull/27>)
* Contributors: Yadunund
```
