### PR TITLE
Add in rosdep key for python3-pydantic on RHEL.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7894,6 +7894,9 @@ python3-pydantic:
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
   nixos: [python3Packages.pydantic]
+  rhel:
+    '*': [python3-pydantic]
+    '8': null
   ubuntu:
     '*': [python3-pydantic]
     bionic:


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

python3-pydantic

## Package Upstream Source:

https://github.com/pydantic/pydantic

## Purpose of using this:

We may consider using this in the ROS 2 core.

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=pydantic