### PR TITLE
ros2_controllers: 3.25.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5868,6 +5868,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - pid_controller
       - position_controllers
       - range_sensor_broadcaster
       - ros2_controllers
@@ -5880,7 +5881,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.24.0-1
+      version: 3.25.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.25.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.24.0-1`

## ackermann_steering_controller

```
* Fix steering controllers library kinematics (#1150 <https://github.com/ros-controls/ros2_controllers/issues/1150>) (#1195 <https://github.com/ros-controls/ros2_controllers/issues/1195>)
* [Steering controllers library] Reference interfaces are body twist (#1168 <https://github.com/ros-controls/ros2_controllers/issues/1168>) (#1174 <https://github.com/ros-controls/ros2_controllers/issues/1174>)
* 🚀 Add PID controller 🎉 (backport #434 <https://github.com/ros-controls/ros2_controllers/issues/434>, #975 <https://github.com/ros-controls/ros2_controllers/issues/975>, #899 <https://github.com/ros-controls/ros2_controllers/issues/899>, #1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>, #951 <https://github.com/ros-controls/ros2_controllers/issues/951>) (#1163 <https://github.com/ros-controls/ros2_controllers/issues/1163>)
* Fix steering controllers library code documentation and naming (#1149 <https://github.com/ros-controls/ros2_controllers/issues/1149>) (#1165 <https://github.com/ros-controls/ros2_controllers/issues/1165>)
* Contributors: mergify[bot]
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Fix steering controllers library kinematics (#1150 <https://github.com/ros-controls/ros2_controllers/issues/1150>) (#1195 <https://github.com/ros-controls/ros2_controllers/issues/1195>)
* [Steering controllers library] Reference interfaces are body twist (#1168 <https://github.com/ros-controls/ros2_controllers/issues/1168>) (#1174 <https://github.com/ros-controls/ros2_controllers/issues/1174>)
* 🚀 Add PID controller 🎉 (backport #434 <https://github.com/ros-controls/ros2_controllers/issues/434>, #975 <https://github.com/ros-controls/ros2_controllers/issues/975>, #899 <https://github.com/ros-controls/ros2_controllers/issues/899>, #1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>, #951 <https://github.com/ros-controls/ros2_controllers/issues/951>) (#1163 <https://github.com/ros-controls/ros2_controllers/issues/1163>)
* Fix steering controllers library code documentation and naming (#1149 <https://github.com/ros-controls/ros2_controllers/issues/1149>) (#1165 <https://github.com/ros-controls/ros2_controllers/issues/1165>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Add mobile robot kinematics 101 and improve steering library docs (#954 <https://github.com/ros-controls/ros2_controllers/issues/954>) (#1161 <https://github.com/ros-controls/ros2_controllers/issues/1161>)
* Bump version of pre-commit hooks (#1157 <https://github.com/ros-controls/ros2_controllers/issues/1157>) (#1159 <https://github.com/ros-controls/ros2_controllers/issues/1159>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* JTC trajectory end time validation fix (#1090 <https://github.com/ros-controls/ros2_controllers/issues/1090>) (#1141 <https://github.com/ros-controls/ros2_controllers/issues/1141>)
* Contributors: mergify[bot]
```

## pid_controller

```
* 🚀 Add PID controller 🎉 (backport #434 <https://github.com/ros-controls/ros2_controllers/issues/434>, #975 <https://github.com/ros-controls/ros2_controllers/issues/975>, #899 <https://github.com/ros-controls/ros2_controllers/issues/899>, #1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>, #951 <https://github.com/ros-controls/ros2_controllers/issues/951>) (#1163 <https://github.com/ros-controls/ros2_controllers/issues/1163>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* 🚀 Add PID controller 🎉 (backport #434 <https://github.com/ros-controls/ros2_controllers/issues/434>, #975 <https://github.com/ros-controls/ros2_controllers/issues/975>, #899 <https://github.com/ros-controls/ros2_controllers/issues/899>, #1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>, #951 <https://github.com/ros-controls/ros2_controllers/issues/951>) (#1163 <https://github.com/ros-controls/ros2_controllers/issues/1163>)
* Add custom rosdoc2 config for ros2_controllers metapackage (#1100 <https://github.com/ros-controls/ros2_controllers/issues/1100>) (#1143 <https://github.com/ros-controls/ros2_controllers/issues/1143>)
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Fix steering controllers library kinematics (#1150 <https://github.com/ros-controls/ros2_controllers/issues/1150>) (#1195 <https://github.com/ros-controls/ros2_controllers/issues/1195>)
* [Steering controllers library] Reference interfaces are body twist (#1168 <https://github.com/ros-controls/ros2_controllers/issues/1168>) (#1174 <https://github.com/ros-controls/ros2_controllers/issues/1174>)
* [STEERING] Add missing tan call for ackermann (#1117 <https://github.com/ros-controls/ros2_controllers/issues/1117>) (#1177 <https://github.com/ros-controls/ros2_controllers/issues/1177>)
* Fix steering controllers library code documentation and naming (#1149 <https://github.com/ros-controls/ros2_controllers/issues/1149>) (#1165 <https://github.com/ros-controls/ros2_controllers/issues/1165>)
* Add mobile robot kinematics 101 and improve steering library docs (#954 <https://github.com/ros-controls/ros2_controllers/issues/954>) (#1161 <https://github.com/ros-controls/ros2_controllers/issues/1161>)
* Fix deprecation warning (#1155 <https://github.com/ros-controls/ros2_controllers/issues/1155>)
* Fix correct usage of angular velocity in update_odometry() function (#1118 <https://github.com/ros-controls/ros2_controllers/issues/1118>) (#1154 <https://github.com/ros-controls/ros2_controllers/issues/1154>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## tricycle_controller

```
* Add mobile robot kinematics 101 and improve steering library docs (#954 <https://github.com/ros-controls/ros2_controllers/issues/954>) (#1161 <https://github.com/ros-controls/ros2_controllers/issues/1161>)
* Bump version of pre-commit hooks (#1157 <https://github.com/ros-controls/ros2_controllers/issues/1157>) (#1159 <https://github.com/ros-controls/ros2_controllers/issues/1159>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* Fix steering controllers library kinematics (#1150 <https://github.com/ros-controls/ros2_controllers/issues/1150>) (#1195 <https://github.com/ros-controls/ros2_controllers/issues/1195>)
* [Steering controllers library] Reference interfaces are body twist (#1168 <https://github.com/ros-controls/ros2_controllers/issues/1168>) (#1174 <https://github.com/ros-controls/ros2_controllers/issues/1174>)
* 🚀 Add PID controller 🎉 (backport #434 <https://github.com/ros-controls/ros2_controllers/issues/434>, #975 <https://github.com/ros-controls/ros2_controllers/issues/975>, #899 <https://github.com/ros-controls/ros2_controllers/issues/899>, #1084 <https://github.com/ros-controls/ros2_controllers/issues/1084>, #951 <https://github.com/ros-controls/ros2_controllers/issues/951>) (#1163 <https://github.com/ros-controls/ros2_controllers/issues/1163>)
* Fix steering controllers library code documentation and naming (#1149 <https://github.com/ros-controls/ros2_controllers/issues/1149>) (#1165 <https://github.com/ros-controls/ros2_controllers/issues/1165>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
