### PR TITLE
octomap_rviz_plugins: 2.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4167,7 +4167,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
-      version: 2.0.0-4
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `2.1.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-4`

## octomap_rviz_plugins

```
* Switch to the system-provided version of octomap (#46 <https://github.com/OctoMap/octomap_rviz_plugins/issues/46>)
* Contributors: Chris Lalancette
```
