### PR TITLE
opennav_docking: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5210,7 +5210,6 @@ repositories:
       version: humble
     release:
       packages:
-      - nova_carter_docking
       - opennav_docking
       - opennav_docking_bt
       - opennav_docking_core

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5203,6 +5203,27 @@ repositories:
       url: https://github.com/ros-event-camera/openeb_vendor.git
       version: humble
     status: developed
+  opennav_docking:
+    doc:
+      type: git
+      url: https://github.com/open-navigation/opennav_docking.git
+      version: humble
+    release:
+      packages:
+      - nova_carter_docking
+      - opennav_docking
+      - opennav_docking_bt
+      - opennav_docking_core
+      - opennav_docking_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/open-navigation/opennav_docking-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/open-navigation/opennav_docking.git
+      version: humble
+    status: maintained
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `opennav_docking` to `0.0.1-1`:

- upstream repository: https://github.com/open-navigation/opennav_docking.git
- release repository: https://github.com/open-navigation/opennav_docking-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
