### PR TITLE
Added python3-streamlit to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9300,6 +9300,10 @@ python3-stonesoup-pip:
   ubuntu:
     pip:
       packages: [stonesoup]
+python3-streamlit-pip:
+  '*':
+    pip:
+      packages: [streamlit]
 python3-suas-interop-clients-pip:
   debian:
     pip:


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

Package name:
python3-streamlit-pip

Package Upstream Source:
https://github.com/streamlit/streamlit)

Purpose of using this:
Streamlit is a framework for creating interactive, web-based applications in Python. This dependency is being used to develop real-time data visualization, image annotation tools, visualization interfaces, and control dashboards for robotics applications. 

Links to Distribution Packages
pip: https://pypi.org/project/streamlit/