### PR TITLE
nav2_minimal_turtlebot_simulation: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3807,6 +3807,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  nav2_minimal_turtlebot_simulation:
+    release:
+      packages:
+      - nav2_minimal_tb3_sim
+      - nav2_minimal_tb4_description
+      - nav2_minimal_tb4_sim
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
+      version: main
+    status: maintained
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_minimal_turtlebot_simulation` to `1.0.0-1`:

- upstream repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
- release repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
