### PR TITLE
Add lsb_release RPM to python3-distro rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5571,10 +5571,10 @@ python3-dill:
   ubuntu: [python3-dill]
 python3-distro:
   debian: [python3-distro]
-  fedora: [python3-distro]
+  fedora: [python3-distro, lsb_release]
   gentoo: [dev-python/distro]
   nixos: [python3Packages.distro]
-  rhel: [python3-distro]
+  rhel: [python3-distro, lsb_release]
   ubuntu: [python3-distro]
 python3-distutils:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5574,7 +5574,9 @@ python3-distro:
   fedora: [python3-distro, lsb_release]
   gentoo: [dev-python/distro]
   nixos: [python3Packages.distro]
-  rhel: [python3-distro, lsb_release]
+  rhel:
+    '*': [python3-distro, lsb_release]
+    '8': [python3-distro, redhat-lsb-core]
   ubuntu: [python3-distro]
 python3-distutils:
   debian:


### PR DESCRIPTION
On Ubuntu, the lsb_release executable is a required dependency of python3-distro. On Fedora and RHEL, it is a soft dependency. To maintain resource parity, we should explicitly list the dependency here.

https://packages.ubuntu.com/noble/python3-distro
https://src.fedoraproject.org/rpms/python-distro/blob/7ad3ed9c12a16bd9a469241be63b3d26316948b4/f/python-distro.spec#_33-35