### PR TITLE
backward_ros: 1.0.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -580,7 +580,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.2-5
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.5-1`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/ros2-gbp/backward_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-5`

## backward_ros

```
* Merge pull request #14 from christophfroehlich/patch-1
  Fix missing cmake config install rule
* Readd old configuration
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
* Update CMakeLists.txt
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
