### PR TITLE
depthai: 2.26.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1114,7 +1114,11 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.26.0-1
+      version: 2.26.1-1
+    source:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: ros-release
     status: developed
   depthimage_to_laserscan:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.26.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.26.0-1`

## depthai

```
* Fix building shared libs (ROS only)
```
