### PR TITLE
rmw_cyclonedds: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5602,7 +5602,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 2.3.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `3.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## rmw_cyclonedds_cpp

```
* Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT (#496 <https://github.com/ros2/rmw_cyclonedds/issues/496>)
* Use rmw_namespace_validation_result_string() in rmw_create_node (#497 <https://github.com/ros2/rmw_cyclonedds/issues/497>)
* Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT (#498 <https://github.com/ros2/rmw_cyclonedds/issues/498>)
* Set received_timestamp to system_clock::now() in message_info (#491 <https://github.com/ros2/rmw_cyclonedds/issues/491>)
* Contributors: Christophe Bedard, Michael Orlov
```
