### PR TITLE
Removing ros2_ouster from Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5870,25 +5870,6 @@ repositories:
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
     status: developed
-  ros2_ouster_drivers:
-    doc:
-      type: git
-      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
-      version: foxy-devel
-    release:
-      packages:
-      - ouster_msgs
-      - ros2_ouster
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
-      version: 0.5.1-4
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/SteveMacenski/ros2_ouster_drivers.git
-      version: foxy-devel
-    status: maintained
   ros2_robotiq_gripper:
     doc:
       type: git


### PR DESCRIPTION
I'm removing this from rolling to disable automatic entry into new distributions after Jazzy from Ouster's new self supported driver. This driver is in essentially archive for existing users but new users should be using the vendor's supported versions. 