### PR TITLE
flir_camera_driver: point all src/doc to ros2-release branch

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2256,7 +2256,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: humble-release
+      version: ros2-release
     release:
       packages:
       - flir_camera_description
@@ -2270,7 +2270,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: humble-release
+      version: ros2-release
     status: maintained
   fluent_bit_vendor:
     source:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1664,7 +1664,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: iron-release
+      version: ros2-release
     release:
       packages:
       - flir_camera_description
@@ -1678,7 +1678,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: iron-release
+      version: ros2-release
     status: maintained
   fluent_rviz:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1736,7 +1736,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: rolling-release
+      version: ros2-release
     release:
       packages:
       - flir_camera_description
@@ -1750,7 +1750,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: rolling-release
+      version: ros2-release
     status: maintained
   fluent_rviz:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1689,7 +1689,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: rolling-release
+      version: ros2-release
     release:
       packages:
       - flir_camera_description
@@ -1703,7 +1703,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
-      version: rolling-release
+      version: ros2-release
     status: maintained
   fluent_rviz:
     doc:


### PR DESCRIPTION
This PR points the flir_camera_driver repo to all the same source tree. Purpose is to simplify release management.
See the discussion with @christophebedard [here](https://github.com/ros/rosdistro/pull/41837)
