### PR TITLE
ros2_control: 3.27.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5873,7 +5873,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.26.0-1
+      version: 3.27.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.27.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.26.0-1`

## controller_interface

```
* [ControllerInterface] Avoid warning about conversion from int64_t to unsigned int (#1173 <https://github.com/ros-controls/ros2_control/issues/1173>) (#1630 <https://github.com/ros-controls/ros2_control/issues/1630>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Remove noqa (#1626 <https://github.com/ros-controls/ros2_control/issues/1626>) (#1629 <https://github.com/ros-controls/ros2_control/issues/1629>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Small improvements to the error output in component parser to make debugging easier. (backport #1580 <https://github.com/ros-controls/ros2_control/issues/1580>) (#1582 <https://github.com/ros-controls/ros2_control/issues/1582>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
