### PR TITLE
ros2_control: 4.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5843,7 +5843,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.12.0-1
+      version: 4.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.12.0-1`

## controller_interface

```
* [ControllerChaining] Export state interfaces from chainable controllers (#1021 <https://github.com/ros-controls/ros2_control/issues/1021>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* Change the spamming checking interface ERROR to DEBUG (#1605 <https://github.com/ros-controls/ros2_control/issues/1605>)
* [ResourceManager] Propagate access to logger and clock interfaces to HardwareComponent (#1585 <https://github.com/ros-controls/ros2_control/issues/1585>)
* [ControllerChaining] Export state interfaces from chainable controllers (#1021 <https://github.com/ros-controls/ros2_control/issues/1021>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

```
* [ControllerChaining] Export state interfaces from chainable controllers (#1021 <https://github.com/ros-controls/ros2_control/issues/1021>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface

```
* [ResourceManager] Propagate access to logger and clock interfaces to HardwareComponent (#1585 <https://github.com/ros-controls/ros2_control/issues/1585>)
* [ControllerChaining] Export state interfaces from chainable controllers (#1021 <https://github.com/ros-controls/ros2_control/issues/1021>)
* Remove mimic parameter from ros2_control tag (#1553 <https://github.com/ros-controls/ros2_control/issues/1553>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* [ResourceManager] Propagate access to logger and clock interfaces to HardwareComponent (#1585 <https://github.com/ros-controls/ros2_control/issues/1585>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

```
* [JointLimits] Add Saturation Joint Limiter that uses clamping method (#971 <https://github.com/ros-controls/ros2_control/issues/971>)
* Contributors: Dr. Denis
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* [ControllerChaining] Export state interfaces from chainable controllers (#1021 <https://github.com/ros-controls/ros2_control/issues/1021>)
* Remove mimic parameter from ros2_control tag (#1553 <https://github.com/ros-controls/ros2_control/issues/1553>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## ros2controlcli

```
* Remove ament linters (#1601 <https://github.com/ros-controls/ros2_control/issues/1601>)
* Contributors: Bence Magyar
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
