### PR TITLE
Update branches for autoware_cmake

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -655,7 +655,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git
-      version: rolling
+      version: main
     status: developed
   autoware_internal_msgs:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -550,7 +550,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git
-      version: rolling
+      version: main
     status: developed
   autoware_internal_msgs:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -560,7 +560,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git
-      version: rolling
+      version: main
     status: developed
   autoware_internal_msgs:
     release:


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

This PR updates the branch that tracks https://github.com/autowarefoundation/autoware_cmake upstream to `main`

## Package name:

autoware_cmake

# The source is here:

https://github.com/autowarefoundation/autoware_cmake

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro