### PR TITLE
rosidl_defaults: 1.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6291,7 +6291,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.7.1-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.0-1`

## rosidl_default_generators

- No changes

## rosidl_default_runtime

```
* Minor update to quality declaration (#27 <https://github.com/ros2/rosidl_defaults/issues/27>)
* Contributors: Christophe Bedard
```
