### PR TITLE
message_filters: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3320,7 +3320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `6.0.1-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.0-1`

## message_filters

```
* Deprecating all C headers (#135 <https://github.com/ros2/message_filters/issues/135>)
* Cleanups (#134 <https://github.com/ros2/message_filters/issues/134>)
* fix link of index.rst in README.md (#133 <https://github.com/ros2/message_filters/issues/133>)
* Contributors: Alejandro Hernández Cordero, Iván López Broceño, Lucas Wendland
```
