### PR TITLE
Rollback rtabmap to latest success build.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7154,7 +7154,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.5-2
+      version: 0.21.5-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
`rtabmap` is failing on it's latest release on `noble` for `Jazzy`, rolling back to the latest successful build: 

https://build.ros2.org/view/Jsrc_uN/job/Jsrc_uN__rtabmap__ubuntu_noble__source/