### PR TITLE
launch: 2.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2717,7 +2717,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `2.0.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## launch

```
* Add conditional substitution (#734 <https://github.com/ros2/launch/issues/734>) (#776 <https://github.com/ros2/launch/issues/776>)
  * Add conditional substitution
  Closes: #727 <https://github.com/ros2/launch/issues/727>
  Co-authored-by: Nick Lamprianidis <mailto:info@nlamprian.me>
* Contributors: Jonas Otto
```

## launch_pytest

- No changes

## launch_testing

```
* Add consider_namespace_packages=False (#766 <https://github.com/ros2/launch/issues/766>) (#778 <https://github.com/ros2/launch/issues/778>)
  * Add consider_namespace_packages=False
  (cherry picked from commit 07f43328054c03067b470d1c9bd707cb1e52d691)
  Co-authored-by: Tony Najjar <mailto:tony.najjar.1997@gmail.com>
* Contributors: mergify[bot]
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
