### PR TITLE
menge_vendor: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3276,7 +3276,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.2.0-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `menge_vendor` to `1.3.0-1`:

- upstream repository: https://github.com/open-rmf/menge_vendor.git
- release repository: https://github.com/ros2-gbp/menge_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-2`

## menge_vendor

- No changes
