### PR TITLE
flex_sync: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1650,6 +1650,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/flex_sync-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flex_sync` to `1.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/flex_sync.git
- release repository: https://github.com/ros2-gbp/flex_sync-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## flex_sync

```
* first release as a ROS2 package
* Contributors: Bernd Pfrommer
```
