### PR TITLE
set source and doc to release for flex_sync package

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2206,7 +2206,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2215,7 +2215,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: humble
+      version: release
     status: developed
   flexbe_app:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1624,7 +1624,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: iron
+      version: release
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1633,7 +1633,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: iron
+      version: release
     status: developed
   flexbe_behavior_engine:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1701,11 +1701,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: jazzy
+      version: release
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: jazzy
+      version: release
     status: developed
   flexbe_behavior_engine:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1649,7 +1649,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1658,7 +1658,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
-      version: rolling
+      version: release
     status: developed
   flexbe_behavior_engine:
     doc:


### PR DESCRIPTION
Please change the source and ros distro branches for the flex_sync package to "release" instead of the currently used distro-specific branches.
This change is related to [this PR and the related discussion](https://github.com/ros/rosdistro/pull/41837) with @christophebedard.
