### PR TITLE
ur_robot_driver: 2.3.9-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8206,7 +8206,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.8-1
+      version: 2.3.9-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.9-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.8-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Add sleep between controller stopper's controller queries (backport of #1038 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1038>)
* Contributors: Felix Exner
```
