### PR TITLE
Add python3-dataclasses-json in rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5463,6 +5463,16 @@ python3-cycler:
     '*': [python3-cycler]
     '7': null
   ubuntu: [python3-cycler]
+python3-dataclasses-json:
+  debian: [python3-dataclasses-json]
+  freebsd: [py39-dataclasses-json]
+  opensuse:
+    '*': [python310-dataclasses-json]
+    '15.2': null
+  ubuntu:
+    '*': [python3-dataclasses-json]
+    bionic: null
+    focal: null
 python3-datadog-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
`python3-dataclasses-json`

## Package Upstream Source:
https://github.com/lidatong/dataclasses-json

## Purpose of using this:
This dependency is used for handling json conversion of dataclasses in python nodes.

## Links to Distribution Packages
PyPI: https://pypi.org/project/dataclasses-json/
