### PR TITLE
sophus: 1.22.9101-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7152,7 +7152,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.22.9100-1
+      version: 1.22.9101-1
     source:
       type: git
       url: https://github.com/clalancette/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.22.9101-1`:

- upstream repository: https://github.com/clalancette/sophus.git
- release repository: https://github.com/ros2-gbp/sophus-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.22.9100-1`
