### PR TITLE
ros2_controllers: 4.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5772,7 +5772,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.8.0-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.9.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.8.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Add mobile robot kinematics 101 and improve steering library docs (#954 <https://github.com/ros-controls/ros2_controllers/issues/954>)
* Bump version of pre-commit hooks (#1157 <https://github.com/ros-controls/ros2_controllers/issues/1157>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* JTC trajectory end time validation fix (#1090 <https://github.com/ros-controls/ros2_controllers/issues/1090>)
* Contributors: Henry Moore
```

## pid_controller

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Add custom rosdoc2 config for ros2_controllers metapackage (#1100 <https://github.com/ros-controls/ros2_controllers/issues/1100>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* [RQT-JTC] limits from jtc controlled joints (#1146 <https://github.com/ros-controls/ros2_controllers/issues/1146>)
* Contributors: Jakub Delicat
```

## steering_controllers_library

```
* Add mobile robot kinematics 101 and improve steering library docs (#954 <https://github.com/ros-controls/ros2_controllers/issues/954>)
* Fix correct usage of angular velocity in update_odometry() function (#1118 <https://github.com/ros-controls/ros2_controllers/issues/1118>)
* Contributors: Christoph Fröhlich, Ferry Schoenmakers
```

## tricycle_controller

```
* Add mobile robot kinematics 101 and improve steering library docs (#954 <https://github.com/ros-controls/ros2_controllers/issues/954>)
* Bump version of pre-commit hooks (#1157 <https://github.com/ros-controls/ros2_controllers/issues/1157>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
