### PR TITLE
beluga: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -722,7 +722,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/Ekumen-OS/beluga.git


### PR DESCRIPTION
Increasing version of package(s) in repository `beluga` to `2.0.2-1`:

- upstream repository: https://github.com/Ekumen-OS/beluga.git
- release repository: https://github.com/ros2-gbp/beluga-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## beluga

```
* Use no-gnu-zero-variadic-macro-arguments only with clang-tidy (#391 <https://github.com/Ekumen-OS/beluga/issues/391>)
* Add 3D NDT sensor model and tests. (#400 <https://github.com/Ekumen-OS/beluga/issues/400>)
* Expand grid concepts to n dimensions (#396 <https://github.com/Ekumen-OS/beluga/issues/396>)
* Add cast from hsize_t to size_t (#392 <https://github.com/Ekumen-OS/beluga/issues/392>)
* Contributors: Nahuel Espinosa, Ramiro Serra
```

## beluga_amcl

```
* Expand grid concepts to n dimensions (#396 <https://github.com/Ekumen-OS/beluga/issues/396>)
* Change NDT sensor model default params (#397 <https://github.com/Ekumen-OS/beluga/issues/397>)
* Contributors: Ramiro Serra
```

## beluga_ros

- No changes
