### PR TITLE
simple_launch: 1.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8809,7 +8809,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.9.2-1
+      version: 1.10.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.10.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.9.2-1`

## simple_launch

```
* scope_included_files to include other launch files in a Group and avoid changing my scope
* remove dead code about prefixing gz plugins
* forward sim_time even for nodes that load a parameter file
* lazy GazeboBridge
* Contributors: Olivier Kermorgant
```
