### PR TITLE
locator_ros_bridge: 2.1.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3723,10 +3723,11 @@ repositories:
     release:
       packages:
       - bosch_locator_bridge
+      - bosch_locator_bridge_utils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.5-1
+      version: 2.1.11-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.11-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.5-1`

## bosch_locator_bridge

```
* made server compatible with Locator version 1.9 (#61 <https://github.com/boschglobal/locator_ros_bridge/issues/61>)
* compatible with 1.9 (#58 <https://github.com/boschglobal/locator_ros_bridge/issues/58>)
* Note in the Readme for earlier versions (#57 <https://github.com/boschglobal/locator_ros_bridge/issues/57>)
* correct some messages types of bridge_node in README (#55 <https://github.com/boschglobal/locator_ros_bridge/issues/55>)
  Message type error of service /bridge_node/disable_map_expansion is found by slaible (Stefan Laible).
* Make minRange non-negative (#53 <https://github.com/boschglobal/locator_ros_bridge/issues/53>)
  In order to tolerate SICK picoScan150, which could produce LaserScan messages with little negative minRange, and avoid minRange validation failure errors raised by Locator.
  set lower limit range_min to 0
* Update server_bridge_node.cpp
  made compatible with Locator version 1.8
* update to humble (#48 <https://github.com/boschglobal/locator_ros_bridge/issues/48>)
* Contributors: Sheung Ying Yuen-Wille, Stefan Laible, TAN Hongkui, Fleer David
```

## bosch_locator_bridge_utils

- No changes
