### PR TITLE
rmw_fastrtps: 9.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5638,7 +5638,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 8.5.0-1
+      version: 9.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.5.0-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT (#763 <https://github.com/ros2/rmw_fastrtps/issues/763>)
* Use rmw_namespace_validation_result_string() in rmw_create_node (#765 <https://github.com/ros2/rmw_fastrtps/issues/765>)
* Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT (#766 <https://github.com/ros2/rmw_fastrtps/issues/766>)
* Use unique mangled names when creating Content Filter Topics (#762 <https://github.com/ros2/rmw_fastrtps/issues/762>)
* Add support for data representation (#756 <https://github.com/ros2/rmw_fastrtps/issues/756>)
* Contributors: Christophe Bedard, Mario Domínguez López, Miguel Company
```
