### PR TITLE
ur_client_library: 1.3.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12333,7 +12333,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.3.6-1
+      version: 1.3.7-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.3.7-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.6-1`

## ur_client_library

```
* [ci] Update CI
  * Run downstream tests for ICI
  * Correctly name jobs
  * Test Jazzy driver
* [start_ursim] Add program directory at correct location also when no model is provided
* [start_ursim] Always check ursim version for compatibility
* [start_ursim] Use a program folder per model
* [ci] Update distros for prerelease test
* Contributors: Felix Exner, Vincenzo Di Pentima
```
