### PR TITLE
ros2_controllers: 4.12.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6088,6 +6088,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - parallel_gripper_controller
       - pid_controller
       - position_controllers
       - range_sensor_broadcaster
@@ -6101,7 +6102,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.11.0-1
+      version: 4.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.11.0-1`

## ackermann_steering_controller

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## admittance_controller

```
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```

## bicycle_steering_controller

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## diff_drive_controller

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Remove duplicated call to rclcpp::shutdown in test (#1220 <https://github.com/ros-controls/ros2_controllers/issues/1220>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Noel Jiménez García, Sai Kishor Kothakota
```

## effort_controllers

```
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```

## force_torque_sensor_broadcaster

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## forward_command_controller

```
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```

## gripper_controllers

```
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Add parallel_gripper_controller, configure gripper speed and effort with hardware interface (#1002 <https://github.com/ros-controls/ros2_controllers/issues/1002>)
* Contributors: Henry Moore, Paul Gesel, Sai Kishor Kothakota
```

## imu_sensor_broadcaster

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## joint_state_broadcaster

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* [JTC] Refactor URDF Model parsing  (#1227 <https://github.com/ros-controls/ros2_controllers/issues/1227>)
* Use the internal methods instead of using the variables directly (#1221 <https://github.com/ros-controls/ros2_controllers/issues/1221>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* [JTC] Fix test_tolerances_via_actions (#1209 <https://github.com/ros-controls/ros2_controllers/issues/1209>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## parallel_gripper_controller

```
* [GripperController] Fix failing tests (#1210 <https://github.com/ros-controls/ros2_controllers/issues/1210>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Add parallel_gripper_controller, configure gripper speed and effort with hardware interface (#1002 <https://github.com/ros-controls/ros2_controllers/issues/1002>)
* Contributors: Paul Gesel, Sai Kishor Kothakota
```

## pid_controller

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## position_controllers

```
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```

## range_sensor_broadcaster

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## tricycle_controller

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## tricycle_steering_controller

```
* Add missing includes (#1226 <https://github.com/ros-controls/ros2_controllers/issues/1226>)
* Change the subscription timeout in the tests to 5ms (#1219 <https://github.com/ros-controls/ros2_controllers/issues/1219>)
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Christoph Fröhlich, Henry Moore, Sai Kishor Kothakota
```

## velocity_controllers

```
* Unused header cleanup (#1199 <https://github.com/ros-controls/ros2_controllers/issues/1199>)
* Fix WaitSet issue in tests  (#1206 <https://github.com/ros-controls/ros2_controllers/issues/1206>)
* Fix parallel gripper controller CI (#1202 <https://github.com/ros-controls/ros2_controllers/issues/1202>)
* Contributors: Henry Moore, Sai Kishor Kothakota
```
