### PR TITLE
Add in rosdep key for python3-semver on RHEL.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8900,6 +8900,7 @@ python3-semver:
   debian: [python3-semver]
   fedora: [python3-semver]
   freebsd: [py36-semver]
+  rhel: [python3-semver]
   ubuntu: [python3-semver]
 python3-sense-emu-pip:
   debian:


### PR DESCRIPTION
This is now required by image_pipeline.

Please update the following dependency in the rosdep database.

## Package name:

python3-semver

## Package Upstream Source:

https://github.com/python-semver/python-semver

## Purpose of using this:

This is a requirement of image_pipeline now: https://github.com/ros-perception/image_pipeline/blob/efb9005a5ca45f4ceb7563fc01d7e33d6f39214d/camera_calibration/package.xml#L30

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/python3-semver