### PR TITLE
nicla_vision_ros2: 1.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4069,6 +4069,11 @@ repositories:
       type: git
       url: https://github.com/ADVRHumanoids/nicla_vision_ros2.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/nicla_vision_ros2-release.git
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ADVRHumanoids/nicla_vision_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nicla_vision_ros2` to `1.1.1-1`:

- upstream repository: https://github.com/ADVRHumanoids/nicla_vision_ros2.git
- release repository: https://github.com/ros2-gbp/nicla_vision_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## nicla_vision_ros2

```
* jazzy bumping
* 1.0.1
* created changelog
* super linted
* debugged
* linted
* arduino version default && speech recognizer vosk
* fix copyright, licenses, contributing
* new nicla rviz image
* build badges!
* better handling of exec dependencies
* also build depend for xacro since CI failing
* Support Nicla disconnection TCP
* Fix ros timestamp tcp
* corrected frame id in simulation
* cam info in ros
* udp check package size
* time fixed 2
* nicla frame as real nicla
* Merge branch 'master' of https://github.com/ADVRHumanoids/nicla_vision_ros2
* simulated sonsors to ros2
* fix ros time
* Update README.md
* no gaz plugin package
* imu works on humble-fortress
* Merge branch 'devel'
* Update README.md
* no default connection type
* Update README.md
* Update README.md
* add img
* Update README.md
* Update README.md
* Assets
* Update README.md
* Merge branch 'devel' of https://github.com/ADVRHumanoids/nicla_vision_ros2 into devel
* launch python with args
* Update README.md
* Update LICENSE
* Update NiclaRosPublisher.py
* Update __init__.py
* trials gazebo
* python3 and some dep
* no audio common msgs in ros2
* better cmake, some better folders
* trasmission ok in udp
* some devels, still wip
* Initial commit
* Contributors: Damiano Gasperini, Davide Torielli, damigas
```
