### PR TITLE
mrpt_sensors: 0.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4655,14 +4655,15 @@ repositories:
       packages:
       - mrpt_generic_sensor
       - mrpt_sensor_bumblebee_stereo
-      - mrpt_sensor_gnns_nmea
+      - mrpt_sensor_gnss_nmea
+      - mrpt_sensor_gnss_novatel
       - mrpt_sensor_imu_taobotics
       - mrpt_sensorlib
       - mrpt_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.2.1-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-1`

## mrpt_generic_sensor

- No changes

## mrpt_sensor_bumblebee_stereo

```
* Add new driver for Novatel OEM6 + NTRIP server
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_nmea

```
* Fix typo in GNSS names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_novatel

- No changes

## mrpt_sensor_imu_taobotics

- No changes

## mrpt_sensorlib

```
* Publish NMEA ROS2 native msgs: GGA, GSA, RMC
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

```
* Fix typo in GNSS names
* Add new driver for Novatel OEM6 + NTRIP server
* Contributors: Jose Luis Blanco-Claraco
```
