### PR TITLE
launch_pal: 0.1.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3522,7 +3522,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.1.6-1
+      version: 0.1.12-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.1.12-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.6-1`

## launch_pal

```
* Update Changelog
* Merge branch 'tpe/upate_std_and_launch_arg' into 'master'
  update lauch args for the omni base
  See merge request common/launch_pal!55
* update lauch args for the omni base
* Contributors: David ter Kuile, davidterkuile, thomas.peyrucain
* Merge branch 'tpe/upate_std_and_launch_arg' into 'master'
  update lauch args for the omni base
  See merge request common/launch_pal!55
* update lauch args for the omni base
* Contributors: davidterkuile, thomas.peyrucain
```
