### PR TITLE
resource_retriever: 3.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5268,7 +5268,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.5.0-1
+      version: 3.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.5.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.0-1`

## libcurl_vendor

```
* Add "lib" to the Windows curl search path. (#96 <https://github.com/ros/resource_retriever/issues/96>)
  In CMake 3.3, a commit made it so that the find_package
  module in CMake had a compatibility mode where it would
  automatically search for packages in a <prefix>/lib subdirectory.
  In CMake 3.6, this compatibility mode was reverted for all
  platforms *except* Windows.
  That means that since CMake 3.3, we haven't actually been
  using the path as specified in curl_DIR, but we have
  instead been inadvertently relying on that fallback behavior.
  In CMake 3.28, that compatibilty mode was also removed for
  Windows, meaning that we are now failing to find_package(curl)
  in downstream packages (like resource_retriever).
  Fix this by adding in the "lib" directory that always should
  have been there.  I'll note that this *only* affects our
  Windows builds, because this code is in a if(WIN32) block.
* Contributors: Chris Lalancette
```

## resource_retriever

```
* Allow spaces (#100 <https://github.com/ros/resource_retriever/issues/100>)
* Contributors: Alejandro Hernández Cordero
```
