### PR TITLE
ros_gz: 0.254.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6119,7 +6119,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.254.1-1
+      version: 0.254.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.254.2-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.254.1-1`

## ros_gz

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_gz_bridge

```
* Add support for gz.msgs.EntityWrench (base branch: ros2) (backport #573 <https://github.com/gazebosim/ros_gz//issues/573>) (#576 <https://github.com/gazebosim/ros_gz//issues/576>)
  * Add support for gz.msgs.EntityWrench (base branch: ros2) (#573 <https://github.com/gazebosim/ros_gz//issues/573>)
  (cherry picked from commit f9afb69d1163633dd978024bb7271a28cf7b551a)
  # Conflicts:
  #     ros_gz_bridge/README.md
  #     ros_gz_bridge/test/utils/gz_test_msg.hpp
  * Fixed merge
  ---------
  Co-authored-by: Victor T. Noppeney <mailto:Vtn21@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Merge pull request #564 <https://github.com/gazebosim/ros_gz//issues/564> from azeey/humble_to_iron
  Humble ➡️ Iron
* Merge humble -> iron
* populate imu covariances when converting (#375 <https://github.com/gazebosim/ros_gz//issues/375>) (#540 <https://github.com/gazebosim/ros_gz//issues/540>)
  Co-authored-by: El Jawad Alaa <mailto:ejalaa12@gmail.com>
* [backport Humble] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#538 <https://github.com/gazebosim/ros_gz//issues/538>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* [backport Iron] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#537 <https://github.com/gazebosim/ros_gz//issues/537>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* 0.244.14
* Changelog
* Added conversion for Detection3D and Detection3DArray (#523 <https://github.com/gazebosim/ros_gz//issues/523>) (#526 <https://github.com/gazebosim/ros_gz//issues/526>)
  Co-authored-by: wittenator <mailto:9154515+wittenator@users.noreply.github.com>
* Add ROS namespaces to GZ topics (#512 <https://github.com/gazebosim/ros_gz//issues/512>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz//issues/503>) (#506 <https://github.com/gazebosim/ros_gz//issues/506>)
* Add a virtual destructor to suppress compiler warning (#502 <https://github.com/gazebosim/ros_gz//issues/502>) (#505 <https://github.com/gazebosim/ros_gz//issues/505>)
  Co-authored-by: Michael Carroll <mailto:mjcarroll@intrinsic.ai>
* Add option to change material color from ROS. (#486 <https://github.com/gazebosim/ros_gz//issues/486>)
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* 0.244.13
* Changelog
* backport pr 374 (#489 <https://github.com/gazebosim/ros_gz//issues/489>)
* populate imu covariances when converting (#488 <https://github.com/gazebosim/ros_gz//issues/488>)
* 0.244.12
* Changelog
* Backport: Add conversion for geometry_msgs/msg/TwistStamped <-> gz.msgs.Twist (#468 <https://github.com/gazebosim/ros_gz//issues/468>) (#470 <https://github.com/gazebosim/ros_gz//issues/470>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Benjamin Perseghetti, El Jawad Alaa, Krzysztof Wojciechowski, Michael Carroll, mergify[bot], wittenator
```

## ros_gz_image

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_gz_interfaces

```
* Add support for gz.msgs.EntityWrench (base branch: ros2) (backport #573 <https://github.com/gazebosim/ros_gz//issues/573>) (#576 <https://github.com/gazebosim/ros_gz//issues/576>)
  * Add support for gz.msgs.EntityWrench (base branch: ros2) (#573 <https://github.com/gazebosim/ros_gz//issues/573>)
  (cherry picked from commit f9afb69d1163633dd978024bb7271a28cf7b551a)
  # Conflicts:
  #     ros_gz_bridge/README.md
  #     ros_gz_bridge/test/utils/gz_test_msg.hpp
  * Fixed merge
  ---------
  Co-authored-by: Victor T. Noppeney <mailto:Vtn21@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* 0.244.14
* Changelog
* Add option to change material color from ROS. (#486 <https://github.com/gazebosim/ros_gz//issues/486>)
  * Message and bridge for MaterialColor.
  This allows bridging MaterialColor from ROS to GZ and is
  important for allowing simulation users to create status lights.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Benjamin Perseghetti, mergify[bot]
```

## ros_gz_sim

```
* Merge pull request #564 <https://github.com/gazebosim/ros_gz//issues/564> from azeey/humble_to_iron
  Humble ➡️ Iron
* Merge humble -> iron
* 0.244.14
* Changelog
* Support <gazebo_ros> in package.xml exports (#492 <https://github.com/gazebosim/ros_gz//issues/492>)
  This copies the implementation from gazebo_ros_paths.py to provide a
  way for packages to set resource paths from package.xml.
  ```
  e.g.  <export>
  <gazebo_ros gazebo_model_path="${prefix}/models"/>
  <gazebo_ros gazebo_media_path="${prefix}/models"/>
  </export>
  ```
  The value of gazebo_model_path and gazebo_media_path is appended to GZ_SIM_RESOURCE_PATH
  The value of plugin_path appended to GZ_SIM_SYSTEM_PLUGIN_PATH
  ---------
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_gz_sim_demos

```
* [backport Humble] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#538 <https://github.com/gazebosim/ros_gz//issues/538>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* [backport Iron] Create bridge for GPSFix msg (#316 <https://github.com/gazebosim/ros_gz//issues/316>) (#537 <https://github.com/gazebosim/ros_gz//issues/537>)
  Co-authored-by: Rousseau Vincent <mailto:vincentrou@gmail.com>
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_ign

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_ign_bridge

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_ign_gazebo

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_ign_gazebo_demos

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_ign_image

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## ros_ign_interfaces

```
* 0.244.14
* Changelog
* 0.244.13
* Changelog
* 0.244.12
* Changelog
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero
```

## test_ros_gz_bridge

```
* 0.244.14
* Changelog
* Correctly export ros_gz_bridge for downstream targets (#503 <https://github.com/gazebosim/ros_gz//issues/503>) (#506 <https://github.com/gazebosim/ros_gz//issues/506>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```
