### PR TITLE
ros_gz: 0.244.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7822,7 +7822,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.15-1
+      version: 0.244.16-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.16-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.244.15-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Add support for gz.msgs.EntityWrench (base branch: ros2) (backport #573 <https://github.com/gazebosim/ros_gz/issues/573>) (#575 <https://github.com/gazebosim/ros_gz/issues/575>)
  * Add support for gz.msgs.EntityWrench (base branch: ros2) (#573 <https://github.com/gazebosim/ros_gz/issues/573>)
  (cherry picked from commit f9afb69d1163633dd978024bb7271a28cf7b551a)
  # Conflicts:
  #     ros_gz_bridge/README.md
  #     ros_gz_bridge/test/utils/gz_test_msg.hpp
  * Fixed merge
  * Update ros_gz_bridge/README.md
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
  ---------
  Co-authored-by: Victor T. Noppeney <mailto:Vtn21@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes

## ros_ign

- No changes

## ros_ign_bridge

- No changes

## ros_ign_gazebo

- No changes

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
