### PR TITLE
rosidl_core: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6254,7 +6254,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_core` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/rosidl_core.git
- release repository: https://github.com/ros2-gbp/rosidl_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## rosidl_core_generators

```
* Add mechanism to disable workaround for dependency groups (#3 <https://github.com/ros2/rosidl_core/issues/3>)
* Contributors: Scott K Logan
```

## rosidl_core_runtime

```
* Add mechanism to disable workaround for dependency groups (#3 <https://github.com/ros2/rosidl_core/issues/3>)
* Contributors: Scott K Logan
```
