### PR TITLE
ros2_tracing: 6.3.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5991,7 +5991,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 6.3.1-1
+      version: 6.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `6.3.2-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.3.1-1`

## ros2trace

- No changes

## tracetools

```
* Fix type for buffer index argument in tracepoint event declaration. (#121 <https://github.com/ros2/ros2_tracing/issues/121>)
* Contributors: Mattis Kieffer
```

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
