### PR TITLE
Fix libusb{,-dev} rules for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6208,10 +6208,11 @@ liburdfdom-tools:
 libusb:
   arch: [libusb-compat]
   debian: [libusb-0.1-4]
-  fedora: [libusb]
+  fedora: [libusb-compat-0.1]
   gentoo: ['virtual/libusb:0']
   macports: [libusb]
   nixos: [libusb-compat-0_1]
+  rhel: [libusb]
   ubuntu: [libusb-0.1-4]
 libusb-1.0:
   arch: [libusbx]
@@ -6237,7 +6238,7 @@ libusb-1.0-dev:
 libusb-dev:
   arch: [libusb-compat]
   debian: [libusb-dev]
-  fedora: [libusb-devel]
+  fedora: [libusb-compat-0.1-devel]
   gentoo: [virtual/libusb]
   macports: [libusb]
   nixos: [libusb1]


### PR DESCRIPTION
The same library provided by the Ubuntu package is provided by `libusb-compat-0.1` and `libusb` on Fedora and RHEL, respectively.

https://packages.ubuntu.com/noble/amd64/libusb-0.1-4/filelist
https://packages.fedoraproject.org/pkgs/libusb-compat-0.1/libusb-compat-0.1-devel/

On RHEL 8, this package is part of PowerTools: https://almalinux.pkgs.org/8/almalinux-powertools-x86_64/libusb-devel-0.1.5-12.el8.x86_64.rpm.html
On RHEL 9, this package is part of CRB: https://almalinux.pkgs.org/9/almalinux-crb-x86_64/libusb-devel-0.1.7-5.el9.x86_64.rpm.html

The motivation for this change is to unblock builds of `openeb_vendor` on RHEL.