### PR TITLE
rcl: 6.0.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5082,7 +5082,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 6.0.5-1
+      version: 6.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `6.0.6-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.5-1`

## rcl

```
* Fix up type_description tests. (#1160 <https://github.com/ros2/rcl/issues/1160>)
* Generate version header using ament_generate_version_header(..) (#1144 <https://github.com/ros2/rcl/issues/1144>)
* Contributors: Chris Lalancette,  G.A. vd. Hoorn, Tomoya.Fujita
```

## rcl_action

```
* Generate version header using ament_generate_version_header(..) (#1144 <https://github.com/ros2/rcl/issues/1144>)
* add RCL_RET_TIMEOUT to action service response. (#1154 <https://github.com/ros2/rcl/issues/1154>)
* Contributors: G.A. vd. Hoorn, Tomoya Fujita
```

## rcl_lifecycle

```
* Generate version header using ament_generate_version_header(..) (#1144 <https://github.com/ros2/rcl/issues/1144>)
* Contributors: G.A. vd. Hoorn, Tomoya.Fujita
```

## rcl_yaml_param_parser

```
* Generate version header using ament_generate_version_header(..) (#1144 <https://github.com/ros2/rcl/issues/1144>)
* Contributors: G.A. vd. Hoorn, Tomoya.Fujita
```
