### PR TITLE
Bump rmf_visualization to 1.5.0-1 on rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5547,7 +5547,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.4.0-2
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git


### PR DESCRIPTION
Bloom succeeded but failed at the last step when opening the rosdistro PR. https://github.com/ros2-gbp/rmf_visualization_msgs-release