### PR TITLE
kobuki_core: 1.4.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2593,7 +2593,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_core-release.git
-      version: 1.4.0-3
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_core` to `1.4.1-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_core.git
- release repository: https://github.com/ros2-gbp/kobuki_core-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-3`

## kobuki_core

```
* [all] fix compilation on aarch64, #51 <https://github.com/kobuki-base/kobuki_core/pull/51>
```
