### PR TITLE
rqt: 1.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6537,7 +6537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.7.1-1
+      version: 1.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.7.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.1-1`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

```
* Added common test to rqt_gui_cpp and deprecate h headers (#311 <https://github.com/ros-visualization/rqt/issues/311>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
