### PR TITLE
ros_gz: 0.244.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7727,7 +7727,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.14-1
+      version: 0.244.15-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.15-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.244.14-1`
