### PR TITLE
Use the right branch on geometry_tutorials

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2653,7 +2653,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: humble
     release:
       packages:
       - geometry_tutorials
@@ -2666,7 +2666,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: humble
     status: developed
   google_benchmark_vendor:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1978,7 +1978,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: iron
     release:
       packages:
       - geometry_tutorials
@@ -1991,7 +1991,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: iron
     status: developed
   google_benchmark_vendor:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1995,7 +1995,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: jazzy
     release:
       packages:
       - geometry_tutorials
@@ -2008,7 +2008,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: jazzy
     status: developed
   google_benchmark_vendor:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1943,7 +1943,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: rolling
     release:
       packages:
       - geometry_tutorials
@@ -1956,7 +1956,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: ros2
+      version: rolling
     status: developed
   google_benchmark_vendor:
     doc:


### PR DESCRIPTION
Related with this PR https://github.com/ros/ros_tutorials/pull/169

I created turtlesim_msgs which is not backportable to other distros. This PR use the right branch 