### PR TITLE
Add python3-pyqt5.qtwebengine rule for RHEL 9

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8304,11 +8304,14 @@ python3-pyqt5.qtquick:
   ubuntu: [python3-pyqt5.qtquick]
 python3-pyqt5.qtwebengine:
   debian: [python3-pyqt5.qtwebengine]
-  fedora: [python3-qt5-webengine]
+  fedora: [python3-qt5-webengine, pyqtwebengine-devel]
   gentoo: [dev-python/PyQtWebEngine]
   nixos: [python3Packages.pyqtwebengine]
   openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python3-qtwebengine-qt5]
+  rhel:
+    '*': [python3-qt5-webengine, pyqtwebengine-devel]
+    '8': null
   ubuntu: [python3-pyqt5.qtwebengine]
 python3-pyqtdarktheme-pip:
   debian:


### PR DESCRIPTION
Also fix the Fedora rule, which was missing the sip files to match the Ubuntu package.

The RHEL package is provided by EPEL, so information for all of these packages is here:
* https://packages.fedoraproject.org/pkgs/pyqtwebengine/python3-qt5-webengine
* https://packages.fedoraproject.org/pkgs/pyqtwebengine/pyqtwebengine-devel