### PR TITLE
Update branches for autoware_lanelet2_extension

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -672,7 +672,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-      version: rolling
+      version: main
     status: developed
   autoware_utils:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -567,7 +567,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-      version: rolling
+      version: main
     status: developed
   autoware_utils:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -577,7 +577,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-      version: rolling
+      version: main
     status: developed
   autoware_utils:
     release:


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

This PR updates the branch that tracks https://github.com/autowarefoundation/autoware_lanelet2_extension upstream to `main`

## Package name:

autoware_lanelet2_extension

# The source is here:

https://github.com/autowarefoundation/autoware_lanelet2_extension

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
