### PR TITLE
rclpy: 7.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5162,7 +5162,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.3.0-1
+      version: 7.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.4.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.3.0-1`

## rclpy

```
* Add top-level try_shutdown method. (#1302 <https://github.com/ros2/rclpy/issues/1302>)
* Make rclpy initialization context-manager aware. (#1298 <https://github.com/ros2/rclpy/issues/1298>)
* Contributors: Chris Lalancette
```
