### PR TITLE
rmw_implementation: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5671,7 +5671,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.16.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.16.0-1`

## rmw_implementation

```
* Add mechanism to disable workaround for dependency groups (#229 <https://github.com/ros2/rmw_implementation/issues/229>)
* Contributors: Scott K Logan
```
