### PR TITLE
ros2_control: 2.42.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7509,7 +7509,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.41.0-1
+      version: 2.42.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.42.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.41.0-1`

## controller_interface

```
* [ControllerInterface] Avoid warning about conversion from int64_t to unsigned int (backport #1173 <https://github.com/ros-controls/ros2_control/issues/1173>) (#1631 <https://github.com/ros-controls/ros2_control/issues/1631>)
* Fix dependencies for source build (#1533 <https://github.com/ros-controls/ros2_control/issues/1533>) (#1535 <https://github.com/ros-controls/ros2_control/issues/1535>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Remove noqa (#1626 <https://github.com/ros-controls/ros2_control/issues/1626>) (#1628 <https://github.com/ros-controls/ros2_control/issues/1628>)
* Bump version of pre-commit hooks (backport #1556 <https://github.com/ros-controls/ros2_control/issues/1556>) (#1557 <https://github.com/ros-controls/ros2_control/issues/1557>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Small improvements to the error output in component parser to make debugging easier. (backport #1580 <https://github.com/ros-controls/ros2_control/issues/1580>) (#1581 <https://github.com/ros-controls/ros2_control/issues/1581>)
* Update joints_userdoc.rst (#1604 <https://github.com/ros-controls/ros2_control/issues/1604>)
* Fix link to gazebosim.org (#1563 <https://github.com/ros-controls/ros2_control/issues/1563>) (#1564 <https://github.com/ros-controls/ros2_control/issues/1564>)
* Add doc page about joint kinematics (#1497 <https://github.com/ros-controls/ros2_control/issues/1497>) (#1559 <https://github.com/ros-controls/ros2_control/issues/1559>)
* Bump version of pre-commit hooks (backport #1556 <https://github.com/ros-controls/ros2_control/issues/1556>) (#1557 <https://github.com/ros-controls/ros2_control/issues/1557>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Bump version of pre-commit hooks (backport #1556 <https://github.com/ros-controls/ros2_control/issues/1556>) (#1557 <https://github.com/ros-controls/ros2_control/issues/1557>)
* Fix dependencies for source build (#1533 <https://github.com/ros-controls/ros2_control/issues/1533>) (#1535 <https://github.com/ros-controls/ros2_control/issues/1535>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
