### PR TITLE
pmb2_simulation: 4.0.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5962,7 +5962,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 4.0.14-1
+      version: 4.0.16-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.0.16-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.14-1`

## pmb2_gazebo

```
* added advanced navigation
* Contributors: antoniobrandi
```

## pmb2_simulation

- No changes
