### PR TITLE
rcpputils: 2.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5193,7 +5193,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.13.0-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.0-1`

## rcpputils

```
* Deprecated path class (#196 <https://github.com/ros2/rcpputils/issues/196>)
* Replace create_temp_directory with the new create_temporary_directory (#198 <https://github.com/ros2/rcpputils/issues/198>)
  * Replace create_temp_directory with the new create_temporary_directory
  - The newly added create_temporary_directory(..) uses
  std::filesystem::path and doesn't have platform-specific code.
  - Also deprecated create_temp_directory(..) and temp_directory_path
* Removed deprecated header get_env.hpp (#195 <https://github.com/ros2/rcpputils/issues/195>)
* Removed rolling mean accumulator deprecated header (#194 <https://github.com/ros2/rcpputils/issues/194>)
* Removed deprecated clamp methods (#193 <https://github.com/ros2/rcpputils/issues/193>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov
```
