### PR TITLE
gazebo_ros_pkgs: 3.8.0-1 in 'jazzy/distribution.yaml' only gazebo_msgs

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1903,6 +1903,14 @@ repositories:
       url: https://github.com/ros-sports/game_controller_spl.git
       version: rolling
     status: developed
+  gazebo_ros_pkgs:
+    release:
+      packages:
+      - gazebo_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
+      version: 3.8.0-1
   generate_parameter_library:
     doc:
       type: git


### PR DESCRIPTION
Part of the works https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1532