### PR TITLE
Revert "depthai: 2.26.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1538,7 +1538,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.26.0-1
+      version: 2.24.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#41438

The last depthai release seems to have caused a regression in `depthai_bridge` and is failing on the build farm: https://build.ros2.org/view/Hbin_ujv8_uJv8/job/Hbin_ujv8_uJv8__depthai_bridge__ubuntu_jammy_arm64__binary/91/

FYI @Serafadam.