### PR TITLE
Set clang-format key to clang-tools-extra on RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -558,7 +558,7 @@ clang-format:
   osx:
     homebrew:
       packages: [clang-format]
-  rhel: [clang]
+  rhel: [clang-tools-extra]
   ubuntu: [clang-format]
 clang-tidy:
   alpine: [clang-extra-tools]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -552,7 +552,7 @@ clang-format:
   alpine: [clang]
   arch: [clang]
   debian: [clang-format]
-  fedora: [clang]
+  fedora: [clang-tools-extra]
   gentoo: [sys-devel/clang]
   nixos: [clang]
   osx:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -552,14 +552,14 @@ clang-format:
   alpine: [clang]
   arch: [clang]
   debian: [clang-format]
-  fedora: [clang-tools-extra]
+  fedora: [clang-tools-extra, git-clang-format]
   gentoo: [sys-devel/clang]
   nixos: [clang]
   osx:
     homebrew:
       packages: [clang-format]
   rhel:
-    '*': [clang-tools-extra]
+    '*': [clang-tools-extra, git-clang-format]
     '7': null
   ubuntu: [clang-format]
 clang-tidy:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -558,7 +558,9 @@ clang-format:
   osx:
     homebrew:
       packages: [clang-format]
-  rhel: [clang-tools-extra]
+  rhel:
+    '*': [clang-tools-extra]
+    '7': null
   ubuntu: [clang-format]
 clang-tidy:
   alpine: [clang-extra-tools]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Set `clang-format` to `clang-tools-extra` on RHEL.

## Package Upstream Source:

N/A

## Purpose of using this:

`ros-jazzy-ament-clang-format` depends on `clang-format` on Ubuntu, but not on RHEL. The rosdep entry for `clang-format` on RHEL is `clang`, which does not provide `clang-format`. The RHEL package that provides `clang-format` is apparently `clang-tools-extra`: https://github.com/ros-tooling/setup-ros/pull/694#issuecomment-2159234767.

Since `clang-tidy` also maps to `clang-tools-extra` on RHEL and skips RHEL 7, I've done the same for `clang-format`.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/clang/clang-tools-extra/
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=clang-tools-extra
