### PR TITLE
etsi_its_messages: 2.0.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1416,23 +1416,14 @@ repositories:
       version: main
     release:
       packages:
-      - etsi_its_cam_coding
-      - etsi_its_cam_conversion
       - etsi_its_cam_msgs
-      - etsi_its_coding
-      - etsi_its_conversion
-      - etsi_its_denm_coding
-      - etsi_its_denm_conversion
       - etsi_its_denm_msgs
-      - etsi_its_messages
       - etsi_its_msgs
       - etsi_its_msgs_utils
-      - etsi_its_primitives_conversion
-      - etsi_its_rviz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
We have noticed that for some of our packages the dependencies have not all been released for jazzy yet. To prevent the buildfarm from failing all the time, we have removed the corresponding packages here for now.

Increasing version of package(s) in repository `etsi_its_messages` to `2.0.2-2`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ros2-gbp/etsi_its_messages-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## etsi_its_cam_coding

- No changes

## etsi_its_cam_conversion

- No changes

## etsi_its_cam_msgs

- No changes

## etsi_its_coding

- No changes

## etsi_its_conversion

- No changes

## etsi_its_denm_coding

- No changes

## etsi_its_denm_conversion

- No changes

## etsi_its_denm_msgs

- No changes

## etsi_its_messages

- No changes

## etsi_its_msgs

- No changes

## etsi_its_msgs_utils

- No changes

## etsi_its_primitives_conversion

- No changes

## etsi_its_rviz_plugins

- No changes
