### PR TITLE
 Add `luma.core` and `luma.oled` pip dependencies to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6866,6 +6866,14 @@ python3-lockfile:
   opensuse: [python-lockfile]
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
+python3-luma.core-pip:
+  "*":
+    pip:
+      package: [luma.core]
+python3-luma.oled-pip:
+  "*":
+    pip:
+      package: [luma.oled]
 python3-lttng:
   alpine: [py3-lttng]
   arch: [python-lttngust]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6866,11 +6866,11 @@ python3-lockfile:
   opensuse: [python-lockfile]
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
-python3-luma.core-pip:
+python3-luma-core-pip:
   '*':
     pip:
       packages: [luma.core]
-python3-luma.oled-pip:
+python3-luma-oled-pip:
   '*':
     pip:
       packages: [luma.oled]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6867,11 +6867,11 @@ python3-lockfile:
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
 python3-luma.core-pip:
-  "*":
+  '*':
     pip:
       package: [luma.core]
 python3-luma.oled-pip:
-  "*":
+  '*':
     pip:
       package: [luma.oled]
 python3-lttng:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6869,11 +6869,11 @@ python3-lockfile:
 python3-luma.core-pip:
   '*':
     pip:
-      package: [luma.core]
+      packages: [luma.core]
 python3-luma.oled-pip:
   '*':
     pip:
-      package: [luma.oled]
+      packages: [luma.oled]
 python3-lttng:
   alpine: [py3-lttng]
   arch: [python-lttngust]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6867,9 +6867,13 @@ python3-lockfile:
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
 python3-luma-core:
-  ubuntu: [python3-luma.core]
+  ubuntu:
+    jammy: [python3-luma.core]
+    noble: [python3-luma.core]
 python3-luma-oled:
-  ubuntu: [python3-luma.oled]
+  ubuntu:
+    jammy: [python3-luma.oled]
+    noble: [python3-luma.oled]
 python3-lttng:
   alpine: [py3-lttng]
   arch: [python-lttngust]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6866,14 +6866,10 @@ python3-lockfile:
   opensuse: [python-lockfile]
   rhel: [python3-lockfile]
   ubuntu: [python3-lockfile]
-python3-luma-core-pip:
-  '*':
-    pip:
-      packages: [luma.core]
-python3-luma-oled-pip:
-  '*':
-    pip:
-      packages: [luma.oled]
+python3-luma-core:
+  ubuntu: [python3-luma.core]
+python3-luma-oled:
+  ubuntu: [python3-luma.oled]
 python3-lttng:
   alpine: [py3-lttng]
   arch: [python-lttngust]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`luma.core`, `luma.oled` 

## Package Upstream Source:

luma.core - https://github.com/rm-hull/luma.core
luma.oled - https://github.com/rm-hull/luma.oled

## Reason to add:
1. luma.core - component library providing a [Pillow](https://pillow.readthedocs.io/)-compatible drawing canvas for Python 3, and other functionality to support drawing primitives and text-rendering capabilities for small displays on the Raspberry Pi and other single board computers
2. luma.oled - Python 3 library interfacing OLED matrix displays with the SSD1306, SSD1309, SSD1322, SSD1325, SSD1327, SSD1331, SSD1351, SH1106, SH1107 or WS0010 driver using I2C/SPI/Parallel on the Raspberry Pi and other linux-based single-board computers

Both libraries are useful for rendering on displays on robots

## Links to Distribution Packages
+ Ubuntu:
  + Jammy:
    + `luma.core`: https://packages.ubuntu.com/jammy/python3-luma.core
    + `luma.oled`: https://packages.ubuntu.com/jammy/python3-luma.oled
  + Noble:
    + `luma.core`: https://packages.ubuntu.com/noble/python3-luma.core
    + `luma.oled`: https://packages.ubuntu.com/noble/python3-luma.oled

