### PR TITLE
gz_sim_vendor: 0.1.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2311,7 +2311,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
-      version: 0.1.0-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sim_vendor` to `0.1.1-2`:

- upstream repository: https://github.com/gazebo-release/gz_sim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sim_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## gz_sim_vendor

```
* Update vendored package version to 8.5.0
* Contributors: Addisu Z. Taddese
```
