### PR TITLE
fastcdr: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1506,7 +1506,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastcdr-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastcdr` to `2.2.2-1`:

- upstream repository: https://github.com/eProsima/Fast-CDR.git
- release repository: https://github.com/ros2-gbp/fastcdr-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`
