### PR TITLE
odri_master_board: 1.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4289,13 +4289,21 @@ repositories:
       version: master
     status: maintained
   odri_master_board:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
+      version: main
     release:
       packages:
       - odri_master_board_sdk
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
-      version: 1.0.6-5
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
+      version: main
     status: maintained
   odri_master_board_sdk:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `odri_master_board` to `1.0.7-1`:

- upstream repository: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
- release repository: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.6-5`

## odri_master_board_sdk

```
* Fix header to have the package working on Noble (@olivier-stasse)
* Fix building Python bindings on Mac (@ManifoldFR)
* Remove fetching Catch2 v3 and detect automatically the installed version. (@olivier-stasse)
* Add Rolling github action (@olivier-stasse)
```
