### PR TITLE
gazebo_ros2_control: 0.4.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2503,7 +2503,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.8-1
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros2_control` to `0.4.9-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros2_control.git
- release repository: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.8-1`

## gazebo_ros2_control

```
* Initialize antiwindup variable properly (#326 <https://github.com/ros-controls/gazebo_ros2_control/issues/326>) (#327 <https://github.com/ros-controls/gazebo_ros2_control/issues/327>)
  (cherry picked from commit 1ef9652ac34ed883dbf8fed27bcf393f78f53d52)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```

## gazebo_ros2_control_demos

- No changes
