### PR TITLE
geometry2: 0.38.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1938,7 +1938,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.38.1-1
+      version: 0.38.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.38.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.38.1-1`

## examples_tf2_py

```
* Switch to using a context manager for the python examples. (#700 <https://github.com/ros2/geometry2/issues/700>)
  That way we can be sure to always clean up, but use less
  code doing so.
* Contributors: Chris Lalancette
```

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Updated deprecated message filter headers (#702 <https://github.com/ros2/geometry2/issues/702>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_ros_py

```
* Switch to using a context manager for the python examples. (#700 <https://github.com/ros2/geometry2/issues/700>)
  That way we can be sure to always clean up, but use less
  code doing so.
* Contributors: Chris Lalancette
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
