### PR TITLE
[realsense2_camera]: Switch from ros2-development to ros2-master

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6714,7 +6714,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-development
+      version: ros2-master
     release:
       packages:
       - realsense2_camera
@@ -6727,7 +6727,7 @@ repositories:
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-development
+      version: ros2-master
     status: developed
   realtime_support:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5249,7 +5249,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-development
+      version: ros2-master
     release:
       packages:
       - realsense2_camera
@@ -5262,7 +5262,7 @@ repositories:
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-development
+      version: ros2-master
     status: developed
   realtime_support:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5302,7 +5302,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-development
+      version: ros2-master
     release:
       packages:
       - realsense2_camera
@@ -5316,7 +5316,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
-      version: ros2-development
+      version: ros2-master
     status: developed
   realtime_support:
     doc:


### PR DESCRIPTION
realsense2_camera master branch will be ros2-master, and all released will be released from this branch.
ros2-development will be kept for development