### PR TITLE
etsi_its_messages: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1818,7 +1818,7 @@ repositories:
       - etsi_its_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
+      url: https://github.com/ros2-gbp/etsi_its_messages-release.git
       version: 2.0.2-1
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1819,7 +1819,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `2.0.2-1`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## etsi_its_cam_coding

- No changes

## etsi_its_cam_conversion

- No changes

## etsi_its_cam_msgs

- No changes

## etsi_its_coding

- No changes

## etsi_its_conversion

- No changes

## etsi_its_denm_coding

- No changes

## etsi_its_denm_conversion

- No changes

## etsi_its_denm_msgs

- No changes

## etsi_its_messages

- No changes

## etsi_its_msgs

- No changes

## etsi_its_msgs_utils

- No changes

## etsi_its_primitives_conversion

```
* Merge pull request #16 from v0-e/ambig_toros_integer
  Explicit toRos_INTEGER(const long&, int64_t&)
* Contributors: Lennart Reiher
```

## etsi_its_rviz_plugins

- No changes
