### PR TITLE
laser_filters: 1.9.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5014,7 +5014,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/laser_filters-release.git
-      version: 1.9.0-1
+      version: 1.9.1-2
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `1.9.1-2`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros-gbp/laser_filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.9.0-1`

## laser_filters

```
* Fix polygon padding on filter load
* Added nodelet for scan filtering pipeline
* Pass in public node handle from nodelet to allow for correct topic remapping
* Do not force obsolete C++11 standard
* Boxfilter dynamic reconfigure for noetic devel
* Make transform time-out configurable
* Do not look for specific time in static filter
* Added examples for InterpolationFilter and LaserScanAngularBoundsFilter
* Added example config and launch file for scan blob filter
* Add static polygon filter
* Improve shadov filter and detector performance
* Speed up speckle filter implementation
* Contributors: Bohdan Yarema, Erwin Bonsma, Giorgos Tsamis, Jon Binney, Lars, Lucas Walter, Michael Ripperger, johntgz, rickvanosch, v4hn
```
