### PR TITLE
mrpt2: 2.13.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3807,7 +3807,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.13.3-2
+      version: 2.13.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.13.4-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.13.3-2`
