### PR TITLE
sick_scan_xd: 3.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7233,6 +7233,21 @@ repositories:
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
       version: main
     status: developed
+  sick_scan_xd:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
+      version: 3.4.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: develop
+    status: developed
   simple_actions:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.4.0-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/ros2-gbp/sick_scan_xd-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sick_scan_xd

```
* Release 3.4.0
  * add: azimut angle table for MRS-1xxx and LMS-1xxx with firmware 2.2.0 oder newer
  * add: dockertests for MRS-1xxx, multiScan and picoScan with ROS-2
  * add: API-funktion SickScanApiSendSOPAS to send SOPAS commands (e.g. "sRN SCdevicestate" or "sRN ContaminationResult")
  * add: generation of TF messages
  * add: Option to deactivate initialization sequence for TiM-7xxS devices
  * add: Documented option "-b master"  to clone the release version
  * fix: #316 API re-init nach close
```
