### PR TITLE
resource_retriever: 3.2.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5337,7 +5337,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.2.2-3
+      version: 3.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.2.3-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.2-3`

## libcurl_vendor

```
* Add "lib" to the Windows curl search path. (#98 <https://github.com/ros/resource_retriever/issues/98>)
* Contributors: Chris Lalancette
```

## resource_retriever

- No changes
