### PR TITLE
Add python3-nest-asyncio

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -281,7 +281,6 @@ libshiboken2-dev:
   alpine: [libshiboken2-dev]
   debian: [libshiboken2-dev]
   fedora: [python3-shiboken2-devel]
-            asyncio.run()
   opensuse: [python3-pyside2-devel]
   rhel:
     '*': [python3-shiboken2-devel]
@@ -294,7 +293,6 @@ mcap-ros2-support:
   fedora:
     pip:
       packages: [mcap-ros2-support]
-            asyncio.run()
   gentoo:
     pip:
       packages: [mcap-ros2-support]
@@ -340,7 +338,6 @@ paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-            asyncio.run()
   openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python-paramiko]
   osx:
@@ -7195,8 +7192,14 @@ python3-nclib-pip:
     pip:
       packages: [nclib]
 python3-nest-asyncio:
+  alpine: [py3-nest_asyncio]
   arch: [python-nest-asyncio]
   debian: [python3-nest-asyncio]
+  fedora: [python3-nest-asyncio]
+  gentoo: [dev-python/nest-asyncio]
+  nixos: [python312Packages.nest-asyncio]
+  opensuse: [python-nest-asyncio]
+  rhel: [python3-nest-asyncio]
   ubuntu: [python3-nest-asyncio]
 python3-netcdf4:
   arch: [python-netcdf4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7198,7 +7198,7 @@ python3-nest-asyncio:
   fedora: [python3-nest-asyncio]
   gentoo: [dev-python/nest-asyncio]
   nixos: [python312Packages.nest-asyncio]
-  opensuse: 
+  opensuse:
     '*': [python-nest-asyncio]
     '15.2': null
   rhel:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -281,6 +281,7 @@ libshiboken2-dev:
   alpine: [libshiboken2-dev]
   debian: [libshiboken2-dev]
   fedora: [python3-shiboken2-devel]
+            asyncio.run()
   opensuse: [python3-pyside2-devel]
   rhel:
     '*': [python3-shiboken2-devel]
@@ -293,6 +294,7 @@ mcap-ros2-support:
   fedora:
     pip:
       packages: [mcap-ros2-support]
+            asyncio.run()
   gentoo:
     pip:
       packages: [mcap-ros2-support]
@@ -338,6 +340,7 @@ paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
+            asyncio.run()
   openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python-paramiko]
   osx:
@@ -7191,6 +7194,10 @@ python3-nclib-pip:
   ubuntu:
     pip:
       packages: [nclib]
+python3-nest-asyncio:
+  arch: [python-nest-asyncio]
+  debian: [python3-nest-asyncio]
+  ubuntu: [python3-nest-asyncio]
 python3-netcdf4:
   arch: [python-netcdf4]
   debian: [python3-netcdf4]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7198,9 +7198,15 @@ python3-nest-asyncio:
   fedora: [python3-nest-asyncio]
   gentoo: [dev-python/nest-asyncio]
   nixos: [python312Packages.nest-asyncio]
-  opensuse: [python-nest-asyncio]
-  rhel: [python3-nest-asyncio]
-  ubuntu: [python3-nest-asyncio]
+  opensuse: 
+    '*': [python-nest-asyncio]
+    '15.2': null
+  rhel:
+    '*': [python3-nest-asyncio]
+    '8': null
+  ubuntu:
+    '*': [python3-nest-asyncio]
+    focal: null
 python3-netcdf4:
   arch: [python-netcdf4]
   debian: [python3-netcdf4]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-nest-asyncio

## Package Upstream Source:

https://github.com/erdewit/nest_asyncio

## Purpose of using this:

This is a widely used package to allow the nesting of asyncio `run_until_complete`.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/bullseye/all/python3-nest-asyncio
- Ubuntu: https://packages.ubuntu.com/jammy/python3-nest-asyncio
- Fedora: https://packages.fedoraproject.org/pkgs/python-nest-asyncio/python3-nest-asyncio/
- Arch: https://archlinux.org/packages/extra/any/python-nest-asyncio/
- Gentoo: https://packages.gentoo.org/packages/dev-python/nest-asyncio
- macOS: Not found
- Alpine: https://pkgs.alpinelinux.org/package/v3.19/community/armv7/py3-nest_asyncio
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=python312Packages.nest-asyncio&from=0&size=50&sort=relevance&type=packages&query=nest+asyncio
- openSUSE: https://software.opensuse.org/package/python-nest-asyncio?locale=en
- rhel: https://rhel.pkgs.org/9/epel-aarch64/python3-nest-asyncio-1.5.6-1.el9.noarch.rpm.html
