### PR TITLE
ur_description: 2.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7855,7 +7855,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.4.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.0-1`

## ur_description

```
* Add migration notes for jazzy (#169 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/169>)
* Remove limits definitions from ros2_control command interfaces (#166 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/166>)
* Sphinx doc (#161 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/161>)
* Use absolute paths for configurable files (#160 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/160>)
* [CI] Fix ref for scheduled jazzy testing binary build (#162 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/162>)
* Add Jazzy to the README (#158 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/158>)
* Contributors: Felix Exner, Vincenzo Di Pentima
```
