### PR TITLE
tiago_navigation: 4.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9485,7 +9485,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.1.2-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.1-1`

## tiago_2dnav

```
* Merge branch 'fix/changed-base-type-name' into 'humble-devel'
  changed diff_drive to pmb2
  See merge request robots/tiago_navigation!110
* fix default
* removed base_type check
* changed diff_drive to pmb2
* Contributors: andreacapodacqua
```

## tiago_laser_sensors

```
* Merge branch 'fix/changed-base-type-name' into 'humble-devel'
  changed diff_drive to pmb2
  See merge request robots/tiago_navigation!110
* fixed laser pipeline name
* changed diff_drive to pmb2
* Contributors: andreacapodacqua
```

## tiago_navigation

- No changes
