### PR TITLE
hebi_cpp_api: 3.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2904,10 +2904,16 @@ repositories:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
+      version: 3.9.0-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
+    status: maintained
   hey5_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api` to `3.9.0-1`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/ros2-gbp/hebi_cpp_api-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## hebi_cpp_api

```
* Bumped up the HEBI CPP API Version to 3.9.0 (changelogs for previous version are available at https://github.com/HebiRobotics/HEBI-Core-Cpp/releases)
* Initial release of HEBI API for ROS 2
* Contributors: Chris Bollinger, Hariharan Ravichandran
```
