### PR TITLE
Add `source` entry for ai_msgs (humble)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -143,6 +143,16 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/affordance_primitives.git
       version: main
+  ai_prompt_msgs:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/ai_prompt_msgs.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/ai_prompt_msgs.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git


### PR DESCRIPTION
This is a new package so I'm adding the `source` entry per https://docs.ros.org/en/humble/How-To-Guides/Releasing/Release-Team-Repository.html#create-a-new-release-repository

This service is intended for prompting AI models.

@brettpac @yassiezar