### PR TITLE
rmf_task: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5373,7 +5373,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.4.0-2
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.0-2`

## rmf_task

```
* Reformat with uncrustify available in noble (#119 <https://github.com/open-rmf/rmf_task/pull/119>)
* Add labels to booking (#110 <https://github.com/open-rmf/rmf_task/pull/110>)
* Cancellation phase (#107 <https://github.com/open-rmf/rmf_task/pull/107>)
* Contributors: Aaron Chong, Grey, Yadunund
```

## rmf_task_sequence

```
* Reformat with uncrustify available in noble (#119 <https://github.com/open-rmf/rmf_task/pull/119>)
* Protect phase switch from race conditions (#111 <https://github.com/open-rmf/rmf_task/pull/111>)
* Cancellation phase (#107 <https://github.com/open-rmf/rmf_task/pull/107>)
* Do not segfault when models cannot be generated (#109 <https://github.com/open-rmf/rmf_task/pull/109>)
* Return nullptr is goal set is empty (#108 <https://github.com/open-rmf/rmf_task/pull/108>)
* Contributors: Grey, Yadunund
```
