### PR TITLE
autoware_adapi_msgs: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -517,7 +517,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_adapi_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_adapi_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## autoware_adapi_v1_msgs

```
* feat(autoware_adapi_v1_msgs): remove energy status (#58 <https://github.com/youtalk/autoware_adapi_msgs/issues/58>)
* feat(autoware_adapi_v1_msgs): add diagnostics (#54 <https://github.com/youtalk/autoware_adapi_msgs/issues/54>)
* Contributors: Takagi, Isamu
```

## autoware_adapi_version_msgs

- No changes
