### PR TITLE
sick_scan_xd: 3.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8800,7 +8800,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.2.5-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.4.0-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/ros2-gbp/sick_scan_xd-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.5-1`

## sick_scan_xd

```
* Release 3.4.0
  * add: azimut angle table for MRS-1xxx and LMS-1xxx with firmware 2.2.0 oder newer
  * add: dockertests for MRS-1xxx, multiScan and picoScan with ROS-2
  * add: API-funktion SickScanApiSendSOPAS to send SOPAS commands (e.g. "sRN SCdevicestate" or "sRN ContaminationResult")
  * add: generation of TF messages
  * add: Option to deactivate initialization sequence for TiM-7xxS devices
  * add: Documented option "-b master"  to clone the release version
  * fix: #316 API re-init nach close
```
