### PR TITLE
Add network_bridge to rosdistro

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3881,6 +3881,16 @@ repositories:
       url: https://github.com/neobotix/neo_simulation2.git
       version: rolling
     status: maintained
+  network_bridge:
+    doc:
+      type: git
+      url: https://github.com/brow1633/network_bridge.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/brow1633/network_bridge.git
+      version: main
+    status: maintained
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

network_bridge

# The source is here:

https://github.com/brow1633/network_bridge

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
