### PR TITLE
situational_graphs_reasoning: 0.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7254,6 +7254,11 @@ repositories:
       version: main
     status: maintained
   situational_graphs_reasoning:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/situational_graphs_reasoning-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_reasoning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `situational_graphs_reasoning` to `0.0.1-1`:

- upstream repository: https://github.com/snt-arg/situational_graphs_reasoning.git
- release repository: https://github.com/ros2-gbp/situational_graphs_reasoning-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
