### PR TITLE
rmf_ros2: 2.2.6-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5470,7 +5470,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.2.5-1
+      version: 2.2.6-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.2.6-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.5-1`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Filter DoorOpen insertion by map name (#354 <https://github.com/open-rmf/rmf_ros2/issues/354>)
* Fix schema dictionary used during robot status override (#352 <https://github.com/open-rmf/rmf_ros2/issues/352>)
* Fix schema loading (#344 <https://github.com/open-rmf/rmf_ros2/issues/344>)
* Contributors: Grey
```

## rmf_fleet_adapter_python

- No changes

## rmf_task_ros2

```
* Fix incorrect std rounding function used when generating timestamp strings for task ID #370 <https://github.com/open-rmf/rmf_ros2/issues/370>)
* Contributors: Aaron Chong
```

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
