### PR TITLE
situational_graphs_reasoning_msgs: 0.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7260,6 +7260,11 @@ repositories:
       version: develop
     status: maintained
   situational_graphs_reasoning_msgs:
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/situational_graphs_reasoning_msgs-release.git
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `situational_graphs_reasoning_msgs` to `0.0.0-1`:

- upstream repository: https://github.com/snt-arg/situational_graphs_reasoning_msgs.git
- release repository: https://github.com/ros2-gbp/situational_graphs_reasoning_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
