### PR TITLE
Add Mavproxy pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6950,6 +6950,16 @@ python3-matplotlib:
     '7': null
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
+python3-mavproxy-pip:
+ debian:
+    pip:
+      packages: [MAVProxy]
+  fedora:
+    pip:
+      packages: [MAVProxy]
+  ubuntu:
+    pip:
+      packages: [MAVProxy]
 python3-mccabe:
   arch: [python-mccabe]
   debian: [python3-mccabe]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6951,7 +6951,7 @@ python3-matplotlib:
   slackware: [python3-matplotlib]
   ubuntu: [python3-matplotlib]
 python3-mavproxy-pip:
- debian:
+  debian:
     pip:
       packages: [MAVProxy]
   fedora:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: python3-mavproxy-pip

## Package Upstream Source:

https://github.com/ArduPilot/MAVProxy

## Purpose of using this:

Allows communicating to UAVs over tcp. I used this greatly for configuration of my UAV before using ROS to control it.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
