### PR TITLE
swri_console: 2.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7289,7 +7289,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.4-6
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.5-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-6`

## swri_console

```
* Implement reading from rosbag2 files (#64 <https://github.com/swri-robotics/swri_console/issues/64>)
* Add human readable time (#63 <https://github.com/swri-robotics/swri_console/issues/63>)
* Remove Old Distro Support (#62 <https://github.com/swri-robotics/swri_console/issues/62>)
* Update package.xml
* Adding ROS-Industrial CI Actions for ROS2 Releases
* Contributors: David Anthony, Matthijs van der Burgh, Ramon Wijnands
```
