### PR TITLE
tiago_navigation: 4.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9467,7 +9467,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.17-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.1.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.17-1`

## tiago_2dnav

```
* Merge branch 'feature/support-different-base-types' into 'humble-devel'
  feat: support different base types
  See merge request robots/tiago_navigation!102
* feat: support base_type on real robot
* feat: support base_type in simulation
* Contributors: antoniobrandi, josegarcia
```

## tiago_laser_sensors

```
* Merge branch 'feature/support-different-base-types' into 'humble-devel'
  feat: support different base types
  See merge request robots/tiago_navigation!102
* added laser filters
* feat: support base_type on real robot
* feat: support base_type in simulation
* Contributors: antoniobrandi, josegarcia
```

## tiago_navigation

- No changes
