### PR TITLE
rclcpp: 28.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5280,7 +5280,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.2-1
+      version: 28.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.3-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `28.1.2-1`

## rclcpp

```
* Add test creating two content filter topics with the same topic name (#2546 <https://github.com/ros2/rclcpp/issues/2546>) (#2549 <https://github.com/ros2/rclcpp/issues/2549>) (#2552 <https://github.com/ros2/rclcpp/issues/2552>)
  Co-authored-by: Mario Domínguez López <mailto:116071334+Mario-DL@users.noreply.github.com>
  (cherry picked from commit 7c096888caf92aa7557e1d3efc5448b56d8ce81c)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Revert "call shutdown in LifecycleNode dtor to avoid leaving the device in unknown state (2nd) (backport #2528 <https://github.com/ros2/rclcpp/issues/2528>) (#2542 <https://github.com/ros2/rclcpp/issues/2542>)" (#2558 <https://github.com/ros2/rclcpp/issues/2558>)
* call shutdown in LifecycleNode dtor to avoid leaving the device in unknown state (2nd) (backport #2528 <https://github.com/ros2/rclcpp/issues/2528>) (#2542 <https://github.com/ros2/rclcpp/issues/2542>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* rclcpp::shutdown should not be called before LifecycleNode dtor. (#2527 <https://github.com/ros2/rclcpp/issues/2527>) (#2540 <https://github.com/ros2/rclcpp/issues/2540>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: Tomoya Fujita, mergify[bot]
```
