### PR TITLE
classic_bags: 0.2.0-1 in 'humble/distribution.yaml' [manual]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1078,16 +1078,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/classic_bags-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
-      version: main
+      version: humble
     status: developed
   clearpath_common:
     doc:


### PR DESCRIPTION
I'm manually making this PR to change the branch name, based on the output of bloom. 

Increasing version of package(s) in repository `classic_bags` to `0.2.0-1`:

- upstream repository: https://github.com/MetroRobots/classic_bags.git
- release repository: https://github.com/ros2-gbp/classic_bags-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`
