### PR TITLE
camera_aravis2: 1.0.0-1 in 'humble/distribution.yaml', 'iron/distribution.yaml', 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -924,6 +924,14 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/camera_aravis2.git
       version: main
+    release:
+      packages:
+      - camera_aravis2
+      - camera_aravis2_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/camera_aravis2-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -709,6 +709,14 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/camera_aravis2.git
       version: main
+    release:
+      packages:
+      - camera_aravis2
+      - camera_aravis2_msgs
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/camera_aravis2-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -813,6 +813,14 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/camera_aravis2.git
       version: main
+    release:
+      packages:
+      - camera_aravis2
+      - camera_aravis2_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/camera_aravis2-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis2` to `1.0.0-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis2.git
- release repository: https://github.com/ros2-gbp/camera_aravis2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## camera_aravis2

```
* Implemented GenICam compliant 'camera_driver_gv' for ROS2
  
  Allowing to access a GenICam compliant via its serial number and publishing an image stream
  
  Supporting multiple substreams
  
  Allowing to flexibly control GenICam-Specific parameters, such as TransportLayerControl, ImageFormatControl, AcquisitionControl, AnalogControl
  
  Support for PTP timestamps.
  
  Support to publish diagnostic messages for camera.
* Implemented 'camera_finder' to list all available GenICam devices.
* Implemented 'camera_xml_exporter' to export camera-specific GenICam support into XML.
* CI/CD support
* Contributors: Boitumelo Ruf
```

## camera_aravis2_msgs

```
* Added camera_aravis2 specific messages
* Contributors: Boitumelo Ruf
```
