### PR TITLE
eigenpy: 3.7.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2500,7 +2500,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `3.7.0-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/stack-of-tasks/eigenpy-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.0-1`
