### PR TITLE
rviz: 14.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7233,7 +7233,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.2-1
+      version: 14.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Correclty load icons of panels with whitespaces in their name (#1241 <https://github.com/ros2/rviz/issues/1241>) (#1242 <https://github.com/ros2/rviz/issues/1242>)
  (cherry picked from commit d390a55b7c038c0b97d9dd17636ee6bdbc9ea86a)
  Co-authored-by: Patrick Roncagliolo <mailto:ronca.pat@gmail.com>
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Fix: issue #1220 <https://github.com/ros2/rviz/issues/1220>. (#1237 <https://github.com/ros2/rviz/issues/1237>) (#1246 <https://github.com/ros2/rviz/issues/1246>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 85dfbef6d96956960b48115f046dbb2539aa0f36)
  Co-authored-by: chama1176 <mailto:kaede6120@gmail.com>
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
