### PR TITLE
etsi_its_messages: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1383,6 +1383,35 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel
     status: maintained
+  etsi_its_messages:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
+      version: main
+    release:
+      packages:
+      - etsi_its_cam_coding
+      - etsi_its_cam_conversion
+      - etsi_its_cam_msgs
+      - etsi_its_coding
+      - etsi_its_conversion
+      - etsi_its_denm_coding
+      - etsi_its_denm_conversion
+      - etsi_its_denm_msgs
+      - etsi_its_messages
+      - etsi_its_msgs
+      - etsi_its_msgs_utils
+      - etsi_its_primitives_conversion
+      - etsi_its_rviz_plugins
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/etsi_its_messages-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
+      version: main
+    status: maintained
   event_camera_codecs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `2.0.2-1`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ros2-gbp/etsi_its_messages-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## etsi_its_cam_coding

- No changes

## etsi_its_cam_conversion

- No changes

## etsi_its_cam_msgs

- No changes

## etsi_its_coding

- No changes

## etsi_its_conversion

- No changes

## etsi_its_denm_coding

- No changes

## etsi_its_denm_conversion

- No changes

## etsi_its_denm_msgs

- No changes

## etsi_its_messages

- No changes

## etsi_its_msgs

- No changes

## etsi_its_msgs_utils

- No changes

## etsi_its_primitives_conversion

```
* Merge pull request #16 from v0-e/ambig_toros_integer
  Explicit toRos_INTEGER(const long&, int64_t&)
* Contributors: Lennart Reiher
```

## etsi_its_rviz_plugins

- No changes
