### PR TITLE
log_view: 0.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3906,6 +3906,10 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/hatchbed/log_view-release.git
       version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
   lsc_ros2_driver:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3900,6 +3900,12 @@ repositories:
       url: https://github.com/boschglobal/locator_ros_bridge.git
       version: humble
     status: maintained
+  log_view:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/hatchbed/log_view-release.git
+      version: 0.2.3-1
   lsc_ros2_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.2.3-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## log_view

```
* Use default C++ version (#16 <https://github.com/hatchbed/log_view/issues/16>)
* Disable mouse move events on exit. (#12 <https://github.com/hatchbed/log_view/issues/12>)
* Contributors: Marc Alban
```
