### PR TITLE
control_msgs: 5.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -907,7 +907,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.2.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.0-1`

## control_msgs

```
* Add message for publishing interface values with name and stamp (#98 <https://github.com/ros-controls/control_msgs/issues/98>)
* Add custom rosdoc2 config (#132 <https://github.com/ros-controls/control_msgs/issues/132>)
* Contributors: Christoph Fröhlich, Manuel Muth
```
