### PR TITLE
depthai: 2.26.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1544,7 +1544,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.24.0-1
+      version: 2.26.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.26.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.24.0-1`

## depthai

```
* Fix building shared libs (ROS only)
```
