### PR TITLE
Add in liboctomap-dev key.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4549,6 +4549,11 @@ libnss3-dev:
   gentoo: [=dev-libs/nss-3*]
   nixos: [nss]
   ubuntu: [libnss3-dev]
+liboctomap-dev:
+  debian: [liboctomap-dev]
+  fedora: [octomap-devel]
+  rhel: [octomap-devel]
+  ubuntu: [liboctomap-dev]
 libogg:
   arch: [libogg]
   debian: [libogg-dev]


### PR DESCRIPTION
The situation with octomap and ROS is complicated.

As it stands, we effectively have a "vendor" package of octomap released into Humble, Iron, Jazzy, and Rolling. However, this is a problem on Jazzy and Rolling on Ubuntu 24.04 since the ABI between what we have released, and what is released in the operating system as "liboctomap-dev" is different.  That means that using it with downstream packages just doesn't work.

The intent here is to add this key in, update all downstream packages to use this key, and then remove octomap from all of Humble, Iron, Jazzy, and Rolling. This will avoid the ABI problem, and just use the system package everywhere.

See https://github.com/ros/rosdistro/issues/41622 for more information.

Note that I expect CI on this to fail until https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2024-71ae26cb75 lands in EPEL-9, about a week from now.

Please add the following dependency to the rosdep database.

## Package name:

liboctomap-dev

## Package Upstream Source:

https://github.com/octomap/octomap

## Purpose of using this:

See the explanation above.

Several packages depend on having octomap available, including:

* hpp-fcl
* octomap_ros
* gz_dartsim_vendor
* mrpt2
* moveit_ros_occupancy_map_monitor
* moveit_core
* geometric_shapes
* octomap_rviz_plugins
* octomap_server

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=liboctomap-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=liboctomap-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://pkgs.org/search/?q=octomap
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=octomap