### PR TITLE
image_pipeline: 5.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2597,7 +2597,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.1-3
+      version: 5.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.3-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.1-3`

## camera_calibration

```
* Added stereo calibration using charuco board (backport #976 <https://github.com/ros-perception/image_pipeline/issues/976>) (#1002 <https://github.com/ros-perception/image_pipeline/issues/1002>)
  From #972 <https://github.com/ros-perception/image_pipeline/issues/972>
  Doing this first for rolling.
  This was a TODO in the repository, opening this PR to add this feature.
  - The main issue why this wasn't possible imo is the way mk_obj_points
  works. I'm using the inbuilt opencv function to get the points there.
  - The other is a condition when aruco markers are detected they are
  added as good points, This is fine in case of mono but in stereo these
  have to be the same number as the object points to find matches although
  this should be possible with aruco.<hr>This is an automatic backport of
  pull request #976 <https://github.com/ros-perception/image_pipeline/issues/976> done by [Mergify](https://mergify.com).
  Co-authored-by: Myron Rodrigues <mailto:41271144+MRo47@users.noreply.github.com>
* Change camera info message to lower case (backport #1005 <https://github.com/ros-perception/image_pipeline/issues/1005>) (#1007 <https://github.com/ros-perception/image_pipeline/issues/1007>)
  Change camera info message to lower case since message type had been
  change in rolling and humble.
  [](https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/CameraInfo.msg)<hr>This
  is an automatic backport of pull request #1005 <https://github.com/ros-perception/image_pipeline/issues/1005> done by
  [Mergify](https://mergify.com).
  ---------
  Co-authored-by: SFhmichael <mailto:146928033+SFhmichael@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

```
* [jazzy] image_publisher: Fix loading of the camera info parameters on startup (backport #983 <https://github.com/ros-perception/image_pipeline/issues/983>) (#995 <https://github.com/ros-perception/image_pipeline/issues/995>)
  As described in
  https://github.com/ros-perception/image_pipeline/issues/965 camera info
  is not loaded from the file on node initialization, but only when the
  parameter is reloaded.
  This PR resolves this issue and should be straightforward to port it to
  Humble, Iron and Jazzy.<hr>This is an automatic backport of pull
  request #983 <https://github.com/ros-perception/image_pipeline/issues/983> done by [Mergify](https://mergify.com).
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
* image_publisher: Fix image, constantly flipping when static image is published (backport #986 <https://github.com/ros-perception/image_pipeline/issues/986>) (#987 <https://github.com/ros-perception/image_pipeline/issues/987>)
  Continuation of
  https://github.com/ros-perception/image_pipeline/pull/984.
  When publishing video stream from a camera, the image was flipped
  correctly. Yet for a static image, which was loaded once, the flip
  function was applied every time ImagePublisher::doWork() was called,
  resulting in the published image being flipped back and forth all the
  time.
  This PR should be straightforward to port it to Humble, Iron and
  Jazzy.<hr>This is an automatic backport of pull request #986 <https://github.com/ros-perception/image_pipeline/issues/986> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* [jazzy] image_publisher: add field of view parameter (backport #985 <https://github.com/ros-perception/image_pipeline/issues/985>) (#992 <https://github.com/ros-perception/image_pipeline/issues/992>)
  Currently, the default value for focal length when no camera info is
  provided defaults to 1.0 rendering whole approximate intrinsics and
  projection matrices useless. Based on [this
  article](https://learnopencv.com/approximate-focal-length-for-webcams-and-cell-phone-cameras/),
  I propose a better approximation of the focal length based on the field
  of view of the camera.
  For most of the use cases, users will either know the field of view of
  the camera the used, or they already calibrated it ahead of time.
  If there is some documentation to fill. please let me know.
  This PR should be straightforward to port it to Humble, Iron and
  Jazzy.
  <hr>This is an automatic backport of pull request #985 <https://github.com/ros-perception/image_pipeline/issues/985> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
* Contributors: mergify[bot]
```

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
