### PR TITLE
image_pipeline: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2515,7 +2515,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.0-2
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.0-2`

## camera_calibration

```
* Change camera info message to lower case (#1005 <https://github.com/ros-perception/image_pipeline/issues/1005>)
  Change camera info message to lower case since message type had been
  change in rolling and humble.
  [](https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/CameraInfo.msg)
* Formatting calib code before refactoring (#999 <https://github.com/ros-perception/image_pipeline/issues/999>)
  As discussed in #975 <https://github.com/ros-perception/image_pipeline/issues/975> and #973 <https://github.com/ros-perception/image_pipeline/issues/973>
  doing the linting first.
  using style from
  [here](https://github.com/ament/ament_lint/blob/rolling/ament_pycodestyle/ament_pycodestyle/configuration/ament_pycodestyle.ini)
* Added stereo calibration using charuco board (#976 <https://github.com/ros-perception/image_pipeline/issues/976>)
  From #972 <https://github.com/ros-perception/image_pipeline/issues/972>
  Doing this first for rolling.
  This was a TODO in the repository, opening this PR to add this feature.
  - The main issue why this wasn't possible imo is the way mk_obj_points
  works. I'm using the inbuilt opencv function to get the points there.
  - The other is a condition when aruco markers are detected they are
  added as good points, This is fine in case of mono but in stereo these
  have to be the same number as the object points to find matches although
  this should be possible with aruco.
* Contributors: Myron Rodrigues, SFhmichael
```

## depth_image_proc

```
* Updated deprecated message filter headers (#1012 <https://github.com/ros-perception/image_pipeline/issues/1012>)
* Contributors: Alejandro Hernández Cordero
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

```
* [rolling] image_publisher: Fix loading of the camera info parameters on startup (#983 <https://github.com/ros-perception/image_pipeline/issues/983>)
  As described in
  https://github.com/ros-perception/image_pipeline/issues/965 camera info
  is not loaded from the file on node initialization, but only when the
  parameter is reloaded.
  This PR resolves this issue and should be straightforward to port it to
  Humble, Iron and Jazzy.
* [rolling] image_publisher: add field of view parameter (#985 <https://github.com/ros-perception/image_pipeline/issues/985>)
  Currently, the default value for focal length when no camera info is
  provided defaults to 1.0 rendering whole approximate intrinsics and
  projection matrices useless. Based on [this
  article](https://learnopencv.com/approximate-focal-length-for-webcams-and-cell-phone-cameras/),
  I propose a better approximation of the focal length based on the field
  of view of the camera.
  For most of the use cases, users will either know the field of view of
  the camera the used, or they already calibrated it ahead of time.
  If there is some documentation to fill. please let me know.
  This PR should be straightforward to port it to Humble, Iron and
  Jazzy.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Krzysztof Wojciechowski
```

## image_rotate

- No changes

## image_view

```
* Updated deprecated message filter headers (#1012 <https://github.com/ros-perception/image_pipeline/issues/1012>)
* Contributors: Alejandro Hernández Cordero
```

## stereo_image_proc

```
* Updated deprecated message filter headers (#1012 <https://github.com/ros-perception/image_pipeline/issues/1012>)
* Contributors: Alejandro Hernández Cordero
```

## tracetools_image_pipeline

- No changes
