### PR TITLE
Add nobleo_socketcan_bridge

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3986,6 +3986,12 @@ repositories:
       version: ros2
     status: developed
     status_description: ROS2 support is work-in-progress. Help wanted!
+  nobleo_socketcan_bridge:
+    source:
+      type: git
+      url: https://github.com/nobleo/nobleo_socketcan_bridge.git
+      version: main
+    status: maintained
   nodl:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

iron

# The source is here:

~~https://github.com/nobleo/ros2_socketcan_bridge~~
https://github.com/nobleo/nobleo_socketcan_bridge

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

~~@JWhitleyWork, since you are maintaining `ros2_socketcan`, are you OK with the name of this package? This is a from-scratch re-implementation of [socketcan_bridge](https://wiki.ros.org/socketcan_bridge) from ROS1. Thats why I want to call it `ros2_socketcan_bridge`~~