### PR TITLE
gz_ros2_control: 1.2.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2352,7 +2352,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.5-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.4-1`

## gz_ros2_control

```
* Simplify access for robot description from CM by overriding RM. (#265 <https://github.com/ros-controls/gz_ros2_control/issues/265>) (#364 <https://github.com/ros-controls/gz_ros2_control/issues/364>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Sai Kishor Kothakota <mailto:saisastra3@gmail.com>
  (cherry picked from commit ced470bf20d4e9313f76582eda4a28f7fc6a6a11)
  Co-authored-by: Dr. Denis <mailto:denis@stoglrobotics.de>
* Update docs and cleanup member of GazeboSimROS2ControlPluginPrivate (#363 <https://github.com/ros-controls/gz_ros2_control/issues/363>) (#367 <https://github.com/ros-controls/gz_ros2_control/issues/367>)
  (cherry picked from commit 9257ad3973e2aebf9756c7a8154efb9673ed1a43)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* fixed robot name (#358 <https://github.com/ros-controls/gz_ros2_control/issues/358>) (#359 <https://github.com/ros-controls/gz_ros2_control/issues/359>)
  (cherry picked from commit c4b3a550f0a6f6462a0d8acff71d911feff719d9)
  Co-authored-by: huzaifa <mailto:84243533+huzzu7@users.noreply.github.com>
* Contributors: mergify[bot]
```
