### PR TITLE
add ros2_babel_fish to rosdistro

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5727,6 +5727,16 @@ repositories:
       version: master
     status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
+  ros2_babel_fish:
+    doc:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
+    status: maintained
   ros2_canopen:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6012,6 +6012,16 @@ repositories:
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
       version: jazzy
     status: maintained
+  ros_babel_fish_test_msgs:
+    doc:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
+    status: maintained
   ros_canopen:
     release:
       packages:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5727,16 +5727,6 @@ repositories:
       version: master
     status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
-  ros_babel_fish:
-    doc:
-      type: git
-      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
-      version: jazzy
-    source:
-      type: git
-      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
-      version: jazzy
-    status: maintained
   ros2_canopen:
     doc:
       type: git
@@ -6011,6 +6001,16 @@ repositories:
       type: git
       url: https://github.com/osrf/ros2launch_security.git
       version: main
+    status: maintained
+  ros_babel_fish:
+    doc:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
     status: maintained
   ros_canopen:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5727,7 +5727,7 @@ repositories:
       version: master
     status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
-  ros2_babel_fish:
+  ros_babel_fish:
     doc:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ros2_babel_fish

# The source is here:
https://github.com/LOEWE-emergenCITY/ros2_babel_fish

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
