### PR TITLE
Update branches for autoware_internal_msgs

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -666,7 +666,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_lanelet2_extension:
     source:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -561,7 +561,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_lanelet2_extension:
     source:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -571,7 +571,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_lanelet2_extension:
     source:


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

This PR updates the branch that tracks https://github.com/autowarefoundation/autoware_internal_msgs upstream to `main`

## Package name:

autoware_internal_msgs

# The source is here:

https://github.com/autowarefoundation/autoware_internal_msgs

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
