### PR TITLE
Update python.yaml for flask packages for OpenEmbedded

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6076,6 +6076,7 @@ python3-flask:
   fedora: [python3-flask]
   gentoo: [dev-python/flask]
   nixos: [python3Packages.flask]
+  openembedded: [python3-flask@meta-python]
   rhel: [python3-flask]
   ubuntu: [python3-flask]
 python3-flask-bcrypt:
@@ -6086,6 +6087,7 @@ python3-flask-cors:
   debian: [python3-flask-cors]
   fedora: [python3-flask-cors]
   nixos: [python3Packages.flask-cors]
+  openembedded: [python3-flask-cors@meta-python]
   rhel:
     '*': [python3-flask-cors]
     '7': null
@@ -6100,6 +6102,7 @@ python3-flask-jwt-extended:
         packages: [flask-jwt-extended]
   freebsd: [py-flask-jwt-extended]
   nixos: [python3Packages.flask-jwt-extended]
+  openembedded: [python3-flask-jwt-extended@meta-python]
   opensuse: [python-flask-jwt-extended]
   ubuntu:
     '*': [python3-python-flask-jwt-extended]
@@ -6110,6 +6113,7 @@ python3-flask-migrate:
   debian: [python3-flask-migrate]
   fedora: [python3-flask-migrate]
   gentoo: [dev-python/flask-migrate]
+  openembedded: [python3-flask-migrate@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-flask-migrate']
     '7': null
@@ -6121,6 +6125,7 @@ python3-flask-restplus-pip:
 python3-flask-socketio:
   debian: [python3-flask-socketio]
   fedora: [python3-flask-socketio]
+  openembedded: [python3-flask-socketio@meta-python]
   ubuntu: [python3-flask-socketio]
 python3-flask-sqlalchemy:
   arch: [python-flask-sqlalchemy]
@@ -6128,6 +6133,7 @@ python3-flask-sqlalchemy:
   fedora: [python3-flask-sqlalchemy]
   gentoo: [dev-python/flask-sqlalchemy]
   nixos: [python3Packages.flask_sqlalchemy]
+  openembedded: [python3-flask-sqlalchemy@meta-python]
   opensuse: [python-Flask-SQLAlchemy]
   rhel:
     '*': [python3-flask-sqlalchemy]


### PR DESCRIPTION
This adds the available OpenEmbedded recipe for the existing flask related packages.

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

 - python3-flask
 - python3-flask-cors
 - python3-flask-jwt-extended
 - python3-flask-migrate
 - python3-flask-socketio 
 - python3-flask-sqlalchemy

## Purpose of using this:

This will allow the Superflore build tool to correctly resolve these dependencies when generating BitBake recipes.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- OpenEmbedded: https://layers.openembedded.org/layerindex/branch/master/layers/
 - python3-flask - https://layers.openembedded.org/layerindex/recipe/45391/ 
 - python3-flask-cors - https://layers.openembedded.org/layerindex/recipe/348202/ 
 - python3-flask-jwt-extended - https://layers.openembedded.org/layerindex/recipe/346322/ 
 - python3-flask-migrate - https://layers.openembedded.org/layerindex/recipe/72590/ 
 - python3-flask-socketio - https://layers.openembedded.org/layerindex/recipe/112435/ 
 - python3-flask-sqlalchemy - https://layers.openembedded.org/layerindex/recipe/72606/


