### PR TITLE
tiago_simulation: 4.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9425,7 +9425,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.1.0-1
+      version: 4.1.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.1.6-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-1`

## tiago_gazebo

```
* Merge branch 'feat/motions' into 'humble-devel'
  change home values as the motion ones
  See merge request robots/tiago_simulation!153
* change home values as the motion ones
* fix launch file name for tiago_nav_bringup (#35)
  * fix launch file name for tiago_nav_bringup
  * undo formating changes
  * undo formatting changes
  * undo formatting changes
  ---------
  Co-authored-by: David Brown <mailto:david.brown@inria.fr>
* Merge branch 'dtk/fix/add-public-sim-arg' into 'humble-devel'
  Pass public sim arg to tiago_bringup launch
  See merge request robots/tiago_simulation!150
* Pass public sim arg to tiago_bringup launch
* Add is_public_sim=true to tuck arm test to fix humble tests
* Merge branch 'omm/feat/public_sim' into 'humble-devel'
  Added is_public_sim check
  See merge request robots/tiago_simulation!149
* Added is_public_sim check
* Contributors: Aina, David Brown, David ter Kuile, davidterkuile, oscarmartinez
```

## tiago_simulation

- No changes

