### PR TITLE
pmb2_robot: 5.0.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5881,7 +5881,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.0.16-1
+      version: 5.0.20-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.0.20-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.16-1`

## pmb2_bringup

- No changes

## pmb2_controller_configuration

- No changes

## pmb2_description

```
* Merge branch 'fix/aca/reduced-laser-noise' into 'humble-devel'
  reduced laser_noise
  See merge request robots/pmb2_robot!130
* reduced laser_noise
* Merge branch 'omm/fix/imu_proper_urdf' into 'humble-devel'
  IMU proper placement
  See merge request robots/pmb2_robot!127
* Style and IMU proper placement
* Contributors: Oscar, andreacapodacqua, davidterkuile
```

## pmb2_robot

- No changes

