### PR TITLE
classic_bags: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -893,7 +893,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/classic_bags-release.git
-      version: 0.1.0-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MetroRobots/classic_bags.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -895,6 +895,7 @@ repositories:
       url: https://github.com/ros2-gbp/classic_bags-release.git
       version: 0.4.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
       version: main


### PR DESCRIPTION
Increasing version of package(s) in repository `classic_bags` to `0.4.0-1`:

- upstream repository: https://github.com/MetroRobots/classic_bags.git
- release repository: https://github.com/ros2-gbp/classic_bags-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-2`
