### PR TITLE
Add ros2_easy_test

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5834,6 +5834,16 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: master
     status: developed
+  ros2_easy_test:
+    doc:
+      type: git
+      url: https://github.com/felixdivo/ros2-easy-test.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/felixdivo/ros2-easy-test.git
+      version: main
+    status: developed
   ros2_kortex:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/felixdivo/ros2-easy-test

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

# Notes

Replaces https://github.com/ros/rosdistro/pull/39892

@felixdivo you marked it [help-wanted](https://github.com/felixdivo/ros2-easy-test/issues/23#event-13176889957) so I'd gave it a shot here.