### PR TITLE
geometry_tutorials: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1958,7 +1958,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.3.6-4
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.6.1-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros2-gbp/geometry_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.6-4`

## geometry_tutorials

- No changes

## turtle_tf2_cpp

```
* Clean rolling CI (#82 <https://github.com/ros/geometry_tutorials/issues/82>)
* Use target_link_libraries (#83 <https://github.com/ros/geometry_tutorials/issues/83>)
* Contributors: Alejandro Hernández Cordero
```

## turtle_tf2_py

- No changes
