### PR TITLE
flex_sync: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1625,6 +1625,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
       version: iron
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/flex_sync-release.git
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flex_sync` to `1.2.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/flex_sync.git
- release repository: https://github.com/ros2-gbp/flex_sync-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## flex_sync

```
* initial release as ROS2 package
* Contributors: Bernd Pfrommer
```
