### PR TITLE
rosx_introspection: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6454,7 +6454,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosx_introspection-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosx_introspection` to `1.0.1-1`:

- upstream repository: https://github.com/facontidavide/rosx_introspection.git
- release repository: https://github.com/ros2-gbp/rosx_introspection-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## rosx_introspection

```
* use CPM to download dependenies
* Merge pull request #9 <https://github.com/facontidavide/rosx_introspection/issues/9> from valgur/feature/cmake-improvements
* Contributors: Davide Faconti, Martin Valgur
```
