### PR TITLE
Add python3-openpyxl

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7443,6 +7443,13 @@ python3-openhsi-pip:
   ubuntu:
     pip:
       packages: [openhsi]
+python3-openpyxl-pip:
+  debian:
+    pip:
+      packages: [openpyxl]
+  ubuntu:
+    pip:
+      packages: [openpyxl]
 python3-opentelemetry-api-pip:
   '*':
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

openpyxl

## Package Upstream Source:

Source code is available at the [link](https://foss.heptapod.net/openpyxl/openpyxl)

## Purpose of using this:

openpyxl is a Python library to read/write Excel 2010 xlsx/xlsm/xltx/xltm files.
Documentation is available at the [link](https://openpyxl.readthedocs.io/en/stable/)

## Links to Distribution Packages

- Debian: 
  - https://packages.debian.org/openpyxl
- Ubuntu: 
  - https://packages.ubuntu.com/openpyxl