### PR TITLE
Adding sick_scan_xd to documentation index for distro iron

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7190,6 +7190,21 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
+      version: 3.4.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
+    status: developed
   simple_actions:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7195,15 +7195,6 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
       version: develop
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.4.0-1
-    source:
-      type: git
-      url: https://github.com/SICKAG/sick_scan_xd.git
-      version: develop
     status: developed
   simple_actions:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7190,21 +7190,6 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
-  sick_scan_xd:
-    doc:
-      type: git
-      url: https://github.com/SICKAG/sick_scan_xd.git
-      version: develop
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.4.0-1
-    source:
-      type: git
-      url: https://github.com/SICKAG/sick_scan_xd.git
-      version: develop
-    status: developed
   simple_actions:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7195,6 +7195,15 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
       version: develop
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
+      version: 3.4.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
     status: developed
   simple_actions:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7190,6 +7190,12 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: master
+    status: developed
   simple_actions:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7233,6 +7233,12 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: master
+    status: developed
   simple_actions:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7238,15 +7238,6 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
       version: develop
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.4.0-1
-    source:
-      type: git
-      url: https://github.com/SICKAG/sick_scan_xd.git
-      version: develop
     status: developed
   simple_actions:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7233,21 +7233,6 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
-  sick_scan_xd:
-    doc:
-      type: git
-      url: https://github.com/SICKAG/sick_scan_xd.git
-      version: develop
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.4.0-1
-    source:
-      type: git
-      url: https://github.com/SICKAG/sick_scan_xd.git
-      version: develop
-    status: developed
   simple_actions:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7238,6 +7238,15 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
       version: develop
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
+      version: 3.4.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
     status: developed
   simple_actions:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7233,6 +7233,21 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
+      version: 3.4.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
+    status: developed
   simple_actions:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO iron

# The source is here:

https://github.com/SICKAG/sick_scan_xd.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
