### PR TITLE
rqt_pr2_dashboard: 0.4.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10486,7 +10486,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/pr2/rqt_pr2_dashboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.4.1-1`:

- upstream repository: https://github.com/PR2/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## rqt_pr2_dashboard

```
* Import setup from setuptools instead of distutils.core #27 <https://github.com/PR2/rqt_pr2_dashboard/issues/27>
* updated package.xml to format version 3
* show console and monitor by default (#25 <https://github.com/PR2/rqt_pr2_dashboard/issues/25>)
* fixes for python3 support (#24 <https://github.com/PR2/rqt_pr2_dashboard/issues/24>)
* add --motor-namespace argument in rqt_pr2_dashboard #23 <https://github.com/PR2/rqt_pr2_dashboard/issues/23>
* Contributors: Arne Hitzmann, Dave Feil-Seifer, Kei Okada, Michael Goerner, Shingo Kitagawa
```
