### PR TITLE
tiago_moveit_config: 3.0.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9448,7 +9448,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_moveit_config-release.git
-      version: 3.0.15-1
+      version: 3.0.16-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_moveit_config` to `3.0.16-1`:

- upstream repository: https://github.com/pal-robotics/tiago_moveit_config.git
- release repository: https://github.com/pal-gbp/tiago_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.15-1`

## tiago_moveit_config

```
* Merge branch 'dtk/move-robot-args' into 'humble-devel'
  Change import for launch args
  See merge request robots/tiago_moveit_config!84
* Change import for launch args
* Contributors: David ter Kuile, davidterkuile
```
