### PR TITLE
rclcpp: 28.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5161,7 +5161,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.3.1-1
+      version: 28.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.3.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `28.3.1-1`

## rclcpp

```
* Updated rcpputils path API (#2579 <https://github.com/ros2/rclcpp/issues/2579>)
* Make the subscriber_triggered_to_receive_message test more reliable. (#2584 <https://github.com/ros2/rclcpp/issues/2584>)
  * Make the subscriber_triggered_to_receive_message test more reliable.
  In the current code, inside of the timer we create the subscription
  and the publisher, publish immediately, and expect the subscription
  to get it immediately.  But it may be the case that discovery
  hasn't even happened between the publisher and the subscription
  by the time the publish call happens.
  To make this more reliable, create the subscription and publish *before*
  we ever create and spin on the timer.  This at least gives 100
  milliseconds for discovery to happen.  That may not be quite enough
  to make this reliable on all platforms, but in my local testing this
  helps a lot.  Prior to this change I can make this fail one out of 10
  times, and after the change I've run 100 times with no failures.
* Have the EventsExecutor use more common code  (#2570 <https://github.com/ros2/rclcpp/issues/2570>)
  * move notify waitable setup to its own function
  * move mutex lock to retrieve_entity utility
  * use entities_need_rebuild_ atomic bool in events-executors
  * remove duplicated set_on_ready_callback for notify_waitable
  * use mutex from base class rather than a new recursive mutex
  * use current_collection_ member in events-executor
  * delay adding notify waitable to collection
  * postpone clearing the current collection
  * commonize notify waitable and collection
  * commonize add/remove node/cbg methods
  * fix linter errors
  ---------
* Removed deprecated methods and classes (#2575 <https://github.com/ros2/rclcpp/issues/2575>)
* Release ownership of entities after spinning cancelled (#2556 <https://github.com/ros2/rclcpp/issues/2556>)
  * Release ownership of entities after spinning cancelled
  * Move release action to every exit point in different spin functions
  * Move wait_result_.reset() before setting spinning to false
  * Update test code
  * Move test code to test_executors.cpp
  ---------
* Split test_executors.cpp even further. (#2572 <https://github.com/ros2/rclcpp/issues/2572>)
  That's because it is too large for Windows Debug to compile,
  so split into smaller bits.
  Even with this split, the file is too big; that's likely
  because we are using TYPED_TEST here, which generates multiple
  symbols per test case.  To deal with this, without further
  breaking up the file, also add in the /bigobj flag when
  compiling on Windows Debug.
* avoid adding notify waitable twice to events-executor collection (#2564 <https://github.com/ros2/rclcpp/issues/2564>)
  * avoid adding notify waitable twice to events-executor entities collection
  * remove redundant mutex lock
  ---------
* Contributors: Alberto Soragna, Alejandro Hernández Cordero, Barry Xu, Chris Lalancette
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Updated rcpputils path API (#2579 <https://github.com/ros2/rclcpp/issues/2579>)
* remove deprecated APIs from component_manager.hpp (#2585 <https://github.com/ros2/rclcpp/issues/2585>)
* Contributors: Alberto Soragna, Alejandro Hernández Cordero
```

## rclcpp_lifecycle

```
* Removed deprecated methods and classes (#2575 <https://github.com/ros2/rclcpp/issues/2575>)
* Fix the lifecycle tests on RHEL-9. (#2583 <https://github.com/ros2/rclcpp/issues/2583>)
  * Fix the lifecycle tests on RHEL-9.
  The full explanation is in the comment, but basically since
  RHEL doesn't support mocking_utils::inject_on_return, we have
  to split out certain tests to make sure resources within a
  process don't collide.
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
