### PR TITLE
ur_robot_driver: 2.4.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7937,7 +7937,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.7-1
+      version: 2.4.8-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.8-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.7-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* moveit_congig: Also install srdf folder (#1033 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1033>)
* Contributors: Felix Exner (fexner)
```

## ur_robot_driver

```
* Add sleep between controller stopper's controller queries (#1038 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1038>)
* Contributors: Felix Exner (fexner)
```
