### PR TITLE
Add PyQt6 to older Ubuntu versions with Pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -470,8 +470,10 @@ pyqt6-dev-tools:
   fedora: [python3-pyqt6-base]
   ubuntu:
     '*': [pyqt6-dev-tools]
-    focal: null
-    jammy: null
+    focal:
+      pip: PyQt6
+    jammy:
+      pip: PyQt6
 pyrebase-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -471,9 +471,11 @@ pyqt6-dev-tools:
   ubuntu:
     '*': [pyqt6-dev-tools]
     focal:
-      pip: PyQt6
+      pip: 
+        packages: [PyQt6]
     jammy:
-      pip: PyQt6
+      pip: 
+        packages: [PyQt6]
 pyrebase-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -471,10 +471,10 @@ pyqt6-dev-tools:
   ubuntu:
     '*': [pyqt6-dev-tools]
     focal:
-      pip: 
+      pip:
         packages: [PyQt6]
     jammy:
-      pip: 
+      pip:
         packages: [PyQt6]
 pyrebase-pip:
   debian:


### PR DESCRIPTION

## Purpose of using this:

To make Guis with PyQt6 on older Ubuntu Versions

Distro packaging links:

## Links to Distribution Packages

https://pypi.org/project/PyQt6/

