### PR TITLE
diagnostics: 3.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-2
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `3.2.1-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.2-2`

## diagnostic_aggregator

```
* Add add_analyzer functionality (#329 <https://github.com/ros/diagnostics/issues/329>)
* Aggregator: publish diagnostics_toplevel_state immediately on every degradation (#324 <https://github.com/ros/diagnostics/issues/324>)
* Contributors: MartinCornelis2, Tim Clephas
```

## diagnostic_common_diagnostics

```
* refactor(sensors_monitor): ros2 port #339 <https://github.com/ros/diagnostics/issues/339>
* refactor(ram_monitor): ros2 port (#338 <https://github.com/ros/diagnostics/issues/338>)
* NTP monitor improvements (#342 <https://github.com/ros/diagnostics/issues/342>)
* Using ubuntu ntp server in systemtest (#346 <https://github.com/ros/diagnostics/issues/346>)
* Fixing ntp launchtest (#330 <https://github.com/ros/diagnostics/issues/330>)
* Contributors: Christian Henkel, Rein Appeldoorn, Tony Najjar
```

## diagnostic_updater

```
* change(diagnosed-publisher): allow specifying node clock (#340 <https://github.com/ros/diagnostics/issues/340>)
* Fix usage of rclcpp::ok with a non-default context (#352 <https://github.com/ros/diagnostics/issues/352>)
* Contributors: Hervé Audren, Rein Appeldoorn
```

## diagnostics

- No changes

## self_test

```
* Building in docker (#335 <https://github.com/ros/diagnostics/issues/335>)
* Contributors: Christian Henkel
```
