### PR TITLE
ros_gz: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6095,7 +6095,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.1-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## ros_gz

```
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* 0.246.0
* Update changelogs
* Port: humble to ros2 (#386 <https://github.com/gazebosim/ros_gz//issues/386>)
* Merge branch 'humble' into mjcarroll/humble_to_ros2
* Update maintainers (#376 <https://github.com/gazebosim/ros_gz//issues/376>)
* Humble ➡️ ROS2 (#323 <https://github.com/gazebosim/ros_gz//issues/323>)
  Humble ➡️ ROS2
* Merge branch 'humble' into ports/humble_to_ros2
* 0.245.0
* Changelog
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz//issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Contributors: Addisu Z. Taddese, Aditya Pande, Alejandro Hernández Cordero, Jose Luis Rivero, Michael Carroll, ahcorde
```

## ros_gz_bridge

```
* Add support for gz.msgs.EntityWrench (base branch: ros2) (#573 <https://github.com/gazebosim/ros_gz//issues/573>)
* Merge pull request #571 <https://github.com/gazebosim/ros_gz//issues/571> from azeey/jazzy_to_ros2
  Merge jazzy ➡️  ros2
* Merge branch 'ros2' into jazzy_to_ros2
* Use memcpy instead of std::copy when bridging images (#565 <https://github.com/gazebosim/ros_gz//issues/565>)
  While testing ros <-> gz communication using the bridge I noticed that the bridge was talking quite a bit of time copying images from Gazebo to ROS. I found that the std::copy operation that we're doing is substantially slower than the memcpy alternative. I think that in principle this shouldn't happen but the numbers are quite clear. Perhaps std::copy is doing something that doesn't use cache effectively
  ---------
  Co-authored-by: Jose Luis Rivero <jrivero@osrfoundation.org>
* Merge jazzy into ros2
* Merge pull request #569 <https://github.com/gazebosim/ros_gz//issues/569> from azeey/iron_to_jazzy
  Merge iron ➡️  jazzy
* Merge iron into jazzy
* Add option to change material color from ROS. (#521 <https://github.com/gazebosim/ros_gz//issues/521>)
  Forward port of #486 <https://github.com/gazebosim/ros_gz//issues/486>.
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  (cherry picked from commit 78dc4823121f085594e6028a93f1e571eb04f58b)
* Merge pull request #564 <https://github.com/gazebosim/ros_gz//issues/564> from azeey/humble_to_iron
  Humble ➡️ Iron
* Merge humble -> iron
* Use ignoreLocalMessages in the bridge (#559 <https://github.com/gazebosim/ros_gz//issues/559>)
  * Ignore local messages
* Update launch files with name parameter (#556 <https://github.com/gazebosim/ros_gz//issues/556>)
  * Name is required.
* Ensure the same container is used for the bridge and gz_server (#553 <https://github.com/gazebosim/ros_gz//issues/553>)
  This also adds a required name parameter for the bridge so that
  multiple different bridges can be created without name collision
* Launch ros_gz_bridge from xml (#550 <https://github.com/gazebosim/ros_gz//issues/550>)
  * Add gzserver with ability to load an SDF file or string
* Launch gzserver and the bridge as composable nodes (#528 <https://github.com/gazebosim/ros_gz//issues/528>)
  * Add gzserver with ability to load an SDF file or string
* Add option to change material color from ROS. (#521 <https://github.com/gazebosim/ros_gz//issues/521>)
  Forward port of #486 <https://github.com/gazebosim/ros_gz//issues/486>.
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
* populate imu covariances when converting (#375 <https://github.com/gazebosim/ros_gz//issues/375>) (#540 <https://github.com/gazebosim/ros_gz//issues/540>)
  Co-authored-by: El Jawad Alaa <mailto:ejalaa12@gmail.com>
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz//issues/531>)
* [backport Humble] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#538 <https://github.com/gazebosim/ros_gz//issues/538>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* [backport Iron] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#537 <https://github.com/gazebosim/ros_gz//issues/537>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* 0.244.14
* Changelog
* Added conversion for Detection3D and Detection3DArray (#523 <https://github.com/gazebosim/ros_gz//issues/523>) (#526 <https://github.com/gazebosim/ros_gz//issues/526>)
  Co-authored-by: wittenator <mailto:9154515+wittenator@users.noreply.github.com>
* Added conversion for Detection3D and Detection3DArray (#523 <https://github.com/gazebosim/ros_gz//issues/523>) (#525 <https://github.com/gazebosim/ros_gz//issues/525>)
  Co-authored-by: wittenator <mailto:9154515+wittenator@users.noreply.github.com>
* [Backport rolling] Add ROS namespaces to GZ topics (#517 <https://github.com/gazebosim/ros_gz//issues/517>)
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
* ign to gz (#519 <https://github.com/gazebosim/ros_gz//issues/519>)
* Add ROS namespaces to GZ topics (#512 <https://github.com/gazebosim/ros_gz//issues/512>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz//issues/503>) (#506 <https://github.com/gazebosim/ros_gz//issues/506>)
* Add a virtual destructor to suppress compiler warning (#502 <https://github.com/gazebosim/ros_gz//issues/502>) (#505 <https://github.com/gazebosim/ros_gz//issues/505>)
  Co-authored-by: Michael Carroll <mailto:mjcarroll@intrinsic.ai>
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz//issues/503>)
* Add a virtual destructor to suppress compiler warning (#502 <https://github.com/gazebosim/ros_gz//issues/502>)
* Add option to change material color from ROS. (#486 <https://github.com/gazebosim/ros_gz//issues/486>)
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* 0.244.13
* Changelog
* backport pr 374 (#489 <https://github.com/gazebosim/ros_gz//issues/489>)
* populate imu covariances when converting (#488 <https://github.com/gazebosim/ros_gz//issues/488>)
* 0.244.12
* Changelog
* Backport: Add conversion for geometry_msgs/msg/TwistStamped <-> gz.msgs.Twist (#468 <https://github.com/gazebosim/ros_gz//issues/468>) (#470 <https://github.com/gazebosim/ros_gz//issues/470>)
* Add conversion for geometry_msgs/msg/TwistStamped <-> gz.msgs.Twist (#468 <https://github.com/gazebosim/ros_gz//issues/468>)
* Added messages for 2D Bounding Boxes to ros_gz_bridge (#458 <https://github.com/gazebosim/ros_gz//issues/458>) (#466 <https://github.com/gazebosim/ros_gz//issues/466>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* populate imu covariances when converting (#375 <https://github.com/gazebosim/ros_gz//issues/375>)
* 0.246.0
* Update changelogs
* Add harmonic CI (#447 <https://github.com/gazebosim/ros_gz//issues/447>)
  * Add harmonic CI
  * Include garden options
  * Add harmonic stanza
  * Additional message headers
  ---------
* SensorNoise msg bridging (#417 <https://github.com/gazebosim/ros_gz//issues/417>)
* Added Altimeter msg bridging (#413 <https://github.com/gazebosim/ros_gz//issues/413>)
* Update README.md (#411 <https://github.com/gazebosim/ros_gz//issues/411>)
  The ROS type for gz.msgs.NavSat messages should be **sensor_msgs/msg/NavSatFix** instead of **sensor_msgs/msg/NavSatFixed**
* Add missing rosidl_cmake dep to ros_gz_bridge (#391 <https://github.com/gazebosim/ros_gz//issues/391>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* allow converting from/to TwistWithCovarianceStamped (#374 <https://github.com/gazebosim/ros_gz//issues/374>)
  * allow converting from/to TwistWithCovarianceStamped
  --------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Added doc (#393 <https://github.com/gazebosim/ros_gz//issues/393>)
* Port: humble to ros2 (#386 <https://github.com/gazebosim/ros_gz//issues/386>)
* Merge branch 'humble' into mjcarroll/humble_to_ros2
* allow converting from/to PoseWithCovarianceStamped (#381 <https://github.com/gazebosim/ros_gz//issues/381>)
  * allow converting from/to PoseWithCovarianceStamped
* Add actuator_msgs to bridge. (#378 <https://github.com/gazebosim/ros_gz//issues/378>)
* Update maintainers (#376 <https://github.com/gazebosim/ros_gz//issues/376>)
* Fix warning message (#371 <https://github.com/gazebosim/ros_gz//issues/371>)
* Improve error messages around config loading (#356 <https://github.com/gazebosim/ros_gz//issues/356>)
* Bringing the Joy to gazebo. (#350 <https://github.com/gazebosim/ros_gz//issues/350>)
  Enable using the gazebo bridge with Joy.
* Fix double wait in ros_gz_bridge (#347 <https://github.com/gazebosim/ros_gz//issues/347>)
* Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>)
* Humble ➡️ ROS2 (#323 <https://github.com/gazebosim/ros_gz//issues/323>)
  Humble ➡️ ROS2
* Merge branch 'humble' into ports/humble_to_ros2
* 0.245.0
* Changelog
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz//issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Remove Humble+ deprecations (#312 <https://github.com/gazebosim/ros_gz//issues/312>)
  * Remove Humble+ deprecations
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz//issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Addisu Z. Taddese, Aditya Pande, Alejandro Hernández Cordero, Arjun K Haridas, Benjamin Perseghetti, Carlos Agüero, El Jawad Alaa, Jose Luis Rivero, Krzysztof Wojciechowski, Michael Carroll, Rousseau Vincent, Victor T. Noppeney, Yadu, ahcorde, wittenator, ymd-stella
```

