### PR TITLE
sdformat_vendor: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7057,7 +7057,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.1.2-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## sdformat_vendor

```
* Update vendored package version to 14.4.0
* Contributors: Addisu Z. Taddese
```
