### PR TITLE
moveit: 2.10.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3569,6 +3569,7 @@ repositories:
       - moveit_ros_planning
       - moveit_ros_planning_interface
       - moveit_ros_robot_interaction
+      - moveit_ros_tests
       - moveit_ros_visualization
       - moveit_ros_warehouse
       - moveit_runtime
@@ -3585,7 +3586,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.10.0-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.9.0-1`

## chomp_motion_planner

```
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_common

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_configs_utils

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Fix xacro args loading issue (#2684 <https://github.com/moveit/moveit2/issues/2684>)
  * Fixed xacro args loading issue
  * Formatting fixes with pre-commit action
* Pass along move_group_capabilities parameters (#2587 <https://github.com/moveit/moveit2/issues/2587>)
  * Pass along move_group_capabilities parameters
  * fix lint check
  * Use move_group_capabilities as default launch argument
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Use different packages for launch and config packages in generate_demo_launch (#2647 <https://github.com/moveit/moveit2/issues/2647>)
* Contributors: Alex Navarro, Forrest Rogers-Marcovitz, Robert Haschke, Tyler Weaver
```

## moveit_core

```
* Enforce liboctomap-dev by using a cmake version range
* Add utility functions to get limits and trajectory message (#2861 <https://github.com/moveit/moveit2/issues/2861>)
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Use std::optional instead of nullptr checking (#2454 <https://github.com/moveit/moveit2/issues/2454>)
* Enable mdof trajectory execution (#2740 <https://github.com/moveit/moveit2/issues/2740>)
  * Add RobotTrajectory conversion from MDOF to joints
  * Convert MDOF trajectories to joint trajectories in planning interfaces
  * Treat mdof joint variables as common joints in
  TrajectoryExecutionManager
  * Convert multi-DOF trajectories to joints in TEM
  * Revert "Convert MDOF trajectories to joint trajectories in planning interfaces"
  This reverts commit 885ee2718594859555b73dc341311a859d31216e.
  * Handle multi-DOF variables in TEM's bound checking
  * Add parameter to optionally enable multi-dof conversion
  * Improve error message about unknown controllers
  * Fix name ordering in JointTrajectory conversion
  * Improve DEBUG output in TEM
  * Comment RobotTrajectory test
  * add acceleration to avoid out of bounds read
* Fix doc reference to non-existent function (#2765 <https://github.com/moveit/moveit2/issues/2765>)
* (core) Remove unused python docs folder (#2746 <https://github.com/moveit/moveit2/issues/2746>)
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
* (core) Install collision_detector_fcl_plugin (#2699 <https://github.com/moveit/moveit2/issues/2699>)
  FCL version of acda563
* Simplify Isometry multiplication benchmarks (#2628 <https://github.com/moveit/moveit2/issues/2628>)
  With the benchmark library, there is no need to specify an iteration count.
  Interestingly, 4x4 matrix multiplication is faster than affine*matrix
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Merge pull request #2660 <https://github.com/moveit/moveit2/issues/2660> from MarqRazz/pr-fix_model_with_collision
  Fix getLinkModelNamesWithCollisionGeometry to include the base link
* validate link has parent
* pre-commit
* Fix getLinkModelNamesWithCollisionGeometry to include the base link of the planning group
* Acceleration Limited Smoothing Plugin for Servo (#2651 <https://github.com/moveit/moveit2/issues/2651>)
* Contributors: Henning Kayser, Marq Rasmussen, Matthijs van der Burgh, Paul Gesel, Robert Haschke, Sebastian Jahr, Shobuj Paul, Tyler Weaver, marqrazz
```

## moveit_hybrid_planning

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Remove HP error codes interface (#2774 <https://github.com/moveit/moveit2/issues/2774>)
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Clean-up hybrid planning package (#2603 <https://github.com/moveit/moveit2/issues/2603>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_kinematics

```
* At least on humble, error is: 'robot_description_kinematics.arm.min_joint_config_distance' has invalid type: expected [double] got [integer]. (#2865 <https://github.com/moveit/moveit2/issues/2865>)
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CI: Fix building of ikfast plugins (#2791 <https://github.com/moveit/moveit2/issues/2791>)
  Ignore missing authentication for Indigo packages using --force-yes.
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Henning Kayser, Robert Haschke, Sebastian Jahr, Tyler Weaver, s-trinh
```

## moveit_planners

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_planners_chomp

```
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Sebastian Jahr, Tyler Weaver
```

## moveit_planners_ompl

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* Do not overwrite the error code with OMPL interface (#2725 <https://github.com/moveit/moveit2/issues/2725>)
  In case of failure, set the error code to the one returned by the
  planning pipeline's solve method rather than overwriting it with
  PLANNING_FAILED.
* Set planner_id in reponses with OMPL interface (#2724 <https://github.com/moveit/moveit2/issues/2724>)
  This avoids a warning PlanningPipeline::generatePlan().
  Co-authored-by: Gaël Écorchard <mailto:gael@km-robotics.cz>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Gaël Écorchard, Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_planners_stomp

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* missing destination path (#2668 <https://github.com/moveit/moveit2/issues/2668>)
* Fix penalty-based cost function in STOMP (#2625 <https://github.com/moveit/moveit2/issues/2625>)
  * Fix penalty-based cost function in STOMP
  This adds several test cases for STOMP's noise generation and cost
  functions, and provides the following fixes:
  * out-of-bounds vector access when tail states of trajectory are invalid
  * smoothed costs overriding values of previous invalid groups
  * missing validity check of last state in trajectory
  * inability to disable cost function interpolation steps
  * total cost of trajectory not summing up to sum of state penalties
  * bug in Gaussian producing infinite values with invalid start states
  * Improve documentation
  ---------
* Contributors: Henning Kayser, Robert Haschke, Sarvajith Adyanthaya, Sebastian Jahr, Tyler Weaver
```

## moveit_plugins

```
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Tyler Weaver
```

## moveit_py

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* Get configuration values of traj_exec_man (#2702 <https://github.com/moveit/moveit2/issues/2702>)
  * (ros_planning) get configuration values of traj_exec_man
  * (py) get configuration values of traj_exec_man
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* log after rclcpp init
* Contributors: Henning Kayser, Matthijs van der Burgh, Robert Haschke, Sebastian Jahr, Tyler Weaver, peterdavidfagan
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_resources_prbt_moveit_config

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_resources_prbt_pg70_support

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_resources_prbt_support

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_ros

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```

## moveit_ros_benchmarks

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Fix CI for Rolling / Ubuntu Noble (#2793 <https://github.com/moveit/moveit2/issues/2793>)
  * docker.yaml: Enable caching
  * [TEMP] moveit2_rolling.repos: add not yet released packages
  * Skip broken ci-testing image: osrf/ros2:testing doesn't contain /opt/ros!
  * use boost::timer::progress_display if available
  check for header to stay compatible with ubuntu 20.04.
  Support boost >= 1.83
  Slightly ugly due to the double alias, but boost::timer was a class
  before 1.72, so using boost::timer::progress_display in the code
  breaks with older versions.
  * cherry-pick of #3547 <https://github.com/moveit/moveit2/issues/3547> from MoveIt1
  * Tag ci image as ci-testing as well
  ---------
  Co-authored-by: Michael Görner <mailto:me@v4hn.de>
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Update deprecated include of boost/progress.hpp to boost/timer/progress_display.hpp (#2811 <https://github.com/moveit/moveit2/issues/2811>)
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Stephanie Eng, Tyler Weaver
```

## moveit_ros_control_interface

```
* Revert "Simplify controller manager namespacing (#2210 <https://github.com/moveit/moveit2/issues/2210>)"
  This reverts commit 55df0bccd5e884649780b4ceeee80891e563b57b.
  The deprecated constructor was being used in the same file
  for the exact use case of enabling namespaces that are not
  specified by the parameter. There is no replacement for
  supporting a dynamic server lookup, however the parameter
  logic could still use simplification.
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Henning Kayser, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_move_group

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* Remove extraneous error message from URDF service (#2736 <https://github.com/moveit/moveit2/issues/2736>)
* Add parameter api integration test (#2662 <https://github.com/moveit/moveit2/issues/2662>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Get robot description from topic in GetUrdfService (#2681 <https://github.com/moveit/moveit2/issues/2681>)
* Fix bug in GetUrdfService move_group capability  (#2669 <https://github.com/moveit/moveit2/issues/2669>)
  * Take both possible closings for links into account
  * Make CI happy
* avoid a relative jump threshold of 0.0 (#2654 <https://github.com/moveit/moveit2/issues/2654>)
* Add get group urdf capability (#2649 <https://github.com/moveit/moveit2/issues/2649>)
* Contributors: Abishalini Sivaraman, Ezra Brooks, Mario Prats, Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_occupancy_map_monitor

```
* Enforce liboctomap-dev by using a cmake version range
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Henning Kayser, Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_perception

```
* Fix segmentation fault in mesh_filter/gl_renderer (#2834 <https://github.com/moveit/moveit2/issues/2834>)
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: CihatAltiparmak, Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_planning

```
* Apply clang-tidy fixes
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Enable mdof trajectory execution (#2740 <https://github.com/moveit/moveit2/issues/2740>)
  * Add RobotTrajectory conversion from MDOF to joints
  * Convert MDOF trajectories to joint trajectories in planning interfaces
  * Treat mdof joint variables as common joints in
  TrajectoryExecutionManager
  * Convert multi-DOF trajectories to joints in TEM
  * Revert "Convert MDOF trajectories to joint trajectories in planning interfaces"
  This reverts commit 885ee2718594859555b73dc341311a859d31216e.
  * Handle multi-DOF variables in TEM's bound checking
  * Add parameter to optionally enable multi-dof conversion
  * Improve error message about unknown controllers
  * Fix name ordering in JointTrajectory conversion
  * Improve DEBUG output in TEM
  * Comment RobotTrajectory test
  * add acceleration to avoid out of bounds read
  ---------
  Co-authored-by: Paul Gesel <mailto:paulgesel@gmail.com>
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
  Co-authored-by: Ezra Brooks <mailto:ezra@brooks.cx>
* Skip flaky PSM launch test (#2822 <https://github.com/moveit/moveit2/issues/2822>)
* change default to 1e308 (#2801 <https://github.com/moveit/moveit2/issues/2801>)
* PSM: keep references to scene_ valid upon receiving full scenes (#2745 <https://github.com/moveit/moveit2/issues/2745>)
  plan_execution-related modules rely on plan.planning_scene_ in many places
  to point to the currently monitored scene (or a diff on top of it).
  Before this patch, if the PSM would receive full scenes during execution,
  plan.planning_scene_ would not include later incremental updates anymore
  because the monitor created a new diff scene.
  ---------
  Co-authored-by: v4hn <mailto:me@v4hn.de>
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* Print links in collision (#2727 <https://github.com/moveit/moveit2/issues/2727>)
* Do not overwrite the error code in planWithSinglePipeline (#2723 <https://github.com/moveit/moveit2/issues/2723>)
  * Do not overwrite the error code in planWithSinglePipeline
  Return the MotionPlanResponse as-is.
  * Do not rely on generatePlan() to set error code
  Do not rely on generatePlan() to set the error code in all cases and
  ensure that the error code is set to FAILURE if generatePlan() returns
  false.
  ---------
  Co-authored-by: Gaël Écorchard <mailto:gael@km-robotics.cz>
* Get configuration values of traj_exec_man (#2702 <https://github.com/moveit/moveit2/issues/2702>)
  * (ros_planning) get configuration values of traj_exec_man
  * (py) get configuration values of traj_exec_man
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Exit earlier on failure in generatePlan (#2726 <https://github.com/moveit/moveit2/issues/2726>)
  With this change, the PlanningPipeline::generatePlan() exits as soon
  as a failure is detected. Before this, break was used to exit the
  current loop of request adapters, planners, or response adapters, but
  the function continued to the next loop. For example, if a planner would
  fail, the response adapters would still be executed.
  Co-authored-by: Gaël Écorchard <mailto:gael@km-robotics.cz>
* srdf publisher node (#2682 <https://github.com/moveit/moveit2/issues/2682>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Get robot description from topic in GetUrdfService (#2681 <https://github.com/moveit/moveit2/issues/2681>)
* Shut down PSM publishing before starting to publish on a potentially new topic (#2680 <https://github.com/moveit/moveit2/issues/2680>)
* Contributors: Abishalini Sivaraman, Ezra Brooks, Gaël Écorchard, Henning Kayser, Matthijs van der Burgh, Paul Gesel, Robert Haschke, Sebastian Castro, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_planning_interface

```
* Apply clang-tidy fixes
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Add getNodeHandle impl (#2840 <https://github.com/moveit/moveit2/issues/2840>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* Add parameter api integration test (#2662 <https://github.com/moveit/moveit2/issues/2662>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Remove unused python content from planning interface directory (#2665 <https://github.com/moveit/moveit2/issues/2665>)
  * Remove unused python content from planning interface directory
  * Cleanup test cmake
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver, methylDragon
```

## moveit_ros_robot_interaction

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_tests

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Add parameter api integration test (#2662 <https://github.com/moveit/moveit2/issues/2662>)
* Contributors: Robert Haschke, Sebastian Jahr
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Add parameter api integration test (#2662 <https://github.com/moveit/moveit2/issues/2662>)
* Contributors: Robert Haschke, Sebastian Jahr
```

## moveit_ros_visualization

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Henning Kayser, Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_ros_warehouse

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_runtime

```
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Tyler Weaver
```

## moveit_servo

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* remove intraprocess comm warning (#2752 <https://github.com/moveit/moveit2/issues/2752>)
* Fix error message text in servo.cpp (#2769 <https://github.com/moveit/moveit2/issues/2769>)
* Fix launch parameters in Servo demos (#2735 <https://github.com/moveit/moveit2/issues/2735>)
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
* [Servo] Fix collision checking with attached objects (#2747 <https://github.com/moveit/moveit2/issues/2747>)
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Attempt to use SCHED_FIFO for Servo regardless of RT kernel (#2653 <https://github.com/moveit/moveit2/issues/2653>)
  * Attempt to use SCHED_FIFO for Servo regardless of RT kernel
  * Update warning message if Servo fails to use SCHED_FIFO
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  * Update moveit_ros/moveit_servo/src/servo_node.cpp
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
  ---------
  Co-authored-by: AndyZe <mailto:andyz@utexas.edu>
  Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Acceleration Limited Smoothing Plugin for Servo (#2651 <https://github.com/moveit/moveit2/issues/2651>)
* Contributors: Marc Bestmann, Nathan Brooks, Paul Gesel, Robert Haschke, Sebastian Castro, Sebastian Jahr, Stephanie Eng, Tyler Weaver
```

## moveit_setup_app_plugins

```
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Tyler Weaver
```

## moveit_setup_assistant

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Add dependency on moveit_configs_utils to moveit_setup_assistant (#2832 <https://github.com/moveit/moveit2/issues/2832>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver, hacker1024
```

## moveit_setup_controllers

```
* Add allow_nonzero_velocity_at_trajectory_end parameter to exported ros2_controllers config file (#2751 <https://github.com/moveit/moveit2/issues/2751>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Sebastian Castro, Tyler Weaver
```

## moveit_setup_core_plugins

```
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Tyler Weaver
```

## moveit_setup_framework

```
* Apply clang-tidy fixes
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_setup_srdf_plugins

```
* Apply clang-tidy fixes
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## moveit_simple_controller_manager

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## pilz_industrial_motion_planner

```
* Apply clang-tidy fixes
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* Unify log names (#2720 <https://github.com/moveit/moveit2/issues/2720>)
  Co-authored-by: Abishalini Sivaraman <mailto:abi.gpuram@gmail.com>
* Add parameter api integration test (#2662 <https://github.com/moveit/moveit2/issues/2662>)
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Sebastian Jahr, Tyler Weaver
```

## pilz_industrial_motion_planner_testutils

```
* Migrate ros-planning org to moveit (#2847 <https://github.com/moveit/moveit2/issues/2847>)
  * Rename github.com/ros-planning -> github.com/moveit
  * Rename ros-planning.github.io -> moveit.github.io
  * Rename ros-planning organization in docker and CI workflow files
  - ghcr.io/ros-planning -> ghcr.io/moveit
  - github.repository == 'moveit/*''
* CMake format and lint in pre-commit (#2683 <https://github.com/moveit/moveit2/issues/2683>)
* Contributors: Robert Haschke, Tyler Weaver
```
