### PR TITLE
aruco_opencv: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -426,7 +426,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `6.0.1-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.0-1`

## aruco_opencv

```
* Fix out of bounds indexes when retrieving camera matrix for rectified images (#47 <https://github.com/fictionlab/ros_aruco_opencv/issues/47>)
  * Add image_is_rectified parameter to example yaml config
* Contributors: Błażej Sowa, Sandip Das
```

## aruco_opencv_msgs

- No changes
