### PR TITLE
demos: 0.34.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1089,7 +1089,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.34.0-1
+      version: 0.34.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.34.1-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.34.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

- No changes

## composition

```
* Change references from "jazzy" to "rolling" on the rolling branch. (#687 <https://github.com/ros2/demos/issues/687>)
* [composition] add launch action console output in the verify section (#677 <https://github.com/ros2/demos/issues/677>)
* Contributors: Chris Lalancette, Mikael Arguedas
```

## demo_nodes_cpp

```
* [demo_nodes_cpp] some readme and executable name fixups (#678 <https://github.com/ros2/demos/issues/678>)
* Fix gcc warnings when building with optimizations. (#672 <https://github.com/ros2/demos/issues/672>)
* Contributors: Chris Lalancette, Mikael Arguedas
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

```
* Update dummy_sensors readme to echo the correct topic (#675 <https://github.com/ros2/demos/issues/675>)
* Contributors: jmackay2
```

## image_tools

- No changes

## intra_process_demo

```
* [intra_process_demo] executable name in README.md fix-up (#690 <https://github.com/ros2/demos/issues/690>)
* Contributors: Trushant Adeshara
```

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
