### PR TITLE
Add libvorbis-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6271,6 +6271,7 @@ libvlccore-dev:
   opensuse: [vlc-devel]
   ubuntu: [libvlccore-dev]
 libvorbis-dev:
+  arch: [libvorbis]
   debian: [libvorbis-dev]
   fedora: [libvorbis-devel]
   nixos: [libvorbis]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6274,6 +6274,7 @@ libvorbis-dev:
   alpine: [libvorbis-dev]
   debian: [libvorbis-dev]
   fedora: [libvorbis-devel]
+  opensuse: [libvorbis-devel]
   rhel: [libvorbis-devel]
   ubuntu: [libvorbis-dev]
 libvpx-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6271,11 +6271,10 @@ libvlccore-dev:
   opensuse: [vlc-devel]
   ubuntu: [libvlccore-dev]
 libvorbis-dev:
-  arch: [libvorbis]
+  alpine: [libvorbis-dev]
   debian: [libvorbis-dev]
   fedora: [libvorbis-devel]
-  nixos: [libvorbis]
-  opensuse: [libvorbis-dev]
+  rhel: [libvorbis-devel]
   ubuntu: [libvorbis-dev]
 libvpx-dev:
   debian: [libvpx-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6270,6 +6270,12 @@ libvlccore-dev:
   fedora: [vlc-devel]
   opensuse: [vlc-devel]
   ubuntu: [libvlccore-dev]
+libvorbis-dev:
+  debian: [libvorbis-dev]
+  fedora: [libvorbis-devel]
+  nixos: [libvorbis]
+  opensuse: [libvorbis-dev]
+  ubuntu: [libvorbis-dev]
 libvpx-dev:
   debian: [libvpx-dev]
   fedora: [libvpx-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name

- libvorbis-dev

## Package Upstream Source

- libvorbis-dev: https://github.com/xiph/vorbis/

## Purpose of using this

- Vorbis is important to playing ogg files

## Links to Distribution Packages

- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/libvorbis-dev
- Debian: https://packages.debian.org/bookworm/libvorbis-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/libvorbis/libvorbis/
- Rhel: http://eastus.azure.repo.almalinux.org/almalinux/9.4/CRB/x86_64/os/Packages/libvorbis-devel-1.3.7-5.el9.i686.rpm
- Ubuntu: https://packages.ubuntu.com/focal/libvorbis-dev
   - REQUIRED
