### PR TITLE
feat: add python3-pygnssutils-pip to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7986,6 +7986,10 @@ python3-pygments:
     '*': [python3-pygments]
     '7': null
   ubuntu: [python3-pygments]
+python3-pygnssutils-pip:
+  '*':
+    pip:
+      packages: [pygnssutils]
 python3-pygraphviz:
   alpine: [py3-pygraphviz]
   debian: [python3-pygraphviz]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-pygnssutils-pip`

No system level dependency is currently available.

## Package Upstream Source:

https://github.com/semuconsulting/pygnssutils

## Purpose of using this:

This dependency is being used for working with gnss in python, e.g. for communicating with an NTRIP server to receive GPS correction signals.

## Links to Distribution Packages
- PyPI: https://pypi.org/project/pygnssutils/