### PR TITLE
Update rmf_variants to 0.1.0-1 on jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5567,11 +5567,11 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
-      version: 0.0.1-3
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_variants.git
-      version: main
+      version: jazzy
     status: developed
   rmf_visualization:
     doc:


### PR DESCRIPTION
Bloom succeeded but failed at the last step when opening the rosdistro PR. https://github.com/ros2-gbp/rmf_variants-release