### PR TITLE
rmf_visualization: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5466,7 +5466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.2.1-2
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.3.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-2`

## rmf_visualization

- No changes

## rmf_visualization_building_systems

```
* Update CI to run on noble and address uncrustify issues (#73 <https://github.com/open-rmf/rmf_visualization/pull/73>)
* Explicitly specify all qos depth (#70 <https://github.com/open-rmf/rmf_visualization/pull/70>)
* Fix deprecated QoS warnings (#69 <https://github.com/open-rmf/rmf_visualization/pull/69>)
* Contributors: Arjo Chakravarty, Teo Koon Peng, Yadunund
```

## rmf_visualization_fleet_states

```
* Explicitly specify all qos depth (#70 <https://github.com/open-rmf/rmf_visualization/pull/70>)
* Contributors: Teo Koon Peng
```

## rmf_visualization_floorplans

```
* Explicitly specify all qos depth (#70 <https://github.com/open-rmf/rmf_visualization/pull/70>)
* Contributors: Teo Koon Peng
```

## rmf_visualization_navgraphs

```
* Update CI to run on noble and address uncrustify issues (#73 <https://github.com/open-rmf/rmf_visualization/pull/73>)
* Explicitly specify all qos depth (#70 <https://github.com/open-rmf/rmf_visualization/pull/70>)
* Contributors: Teo Koon Peng, Yadunund
```

## rmf_visualization_obstacles

- No changes

## rmf_visualization_rviz2_plugins

```
* Update CI to run on noble and address uncrustify issues (#73 <https://github.com/open-rmf/rmf_visualization/pull/73>)
* Explicitly specify all qos depth (#70 <https://github.com/open-rmf/rmf_visualization/pull/70>)
* Fix adapter lift request publisher QoS to transient local (#66 <https://github.com/open-rmf/rmf_visualization/pull/66>)
* Contributors: Luca Della Vedova, Teo Koon Peng, Yadunund
```

## rmf_visualization_schedule

```
* Update CI to run on noble and address uncrustify issues (#73 <https://github.com/open-rmf/rmf_visualization/pull/73>)
* Contributors: Yadunund
```
