### PR TITLE
Add lm_sensors rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5861,6 +5861,7 @@ libsensors4-dev:
   nixos: [lm_sensors]
   openembedded: [lmsensors@meta-oe]
   opensuse: [libsensors4-devel]
+  rhel: [lm_sensors-devel]
   ubuntu: [libsensors4-dev]
 libserial-dev:
   debian: [libserial-dev]


### PR DESCRIPTION
In RHEL 8, this package is part of BaseOS: https://almalinux.pkgs.org/8/almalinux-baseos-x86_64/lm_sensors-devel-3.4.0-23.20180522git70f7e08.el8.x86_64.rpm.html
In RHEL 9, this package is part of AppStream: https://almalinux.pkgs.org/9/almalinux-appstream-x86_64/lm_sensors-devel-3.6.0-10.el9.x86_64.rpm.html

The motivation for this change is to unblock RHEL/Fedora builds of `diagnostic_common_diagnostics`.