### PR TITLE
gz_msgs_vendor: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2203,7 +2203,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_msgs_vendor` to `0.1.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_msgs_vendor.git
- release repository: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## gz_msgs_vendor

```
* Update vendored package version to 10.3.0
* Contributors: Addisu Z. Taddese
```
