### PR TITLE
gz_dartsim_vendor: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2123,7 +2123,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_dartsim_vendor` to `0.1.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_dartsim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## gz_dartsim_vendor

```
* Switch to using the liboctomap-dev key for a dependency. (#5 <https://github.com/gazebo-release/gazebo_dartsim_vendor/issues/5>)
  This is now available in rosdep.
* Contributors: Chris Lalancette
```
