### PR TITLE
Update rmf_ros2 to 2.7.2-1 on jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5461,7 +5461,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.6.0-2
+      version: 2.7.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Bloom succeeded but failed at the last step when opening the rosdistro PR. https://github.com/ros2-gbp/rmf_ros2-release