## ros_gz_image

```
* Merge pull request #571 <https://github.com/gazebosim/ros_gz//issues/571> from azeey/jazzy_to_ros2
  Merge jazzy ➡️  ros2
* Merge jazzy into ros2
* Merge pull request #569 <https://github.com/gazebosim/ros_gz//issues/569> from azeey/iron_to_jazzy
  Merge iron ➡️  jazzy
* Merge iron into jazzy
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz//issues/531>)
* 0.244.14
* Changelog
* ign to gz (#519 <https://github.com/gazebosim/ros_gz//issues/519>)
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* 0.246.0
* Update changelogs
* Add harmonic CI (#447 <https://github.com/gazebosim/ros_gz//issues/447>)
  * Add harmonic CI
  * Include garden options
  * Add harmonic stanza
  * Additional message headers
  ---------
* Port: humble to ros2 (#386 <https://github.com/gazebosim/ros_gz//issues/386>)
* Merge branch 'humble' into mjcarroll/humble_to_ros2
* Update maintainers (#376 <https://github.com/gazebosim/ros_gz//issues/376>)
* Fix linter error by reordering headers (#373 <https://github.com/gazebosim/ros_gz//issues/373>)
* Add QoS profile parameter to image bridge (#335 <https://github.com/gazebosim/ros_gz//issues/335>)
* Fix double wait in ros_gz_bridge (#347 <https://github.com/gazebosim/ros_gz//issues/347>)
* Humble ➡️ ROS2 (#323 <https://github.com/gazebosim/ros_gz//issues/323>)
  Humble ➡️ ROS2
* Merge branch 'humble' into ports/humble_to_ros2
* 0.245.0
* Changelog
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz//issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz//issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Addisu Z. Taddese, Aditya Pande, Alejandro Hernández Cordero, Jose Luis Rivero, Michael Carroll, Sebastian Castro, ahcorde, ymd-stella
```

