### PR TITLE
rqt_bag: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6512,7 +6512,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.6.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-1`

## rqt_bag

```
* Adapted to rosbag2_py (#156 <https://github.com/ros-visualization/rqt_bag/issues/156>)
* Fixed button icons (#159 <https://github.com/ros-visualization/rqt_bag/issues/159>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_bag_plugins

```
* Adapted to rosbag2_py (#156 <https://github.com/ros-visualization/rqt_bag/issues/156>)
* Fixed image timeline renderer (#158 <https://github.com/ros-visualization/rqt_bag/issues/158>)
* Contributors: Alejandro Hernández Cordero
```
