### PR TITLE
py_binding_tools: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6166,7 +6166,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-gbp/py_binding_tools-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.0.1-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros-gbp/py_binding_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## py_binding_tools

```
* rclcpp.init(None) will resort to sys.argv as with rclpy.init(None)
* Contributors: Robert Haschke
```
