### PR TITLE
classic_bags: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -921,7 +921,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/classic_bags-release.git
-      version: 0.1.0-3
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MetroRobots/classic_bags.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -923,6 +923,7 @@ repositories:
       url: https://github.com/ros2-gbp/classic_bags-release.git
       version: 0.4.0-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/classic_bags.git
       version: main


### PR DESCRIPTION
Increasing version of package(s) in repository `classic_bags` to `0.4.0-1`:

- upstream repository: https://github.com/MetroRobots/classic_bags.git
- release repository: https://github.com/ros2-gbp/classic_bags-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-3`
