### PR TITLE
ros2_control: 4.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5834,7 +5834,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.11.0-1
+      version: 4.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.11.0-1`

## controller_interface

- No changes

## controller_manager

```
* [rqt_controller_manager] Add hardware components (#1455 <https://github.com/ros-controls/ros2_control/issues/1455>)
* [RM] Rename load_urdf method to load_and_initialize_components and add error handling there to avoid stack crashing when error happens. (#1354 <https://github.com/ros-controls/ros2_control/issues/1354>)
* Fix update period for the first update after activation (#1551 <https://github.com/ros-controls/ros2_control/issues/1551>)
* Bump version of pre-commit hooks (#1556 <https://github.com/ros-controls/ros2_control/issues/1556>)
* Contributors: Christoph Fröhlich, Dr. Denis, github-actions[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add resources_lock_ lock_guards to avoid race condition when loading robot_description through topic (#1451 <https://github.com/ros-controls/ros2_control/issues/1451>)
* [RM] Rename load_urdf method to load_and_initialize_components and add error handling there to avoid stack crashing when error happens. (#1354 <https://github.com/ros-controls/ros2_control/issues/1354>)
* Small improvements to the error output in component parser to make debugging easier. (#1580 <https://github.com/ros-controls/ros2_control/issues/1580>)
* Fix link to gazebosim.org (#1563 <https://github.com/ros-controls/ros2_control/issues/1563>)
* Add doc page about joint kinematics (#1497 <https://github.com/ros-controls/ros2_control/issues/1497>)
* Bump version of pre-commit hooks (#1556 <https://github.com/ros-controls/ros2_control/issues/1556>)
* [Feature] Hardware Components Grouping (#1458 <https://github.com/ros-controls/ros2_control/issues/1458>)
* Contributors: Christoph Fröhlich, Dr. Denis, Sai Kishor Kothakota, github-actions[bot]
```

## hardware_interface_testing

```
* [RM] Rename load_urdf method to load_and_initialize_components and add error handling there to avoid stack crashing when error happens. (#1354 <https://github.com/ros-controls/ros2_control/issues/1354>)
* Contributors: Dr. Denis
```

## joint_limits

```
* Reactivate generate_version_header (#1544 <https://github.com/ros-controls/ros2_control/issues/1544>)
* Bump version of pre-commit hooks (#1556 <https://github.com/ros-controls/ros2_control/issues/1556>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```

## ros2_control

```
* Add custom rosdoc2 config for ros2_control metapackage (#1484 <https://github.com/ros-controls/ros2_control/issues/1484>)
* Contributors: Christoph Fröhlich
```

## ros2_control_test_assets

```
* [RM] Rename load_urdf method to load_and_initialize_components and add error handling there to avoid stack crashing when error happens. (#1354 <https://github.com/ros-controls/ros2_control/issues/1354>)
* [Feature] Hardware Components Grouping (#1458 <https://github.com/ros-controls/ros2_control/issues/1458>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## ros2controlcli

- No changes

## rqt_controller_manager

```
* [rqt_controller_manager] Add hardware components (#1455 <https://github.com/ros-controls/ros2_control/issues/1455>)
* Contributors: Christoph Fröhlich
```

## transmission_interface

- No changes
