### PR TITLE
perception_pcl: 2.5.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4375,7 +4375,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.5.3-1
+      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.5.4-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.3-1`
