### PR TITLE
resource_retriever: 3.4.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5446,7 +5446,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.4.2-2
+      version: 3.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.4.3-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.4.2-2`

## libcurl_vendor

- No changes

## resource_retriever

```
* Allow spaces (#100 <https://github.com/ros/resource_retriever/issues/100>) (#101 <https://github.com/ros/resource_retriever/issues/101>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
```
