### PR TITLE
ros_tutorials: 1.9.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6151,10 +6151,11 @@ repositories:
     release:
       packages:
       - turtlesim
+      - turtlesim_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.9.2-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.9.1-1`

## turtlesim

```
* Create turtlesim_msgs (#169 <https://github.com/ros/ros_tutorials/issues/169>)
* Contributors: Alejandro Hernández Cordero
```

## turtlesim_msgs

```
* Create turtlesim_msgs (#169 <https://github.com/ros/ros_tutorials/issues/169>)
* Contributors: Alejandro Hernández Cordero
```
