### PR TITLE
ros2_control: 3.26.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.25.0-1
+      version: 3.26.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.26.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.25.0-1`

## controller_interface

```
* Fix dependencies for source build (#1533 <https://github.com/ros-controls/ros2_control/issues/1533>) (#1536 <https://github.com/ros-controls/ros2_control/issues/1536>)
* Contributors: mergify[bot]
```

## controller_manager

```
* [rqt_controller_manager] Add hardware components (#1455 <https://github.com/ros-controls/ros2_control/issues/1455>) (#1587 <https://github.com/ros-controls/ros2_control/issues/1587>)
* Bump version of pre-commit hooks (backport #1556 <https://github.com/ros-controls/ros2_control/issues/1556>) (#1558 <https://github.com/ros-controls/ros2_control/issues/1558>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix link to gazebosim.org (#1563 <https://github.com/ros-controls/ros2_control/issues/1563>) (#1565 <https://github.com/ros-controls/ros2_control/issues/1565>)
* Add doc page about joint kinematics (#1497 <https://github.com/ros-controls/ros2_control/issues/1497>) (#1560 <https://github.com/ros-controls/ros2_control/issues/1560>)
* Bump version of pre-commit hooks (backport #1556 <https://github.com/ros-controls/ros2_control/issues/1556>) (#1558 <https://github.com/ros-controls/ros2_control/issues/1558>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Bump version of pre-commit hooks (backport #1556 <https://github.com/ros-controls/ros2_control/issues/1556>) (#1558 <https://github.com/ros-controls/ros2_control/issues/1558>)
* Fix dependencies for source build (#1533 <https://github.com/ros-controls/ros2_control/issues/1533>) (#1536 <https://github.com/ros-controls/ros2_control/issues/1536>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* [rqt_controller_manager] Add hardware components (#1455 <https://github.com/ros-controls/ros2_control/issues/1455>) (#1587 <https://github.com/ros-controls/ros2_control/issues/1587>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
