### PR TITLE
Adding adi_tmc_coe to documentation index for distro

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -94,13 +94,6 @@ repositories:
     doc:
       type: git
       url: https://github.com/analogdevicesinc/adi_tmc_coe.git
-<<<<<<< HEAD
-      version: noetic
-    source:
-      type: git
-      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
-=======
->>>>>>> 609a248f4 (Update noetic/distribution.yaml)
       version: noetic
     source:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -99,6 +99,10 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/adi_tmc_coe.git
       version: noetic
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+      version: noetic
     status: maintained
   agni_tf_tools:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -90,6 +90,16 @@ repositories:
       url: https://github.com/analogdevicesinc/tmcl_ros.git
       version: noetic
     status: maintained
+  adi_tmc_coe:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+      version: noetic
+    status: maintained
   agni_tf_tools:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -94,10 +94,13 @@ repositories:
     doc:
       type: git
       url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+<<<<<<< HEAD
       version: noetic
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+=======
+>>>>>>> 609a248f4 (Update noetic/distribution.yaml)
       version: noetic
     source:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,6 +75,16 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  adi_tmc_coe:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+      version: noetic
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
+      version: noetic
+    status: maintained
   adi_tmcl:
     doc:
       type: git
@@ -88,16 +98,6 @@ repositories:
     source:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros.git
-      version: noetic
-    status: maintained
-  adi_tmc_coe:
-    doc:
-      type: git
-      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
-      version: noetic
-    source:
-      type: git
-      url: https://github.com/analogdevicesinc/adi_tmc_coe.git
       version: noetic
     status: maintained
   agni_tf_tools:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

adi_tmc_coe

# The source is here:

https://github.com/analogdevicesinc/adi_tmc_coe

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
