### PR TITLE
sophus: 1.22.9101-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8927,7 +8927,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/clalancette/sophus.git
-      version: release/1.3.x
+      version: release/1.22.x
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -8936,7 +8936,7 @@ repositories:
     source:
       type: git
       url: https://github.com/clalancette/sophus.git
-      version: release/1.3.x
+      version: release/1.22.x
     status: maintained
   spatio_temporal_voxel_layer:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8932,7 +8932,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.3.2-1
+      version: 1.22.9101-1
     source:
       type: git
       url: https://github.com/clalancette/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.22.9101-1`:

- upstream repository: https://github.com/clalancette/sophus.git
- release repository: https://github.com/ros2-gbp/sophus-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.2-1`
