### PR TITLE
rviz: 14.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7001,7 +7001,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.2.3-1
+      version: 14.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.2.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.2.3-1`

## rviz2

```
* Fixed RViz2 linters (#1231 <https://github.com/ros2/rviz/issues/1231>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_assimp_vendor

```
* Update ASSIMP_VENDOR CMakeLists.txt (#1226 <https://github.com/ros2/rviz/issues/1226>)
  CLEAN UNUSED CHECK
  SE MIN ASSIMP VERSION TO 5.3.1
  SET C++ VERSION TO 17
* Contributors: mosfet80
```

## rviz_common

```
* Updated deprecated message filter headers (#1239 <https://github.com/ros2/rviz/issues/1239>)
* Correclty load icons of panels with whitespaces in their name (#1241 <https://github.com/ros2/rviz/issues/1241>)
* Contributors: Alejandro Hernández Cordero, Patrick Roncagliolo
```

## rviz_default_plugins

```
* Updated deprecated message filter headers (#1239 <https://github.com/ros2/rviz/issues/1239>)
* Fixed RViz default plugin license linter (#1230 <https://github.com/ros2/rviz/issues/1230>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix: issue #1220 <https://github.com/ros2/rviz/issues/1220>. (#1237 <https://github.com/ros2/rviz/issues/1237>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Added common test: rviz_rendering (#1233 <https://github.com/ros2/rviz/issues/1233>)
* Contributors: Alejandro Hernández Cordero, chama1176
```

## rviz_rendering_tests

```
* Added common test to rviz_rendering_tests (#1234 <https://github.com/ros2/rviz/issues/1234>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_visual_testing_framework

```
* Added common test to rviz_visual_testing_framework (#1235 <https://github.com/ros2/rviz/issues/1235>)
* Contributors: Alejandro Hernández Cordero
```
