### PR TITLE
image_common: 5.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2460,7 +2460,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.2.1-1
+      version: 5.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.3.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.2.1-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* Preparing for qos deprecation (#315 <https://github.com/ros-perception/image_common/issues/315>)
* Contributors: Lucas Wendland
```
