### PR TITLE
urdf_test: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10154,7 +10154,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/urdf_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.0.3-1`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## urdf_test

```
* Fix deprecated QOS warning
* Contributors: David ter Kuile
```
