### PR TITLE
rc_genicam_driver: 0.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6365,7 +6365,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.3.1-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## rc_genicam_driver

```
* Fix: parameter 'camera_wb_red' cannot be set
* Fixed limiting float parameters to avoid errors due to rounding
* Fix: don't treat unknown parameters as error in the parameter callback (e.g. for new enable_pub_plugins param injected by image_transport)
* Fix: Declaring parameters dynamic so that undeclaring works on cleanup
```
