### PR TITLE
rmf_utils: 1.6.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5552,7 +5552,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.6.0-3
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_utils` to `1.6.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_utils.git
- release repository: https://github.com/ros2-gbp/rmf_utils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-3`

## rmf_utils

- No changes
