### PR TITLE
ros2_socketcan: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7617,10 +7617,13 @@ repositories:
       url: https://github.com/autowarefoundation/ros2_socketcan.git
       version: main
     release:
+      packages:
+      - ros2_socketcan
+      - ros2_socketcan_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.1.0-3
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.3.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/ros2-gbp/ros2_socketcan-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-3`

## ros2_socketcan

```
* Jazzy release
* fix: add missing header (#42 <https://github.com/autowarefoundation/ros2_socketcan/issues/42>)
* Allow remapping of the canbus topics (#39 <https://github.com/autowarefoundation/ros2_socketcan/issues/39>)
* Contributors: Joshua Whitley, Tim Clephas
```

## ros2_socketcan_msgs

```
* Jazzy release
```
