### PR TITLE
rclpy: 7.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5138,7 +5138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.2.0-1
+      version: 7.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.3.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.2.0-1`

## rclpy

```
* Docstring specifying proper destruction and creation of Rate, Timer and GuardCondition (#1286 <https://github.com/ros2/rclpy/issues/1286>)
* Make timers context-aware. (#1296 <https://github.com/ros2/rclpy/issues/1296>)
* Make service lients context-aware. (#1295 <https://github.com/ros2/rclpy/issues/1295>)
* Make service servers context-manager aware. (#1294 <https://github.com/ros2/rclpy/issues/1294>)
* Make nodes context-manager aware. (#1293 <https://github.com/ros2/rclpy/issues/1293>)
* Make subscriptions context-manager aware. (#1291 <https://github.com/ros2/rclpy/issues/1291>)
* Make publishers context-manager aware. (#1289 <https://github.com/ros2/rclpy/issues/1289>)
* (NumberOfEntities) improve performance (#1285 <https://github.com/ros2/rclpy/issues/1285>)
* Using Generics for messages (#1239 <https://github.com/ros2/rclpy/issues/1239>)
* Contributors: Chris Lalancette, Elian NEPPEL, Matthijs van der Burgh, Michael Carlstrom
```
