### PR TITLE
rig_reconfigure: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5319,7 +5319,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.4.0-3
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.5.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: https://github.com/ros2-gbp/rig_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-3`

## rig_reconfigure

```
* create config directory if it doesnt exist (#40 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/40>)
* Persist window size via .ini file (#36 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/36>)
* Replace linear node list with tree representation (#34 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/34>)
* Fixes for default parameters (#33 <https://github.com/teamspatzenhirn/rig_reconfigure/issues/33>)
* Contributors: Dominik, Jonas Otto
```