## ros_gz_interfaces

```
* Add support for gz.msgs.EntityWrench (base branch: ros2) (#573 <https://github.com/gazebosim/ros_gz//issues/573>)
* Add option to change material color from ROS. (#521 <https://github.com/gazebosim/ros_gz//issues/521>)
  Forward port of #486 <https://github.com/gazebosim/ros_gz//issues/486>.
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  (cherry picked from commit 78dc4823121f085594e6028a93f1e571eb04f58b)
* Add option to change material color from ROS. (#521 <https://github.com/gazebosim/ros_gz//issues/521>)
  Forward port of #486 <https://github.com/gazebosim/ros_gz//issues/486>.
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* 0.244.14
* Changelog
* Add option to change material color from ROS. (#486 <https://github.com/gazebosim/ros_gz//issues/486>)
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* 0.246.0
* Update changelogs
* SensorNoise msg bridging (#417 <https://github.com/gazebosim/ros_gz//issues/417>)
* Added Altimeter msg bridging (#413 <https://github.com/gazebosim/ros_gz//issues/413>)
* Port: humble to ros2 (#386 <https://github.com/gazebosim/ros_gz//issues/386>)
* Merge branch 'humble' into mjcarroll/humble_to_ros2
* Update maintainers (#376 <https://github.com/gazebosim/ros_gz//issues/376>)
* Humble ➡️ ROS2 (#323 <https://github.com/gazebosim/ros_gz//issues/323>)
  Humble ➡️ ROS2
* Merge branch 'humble' into ports/humble_to_ros2
* Export rcl_interfaces exec dependency (#317 <https://github.com/gazebosim/ros_gz//issues/317>)
* 0.245.0
* Changelog
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz//issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Contributors: Addisu Z. Taddese, Aditya Pande, Alejandro Hernández Cordero, Benjamin Perseghetti, Jose Luis Rivero, Michael Carroll, Victor T. Noppeney, ahcorde
```

