### PR TITLE
Bump rmf_task to 2.5.1-1

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5500,11 +5500,11 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.4.0-3
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: jazzy
     status: developed
   rmf_traffic:
     doc:


### PR DESCRIPTION
Manually bumping version since bloom failed at the last step. https://github.com/ros2-gbp/rmf_task-release