### PR TITLE
Add python3-urwid as rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9796,6 +9796,9 @@ python3-urllib3:
   ubuntu: [python3-urllib3]
 python3-urwid:
   debian: [python3-urwid]
+  fedora: [python3-urwid]
+  opensuse: [python3-urwid]
+  rhel: [python3-urwid]
   ubuntu: [python3-urwid]
 python3-usb:
   debian: [python3-usb]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9794,6 +9794,9 @@ python3-urllib3:
   gentoo: [dev-python/urllib3]
   nixos: [python3Packages.urllib3]
   ubuntu: [python3-urllib3]
+python3-urwid:
+  debian: [python3-urwid]
+  ubuntu: [python3-urwid]
 python3-usb:
   debian: [python3-usb]
   gentoo: [dev-python/pyusb]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-urwid`

## Package Upstream Source:

https://github.com/urwid/urwid

## Purpose of using this:

Urwid is a Python package used create user interfaces within the terminal. Terminals can be useful to control functionality in situations where GUIs aren't available. Python package documentation: https://urwid.org/index.html

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-urwid
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-urwid