### PR TITLE
tiago_simulation: 4.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9523,7 +9523,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.1.7-1
+      version: 4.1.8-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.1.8-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.7-1`

## tiago_gazebo

```
* Merge branch 'fix/enable_slam' into 'humble-devel'
  Add slam argument for navigation
  See merge request robots/tiago_simulation!157
* Add missing use_sim_time launch argument
* Add slam argument for navigation
* Merge branch 'abr/feat/advanced-navigation' into 'humble-devel'
  added advanced navigation
  See merge request robots/tiago_simulation!156
* using base_type
* added advanced navigation
* Contributors: Noel Jimenez, antoniobrandi, davidterkuile
```

## tiago_simulation

- No changes
