### PR TITLE
osrf_testing_tools_cpp: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4250,7 +4250,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `2.2.0-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## osrf_testing_tools_cpp

```
* Update CMakeLists.txt (#85 <https://github.com/osrf/osrf_testing_tools_cpp/issues/85>)
* Contributors: mosfet80
```
