### PR TITLE
Update distribution.yaml: add rosx_introspection

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7989,7 +7989,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git
-      version: main
+      version: master
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7993,7 +7993,7 @@ repositories:
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git
-      version: main
+      version: master
     status: developed
   rot_conv_lib:
     release:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7985,6 +7985,16 @@ repositories:
       url: https://github.com/DFKI-NI/rospy_message_converter.git
       version: humble
     status: maintained
+  rosx_introspection:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/rosx_introspection.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/facontidavide/rosx_introspection.git
+      version: main
+    status: developed
   rot_conv_lib:
     release:
       packages:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

rosx_introspection

## Package Upstream Source:

https://github.com/facontidavide/rosx_introspection

## Purpose of using this:

Needed by **foxglove_bridge**

## Links to Distribution Packages

Not yet

# Please Add This Package to be indexed in the rosdistro.

rosx_introspection

# The source is here:

https://github.com/facontidavide/rosx_introspection.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
