### PR TITLE
situational_graphs_wrapper: 0.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8894,6 +8894,11 @@ repositories:
       version: main
     status: maintained
   situational_graphs_wrapper:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/situational_graphs_wrapper-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `situational_graphs_wrapper` to `0.0.0-1`:

- upstream repository: https://github.com/snt-arg/situational_graphs_wrapper.git
- release repository: https://github.com/ros2-gbp/situational_graphs_wrapper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
