### PR TITLE
sros2: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7264,7 +7264,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.14.0-1
+      version: 0.15.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.15.0-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.14.0-1`

## sros2

```
* [FIX] remove dangerous mutable default arguments in generate_artifacts (#318 <https://github.com/ros2/sros2/issues/318>)
* Fix sros2 tests on Windows Debug. (#317 <https://github.com/ros2/sros2/issues/317>)
* [TESTS] Update tests and add test for generate_artifacts (#311 <https://github.com/ros2/sros2/issues/311>)
* remove deprecated create_key and list_keys verbs (#302 <https://github.com/ros2/sros2/issues/302>)
* Fix linux tutorial: cloning example policies and set of default policies for a node (#295 <https://github.com/ros2/sros2/issues/295>)
* Contributors: Chris Lalancette, Mikael Arguedas
```

## sros2_cmake

- No changes
