### PR TITLE
rqt_tf_tree: 1.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6827,7 +6827,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.4-3
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.0.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros2-gbp/rqt_tf_tree-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.4-3`

## rqt_tf_tree

```
* Explicitly import clock to fix test fail in Humble (#50 <https://github.com/ros-visualization/rqt_tf_tree/issues/50>)
* Fixed pytest for buildfarm (#49 <https://github.com/ros-visualization/rqt_tf_tree/issues/49>)
* Use S_TO_NS from rclpy.constants instead of rclpy.time.CONVERSION_CONSTANT (#48 <https://github.com/ros-visualization/rqt_tf_tree/issues/48>)
```
