### PR TITLE
metavision_driver: 2.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3254,7 +3254,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 1.2.8-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `2.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.8-1`

## metavision_driver

```
* depend on openeb_vendor
* work around foxy API differences
* fail more gracefully when EVT2 file is fed in
* fixed bug when playing back from file
* Contributors: Bernd Pfrommer
```
