### PR TITLE
point_cloud_transport: 4.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4718,7 +4718,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.2-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.0.1-1`

## point_cloud_transport

```
* Stop using ament_target_dependencies. (#86 <https://github.com/ros-perception/point_cloud_transport/issues/86>) (#87 <https://github.com/ros-perception/point_cloud_transport/issues/87>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
```

## point_cloud_transport_py

- No changes
