### PR TITLE
situational_graphs_datasets: 0.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8865,6 +8865,11 @@ repositories:
       version: humble
     status: developed
   situational_graphs_datasets:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/situational_graphs_dataset-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_datasets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `situational_graphs_datasets` to `0.0.0-1`:

- upstream repository: https://github.com/snt-arg/situational_graphs_datasets.git
- release repository: https://github.com/ros2-gbp/situational_graphs_dataset-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
