### PR TITLE
Revert "diagnostics: 4.2.0-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1206,12 +1206,12 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.2.0-1
+      version: 3.1.2-3
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2-jazzy
+      version: ros2
     status: maintained
   dolly:
     doc:


### PR DESCRIPTION
Reverts ros/rosdistro#41859 

This update seems to be causing a bunch of downstream projects to fail: https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__diagnostic_updater__ubuntu_noble_amd64__binary/

Adding a heads up issue to the source repo: https://github.com/ros/diagnostics/issues/387