### PR TITLE
Add Fedora/RHEL rosdep rules for a few flake8 plugins

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5925,7 +5925,13 @@ python3-flake8-blind-except:
     bullseye:
       pip:
         packages: [flake8-blind-except]
+  fedora: [python3-flake8-blind-except]
   opensuse: [python3-flake8-blind-except]
+  rhel:
+    '*': [python3-flake8-blind-except]
+    '8':
+      pip:
+        packages: [flake8-blind-except]
   ubuntu:
     '*': [python3-flake8-blind-except]
     bionic: null
@@ -5963,7 +5969,13 @@ python3-flake8-class-newline:
     bullseye:
       pip:
         packages: [flake8-class-newline]
+  fedora: [python3-flake8-class-newline]
   opensuse: [python3-flake8-class-newline]
+  rhel:
+    '*': [python3-flake8-class-newline]
+    '8':
+      pip:
+        packages: [flake8-class-newline]
   ubuntu:
     '*': [python3-flake8-class-newline]
     bionic: null
@@ -6000,7 +6012,13 @@ python3-flake8-deprecated:
     bullseye:
       pip:
         packages: [flake8-deprecated]
+  fedora: [python3-flake8-deprecated]
   opensuse: [python3-flake8-deprecated]
+  rhel:
+    '*': [python3-flake8-deprecated]
+    '8':
+      pip:
+        packages: [flake8-deprecated]
   ubuntu:
     '*': [python3-flake8-deprecated]
     bionic: null


### PR DESCRIPTION
- [flake8-blind-except](https://packages.fedoraproject.org/pkgs/python-flake8-blind-except/python3-flake8-blind-except/)
- [flake8-class-newline](https://packages.fedoraproject.org/pkgs/python-flake8-class-newline/python3-flake8-class-newline/)
- [flake8-deprecated](https://packages.fedoraproject.org/pkgs/python-flake8-deprecated/python3-flake8-deprecated/)