### PR TITLE
Update branches for autoware_utils

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -683,7 +683,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_utils.git
-      version: rolling
+      version: main
     status: developed
   avt_vimba_camera:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -578,7 +578,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_utils.git
-      version: rolling
+      version: main
     status: developed
   avt_vimba_camera:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -588,7 +588,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_utils.git
-      version: rolling
+      version: main
     status: developed
   avt_vimba_camera:
     doc:


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

This PR updates the branch that tracks https://github.com/autowarefoundation/autoware_utils upstream to `main`

## Package name:

autoware_utils

# The source is here:

https://github.com/autowarefoundation/autoware_utils

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro