### PR TITLE
lidar_situational_graphs: 0.0.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2986,6 +2986,15 @@ repositories:
       version: iron
     status: maintained
   lidar_situational_graphs:
+    doc:
+      type: git
+      url: https://github.com/snt-arg/lidar_situational_graphs.git
+      version: 0.0.1
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/lidar_situational_graphs-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/snt-arg/lidar_situational_graphs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lidar_situational_graphs` to `0.0.1-1`:

- upstream repository: https://github.com/snt-arg/lidar_situational_graphs.git
- release repository: https://github.com/ros2-gbp/lidar_situational_graphs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
