### PR TITLE
rmw_cyclonedds: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5653,7 +5653,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `3.0.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## rmw_cyclonedds_cpp

```
* Fix the triggering of guard conditions. (#504 <https://github.com/ros2/rmw_cyclonedds/issues/504>)
  When a guard condition goes active, we have to remember
  to increase the trig_idx so we look at the next trigger.
  Otherwise, we can get into situations where we skip a
  triggered member.
* Contributors: Chris Lalancette
```
