### PR TITLE
add ros_battery_monitoring repository

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6109,6 +6109,13 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros_battery_monitoring:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
+    status: developed
   ros_canopen:
     release:
       packages:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6110,6 +6110,10 @@ repositories:
       version: main
     status: maintained
   ros_battery_monitoring:
+    doc:
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6266,6 +6266,10 @@ repositories:
       version: jazzy
     status: maintained
   ros_battery_monitoring:
+    doc:
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6265,6 +6265,13 @@ repositories:
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
       version: jazzy
     status: maintained
+  ros_battery_monitoring:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
+    status: developed
   ros_canopen:
     release:
       packages:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6062,6 +6062,10 @@ repositories:
       version: main
     status: maintained
   ros_battery_monitoring:
+    doc:
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6061,6 +6061,13 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros_battery_monitoring:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
+    status: developed
   ros_canopen:
     release:
       packages:


### PR DESCRIPTION
Please add the https://github.com/ipa320/ros_battery_monitoring repository to rosdistro for indexing and later binary release of the contained packages:
* battery_state_broadcaster
* battery_state_rviz_overlay

The first package implements a ros2_control broadcaster for BatteryState messages, while the node in the second package converts these packages into OverlayText messages for display as 2d overlays in rviz.

Feedback on package naming is appreciated, in particular whether `battery_state_broadcaster` should be named `ros2_control_battery_state_broadcaster` or if that would wrongly imply any "official affiliation" with the ros2_control project.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
