### PR TITLE
geometry_tutorials: 0.3.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2681,7 +2681,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.3.6-1
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.3.7-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros2-gbp/geometry_tutorials-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.6-1`

## geometry_tutorials

- No changes

## turtle_tf2_cpp

```
* Migrate std::bind calls to lambda expressions (#76 <https://github.com/ros/geometry_tutorials/issues/76>)
  * ♻️ Geometry msgs lambda refactor
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Fix a few more minor nitpicks. (#72 <https://github.com/ros/geometry_tutorials/issues/72>)
  1.  Remove dependencies from the targets that don't need them.
  2.  Remove a totally unnecessary typedef.
  3.  Remove unnecessary casts to float.
* Contributors: Chris Lalancette, Felipe Gomes de Melo
```

## turtle_tf2_py

```
* Fix a few more minor nitpicks. (#72 <https://github.com/ros/geometry_tutorials/issues/72>)
  1.  Remove dependencies from the targets that don't need them.
  2.  Remove a totally unnecessary typedef.
  3.  Remove unnecessary casts to float.
* Contributors: Chris Lalancette
```
