### PR TITLE
Add python3-pyqt6.qtmultimedia

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8317,11 +8317,12 @@ python3-pyqt5.qtwebengine:
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqt6.qtmultimedia:
   debian:
-    bullseye: null
     '*': [python3-pyqt6.qtmultimedia]
+    bullseye: null
   ubuntu:
-    '*': null
-    'noble': [python3-pyqt6.qtmultimedia]
+    '*': [python3-pyqt6.qtmultimedia]
+    focal: null
+    jammy: null
 python3-pyqtdarktheme-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8304,7 +8304,9 @@ python3-pyqt5.qtwebengine:
   opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqt6.qtmultimedia:
-  debian: [python3-pyqt6.qtmultimedia]
+  debian:
+    bullseye: null
+    '*': [python3-pyqt6.qtmultimedia]
   ubuntu:
     '*': null
     'noble': [python3-pyqt6.qtmultimedia]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8303,6 +8303,11 @@ python3-pyqt5.qtwebengine:
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python3-qtwebengine-qt5]
   ubuntu: [python3-pyqt5.qtwebengine]
+python3-pyqt6.qtmultimedia:
+  debian: [python3-pyqt6.qtmultimedia]
+  ubuntu:
+    '*': null
+    'noble': [python3-pyqt6.qtmultimedia]
 python3-pyqtdarktheme-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pyqt6.qtmultimedia

## Package Upstream Source:

https://pypi.org/project/PyQt6/

## Purpose of using this:

Used for working with audio and video in GUI applications

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-pyqt6.qtmultimedia
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-pyqt6.qtmultimedia
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
