### PR TITLE
lidar_situational_graphs: 0.0.1-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3010,7 +3010,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/lidar_situational_graphs-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/snt-arg/lidar_situational_graphs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lidar_situational_graphs` to `0.0.1-2`:

- upstream repository: https://github.com/snt-arg/lidar_situational_graphs.git
- release repository: https://github.com/ros2-gbp/lidar_situational_graphs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.0.1-1`
