### PR TITLE
Update tracking branch for autoware_msgs to main

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -678,7 +678,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_utils:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -573,7 +573,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_utils:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -583,7 +583,7 @@ repositories:
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git
-      version: rolling
+      version: main
     status: developed
   autoware_utils:
     release:


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

This PR updates the branch that tracks https://github.com/autowarefoundation/autoware_msgs upstream to `main`

## Package name:

autoware_msgs

# The source is here:

https://github.com/autowarefoundation/autoware_msgs

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
