### PR TITLE
ridgeback: 0.3.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8973,7 +8973,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.3.4-1
+      version: 0.3.5-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ridgeback` to `0.3.5-1`:

- upstream repository: https://github.com/ridgeback/ridgeback.git
- release repository: https://github.com/clearpath-gbp/ridgeback-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.4-1`

## ridgeback_control

```
* Reduce turbo gains
  Reduce gains to be the same as non-turbo levels. This way holding either button will allow the robot to drive, but without the safety concerns about a fully-loaded payload moving at full speed.
* Add teleop turbo support
  We define a turbo button, but don't actually set the gains; this means pressing B5 uses the default 0.0 multiplier, causing the robot to stop.
  This MR adds 1.1x multipliers to the linear speed (maximum advertised speed is 1.1m/s) but keeps the same angular maximum.
  Tested on an integration project prior to shipping (and then reverted). Integration reports it worked as expected.
* Contributors: Chris Iverach-Brereton
```

## ridgeback_description

- No changes

## ridgeback_msgs

- No changes

## ridgeback_navigation

- No changes
