### PR TITLE
psdk_ros2: 1.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6103,7 +6103,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/umdlife/psdk_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `psdk_ros2` to `1.3.1-1`:

- upstream repository: https://github.com/umdlife/psdk_ros2.git
- release repository: https://github.com/ros2-gbp/psdk_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.3.0-1`

## psdk_interfaces

- No changes

## psdk_wrapper

```
* Merge pull request #116 <https://github.com/umdlife/psdk_ros2/issues/116> from umdlife/hotfix/fpv-stream
  Use the fpv publisher to output the encoded streaming of the FPV camera
* Contributors: Victor Massagué Respall, biancabnd
```
