### PR TITLE
Add `source` entry for ros2_openai_server (jazzy)

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5875,6 +5875,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: jazzy
     status: developed
+  robosoft_openai:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/robosoft_openai.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/robosoft_openai.git
+      version: jazzy
+    status: developed
   robot_calibration:
     doc:
       type: git
@@ -6042,12 +6052,6 @@ repositories:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
-    status: developed
-  ros2_openai_server:
-    source:
-      type: git
-      url: https://github.com/robosoft-ai/ros2_openai_server.git
-      version: jazzy
     status: developed
   ros2_ouster_drivers:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6043,6 +6043,12 @@ repositories:
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
     status: developed
+  ros2_openai_server:
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/ros2_openai_server.git
+      version: jazzy
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
This is a new package so I'm adding the `source` entry per https://docs.ros.org/en/jazzy/How-To-Guides/Releasing/Release-Team-Repository.html#create-a-new-release-repository

@brettpac @yassiezar