### PR TITLE
qt_gui_core: 2.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4884,7 +4884,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.8.1-1
+      version: 2.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.8.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.1-1`

## qt_dotgraph

- No changes

## qt_gui

- No changes

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Add common linters and make them happy to qt_gui_cpp (#295 <https://github.com/ros-visualization/qt_gui_core/issues/295>)
* Deprecated h headers (#294 <https://github.com/ros-visualization/qt_gui_core/issues/294>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_py_common

- No changes
