### PR TITLE
situational_graphs_datasets: 0.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7237,6 +7237,15 @@ repositories:
       version: devel
     status: maintained
   situational_graphs_datasets:
+    doc:
+      type: git
+      url: https://github.com/snt-arg/situational_graphs_datasets.git
+      version: develop
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/situational_graphs_dataset-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_datasets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `situational_graphs_datasets` to `0.0.0-1`:

- upstream repository: https://github.com/snt-arg/situational_graphs_datasets.git
- release repository: https://github.com/ros2-gbp/situational_graphs_dataset-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
