### PR TITLE
kuka_drivers: 0.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3410,6 +3410,26 @@ repositories:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git
       version: master
+    release:
+      packages:
+      - fri_configuration_controller
+      - fri_state_broadcaster
+      - iiqka_moveit_example
+      - joint_group_impedance_controller
+      - kuka_control_mode_handler
+      - kuka_controllers
+      - kuka_driver_interfaces
+      - kuka_drivers
+      - kuka_drivers_core
+      - kuka_event_broadcaster
+      - kuka_iiqka_eac_driver
+      - kuka_kss_rsi_driver
+      - kuka_rsi_simulator
+      - kuka_sunrise_fri_driver
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/kuka_drivers-release.git
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_drivers` to `0.9.0-1`:

- upstream repository: https://github.com/kroshu/kuka_drivers.git
- release repository: https://github.com/ros2-gbp/kuka_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## fri_configuration_controller

```
* Add controller for managing FRI configuration
* Contributors: Aron Svastits
```

## fri_state_broadcaster

```
* Add controller for broadcasting FRI states
* Contributors: Aron Svastits
```

## iiqka_moveit_example

```
* Add package with moveit examples for the KUKA iiQKA driver
* Contributors: Aron Svastits, Gergely Kovacs
```

## joint_group_impedance_controller

```
* Add controller for updating stiffness and damping command interfaces
* Contributors: Aron Svastits
```

## kuka_control_mode_handler

```
* Add controller for handling the control mode of KUKA robots
* Contributors: Aron Svastits, Sandor Komaromi
```

## kuka_controllers

```
* Add meta-package for controllers needed for KUKA drivers
* Contributors: Aron Svastits
```

## kuka_driver_interfaces

```
* Add package with message definitions necessary for KUKA drivers
* Contributors: Aron Svastits
```

## kuka_drivers

```
* Add meta-package for KUKA drivers
* Contributors: Aron Svastits
```

## kuka_drivers_core

```
* Add package with core features necessary for all KUKA drivers
* Contributors: Aron Svastits, Gergely Kovacs, Mark Szitanics, Sandor Komaromi
```

## kuka_event_broadcaster

```
* Add controller for broadcasting events from KUKA robots
* Contributors: Aron Svastits
```

## kuka_iiqka_eac_driver

```
* Add package with driver for KUKA iiQKA robots
* Contributors: Aron Svastits, Gergely Kovacs, Mark Szitanics, Sandor Komaromi
```

## kuka_kss_rsi_driver

```
* Add package with driver for KUKA KSS robots
* Contributors: Aron Svastits, Gergely Kovacs, Marton Antal, Lars Tingelstad
```

## kuka_rsi_simulator

```
* Add package with simulator for KUKA RSI driven robots
* Contributors: Aron Svastits, Lars Tingelstad
```

## kuka_sunrise_fri_driver

```
* Add package with driver for KUKA Sunrise robots
* Contributors: Aron Svastits, Zoltan Resi, Gergely Kovacs
```
