### PR TITLE
network_bridge: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4033,6 +4033,11 @@ repositories:
       type: git
       url: https://github.com/brow1633/network_bridge.git
       version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/network_bridge-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/brow1633/network_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_bridge` to `1.0.2-1`:

- upstream repository: https://github.com/brow1633/network_bridge.git
- release repository: https://github.com/ros2-gbp/network_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## network_bridge

```
* Move launch_testing_ament_cmake requirement to if testing block
* Contributors: Ethan Brown
```
