### PR TITLE
mavros: 2.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3935,7 +3935,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.8.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.0-1`

## libmavconn

```
* Merge branch 'master' into ros2
  * master:
  1.19.0
  update changelog
  gps_global_origin: remove LLA to ECEF conversion
* 1.19.0
* update changelog
* Contributors: Vladimir Ermakov
```

## mavros

```
* param: replace old rmw_qos usage
* sys_status: replace rmw_qos too
* command: fix humble condition
* regenerate all using cogall.sh
* command: keep support for humble
* command: fix misprint
* command: replace deprecated rmw_qos
* reformat with jazzy's ament_uncrustify
* Merge branch 'master' into ros2
  * master:
  1.19.0
  update changelog
  gps_global_origin: remove LLA to ECEF conversion
* 1.19.0
* update changelog
* gps_global_origin: remove LLA to ECEF conversion
  gps_global_origin is being published as
  geographic_msgs::GeoPointStamped
  message, which wants LLA format
  https://docs.ros.org/en/api/geographic_msgs/html/msg/GeoPointStamped.html
  FIX https://github.com/mavlink/mavros/issues/1381
* Update mavlink.py
  Kept #569 <https://github.com/mavlink/mavros/issues/569> FIXME tag
* Update mavlink.py
  Fixed bug #569 <https://github.com/mavlink/mavros/issues/569> from mavros. Fixed another bug in the building of the ros mavlink message- the seq field was not added to the ros mavlink message.
* Contributors: Beniamino Pozzan, Vladimir Ermakov, danielkalmanson
```

## mavros_extras

```
* gimbal_control: fix build
* gimbal_control: fix using
* gimbal_control: connect service on use
* regenerate all using cogall.sh
* reformat with jazzy's ament_uncrustify
* Merge branch 'master' into ros2
  * master:
  1.19.0
  update changelog
  gps_global_origin: remove LLA to ECEF conversion
* 1.19.0
* update changelog
* removed prefix in enums in messages and changed to use existing functions for string and quaternion convert
* Adding example service calls
* Code cleanup
* Removed exception after testing behavior
  Replaced with service call failure with MAV_RESULT_DENIED result value (2)
* Corrected build errors and warnings
* Final touches
  Added functionality that was overlooked for camera tracking if supported, added copyright info, added custom exception thrown when mode enumerator is not understood
* Added gimbal_control plugin
  Added all functionality to support a plugin to enable compatibility with MAVLink Gimbal Protocol v2
* Contributors: Frederik Mazur Andersen, Mark-Beaty, Vladimir Ermakov
```

## mavros_msgs

```
* regenerate all using cogall.sh
* Merge branch 'master' into ros2
  * master:
  1.19.0
  update changelog
  gps_global_origin: remove LLA to ECEF conversion
* 1.19.0
* update changelog
* removed prefix in enums in messages and changed to use existing functions for string and quaternion convert
* Final touches
  Added functionality that was overlooked for camera tracking if supported, added copyright info, added custom exception thrown when mode enumerator is not understood
* Added gimbal_control plugin
  Added all functionality to support a plugin to enable compatibility with MAVLink Gimbal Protocol v2
* Contributors: Frederik Mazur Andersen, Mark-Beaty, Vladimir Ermakov
```
