### PR TITLE
classic_bags: 0.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -804,7 +804,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -814,7 +814,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
-      version: main
+      version: iron
     status: developed
   color_names:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -809,7 +809,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/classic_bags-release.git
-      version: 0.1.0-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `classic_bags` to `0.3.0-1`:

- upstream repository: https://github.com/MetroRobots/classic_bags.git
- release repository: https://github.com/ros2-gbp/classic_bags-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`
