### PR TITLE
Add python3-opencv-pip to obtain the newest version possible

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7454,6 +7454,10 @@ python3-opencv:
     '7': null
     '8': null
   ubuntu: [python3-opencv]
+python3-opencv-pip:
+  '*':
+    pip:
+      packages: [opencv-python]
 python3-opengl:
   debian: [python3-opengl]
   fedora: [python3-pyopengl]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

opencv-python

## Package Upstream Source:

[https://pypi.org/project/opencv-python/](https://github.com/opencv/opencv)

## Purpose of using this:

NMSBoxesBatched was added in a later version of OpenCV which is available only on PyPi.

## Links to Distribution Packages

- pip: [https://pypi.org/project/opencv-python/](https://pypi.org/project/opencv-python/)