### PR TITLE
diagnostics: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1629,7 +1629,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1634,7 +1634,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2
+      version: ros2-humble
     status: maintained
   dolly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.0.0-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.2-1`
