### PR TITLE
launch_pal: 0.1.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3563,7 +3563,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.1.13-1
+      version: 0.1.15-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.1.15-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.13-1`

## launch_pal

```
* Merge branch 'omm/feat/composition_utils' into 'master'
  Composition utils
  See merge request common/launch_pal!38
* Added package field for extended usability
* Readme and new type variable name
* Removing pal_computer_monitor dep
* Composition utils to generate containers from a yaml files
* Merge branch 'paps007' into 'master'
  Add implementation of PAPS-007 'get_pal_configuration'
  See merge request common/launch_pal!57
* add impl of PAPS-007 'get_pal_configuration'
* Merge branch 'abr/feat/advanced-navigation' into 'master'
  added advanced navigation
  See merge request common/launch_pal!58
* added advanced navigation
* Contributors: Noel Jimenez, Oscar, Séverin Lemaignan, antoniobrandi, davidterkuile
```
