### PR TITLE
rosbag2: 0.26.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6326,7 +6326,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.3-1
+      version: 0.26.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.4-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.26.3-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* fix(start-offset): allow specifying a start offset of 0 (#1682 <https://github.com/ros2/rosbag2/issues/1682>) (#1713 <https://github.com/ros2/rosbag2/issues/1713>)
  Co-authored-by: Rein Appeldoorn <mailto:reinzor@gmail.com>
* Exclude recorded /clock topic when --clock option is specified (#1646 <https://github.com/ros2/rosbag2/issues/1646>) (#1706 <https://github.com/ros2/rosbag2/issues/1706>)
  Co-authored-by: Kosuke Takeuchi <mailto:kosuke.tnp@gmail.com>
* [jazzy] Sweep cleanup in rosbag2 recorder CLI args verification code (backport #1633 <https://github.com/ros2/rosbag2/issues/1633>) (#1684 <https://github.com/ros2/rosbag2/issues/1684>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Add --log-level to ros2 bag play and record (#1625 <https://github.com/ros2/rosbag2/issues/1625>) (#1674 <https://github.com/ros2/rosbag2/issues/1674>)
  Co-authored-by: Roman Sokolkov <mailto:rsokolkov@gmail.com>
* [jazzy] Add optional  '--topics' CLI argument for 'ros2 bag record' (backport #1632 <https://github.com/ros2/rosbag2/issues/1632>) (#1640 <https://github.com/ros2/rosbag2/issues/1640>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
```

## rosbag2

- No changes

## rosbag2_compression

```
* Fix for regression in open_succeeds_twice and minimal_writer_example tests (#1667 <https://github.com/ros2/rosbag2/issues/1667>) (#1675 <https://github.com/ros2/rosbag2/issues/1675>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1725 <https://github.com/ros2/rosbag2/issues/1725>) (#1731 <https://github.com/ros2/rosbag2/issues/1731>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing (#1700 <https://github.com/ros2/rosbag2/issues/1700>) (#1710 <https://github.com/ros2/rosbag2/issues/1710>)
  Co-authored-by: Cole Tucker <mailto:coalman321@users.noreply.github.com>
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Add bindings for LocalMessageDefinitionSource (#1697 <https://github.com/ros2/rosbag2/issues/1697>) (#1701 <https://github.com/ros2/rosbag2/issues/1701>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: methylDragon <mailto:methylDragon@gmail.com>
* Add --log-level to ros2 bag play and record (#1625 <https://github.com/ros2/rosbag2/issues/1625>) (#1674 <https://github.com/ros2/rosbag2/issues/1674>)
  Co-authored-by: Roman Sokolkov <mailto:rsokolkov@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

```
* Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1725 <https://github.com/ros2/rosbag2/issues/1725>) (#1731 <https://github.com/ros2/rosbag2/issues/1731>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing (#1700 <https://github.com/ros2/rosbag2/issues/1700>) (#1710 <https://github.com/ros2/rosbag2/issues/1710>)
  Co-authored-by: Cole Tucker <mailto:coalman321@users.noreply.github.com>
* [jazzy] Sweep cleanup in rosbag2 recorder CLI args verification code (backport #1633 <https://github.com/ros2/rosbag2/issues/1633>) (#1684 <https://github.com/ros2/rosbag2/issues/1684>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Fix for regression in open_succeeds_twice and minimal_writer_example tests (#1667 <https://github.com/ros2/rosbag2/issues/1667>) (#1675 <https://github.com/ros2/rosbag2/issues/1675>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add optional  '--topics' CLI argument for 'ros2 bag record' (backport #1632 <https://github.com/ros2/rosbag2/issues/1632>) (#1640 <https://github.com/ros2/rosbag2/issues/1640>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* Bugfix for issue where unable to create composable nodes with compression (#1679 <https://github.com/ros2/rosbag2/issues/1679>) (#1716 <https://github.com/ros2/rosbag2/issues/1716>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Add unit tests to cover message's send and received timestamps during recording (#1641 <https://github.com/ros2/rosbag2/issues/1641>) (#1673 <https://github.com/ros2/rosbag2/issues/1673>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Add support for "all" and "exclude" in RecordOptions YAML decoder (#1664 <https://github.com/ros2/rosbag2/issues/1664>) (#1676 <https://github.com/ros2/rosbag2/issues/1676>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
