### PR TITLE
mp2p_icp: 1.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3644,7 +3644,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.5.2-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.1-1`

## mp2p_icp

```
* Add sm2mm yaml example for dynamic/static obstacles
* Update sample sm2mm pipelines to use de-skew
* docs: add mm-filter example
* Fix pointcloud ptr typo
* More safety sanity checks added in mm-viewer and sm2mm
* BUGFIX: Generator should not create empty maps for GPS observations
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera López
```
