### PR TITLE
openeb_vendor: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5415,7 +5415,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/openeb_vendor-release.git
-      version: 1.1.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openeb_vendor` to `2.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/openeb_vendor.git
- release repository: https://github.com/ros2-gbp/openeb_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.2-1`

## openeb_vendor

```
* upgrade to 4.6.2
* also build on humble
* Contributors: Bernd Pfrommer
```
