### PR TITLE
mrpt2: 2.13.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3582,7 +3582,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.13.3-1
+      version: 2.13.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.13.4-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.13.3-1`
