### PR TITLE
sophus: 1.22.9101-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7400,7 +7400,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/clalancette/sophus.git
-      version: release/1.3.x
+      version: release/1.22.x
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -7409,7 +7409,7 @@ repositories:
     source:
       type: git
       url: https://github.com/clalancette/sophus.git
-      version: release/1.3.x
+      version: release/1.22.x
     status: maintained
   spatio_temporal_voxel_layer:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7405,7 +7405,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.3.2-1
+      version: 1.22.9101-1
     source:
       type: git
       url: https://github.com/clalancette/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.22.9101-1`:

- upstream repository: https://github.com/clalancette/sophus.git
- release repository: https://github.com/ros2-gbp/sophus-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.2-1`
