### PR TITLE
sros2: 0.13.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7452,7 +7452,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.13.0-3
+      version: 0.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.13.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.13.0-3`

## sros2

```
* Fix sros2 tests on Windows Debug. (#317 <https://github.com/ros2/sros2/issues/317>) (#320 <https://github.com/ros2/sros2/issues/320>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* [TESTS] Update tests and add test for generate_artifacts (#311 <https://github.com/ros2/sros2/issues/311>) (#319 <https://github.com/ros2/sros2/issues/319>)
  Co-authored-by: Mikael Arguedas <mailto:mikael.arguedas@gmail.com>
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
