### PR TITLE
Revert "Revert "rtabmap: 0.21.5-1 in 'jazzy/distribution.yaml' [bloom]""

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7044,7 +7044,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.1-4
+      version: 0.21.5-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Reverts ros/rosdistro#41812.

Previous `0.21.1-4` version [fails on noble](https://build.ros2.org/job/Jbin_uN64__rtabmap__ubuntu_noble_amd64__binary), going back to the newer one `0.21.5-1` and probably seeking a blacklist of the job in RHEL.

More context: https://github.com/introlab/rtabmap/issues/1306.

 