### PR TITLE
kuka_drivers: 0.9.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3432,7 +3432,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_drivers-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_drivers` to `0.9.2-1`:

- upstream repository: https://github.com/kroshu/kuka_drivers.git
- release repository: https://github.com/ros2-gbp/kuka_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.1-1`

## fri_configuration_controller

```
* Fix GCC warning causing unstable build
```

## fri_state_broadcaster

```
* Fix GCC warning causing unstable build
```

## iiqka_moveit_example

```
* Fix GCC warning causing unstable build
```

## joint_group_impedance_controller

```
* Fix GCC warning causing unstable build
```

## kuka_control_mode_handler

```
* Fix GCC warning causing unstable build
```

## kuka_controllers

```
* Fix GCC warning causing unstable build
```

## kuka_driver_interfaces

```
* Fix GCC warning causing unstable build
```

## kuka_drivers

```
* Fix GCC warning causing unstable build
```

## kuka_drivers_core

```
* Fix GCC warning causing unstable build
```

## kuka_event_broadcaster

```
* Fix GCC warning causing unstable build
```

## kuka_iiqka_eac_driver

```
* Fix GCC warning causing unstable build
```

## kuka_kss_rsi_driver

```
* Fix GCC warning causing unstable build
```

## kuka_rsi_simulator

```
* Fix GCC warning causing unstable build
```

## kuka_sunrise_fri_driver

```
* Fix GCC warning causing unstable build
```
