### PR TITLE
gz_sensors_vendor: 0.1.2-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2296,7 +2296,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.1.1-1
+      version: 0.1.2-3
     source:
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.1.2-3`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## gz_sensors_vendor

```
* Update vendored package version to 8.2.0
* Contributors: Addisu Z. Taddese
```
