### PR TITLE
nav2_minimal_turtlebot_simulation: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3879,7 +3879,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_minimal_turtlebot_simulation` to `1.0.1-1`:

- upstream repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
- release repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`
