### PR TITLE
add qml_ros2_plugin to rosdistro

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4813,6 +4813,16 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: jazzy
     status: maintained
+  qml_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml_ros2_plugin.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml_ros2_plugin.git
+      version: master
+    status: maintained
   qpoases_vendor:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

qml_ros2_plugin

# The source is here:
https://github.com/StefanFabian/qml_ros2_plugin

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
