### PR TITLE
gz_transport_vendor: 0.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2424,7 +2424,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_transport_vendor` to `0.0.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_transport_vendor.git
- release repository: https://github.com/ros2-gbp/gz_transport_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-1`

## gz_transport_vendor

```
* Update vendored package version to 13.4.0
* Contributors: Addisu Z. Taddese
```
