### PR TITLE
rmf_simulation: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5399,7 +5399,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.3.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## rmf_building_sim_gz_plugins

```
* Fix door drift in simulation (#126 <https://github.com/open-rmf/rmf_simulation/pull/126>)
* Contributors: Luca Della Vedova
```

## rmf_robot_sim_common

- No changes

## rmf_robot_sim_gz_plugins

- No changes
