### PR TITLE
etsi_its_messages: 2.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2642,6 +2642,10 @@ repositories:
       version: noetic-devel
     status: maintained
   etsi_its_messages:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
+      version: main
     release:
       packages:
       - etsi_its_cam_coding
@@ -2660,7 +2664,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
-      version: 2.0.1-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `2.0.2-2`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## etsi_its_cam_coding

- No changes

## etsi_its_cam_conversion

- No changes

## etsi_its_cam_msgs

- No changes

## etsi_its_coding

- No changes

## etsi_its_conversion

- No changes

## etsi_its_denm_coding

- No changes

## etsi_its_denm_conversion

- No changes

## etsi_its_denm_msgs

- No changes

## etsi_its_messages

- No changes

## etsi_its_msgs

- No changes

## etsi_its_msgs_utils

- No changes

## etsi_its_primitives_conversion

```
* Merge pull request #16 from v0-e/ambig_toros_integer
  Explicit toRos_INTEGER(const long&, int64_t&)
* Contributors: Lennart Reiher
```

## etsi_its_rviz_plugins

- No changes
