### PR TITLE
rmf_api_msgs: 0.1.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5365,7 +5365,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.1.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## rmf_api_msgs

```
* Add mutex group information to robot_state (#51 <https://github.com/open-rmf/rmf_api_msgs/issues/51>)
* Introduce schemas for robot commission request (#48 <https://github.com/open-rmf/rmf_api_msgs/issues/48>)
* Contributors: Grey
```
