### PR TITLE
moveit_msgs: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3582,7 +3582,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.4.0-3
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_msgs` to `2.5.0-1`:

- upstream repository: https://github.com/moveit/moveit_msgs.git
- release repository: https://github.com/ros2-gbp/moveit_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-3`

## moveit_msgs

```
* Update CI jobs to run Jazzy, Iron
* Adds get group urdf service (#174 <https://github.com/ros-planning/moveit_msgs/issues/174>)
  * Add service
  * Format
  * Format and use MoveItErrorCode
* Contributors: Henning Kayser, Sebastian Jahr
```
