### PR TITLE
Include draco-static RPM in libdraco-dev rule to match Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3281,7 +3281,9 @@ libdpkg-dev:
 libdraco-dev:
   arch: [draco]
   debian: [libdraco-dev]
-  fedora: [draco-devel, draco-static]
+  fedora:
+    '*': [draco-devel, draco-static]
+    '39': [draco-devel]
   nixos: [draco]
   rhel:
     '*': [draco-devel, draco-static]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3281,10 +3281,10 @@ libdpkg-dev:
 libdraco-dev:
   arch: [draco]
   debian: [libdraco-dev]
-  fedora: [draco-devel]
+  fedora: [draco-devel, draco-static]
   nixos: [draco]
   rhel:
-    '*': [draco-devel]
+    '*': [draco-devel, draco-static]
     '8': null
   ubuntu:
     '*': [libdraco-dev]


### PR DESCRIPTION
On Ubuntu, the libdraco-dev package contains both dynamic and static libraries for draco. On Fedora and RHEL, the libraries are part of separate subpackages.

https://packages.ubuntu.com/noble/amd64/libdraco-dev/filelist
https://packages.fedoraproject.org/pkgs/draco/