### PR TITLE
mp2p_icp: 1.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3587,7 +3587,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.4.3-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.2-1`

## mp2p_icp

```
* Add pointcloud_sanity_check() auxiliary function
* Generator: more DEBUG level traces
* BUGFIX: FilterDeskew generated buggy output points if the input does not contain timestamps
* Add sanity checks for point cloud fields
* ICP log records now also store the dynamic variables. icp-log-viewer displays them.
* ICP log files: automatically create output directory if it does not exist
* Update ros2 badges (added Jazzy)
* Contributors: Jose Luis Blanco-Claraco
```
