### PR TITLE
rcl: 9.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5022,7 +5022,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.3.0-1
+      version: 9.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.4.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.3.0-1`

## rcl

```
* Add mechanism to disable workaround for dependency groups (#1151 <https://github.com/ros2/rcl/issues/1151>)
* remap_impl: minor typo (#1158 <https://github.com/ros2/rcl/issues/1158>)
* Fix up rmw_cyclonedds timestamp testing. (#1156 <https://github.com/ros2/rcl/issues/1156>)
* Add 'mimick' label to tests which use Mimick (#1152 <https://github.com/ros2/rcl/issues/1152>)
* Contributors: Chris Lalancette, G.A. vd. Hoorn, Scott K Logan
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Add 'mimick' label to tests which use Mimick (#1152 <https://github.com/ros2/rcl/issues/1152>)
* Contributors: Scott K Logan
```
