### PR TITLE
mp2p_icp: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3643,7 +3643,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.5.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.0-1`

## mp2p_icp

```
* Update docs
* ICP: Add optional functors for before-logging maps
* icp-log-viewer UI: fix potential out-of-range exception when autoplay is on
* FilterAdjustTimestamps: add new param 'time_offset' useful for multiple LiDARs setups
* Contributors: Jose Luis Blanco-Claraco
```
