### PR TITLE
Adding neo_nav2_bringup as new repo to humble and iron

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4988,6 +4988,16 @@ repositories:
       url: https://github.com/koide3/ndt_omp.git
       version: master
     status: developed
+  neo_nav2_bringup:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: humble
+    status: maintained
   neo_simulation2:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3918,6 +3918,16 @@ repositories:
       url: https://github.com/koide3/ndt_omp.git
       version: master
     status: developed
+  neo_nav2_bringup:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: iron
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: iron
+    status: maintained
   neo_simulation2:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3877,16 +3877,6 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: rolling
     status: maintained
-  neo_nav2_bringup:
-    doc:
-      type: git
-      url: https://github.com/neobotix/neo_nav2_bringup.git
-      version: rolling
-    source:
-      type: git
-      url: https://github.com/neobotix/neo_nav2_bringup.git
-      version: rolling
-    status: maintained
   neo_simulation2:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3877,6 +3877,16 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: rolling
     status: maintained
+  neo_nav2_bringup:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: rolling
+    status: maintained
   neo_simulation2:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

neo_nav2_bringup

## Package Upstream Source:

https://github.com/neobotix/neo_nav2_bringup/

## Purpose of using this:

 This dependency contains the boilerplate code for starting and configuring the Nav2 stack for all the neobotix robots

