### PR TITLE
Bump rmf_api_msgs to 0.3.1-1

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5356,11 +5356,11 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.2.1-3
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
-      version: main
+      version: jazzy
     status: developed
   rmf_battery:
     doc:


### PR DESCRIPTION
Manually bump since bloom failed at the last step. https://github.com/ros2-gbp/rmf_api_msgs-release