### PR TITLE
octomap_mapping: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5189,7 +5189,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.0.0-3
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.3.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-3`

## octomap_mapping

- No changes

## octomap_server

```
* Switch to the system-provided octomap library. (#134 <https://github.com/octomap/octomap_mapping/issues/134>)
* Contributors: Chris Lalancette
```
