### PR TITLE
Bump rmf_api_msgs to 0.4.0-1

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5295,7 +5295,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Manually opening this PR since bloom failed at the last step. The bloom itself succeeded https://github.com/ros2-gbp/rmf_api_msgs-release