### PR TITLE
python_qt_binding: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4836,7 +4836,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.3.1-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## python_qt_binding

```
* Skip running the tests on Windows Debug. (#142 <https://github.com/ros-visualization/python_qt_binding/issues/142>)
* Contributors: Chris Lalancette
```
