### PR TITLE
Add python3-pytest-xvfb Dependency to ROSDEP

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8487,8 +8487,8 @@ python3-pytest-xvfb:
   nixos: [python312Packages.pytest-xvfb]
   opensuse: [python3-pytest-xvfb]
   rhel:
-    "*": [python3-pytest-xvfb]
-    "7": ['python%{python3_pkgversion}-pytest-xvfb']
+    pip:
+      packages: [pytest-xvfb]
   ubuntu: [python3-pytest-xvfb]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8479,6 +8479,17 @@ python3-pytest-xdist:
     "*": [python3-pytest-xdist]
     "7": ['python%{python3_pkgversion}-pytest-xdist']
   ubuntu: [python3-pytest-xdist]
+python3-pytest-xvfb:
+  arch: [python-pytest-xvfb]
+  debian: [python3-pytest-xvfb]
+  fedora: [python3-pytest-xvfb]
+  gentoo: [dev-python/pytest-xvfb]
+  nixos: [python312Packages.pytest-xvfb]
+  opensuse: [python3-pytest-xvfb]
+  rhel:
+    "*": [python3-pytest-xvfb]
+    "7": ['python%{python3_pkgversion}-pytest-xvfb']
+  ubuntu: [python3-pytest-xvfb]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:
   debian:


### PR DESCRIPTION
## Package name: python3-pytest-xvfb

## Package Upstream Source:
https://github.com/The-Compiler/pytest-xvfb

## Purpose of using this:

To unit test guis on CI without a gui.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-pytest-xvfb
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-pytest-xvfb
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-pytest-xvfb/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pytest-xvfb
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.05&show=python311Packages.pytest-xvfb&from=0&size=50&sort=relevance&type=packages&query=pytest-xvfb
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pytest-xvfb?search_term=python3-pytest-xvfb
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE
