### PR TITLE
proxsuite: 0.6.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5928,7 +5928,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
-      version: 0.3.6-2
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `proxsuite` to `0.6.5-1`:

- upstream repository: https://github.com/Simple-Robotics/proxsuite.git
- release repository: https://github.com/ros2-gbp/proxsuite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.6-2`
