### PR TITLE
rcl_interfaces: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5073,7 +5073,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `2.2.0-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## action_msgs

```
* Add missing build_export_depend on rosidl_core_runtime (#165 <https://github.com/ros2/rcl_interfaces/issues/165>)
* Contributors: Scott K Logan
```

## builtin_interfaces

```
* Add missing build_export_depend on rosidl_core_runtime (#165 <https://github.com/ros2/rcl_interfaces/issues/165>)
* Contributors: Scott K Logan
```

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

- No changes

## rosgraph_msgs

- No changes

## service_msgs

```
* Add missing build_export_depend on rosidl_core_runtime (#165 <https://github.com/ros2/rcl_interfaces/issues/165>)
* Contributors: Scott K Logan
```

## statistics_msgs

- No changes

## test_msgs

- No changes

## type_description_interfaces

```
* Add missing build_export_depend on rosidl_core_runtime (#165 <https://github.com/ros2/rcl_interfaces/issues/165>)
* Contributors: Scott K Logan
```
