### PR TITLE
mola: 1.0.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3327,6 +3327,7 @@ repositories:
       - mola_kernel
       - mola_launcher
       - mola_metric_maps
+      - mola_navstate_fg
       - mola_navstate_fuse
       - mola_pose_list
       - mola_relocalization
@@ -3336,7 +3337,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.0.6-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.5-1`

## kitti_metrics_eval

- No changes

## mola

```
* Create new NavStateFilter interface and separate the simple fuser and the factor-graph approach in two packages
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

- No changes

## mola_demos

- No changes

## mola_imu_preintegration

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_kernel

```
* Create new NavStateFilter interface and separate the simple fuser and the factor-graph approach in two packages
* mola_kernel: renamed factor FactorConstVelKinematics
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

- No changes

## mola_navstate_fg

```
* Create new NavStateFilter interface and separate the simple fuser and the factor-graph approach in two packages
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fuse

```
* Create new NavStateFilter interface and separate the simple fuser and the factor-graph approach in two packages
* Twist in local frame
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

```
* traj_tf program split in two: traj_tf_left and traj_tf_right for the two types of transformations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

- No changes

## mola_yaml

- No changes
