### PR TITLE
aruco_opencv: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -216,7 +216,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/fictionlab-gbp/aruco_opencv-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/fictionlab/aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `0.4.1-1`:

- upstream repository: https://github.com/fictionlab/aruco_opencv.git
- release repository: https://github.com/fictionlab-gbp/aruco_opencv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## aruco_opencv

```
* Fix erroneous retrieval of intrinsic matrix of rectified images from camera_info P matrix (#45 <https://github.com/fictionlab/aruco_opencv/issues/45>)
* Contributors: Sandip Das
```

## aruco_opencv_msgs

- No changes