## ros_gz_sim

```
* Merge pull request #571 <https://github.com/gazebosim/ros_gz//issues/571> from azeey/jazzy_to_ros2
  Merge jazzy ➡️  ros2
* Merge jazzy into ros2
* Merge pull request #569 <https://github.com/gazebosim/ros_gz//issues/569> from azeey/iron_to_jazzy
  Merge iron ➡️  jazzy
* Merge remote-tracking branch 'origin/jazzy' into iron_to_jazzy
* Add a ROS node that runs Gazebo (#500 <https://github.com/gazebosim/ros_gz//issues/500>) (#567 <https://github.com/gazebosim/ros_gz//issues/567>)
  * Add gzserver with ability to load an SDF file or string
  ---------
  (cherry picked from commit 92a2891f4adf35e4a4119aca2447dee93e22a06a)
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Merge iron into jazzy
* Merge pull request #564 <https://github.com/gazebosim/ros_gz//issues/564> from azeey/humble_to_iron
  Humble ➡️ Iron
* Merge humble -> iron
* Update launch files with name parameter (#556 <https://github.com/gazebosim/ros_gz//issues/556>)
  * Name is required.
* Launch gz_spawn_model from xml (#551 <https://github.com/gazebosim/ros_gz//issues/551>)
  Spawn models from XML.
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Launch ros_gz_bridge from xml (#550 <https://github.com/gazebosim/ros_gz//issues/550>)
  * Add gzserver with ability to load an SDF file or string
* Launch gzserver and the bridge as composable nodes (#528 <https://github.com/gazebosim/ros_gz//issues/528>)
  * Add gzserver with ability to load an SDF file or string
* Add a ROS node that runs Gazebo (#500 <https://github.com/gazebosim/ros_gz//issues/500>)
  * Add gzserver with ability to load an SDF file or string
  ---------
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz//issues/531>)
* 0.244.14
* Changelog
* ign to gz (#519 <https://github.com/gazebosim/ros_gz//issues/519>)
* Support <gazebo_ros> in package.xml exports (#492 <https://github.com/gazebosim/ros_gz//issues/492>)
  This copies the implementation from gazebo_ros_paths.py to provide a
  way for packages to set resource paths from package.xml.
  ```
  e.g.  <export>
  <gazebo_ros gazebo_model_path="${prefix}/models"/>
  <gazebo_ros gazebo_media_path="${prefix}/models"/>
  </export>
  ```
  The value of gazebo_model_path and gazebo_media_path is appended to GZ_SIM_RESOURCE_PATH
  The value of plugin_path appended to GZ_SIM_SYSTEM_PLUGIN_PATH
  ---------
* Undeprecate use of commandline flags (#491 <https://github.com/gazebosim/ros_gz//issues/491>)
* 0.244.13
* Changelog
* Remove deprecations using ros_gz_sim_create (#476 <https://github.com/gazebosim/ros_gz//issues/476>)
* Added support for using ROS 2 parameters to spawn entities in Gazebo using ros_gz_sim::create (#475 <https://github.com/gazebosim/ros_gz//issues/475>)
* Fix bug in create where command line arguments were truncated (#472 <https://github.com/gazebosim/ros_gz//issues/472>)
* 0.244.12
* Changelog
* Filter ROS arguments before gflags parsing (#453 <https://github.com/gazebosim/ros_gz//issues/453>)
* 0.246.0
* Update changelogs
* Add harmonic CI (#447 <https://github.com/gazebosim/ros_gz//issues/447>)
  * Add harmonic CI
  * Include garden options
  * Add harmonic stanza
  * Additional message headers
  ---------
* Replace deprecated ign_find_package with gz_find_package (#432 <https://github.com/gazebosim/ros_gz//issues/432>)
  Co-authored-by: jmackay2 <mailto:jmackay@gmail.com>
* Port: humble to ros2 (#386 <https://github.com/gazebosim/ros_gz//issues/386>)
* Merge branch 'humble' into mjcarroll/humble_to_ros2
* Update maintainers (#376 <https://github.com/gazebosim/ros_gz//issues/376>)
* set on_exit_shutdown argument for gz-sim ExecuteProcess (#355 <https://github.com/gazebosim/ros_gz//issues/355>)
* Humble ➡️ ROS2 (#323 <https://github.com/gazebosim/ros_gz//issues/323>)
  Humble ➡️ ROS2
* Merge branch 'humble' into ports/humble_to_ros2
* 0.245.0
* Changelog
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz//issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz//issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Addisu Z. Taddese, Aditya Pande, Alejandro Hernández Cordero, Ayush Singh, Carlos Agüero, Jose Luis Rivero, Michael Carroll, ahcorde, andermi, jmackay2, mergify[bot]
```

