### PR TITLE
Add pytest-ruff

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8458,6 +8458,16 @@ python3-pytest-mock:
       packages: [pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
+python3-pytest-ruff-pip:
+  debian:
+    pip:
+      packages: [pytest-ruff]
+  fedora:
+    pip:
+      packages: [pytest-ruff]
+  ubuntu:
+    pip:
+      packages: [pytest-ruff]
 python3-pytest-timeout:
   arch: [python-pytest-timeout]
   debian: [python3-pytest-timeout]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pytest-ruff-pip

## Package Upstream Source:

https://pypi.org/project/pytest-ruff/

## Purpose of using this:

To unit test ruff linting with pytest

