### PR TITLE
Add `source` entry for ai_msgs (jazzy)

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  ai_prompt_msgs:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/ai_prompt_msgs.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/ai_prompt_msgs.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git


### PR DESCRIPTION
This is a new package so I'm adding the `source` entry per https://docs.ros.org/en/jazzy/How-To-Guides/Releasing/Release-Team-Repository.html#create-a-new-release-repository

This service is intended for prompting AI models.

@brettpac @yassiezar