### PR TITLE
Add rapidjson-dev rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7897,6 +7897,7 @@ rapidjson-dev:
   fedora: [rapidjson]
   gentoo: [dev-libs/rapidjson]
   nixos: [rapidjson]
+  rhel: [rapidjson-devel]
   ubuntu: [rapidjson-dev]
 readline-dev:
   arch: [readline]


### PR DESCRIPTION
This package is provided by EPEL for RHEL 8 and 9: https://packages.fedoraproject.org/pkgs/rapidjson/rapidjson-devel/

The motivation for this is to unblock builds of `rosx_introspection` for RHEL.