### PR TITLE
ur_robot_driver: 2.3.8-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8141,7 +8141,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.7-1
+      version: 2.3.8-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.8-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.7-1`

## ur

- No changes

## ur_calibration

```
* Fix calibration (#1023 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1023>)
* Contributors: Felix Exner, Vincenzo Di Pentima
```

## ur_controllers

```
* this simple fix should fix the goal time violated issue (#1000 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1000>)
* Contributors: Lennart Nachtigall
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add servo node config to disable advertising /get_planning_scene (#990 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/990>)
* Contributors: Ruddick Lawrence
```

## ur_robot_driver

```
* Remove extra spaces from start_ursim statement in tests ( backport of #1010 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1010>)
* Use robot_receive_timeout instead of keepalive_count (#1003 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1003>)
* Added kinematics_params_file to launch arguments (#1006 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1006>)
* Contributors: Felix Exner, Vincenzo Di Pentima
```
