### PR TITLE
Revert "rtabmap: 0.21.5-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7044,7 +7044,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.5-1
+      version: 0.21.1-4
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Reverts ros/rosdistro#41354

Downgrading `rtabmap` due to a [Jazzy RHEL regression](http://repo.ros2.org/status_page/ros_jazzy_rhel.html?q=REGRESSION) to avoid removing the package on the [upcoming Jazzy sync](https://discourse.ros.org/t/preparing-for-jazzy-sync-and-patch-release-2024-06-28/).

Added an issue heads up to the repo [here](https://github.com/introlab/rtabmap/issues/1306).