### PR TITLE
pal_gripper: 3.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5494,10 +5494,11 @@ repositories:
       - pal_gripper
       - pal_gripper_controller_configuration
       - pal_gripper_description
+      - pal_gripper_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.2.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

```
* aadd broadcaster controller & the gazebo configuration
* Contributors: Aina Irisarri
```

## pal_gripper_description

```
* follow gripper ros2 structure
* add fixed link
* add ros2_control
* port to ros2 gazebo.urdf
* Contributors: Aina Irisarri
```

## pal_gripper_simulation

```
* remove unnecessary find_package
* add joint_broadcaster controlker
* create pal_gripper_simulation package
* Contributors: Aina Irisarri
* remove unnecessary find_package
* add joint_broadcaster controlker
* create pal_gripper_simulation package
* Contributors: Aina Irisarri
```
