### PR TITLE
rmf_ros2: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5374,7 +5374,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.7.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.0-1`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Fix race condition for ingesting/dispensing and disable uncrustify tests by default (#362 <https://github.com/open-rmf/rmf_ros2/pull/362>)
* Event based lift / door logic (#320 <https://github.com/open-rmf/rmf_ros2/pull/320>)
* Filter DoorOpen insertion by map name (#353 <https://github.com/open-rmf/rmf_ros2/pull/353>)
* Fix schema dictionary used during robot status override (#349 <https://github.com/open-rmf/rmf_ros2/pull/349>)
* Add fleet-level reassign dispatched tasks API (#348 <https://github.com/open-rmf/rmf_ros2/pull/348>)
* Automatically begin or cancel idle behavior when commission changes (#346 <https://github.com/open-rmf/rmf_ros2/pull/346>)
* Disable automatic retreat (#330 <https://github.com/open-rmf/rmf_ros2/pull/330>)
* Manual release of mutex groups (#339 <https://github.com/open-rmf/rmf_ros2/pull/339>)
* Stabilize commissioning feature (#338 <https://github.com/open-rmf/rmf_ros2/pull/338>)
* Release other mutexes if robot started charging (#334 <https://github.com/open-rmf/rmf_ros2/pull/334>)
* Support labels in booking information (#328 <https://github.com/open-rmf/rmf_ros2/pull/328>)
* Fix interaction between emergency pullover and finishing task (#333 <https://github.com/open-rmf/rmf_ros2/pull/333>)
* Contributors: Aaron Chong, Grey, Luca Della Vedova, Xiyu, Yadunund
```

## rmf_fleet_adapter_python

```
* Add fleet-level reassign dispatched tasks API (#348 <https://github.com/open-rmf/rmf_ros2/pull/348>)
* Disable automatic retreat (#330 <https://github.com/open-rmf/rmf_ros2/pull/330>)
* Stabilize commissioning feature (#338 <https://github.com/open-rmf/rmf_ros2/pull/338>)
* Add all_known_lifts in Graph binding (#336 <https://github.com/open-rmf/rmf_ros2/pull/336>)
* Add Speed Limit Requests (#335 <https://github.com/open-rmf/rmf_ros2/pull/335>)
* Contributors: cwrx777, Grey, Pranay Shirodkar, Xiyu, Yadunund
```

## rmf_task_ros2

```
* Fix race condition for ingesting/dispensing and disable uncrustify tests by default (#362 <https://github.com/open-rmf/rmf_ros2/pull/362>)
* Dispatcher only use websockets when dispatch fails (#355 <https://github.com/open-rmf/rmf_ros2/pull/355>)
* Contributors: Aaron Chong, Grey, Luca Della Vedova, Yadunund
```

## rmf_traffic_ros2

```
* Fix race condition for ingesting/dispensing and disable uncrustify tests by default (#362 <https://github.com/open-rmf/rmf_ros2/pull/362>)
* Fix serialization of exit events (#364 <https://github.com/open-rmf/rmf_ros2/pull/364>)
* Contributors: Grey, Luca Della Vedova, Yadunund
```

## rmf_websocket

```
* Fix race condition for ingesting/dispensing and disable uncrustify tests by default (#362 <https://github.com/open-rmf/rmf_ros2/pull/362>)
* Fix deadlock in websocket server (#342 <https://github.com/open-rmf/rmf_ros2/pull/342>)
* Lower debug level of some messages in rmf_websocket (#340 <https://github.com/open-rmf/rmf_ros2/pull/340>)
* Refactors the socket broadcast client (#329 <https://github.com/open-rmf/rmf_ros2/pull/329>)
* Contributors: Arjo Chakravarty, Grey, Luca Della Vedova, Yadunund
```
