### PR TITLE
Bump rmf_demos to 2.4.0-1

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5352,6 +5352,19 @@ repositories:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
       version: main
+    release:
+      packages:
+      - rmf_demos
+      - rmf_demos_assets
+      - rmf_demos_bridges
+      - rmf_demos_fleet_adapter
+      - rmf_demos_gz
+      - rmf_demos_maps
+      - rmf_demos_tasks
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_demos-release.git
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Bloom succeeded but failed at the last step when opening the rosdistro PR. https://github.com/ros2-gbp/rmf_demos-release