### PR TITLE
Add `source` entry for ros2_openai_server (humble)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7487,6 +7487,12 @@ repositories:
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
     status: developed
+  ros2_openai_server:
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/ros2_openai_server.git
+      version: humble
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7251,6 +7251,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: humble
     status: developed
+  robosoft_openai:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/robosoft_openai.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/robosoft_openai.git
+      version: humble
+    status: developed
   robot_calibration:
     doc:
       type: git
@@ -7486,12 +7496,6 @@ repositories:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
-    status: developed
-  ros2_openai_server:
-    source:
-      type: git
-      url: https://github.com/robosoft-ai/ros2_openai_server.git
-      version: humble
     status: developed
   ros2_ouster_drivers:
     doc:


### PR DESCRIPTION
This is a new package so I'm adding the `source` entry per https://docs.ros.org/en/humble/How-To-Guides/Releasing/Release-Team-Repository.html#create-a-new-release-repository

@brettpac @yassiezar