### PR TITLE
rmf_variants: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5507,7 +5507,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
-      version: 0.0.1-2
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_variants.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_variants` to `0.2.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_variants.git
- release repository: https://github.com/ros2-gbp/rmf_variants-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-2`

## rmf_dev

- No changes
