### PR TITLE
gz_ros2_control: 2.0.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2281,7 +2281,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.3.1-1
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.0-3`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.1-1`

## gz_ros2_control

```
* Propagate the node clock and logging interface (#368 <https://github.com/ros-controls/gz_ros2_control/issues/368>)
* Update docs and cleanup member of GazeboSimROS2ControlPluginPrivate (#363 <https://github.com/ros-controls/gz_ros2_control/issues/363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## gz_ros2_control_demos

```
* fixed robot name (#358 <https://github.com/ros-controls/gz_ros2_control/issues/358>)
* Contributors: huzaifa
```
