### PR TITLE
performance_test_fixture: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4388,7 +4388,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## performance_test_fixture

```
* Fix a warning when building on Ubuntu Noble. (#26 <https://github.com/ros2/performance_test_fixture/issues/26>)
* Contributors: Chris Lalancette
```
