### PR TITLE
behaviortree_cpp_v3: 3.8.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -610,7 +610,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.6-1
+      version: 3.8.7-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v3` to `3.8.7-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.6-1`

## behaviortree_cpp_v3

```
* Backport of some build-related flatbuffers changes (#825 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/825>)
  * From flatbuffers upstream: Fix compiler error
  Original author of change: avaliente-bc
  Backport/update from upstream flatbuffers repository.
  Change taken from https://github.com/google/flatbuffers/pull/7227
  * From flatbuffers upstream: Fix include of string_view with C++17 abseil
  Original author of change: ocpalo
  Backport/update from upstream flatbuffers repository.
  Changes taken from https://github.com/google/flatbuffers/pull/7897.
* Add in call to ament_export_targets. (#826 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/826>)
  That way downstream ament packages can use this
  package as a CMake target.
* Fixed #810 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/810> - halting of subsequent nodes in ReactiveSequence/Fallback (#817 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/817>)
  * ReactiveSequence and ReactiveFallback will behave more similarly to 3.8
  * Reactive Sequence/Fallback defaulting to allow multiple async nodes
  ---------
  Co-authored-by: Davide Faconti <mailto:davide.faconti@gmail.com>
  Co-authored-by: Matej Vargovcik <mailto:vargovcik@robotechvision.com>
* Merge pull request #769 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/769> from bi0ha2ard/fewer_boost_dependencies
  depend only on libboost-coroutine(-dev) for v3.8
* fix(dependency): depend only on libboost-coroutine(-dev)
  At least on Ubuntu, boost-all-dev depends on openmpi, which depends on a
  fortran compiler and gcc. This is very heavy for Docker containers where
  only exec dependencies are really needed.
* alternative to #719 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/719>
* fix issue #725 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/725> : SetBlackboard can copy entries
* Contributors: Chris Lalancette, Davide Faconti, Felix, Lars Toenning, afrixs
```
