### PR TITLE
rosbag2: 0.22.7-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6241,7 +6241,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.22.6-1
+      version: 0.22.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.22.7-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.22.6-1`

## mcap_vendor

- No changes

## ros2bag

```
* Allow to specify start offset from CLI arguments equal to 0.0 for the rosbag2 player (#1714 <https://github.com/ros2/rosbag2/issues/1714>)
* Add --log-level to ros2 bag play and record (#1654 <https://github.com/ros2/rosbag2/issues/1654>)
* Resolve recording option problem (#1649 <https://github.com/ros2/rosbag2/issues/1649>)
* Contributors: Barry Xu, Michael Orlov, Rein Appeldoorn, Roman
```

## rosbag2

- No changes

## rosbag2_compression

```
* Fix for regression in open_succeeds_twice and minimal_writer_example tests (#1669 <https://github.com/ros2/rosbag2/issues/1669>)
* Bugfix for writer not being able to open again after closing (#1635 <https://github.com/ros2/rosbag2/issues/1635>)
* Contributors: Michael Orlov, Yannick Schulz
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing (#1711 <https://github.com/ros2/rosbag2/issues/1711>)
* Bugfix for writer not being able to open again after closing (#1635 <https://github.com/ros2/rosbag2/issues/1635>)
* Add BagSplitInfo service call on bag close (#1636 <https://github.com/ros2/rosbag2/issues/1636>)
* Contributors: Cole Tucker, Michael Orlov, Yannick Schulz
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Gracefully handle SIGINT and SIGTERM signals for play and burst CLI (#1690 <https://github.com/ros2/rosbag2/issues/1690>)
* Fix for false negative tests in rosbag2_py (#1688 <https://github.com/ros2/rosbag2/issues/1688>)
* Add --log-level to ros2 bag play and record (#1654 <https://github.com/ros2/rosbag2/issues/1654>)
* Contributors: Michael Orlov, Roman
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Propagate "custom_data" and "ros_distro" in to the metadata.yaml file during re-indexing (#1711 <https://github.com/ros2/rosbag2/issues/1711>)
* Fix for regression in open_succeeds_twice and minimal_writer_example tests (#1669 <https://github.com/ros2/rosbag2/issues/1669>)
* Bugfix for writer not being able to open again after closing (#1635 <https://github.com/ros2/rosbag2/issues/1635>)
* Contributors: Cole Tucker, Michael Orlov, Yannick Schulz
```

## rosbag2_transport

```
* Gracefully handle SIGINT and SIGTERM signals for play and burst CLI (#1690 <https://github.com/ros2/rosbag2/issues/1690>)
* Contributors: Michael Orlov
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
