### PR TITLE
rclpy: 4.1.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5198,7 +5198,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 4.1.5-1
+      version: 4.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `4.1.6-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.5-1`

## rclpy

```
* update RCL_RET_TIMEOUT error handling with action service response. (#1277 <https://github.com/ros2/rclpy/issues/1277>)
* Contributors: Tomoya Fujita
```
