### PR TITLE
ros2_control: 4.14.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.13.0-1
+      version: 4.14.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.14.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.13.0-1`

## controller_interface

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* move critical variables to the private context (#1623 <https://github.com/ros-controls/ros2_control/issues/1623>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```

## controller_manager

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* Remove noqa (#1626 <https://github.com/ros-controls/ros2_control/issues/1626>)
* Fix controller starting with later load of robot description test (#1624 <https://github.com/ros-controls/ros2_control/issues/1624>)
* [CM] Remove support for the description parameter and use only robot_description topic (#1358 <https://github.com/ros-controls/ros2_control/issues/1358>)
* Contributors: Christoph Fröhlich, Dr. Denis, Henry Moore, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* [ResourceManager] Make destructor virtual for use in derived classes (#1607 <https://github.com/ros-controls/ros2_control/issues/1607>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* Fix typos in test_resource_manager.cpp (#1609 <https://github.com/ros-controls/ros2_control/issues/1609>)
* Contributors: Henry Moore, Parker Drouillard
```

## joint_limits

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* Contributors: Henry Moore
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* Contributors: Henry Moore
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Unused header cleanup (#1627 <https://github.com/ros-controls/ros2_control/issues/1627>)
* Contributors: Henry Moore
```
