### PR TITLE
Add in rosdep key for fastjsonschema.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5795,6 +5795,15 @@ python3-fasteners-pip:
   ubuntu:
     pip:
       packages: [fasteners]
+python3-fastjsonschema:
+  debian: [python3-fastjsonschema]
+  fedora: [python3-fastjsonschema]
+  rhel:
+    '*': [python3-fastjsonschema]
+    '8': null
+  ubuntu:
+    '*': [python3-fastjsonschema]
+    focal: null
 python3-fastkml:
   debian: [python3-fastkml]
   ubuntu: [python3-fastkml]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-fastjsonschema

## Package Upstream Source:

https://github.com/horejsek/python-fastjsonschema

## Purpose of using this:

We may end up using it in the ROS 2 core.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-fastjsonschema
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-fastjsonschema
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-fastjsonschema/python3-fastjsonschema/
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=fastjsonschema