### PR TITLE
lidar_situational_graphs: 0.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3824,6 +3824,15 @@ repositories:
       version: humble
     status: maintained
   lidar_situational_graphs:
+    doc:
+      type: git
+      url: https://github.com/snt-arg/lidar_situational_graphs.git
+      version: 0.0.1
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/lidar_situational_graphs-release.git
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/snt-arg/lidar_situational_graphs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lidar_situational_graphs` to `0.0.1-2`:

- upstream repository: https://github.com/snt-arg/lidar_situational_graphs.git
- release repository: https://github.com/ros2-gbp/lidar_situational_graphs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
