### PR TITLE
pal_maps: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5531,7 +5531,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_maps-release.git
-      version: 0.0.2-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_maps` to `0.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_maps.git
- release repository: https://github.com/pal-gbp/pal_maps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## pal_maps

```
* Merge branch 'abr/fix/map-name' into 'humble-devel'
  renamed pal office map
  See merge request navigation/pal_maps!3
* renamed pal office map
* Contributors: antoniobrandi
```
