### PR TITLE
launch_pal: 0.1.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3557,7 +3557,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.1.12-1
+      version: 0.1.13-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.1.13-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.12-1`

## launch_pal

```
* Merge branch 'dtk/move-robot-args' into 'master'
  Dtk/move robot args
  See merge request common/launch_pal!56
* Remove robot configurations
* ArgFactory class to create launch args from yaml
* Move common args
* Contributors: David ter Kuile, davidterkuile
```
