### PR TITLE
ros2_tracing: 8.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6081,7 +6081,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.2.0-2
+      version: 8.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.1-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.0-2`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

```
* Fix type for buffer index argument in tracepoint event declaration. (#117 <https://github.com/ros2/ros2_tracing/issues/117>) (#119 <https://github.com/ros2/ros2_tracing/issues/119>)
  (cherry picked from commit 7e8d42e3816dc9f7dc268109a2bb9cc66cc4d4ee)
  Co-authored-by: Mattis Kieffer <mailto:62772198+mat-kie@users.noreply.github.com>
* Contributors: mergify[bot]
```

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
