### PR TITLE
create3_examples: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1368,6 +1368,18 @@ repositories:
       version: humble-devel
     status: maintained
   create3_examples:
+    release:
+      packages:
+      - create3_coverage
+      - create3_examples_msgs
+      - create3_examples_py
+      - create3_lidar_slam
+      - create3_republisher
+      - create3_teleop
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/create3_examples-release.git
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/iRobotEducation/create3_examples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_examples` to `0.0.5-1`:

- upstream repository: https://github.com/iRobotEducation/create3_examples.git
- release repository: https://github.com/ros2-gbp/create3_examples-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## create3_coverage

```
* update create3_coverage package.xml
* Contributors: Alberto Soragna
```

## create3_examples_msgs

- No changes

## create3_examples_py

- No changes

## create3_lidar_slam

- No changes

## create3_republisher

- No changes

## create3_teleop

- No changes
