### PR TITLE
pal_robotiq_gripper: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5545,7 +5545,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
-      version: 2.0.0-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_robotiq_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_robotiq_gripper` to `2.0.3-1`:

- upstream repository: https://github.com/pal-robotics/pal_robotiq_gripper.git
- release repository: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## pal_robotiq_controller_configuration

- No changes

## pal_robotiq_description

```
* Merge branch 'fix/mimic_multiplier' into 'humble-devel'
  fix ros2 control multiplier
  See merge request robots/pal_robotiq_gripper!24
* fix ros2 control multiplier
* Contributors: Aina Irisarri, davidterkuile
```

## pal_robotiq_gripper

- No changes

