### PR TITLE
rmw_cyclonedds: 2.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5817,7 +5817,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `2.2.2-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`

## rmw_cyclonedds_cpp

```
* Fix the triggering of guard conditions. (#504 <https://github.com/ros2/rmw_cyclonedds/issues/504>) (#505 <https://github.com/ros2/rmw_cyclonedds/issues/505>)
  When a guard condition goes active, we have to remember
  to increase the trig_idx so we look at the next trigger.
  Otherwise, we can get into situations where we skip a
  triggered member.
  (cherry picked from commit 899bbdf73fb57c8f5926b31e9570f017b8c2fdb9)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
