### PR TITLE
Add swig rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8369,6 +8369,7 @@ swig:
   gentoo: [dev-lang/swig]
   nixos: [swig]
   openembedded: [swig@openembedded-core]
+  rhel: [swig]
   ubuntu: [swig]
 swig-wx:
   gentoo: [dev-lang/swig]


### PR DESCRIPTION
On RHEL 8, this package is part of AppStream: https://almalinux.pkgs.org/8/almalinux-appstream-x86_64/swig-4.1.1-1.module_el8.8.0+3488+86d650f8.x86_64.rpm.html
On RHEL 9, this package is part of CRB: https://almalinux.pkgs.org/9/almalinux-crb-x86_64/swig-4.0.2-8.el9.x86_64.rpm.html

The motivation for this is to unblock builds of `fields2cover` on RHEL