### PR TITLE
rosbag2: 0.28.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6169,7 +6169,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.27.0-1
+      version: 0.28.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.28.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.27.0-1`

## liblz4_vendor

- No changes

## mcap_vendor

```
* Update mcap-releases-cpp- into CMakeLists.txt (#1612 <https://github.com/ros2/rosbag2/issues/1612>)
* Contributors: mosfet80
```

## ros2bag

```
* fix(start-offset): allow specifying a start offset of 0 (#1682 <https://github.com/ros2/rosbag2/issues/1682>)
* Exclude recorded /clock topic when --clock option is specified (#1646 <https://github.com/ros2/rosbag2/issues/1646>)
* Sweep cleanup in rosbag2 recorder CLI args verification code (#1633 <https://github.com/ros2/rosbag2/issues/1633>)
* Add --log-level to ros2 bag play and record (#1625 <https://github.com/ros2/rosbag2/issues/1625>)
* Add optional  '--topics' CLI argument for 'ros2 bag record' (#1632 <https://github.com/ros2/rosbag2/issues/1632>)
* Contributors: Kosuke Takeuchi, Michael Orlov, Rein Appeldoorn, Roman
```

## rosbag2

- No changes

## rosbag2_compression

```
* Fix for regression in open_succeeds_twice and minimal_writer_example tests (#1667 <https://github.com/ros2/rosbag2/issues/1667>)
* Bugfix for writer not being able to open again after closing (#1599 <https://github.com/ros2/rosbag2/issues/1599>)
* Contributors: Michael Orlov, yschulz
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing (#1700 <https://github.com/ros2/rosbag2/issues/1700>)
* Bugfix for writer not being able to open again after closing (#1599 <https://github.com/ros2/rosbag2/issues/1599>)
* Contributors: Cole Tucker, yschulz
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Add bindings for LocalMessageDefinitionSource (#1697 <https://github.com/ros2/rosbag2/issues/1697>)
* Add --log-level to ros2 bag play and record (#1625 <https://github.com/ros2/rosbag2/issues/1625>)
* Included to_rclcpp_qos_vector to Python wrappers (#1642 <https://github.com/ros2/rosbag2/issues/1642>)
* Contributors: Alejandro Hernández Cordero, Roman, methylDragon
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Add vscode gitignore rule and remove vscode folder (#1698 <https://github.com/ros2/rosbag2/issues/1698>)
* Contributors: methylDragon
```

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing (#1700 <https://github.com/ros2/rosbag2/issues/1700>)
* Sweep cleanup in rosbag2 recorder CLI args verification code (#1633 <https://github.com/ros2/rosbag2/issues/1633>)
* Fix for regression in open_succeeds_twice and minimal_writer_example tests (#1667 <https://github.com/ros2/rosbag2/issues/1667>)
* Add optional  '--topics' CLI argument for 'ros2 bag record' (#1632 <https://github.com/ros2/rosbag2/issues/1632>)
* Bugfix for writer not being able to open again after closing (#1599 <https://github.com/ros2/rosbag2/issues/1599>)
* Contributors: Cole Tucker, Michael Orlov, yschulz
```

## rosbag2_transport

```
* Bugfix for issue where unable to create composable nodes with compression (#1679 <https://github.com/ros2/rosbag2/issues/1679>)
* Add support for "all" and "exclude" in RecordOptions YAML decoder (#1664 <https://github.com/ros2/rosbag2/issues/1664>)
* Add unit tests to cover message's send and received timestamps during recording (#1641 <https://github.com/ros2/rosbag2/issues/1641>)
* Contributors: Michael Orlov
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