## ros_gz_sim_demos

```
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* Use gz_vendor packages (#531 <https://github.com/gazebosim/ros_gz//issues/531>)
* [backport Humble] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#538 <https://github.com/gazebosim/ros_gz//issues/538>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* [backport Iron] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#537 <https://github.com/gazebosim/ros_gz//issues/537>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* Remove deprecations using ros_gz_sim_create (#476 <https://github.com/gazebosim/ros_gz//issues/476>)
* 0.244.12
* Changelog
* 0.246.0
* Update changelogs
* Added more topic to the bridge (#422 <https://github.com/gazebosim/ros_gz//issues/422>)
* Fix incorrect subscription on demo (#405 <https://github.com/gazebosim/ros_gz//issues/405>) (#408 <https://github.com/gazebosim/ros_gz//issues/408>)
  This PR fixes an incorrect subscription on one of the demos. Running
  ```
  ros2 launch ros_gz_sim_demos gpu_lidar_bridge.launch.py
  ```
  causes rviz2 to crash and exit with the error:
  ```
  rviz2-3]
  [rviz2-3] >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
  [rviz2-3] This error state is being overwritten:
  [rviz2-3]
  [rviz2-3]   'create_subscription() called for existing topic name rt/lidar with incompatible type sensor_msgs::msg::dds\_::PointCloud2\_, at ./src/subscription.cpp:146, at ./src/rcl/subscription.c:108'
  [rviz2-3]
  [rviz2-3] with this new error message:
  [rviz2-3]
  [rviz2-3]   'invalid allocator, at ./src/rcl/subscription.c:218'
  [rviz2-3]
  [rviz2-3] rcutils_reset_error() should be called after error handling to avoid this.
  ```
  This is due to an incorrect subscription on the part of the demo. This
  PR fixes it by getting a subscription to the right topic for the
  pointcloud display. (lidar/points instead of lidar). Was tested on
  garden + humble.
  Co-authored-by: Arjo Chakravarty <mailto:arjoc@intrinsic.ai>
* Port: humble to ros2 (#386 <https://github.com/gazebosim/ros_gz//issues/386>)
* Merge branch 'humble' into mjcarroll/humble_to_ros2
* Update maintainers (#376 <https://github.com/gazebosim/ros_gz//issues/376>)
* Rename 'ign gazebo' to 'gz sim' (#343 <https://github.com/gazebosim/ros_gz//issues/343>)
* Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>)
* Humble ➡️ ROS2 (#323 <https://github.com/gazebosim/ros_gz//issues/323>)
  Humble ➡️ ROS2
* Merge branch 'humble' into ports/humble_to_ros2
* Fixed ros_gz_sim_demos launch files (#319 <https://github.com/gazebosim/ros_gz//issues/319>)
* 0.245.0
* Changelog
* humble to ros2 (#311 <https://github.com/gazebosim/ros_gz//issues/311>)
  Co-authored-by: Michael Carroll <mailto:michael@openrobotics.org>
* Merge remote-tracking branch 'origin/humble' into ahcorde/humble_to_ros2
* Remove all ignition references on ROS 2 branch (#302 <https://github.com/gazebosim/ros_gz//issues/302>)
  * Remove all shims
  * Update CMakeLists and package.xml for garden
  * Complete garden gz renaming
  * Drop fortress CI
* Contributors: Addisu Z. Taddese, Aditya Pande, Alejandro Hernández Cordero, Clyde McQueen, Jose Luis Rivero, Michael Carroll, Rousseau Vincent, ahcorde
```

## test_ros_gz_bridge

```
* Prepare for 1.0.0 Release (#495 <https://github.com/gazebosim/ros_gz//issues/495>)
* 0.244.14
* Changelog
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz//issues/503>) (#506 <https://github.com/gazebosim/ros_gz//issues/506>)
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz//issues/503>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Michael Carroll
```
