### PR TITLE
Update branches for autoware_adapi_msgs

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -626,7 +626,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_auto_msgs:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -521,7 +521,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_auto_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -531,7 +531,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_auto_msgs:
     doc:


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

This PR updates the branch that tracks https://github.com/autowarefoundation/autoware_adapi_msgs upstream to `main`

## Package name:

autoware_adapi_msgs

# The source is here:

https://github.com/autowarefoundation/autoware_adapi_msgs 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
