### PR TITLE
tiago_robot: 4.2.17-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9505,7 +9505,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.2.16-1
+      version: 4.2.17-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.2.17-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.16-1`

## tiago_bringup

- No changes

## tiago_controller_configuration

```
* change module name into 10_*
* change the bases config file for their packages config files
* Contributors: Aina
```

## tiago_description

```
* change module name into 10_*
* Contributors: Aina
```

## tiago_robot

- No changes
