### PR TITLE
ros2_socketcan: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5939,7 +5939,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.2.0-2
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_socketcan` to `1.3.0-1`:

- upstream repository: https://github.com/autowarefoundation/ros2_socketcan.git
- release repository: https://github.com/ros2-gbp/ros2_socketcan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-2`

## ros2_socketcan

```
* Jazzy release
* fix: add missing header (#42 <https://github.com/autowarefoundation/ros2_socketcan/issues/42>)
* Allow remapping of the canbus topics (#39 <https://github.com/autowarefoundation/ros2_socketcan/issues/39>)
* Contributors: Joshua Whitley, Tim Clephas
```

## ros2_socketcan_msgs

```
* Jazzy release
```
