### PR TITLE
added flex_sync to humble/iron/jazzy/rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2102,6 +2102,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: humble-devel
     status: maintained
+  flex_sync:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: humble
+    status: developed
   flexbe_app:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1620,6 +1620,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: rolling-devel
     status: maintained
+  flex_sync:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: iron
+    status: developed
   flexbe_behavior_engine:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1670,6 +1670,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: rolling-devel
     status: maintained
+  flex_sync:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: jazzy
+    status: developed
   flexbe_behavior_engine:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1622,6 +1622,16 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: rolling-devel
     status: maintained
+  flex_sync:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: rolling
+    status: developed
   flexbe_behavior_engine:
     doc:
       type: git


### PR DESCRIPTION
# Please add flex_sync to be indexed in the rosdistro.

ROSDISTRO NAME: humble, iron, jazzy, rolling

# The source is here:

https://github.com/ros-misc-utilities/flex_sync

Note: this package is similar to the well-known message_filters package, but is more flexible because the number of topics to be synchronized can be determined at run time.
I'm open to suggestions for a better name for the package. I did not want to name it something with "flexible_message_filters" to avoid confusion with a well established ros package, but also because message_filters is not that descriptive a name for a package that synchronizes messages.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x[ This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
