### PR TITLE
foxglove_bridge: 0.7.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1780,7 +1780,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.7-1
+      version: 0.7.9-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.7.9-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.7-1`

## foxglove_bridge

```
* Fix parsing of IDL message definitions (#313 <https://github.com/foxglove/ros-foxglove-bridge/issues/313>)
* Support publishing client message as loaned message (#314 <https://github.com/foxglove/ros-foxglove-bridge/issues/314>)
* fix: remove extra ";" in websocket_server.hpp (#311 <https://github.com/foxglove/ros-foxglove-bridge/issues/311>)
* Fix rolling smoke tests crashing (#309 <https://github.com/foxglove/ros-foxglove-bridge/issues/309>)
* Contributors: Andrey Milko, Hans-Joachim Krauch
```
