### PR TITLE
geometry_tutorials: 0.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2031,7 +2031,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.3.6-5
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.5.0-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros2-gbp/geometry_tutorials-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.6-5`

## geometry_tutorials

- No changes

## turtle_tf2_cpp

```
* Migrate std::bind calls to lambda expressions (#76 <https://github.com/ros/geometry_tutorials/issues/76>)
  * ♻️ Geometry msgs lambda refactor
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Fix a few more minor nitpicks. (#72 <https://github.com/ros/geometry_tutorials/issues/72>)
  1.  Remove dependencies from the targets that don't need them.
  2.  Remove a totally unnecessary typedef.
  3.  Remove unnecessary casts to float.
* Contributors: Chris Lalancette, Felipe Gomes de Melo
```

## turtle_tf2_py

```
* Fix a few more minor nitpicks. (#72 <https://github.com/ros/geometry_tutorials/issues/72>)
  1.  Remove dependencies from the targets that don't need them.
  2.  Remove a totally unnecessary typedef.
  3.  Remove unnecessary casts to float.
* Contributors: Chris Lalancette
```
