### PR TITLE
gz_ros2_control: 1.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2278,10 +2278,11 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
+      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2278,7 +2278,6 @@ repositories:
       packages:
       - gz_ros2_control
       - gz_ros2_control_demos
-      - gz_ros2_control_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.3.1-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## gz_ros2_control

```
* Simplify access for robot description from CM by overriding RM. (#265 <https://github.com/ros-controls/gz_ros2_control/issues/265>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Harden behavior if a joint is not found in the model (#325 <https://github.com/ros-controls/gz_ros2_control/issues/325>)
  * Don't crash if a joint does not exist
* Don't crash if a wrong config was detected (#324 <https://github.com/ros-controls/gz_ros2_control/issues/324>)
* Changed to use spin instead of spin_once to enable multithreading with MultiThreadedExecutor (#315 <https://github.com/ros-controls/gz_ros2_control/issues/315>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Christoph Fröhlich, Dr. Denis, Takashi Sato
```

## gz_ros2_control_demos

```
* Ackermann steering example (#349 <https://github.com/ros-controls/gz_ros2_control/issues/349>)
* Rename variable in launch file (#327 <https://github.com/ros-controls/gz_ros2_control/issues/327>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* added color definitions (#310 <https://github.com/ros-controls/gz_ros2_control/issues/310>)
* Remove stamped twist parameter (#308 <https://github.com/ros-controls/gz_ros2_control/issues/308>)
* Contributors: Christoph Fröhlich, Reza Kermani, huzaifa
```

## gz_ros2_control_tests

- No changes
