### PR TITLE
aruco_opencv: 2.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -531,7 +531,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `2.3.1-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## aruco_opencv

```
* Fix out of bounds indexes when retrieving camera matrix for rectified images (#47 <https://github.com/fictionlab/ros_aruco_opencv/issues/47>) (#49 <https://github.com/fictionlab/ros_aruco_opencv/issues/49>)
  * Add image_is_rectified parameter to example yaml config
* Contributors: Błażej Sowa, Sandip Das
```

## aruco_opencv_msgs

- No changes
