### PR TITLE
geometric_shapes: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1863,7 +1863,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.1.3-4
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.2.0-1`:

- upstream repository: https://github.com/moveit/geometric_shapes.git
- release repository: https://github.com/ros2-gbp/geometric_shapes-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.3-4`

## geometric_shapes

```
* Jazzy Support (#241 <https://github.com/moveit/geometric_shapes/issues/241>)
  * Update CI workflows to Rolling, Jazzy, Humble
  * Fix octomap dependency version to 1.9.7...<1.10.0
* Fix Box::print (#237 <https://github.com/moveit/geometric_shapes/issues/237>)
* CI: Fix cache key (#236 <https://github.com/moveit/geometric_shapes/issues/236>)
* Switch to clang-format-14 (#228 <https://github.com/moveit/geometric_shapes/issues/228>)
* Add humble testing (#221 <https://github.com/moveit/geometric_shapes/issues/221>)
* Update black version (#218 <https://github.com/moveit/geometric_shapes/issues/218>)
* Contributors: Henning Kayser, Matthijs van der Burgh, Stephanie Eng, Vatan Aksoy Tezer, Robert Haschke, Jafar Abdi
```
