### PR TITLE
rmw_connextdds: 0.24.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5585,7 +5585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.23.0-1
+      version: 0.24.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.24.0-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.23.0-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT (#150 <https://github.com/ros2/rmw_connextdds/issues/150>)
* Use rmw_namespace_validation_result_string() in rmw_create_node (#151 <https://github.com/ros2/rmw_connextdds/issues/151>)
* Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT (#152 <https://github.com/ros2/rmw_connextdds/issues/152>)
* Contributors: Christophe Bedard
```

## rti_connext_dds_cmake_module

- No changes
