### PR TITLE
Bump pybind11_json_vendor to 0.5.0-1

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4765,7 +4765,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.4.1-2
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git


### PR DESCRIPTION
Manually opening PR since the last step failed during bloom-release. The bloom job itself succeeded https://github.com/ros2-gbp/pybind11_json_vendor-release