### PR TITLE
autoware_lanelet2_extension: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -669,6 +669,14 @@ repositories:
       version: main
     status: developed
   autoware_lanelet2_extension:
+    release:
+      packages:
+      - autoware_lanelet2_extension
+      - autoware_lanelet2_extension_python
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.4.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## autoware_lanelet2_extension

```
* Merge pull request #11 <https://github.com/youtalk/autoware_lanelet2_extension/issues/11> from youtalk/import-update
  feat: import updates from autoware_common
* fix link
* feat(lanelet2_extension): overwriteLaneletsCenterline supports "waypoints" (#252 <https://github.com/youtalk/autoware_lanelet2_extension/issues/252>)
  * feat(lanelet2_extension): centerline is converted to waypoints
  * fix lanelet2_extension_python
  * update README
  * fix
  * fix
  * early return
  * fix clang-tidy
  * Update tmp/lanelet2_extension/lib/utilities.cpp
  Co-authored-by: Ryohsuke Mitsudome <mailto:43976834+mitsudome-r@users.noreply.github.com>
  * style(pre-commit): autofix
  * fix
  ---------
  Co-authored-by: Ryohsuke Mitsudome <mailto:43976834+mitsudome-r@users.noreply.github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* fix: boost optional build error on rolling environment (#241 <https://github.com/youtalk/autoware_lanelet2_extension/issues/241>)
* perf(lanelet2_extension): use std::unordered_set<>::find instead of std::find (#244 <https://github.com/youtalk/autoware_lanelet2_extension/issues/244>)
  perf(exists): use std::unordered_set<>::find instead of std::find
* Contributors: Maxime CLEMENT, Takayuki Murooka, Yutaka Kondo, ぐるぐる
```

## autoware_lanelet2_extension_python

- No changes
