### PR TITLE
tracetools_analysis: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7601,7 +7601,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
-      version: 3.0.0-5
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-tracing/tracetools_analysis.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tracetools_analysis` to `3.1.0-1`:

- upstream repository: https://github.com/ros-tracing/tracetools_analysis.git
- release repository: https://github.com/ros2-gbp/tracetools_analysis-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-5`

## tracetools_analysis

```
* Use tracepoint names from tracetools_trace and add tests (#25 <https://github.com/ros-tracing/tracetools_analysis/issues/25>)
* Use underscores in setup.cfg (#21 <https://github.com/ros-tracing/tracetools_analysis/issues/21>)
* Skip TestDataModelUtil.test_convert_time_columns if pandas < 2.2.0 (#20 <https://github.com/ros-tracing/tracetools_analysis/issues/20>)
* Fix warnings when using mypy>=1.8.0 (#16 <https://github.com/ros-tracing/tracetools_analysis/issues/16>)
* Support traces with multiple callbacks for same pointer (#13 <https://github.com/ros-tracing/tracetools_analysis/issues/13>) (#15 <https://github.com/ros-tracing/tracetools_analysis/issues/15>)
* Update path to ros2_tracing in notebooks (#8 <https://github.com/ros-tracing/tracetools_analysis/issues/8>)
* Refactored for compatibility with Bokeh 3.2.0 (#7 <https://github.com/ros-tracing/tracetools_analysis/issues/7>)
* Fix mypy errors (#4 <https://github.com/ros-tracing/tracetools_analysis/issues/4>)
* Contributors: Christophe Bedard, Oren Bell
```
