### PR TITLE
gz_ros2_control: 1.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2374,7 +2374,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.4-1
+      version: 1.2.6-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.6-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.4-1`

## gz_ros2_control

```
* Propagate the node clock and logging interface (#368 <https://github.com/ros-controls/gz_ros2_control/issues/368>) (#373 <https://github.com/ros-controls/gz_ros2_control/issues/373>)
  (cherry picked from commit a1d9bd46fc491c0de35f86f9c14c1620cbcdb037)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes
