### PR TITLE
Add missing nixos rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8443,7 +8443,7 @@ tbb:
   fedora: [tbb-devel]
   gentoo: [dev-cpp/tbb]
   macports: [tbb]
-  nixos: [tbb_2021_8]
+  nixos: [tbb]
   openembedded: [tbb@meta-oe]
   opensuse: [tbb-devel]
   rhel: [tbb-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8443,7 +8443,7 @@ tbb:
   fedora: [tbb-devel]
   gentoo: [dev-cpp/tbb]
   macports: [tbb]
-  nixos: [tbb]
+  nixos: [tbb_2021_11]
   openembedded: [tbb@meta-oe]
   opensuse: [tbb-devel]
   rhel: [tbb-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4552,6 +4552,7 @@ libnss3-dev:
 liboctomap-dev:
   debian: [liboctomap-dev]
   fedora: [octomap-devel]
+  nixos: [octomap]
   rhel: [octomap-devel]
   ubuntu: [liboctomap-dev]
 libogg:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5806,6 +5806,7 @@ python3-fastapi:
       pip:
         packages: [fastapi]
   fedora: [python-fastapi]
+  nixos: [python3Packages.fastapi]
   ubuntu:
     '*': [python3-fastapi]
     bionic:
@@ -6151,6 +6152,7 @@ python3-flask-restplus-pip:
 python3-flask-socketio:
   debian: [python3-flask-socketio]
   fedora: [python3-flask-socketio]
+  nixos: [python3Packages.flask-socketio]
   openembedded: [python3-flask-socketio@meta-python]
   ubuntu: [python3-flask-socketio]
 python3-flask-sqlalchemy:
@@ -7564,6 +7566,7 @@ python3-padatious-pip:
 python3-paho-mqtt:
   debian: [python3-paho-mqtt]
   fedora: [python3-paho-mqtt]
+  nixos: [python3Packages.paho-mqtt]
   rhel:
     '*': [python3-paho-mqtt]
     '7': null
@@ -8969,6 +8972,7 @@ python3-semver:
   debian: [python3-semver]
   fedora: [python3-semver]
   freebsd: [py36-semver]
+  nixos: [python3Packages.semver]
   rhel: [python3-semver]
   ubuntu: [python3-semver]
 python3-sense-emu-pip:
@@ -9804,6 +9808,7 @@ python3-uvicorn:
   alpine: [uvicorn]
   debian: [python3-uvicorn]
   fedora: [python-uvicorn]
+  nixos: [python3Packages.uvicorn]
   ubuntu:
     '*': [python3-uvicorn]
     bionic:


### PR DESCRIPTION
Added some nixos rules to fix generating nix derivations for rolling packages.

Also changed rule for `tbb` to point to `tbb_2021_11` as `tbb_2021_8` no longer exists in nixpkgs

Links to distribution packages:
https://search.nixos.org/packages?channel=24.05&show=tbb_2021_11
https://search.nixos.org/packages?channel=24.05&show=octomap
https://search.nixos.org/packages?channel=24.05&show=python311Packages.fastapi
https://search.nixos.org/packages?channel=24.05&show=python311Packages.flask-socketio
https://search.nixos.org/packages?channel=24.05&show=python311Packages.paho-mqtt
https://search.nixos.org/packages?channel=24.05&show=python311Packages.semver
https://search.nixos.org/packages?channel=24.05&show=python311Packages.uvicorn
