### PR TITLE
sophus: 1.22.9102-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7193,7 +7193,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.22.9101-1
+      version: 1.22.9102-1
     source:
       type: git
       url: https://github.com/clalancette/sophus.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sophus` to `1.22.9102-1`:

- upstream repository: https://github.com/clalancette/sophus.git
- release repository: https://github.com/ros2-gbp/sophus-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.22.9101-1`
