### PR TITLE
Add `tkintermapview` pip dependency to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9594,6 +9594,10 @@ python3-tk:
   opensuse: [python3-tk]
   rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
+python3-tkintermapview-git:
+  '*':
+    pip:
+      packages: [tkintermapview]
 python3-toml:
   debian: [python3-toml]
   fedora: [python3-toml]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9594,7 +9594,7 @@ python3-tk:
   opensuse: [python3-tk]
   rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
-python3-tkintermapview-git:
+python3-tkintermapview-pip:
   '*':
     pip:
       packages: [tkintermapview]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`tkintermapview`

## Package Upstream Source:

https://github.com/TomSchimansky/TkinterMapView

## Purpose of using this:

This dependency is being used to build GUIs with maps in my ROS project. It is a dependency of my project, so it would be valuable to include it as a rosdep key so that others can easily include it too.

Distro packaging links:

Pip only, since the project is relatively young.

https://pypi.org/project/tkintermapview/
