### PR TITLE
Switch the humble bond_core branch to galactic.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -847,7 +847,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: ros2
+      version: galactic
     release:
       packages:
       - bond
@@ -862,7 +862,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: ros2
+      version: galactic
     status: maintained
   boost_geometry_util:
     doc:


### PR DESCRIPTION
That's the last one it was released for, and also what is listed in https://github.com/ros2-gbp/bond_core-release/blob/4494f4d24a62267a10c6178812669426d35c79d0/tracks.yaml#L95