### PR TITLE
fix debian bullseye package name

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9889,7 +9889,7 @@ python3-vcstool:
   alpine: [vcstool]
   debian: 
     '*': [python3-vcstool]
-    'bullseye': [python3-vcstools]
+    bullseye: [python3-vcstools]
   fedora: [python3-vcstool]
   gentoo: [vcstool]
   macports:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9887,7 +9887,9 @@ python3-uvloop:
   ubuntu: [python3-uvloop]
 python3-vcstool:
   alpine: [vcstool]
-  debian: [python3-vcstool]
+  debian: 
+    '*': [python3-vcstool]
+    'bullseye': [python3-vcstools]
   fedora: [python3-vcstool]
   gentoo: [vcstool]
   macports:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9887,7 +9887,7 @@ python3-uvloop:
   ubuntu: [python3-uvloop]
 python3-vcstool:
   alpine: [vcstool]
-  debian: 
+  debian:
     '*': [python3-vcstool]
     bullseye: [python3-vcstools]
   fedora: [python3-vcstool]


### PR DESCRIPTION
fix debian bullseye package name from python3-vcstool to python3-vcstools


## Package name:

python3-vcstools

## Package Upstream Source:

python3-vcstools for debian bullseye
python3-vcstool for other Debian distributions


## Purpose of using this:

python3-vcstool not exist in debian bullseye distro


## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
https://packages.debian.org/bullseye/python3-vcstools


<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME : ALL

# The source is here:

https://packages.debian.org/bullseye/python3-vcstools

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
