### PR TITLE
Update distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5355,7 +5355,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/locator_ros_bridge-release.git
-      version: 1.0.10-1
+      version: 1.0.11-2
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository locator_ros_bridge to 1.0.11-2:

* upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
* release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
* distro file: noetic/distribution.yaml
* bloom version: 0.10.7
* previous version for package: 1.0.10-1

