### PR TITLE
Add pyqtdarktheme pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8247,7 +8247,7 @@ python3-pyproj:
     '7': null
   ubuntu: [python3-pyproj]
 python3-pyqtdarktheme-pip:
-   debian:
+  debian:
     pip:
       packages: [pyqtdarktheme]
   fedora:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8246,6 +8246,12 @@ python3-pyproj:
     '*': ['python%{python3_pkgversion}-pyproj']
     '7': null
   ubuntu: [python3-pyproj]
+python3-pyqrcode:
+  arch: [python-qrcode]
+  debian: [python3-pyqrcode]
+  gentoo: [dev-python/pyqrcode]
+  nixos: [python3Packages.pyqrcode]
+  ubuntu: [python3-pyqrcode]
 python3-pyqtdarktheme-pip:
   debian:
     pip:
@@ -8259,12 +8265,6 @@ python3-pyqtdarktheme-pip:
   ubuntu:
     pip:
       packages: [pyqtdarktheme]
-python3-pyqrcode:
-  arch: [python-qrcode]
-  debian: [python3-pyqrcode]
-  gentoo: [dev-python/pyqrcode]
-  nixos: [python3Packages.pyqrcode]
-  ubuntu: [python3-pyqrcode]
 python3-pyqt5:
   alpine: [py3-qt5]
   arch: [python-pyqt5]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8252,19 +8252,6 @@ python3-pyqrcode:
   gentoo: [dev-python/pyqrcode]
   nixos: [python3Packages.pyqrcode]
   ubuntu: [python3-pyqrcode]
-python3-pyqtdarktheme-pip:
-  debian:
-    pip:
-      packages: [pyqtdarktheme]
-  fedora:
-    pip:
-      packages: [pyqtdarktheme]
-  osx:
-    pip:
-      packages: [pyqtdarktheme]
-  ubuntu:
-    pip:
-      packages: [pyqtdarktheme]
 python3-pyqt5:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
@@ -8288,6 +8275,19 @@ python3-pyqt5.qtwebengine:
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
+python3-pyqtdarktheme-pip:
+  debian:
+    pip:
+      packages: [pyqtdarktheme]
+  fedora:
+    pip:
+      packages: [pyqtdarktheme]
+  osx:
+    pip:
+      packages: [pyqtdarktheme]
+  ubuntu:
+    pip:
+      packages: [pyqtdarktheme]
 python3-pyqtgraph:
   debian: [python3-pyqtgraph]
   fedora: [python3-pyqtgraph]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8246,6 +8246,19 @@ python3-pyproj:
     '*': ['python%{python3_pkgversion}-pyproj']
     '7': null
   ubuntu: [python3-pyproj]
+python3-pyqtdarktheme-pip:
+   debian:
+    pip:
+      packages: [pyqtdarktheme]
+  fedora:
+    pip:
+      packages: [pyqtdarktheme]
+  osx:
+    pip:
+      packages: [pyqtdarktheme]
+  ubuntu:
+    pip:
+      packages: [pyqtdarktheme]
 python3-pyqrcode:
   arch: [python-qrcode]
   debian: [python3-pyqrcode]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name: python3-pyqtdarktheme-pip

## Package Upstream Source:

https://github.com/5yutan5/PyQtDarkTheme

## Purpose of using this:

Has nice CSS for creating dark themes for PyQt. 

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
