### PR TITLE
off_highway_sensor_drivers: 0.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5118,7 +5118,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 0.6.0-2
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `0.6.1-1`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-2`

## off_highway_can

```
* Fix missing dependency that was find_packaged (#7)
  * Fix missing dependency that was find_packaged
  * Use ament_lint_common
  ---------
* Contributors: Tim Clephas
```

## off_highway_general_purpose_radar

- No changes

## off_highway_general_purpose_radar_msgs

- No changes

## off_highway_premium_radar_sample

- No changes

## off_highway_premium_radar_sample_msgs

- No changes

## off_highway_radar

- No changes

## off_highway_radar_msgs

- No changes

## off_highway_sensor_drivers

- No changes

## off_highway_sensor_drivers_examples

- No changes

## off_highway_uss

- No changes

## off_highway_uss_msgs

- No changes
