### PR TITLE
opennav_docking: 0.0.2-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5217,7 +5217,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/open-navigation/opennav_docking-release.git
-      version: 0.0.1-1
+      version: 0.0.2-4
     source:
       type: git
       url: https://github.com/open-navigation/opennav_docking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `opennav_docking` to `0.0.2-4`:

- upstream repository: https://github.com/open-navigation/opennav_docking.git
- release repository: https://github.com/open-navigation/opennav_docking-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-1`
