### PR TITLE
ros_gz: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6107,7 +6107,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.1-2
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.0.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-2`

## ros_gz

- No changes

## ros_gz_bridge

```
* Making use_composition true by default (#578 <https://github.com/gazebosim/ros_gz/issues/578>)
* Contributors: Addisu Z. Taddese
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Making use_composition true by default (#578 <https://github.com/gazebosim/ros_gz/issues/578>)
* Contributors: Addisu Z. Taddese
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
