### PR TITLE
pmb2_navigation: 4.0.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5856,12 +5856,11 @@ repositories:
       packages:
       - pmb2_2dnav
       - pmb2_laser_sensors
-      - pmb2_maps
       - pmb2_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.0.12-1
+      version: 4.0.19-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.0.19-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.12-1`

## pmb2_2dnav

```
* fix incorrect map path
* Contributors: David Brown
```

## pmb2_laser_sensors

- No changes

## pmb2_navigation

- No changes
