### PR TITLE
image_common: 5.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2489,7 +2489,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.3.0-1
+      version: 5.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.3.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

```
* Added common test to camera info manager (#318 <https://github.com/ros-perception/image_common/issues/318>)
* Contributors: Alejandro Hernández Cordero
```

## image_common

- No changes

## image_transport

```
* Updated deprecated message filter headers (#320 <https://github.com/ros-perception/image_common/issues/320>)
* Removed outdated comment (#319 <https://github.com/ros-perception/image_common/issues/319>)
* Contributors: Alejandro Hernández Cordero
```
