### PR TITLE
libstatistics_collector: 1.7.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3159,7 +3159,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.7.2-1
+      version: 1.7.3-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `1.7.3-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.2-1`

## libstatistics_collector

```
* fix: add void annotation (#194 <https://github.com/ros-tooling/libstatistics_collector/issues/194>) (#195 <https://github.com/ros-tooling/libstatistics_collector/issues/195>)
* Contributors: Daisuke Nishimatsu
```
