### PR TITLE
mp2p_icp: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3614,7 +3614,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.4.3-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.5.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.3-1`

## mp2p_icp

```
* ICP: Add optional user-provided per-iteration hooks
* Add new filter: FilterByRing
* Add new filter: FilterAdjustTimestamps
* Add sanity checks for point cloud fields.
* Fix typo in default class for FilterDeskew
* generators API: add bool return type to detect if observation was actually processed
* generic Generator: handle velodyne observations so timestamps are generated
* Contributors: Jose Luis Blanco-Claraco
```
