### PR TITLE
rclcpp: 28.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5146,7 +5146,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.3.0-1
+      version: 28.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.3.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `28.3.0-1`

## rclcpp

```
* Remove unnecessary msg includes in tests (#2566 <https://github.com/ros2/rclcpp/issues/2566>)
* Fix copy-paste errors in function docs (#2565 <https://github.com/ros2/rclcpp/issues/2565>)
* Fix typo in function doc (#2563 <https://github.com/ros2/rclcpp/issues/2563>)
* Contributors: Christophe Bedard
```

## rclcpp_action

```
* Fix typo in function doc (#2563 <https://github.com/ros2/rclcpp/issues/2563>)
* Contributors: Christophe Bedard
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
