### PR TITLE
flir_camera_driver: 2.0.18-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1723,7 +1723,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
-      version: 2.0.15-2
+      version: 2.0.18-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `2.0.18-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros2-gbp/flir_camera_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.15-2`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* point to new spinnaker sdk for noble
* renamed stereo_synced file and added doc
* added user set control examples for blackfly/blackfly_s
* Contributors: Bernd Pfrommer
```

## spinnaker_synchronized_camera_driver

```
* added primary_secondary launch file
* Contributors: Bernd Pfrommer
```
