### PR TITLE
Add `alive-progress` pip dependencies to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4884,6 +4884,10 @@ python3-alembic:
     '*': [python3-alembic]
     '7': null
   ubuntu: [python3-alembic]
+python3-alive-progress-pip:
+  '*':
+    pip:
+      packages: [alive-progress]
 python3-ansible-runner-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

`python3-alive-progress-pip`

## Package Upstream Source:

[https://github.com/rsalmei/alive-progress](https://github.com/rsalmei/alive-progress)

## Purpose of using this:

The `alive-progress` package is useful for displaying the progress of a for loop. It helps with visualizing progress, but also with confirming if a process is stuck or just long.

## Links to Distribution Packages

- pip: https://pypi.org/
  - [https://pypi.org/project/alive-progress/](https://pypi.org/project/alive-progress/)
