### PR TITLE
Bump rmf_visualization_msgs to 1.4.1-1

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5606,7 +5606,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.4.0-3
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git


### PR DESCRIPTION
Bloom succeeded but failed at the last step when opening the rosdistro PR. https://github.com/ros2-gbp/rmf_visualization_msgs-release