### PR TITLE
image_pipeline: 3.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3184,7 +3184,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.4-1
+      version: 3.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `3.0.5-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.4-1`

## camera_calibration

```
* Change camera info message to lower case (backport #1005 <https://github.com/ros-perception/image_pipeline/issues/1005>) (#1008 <https://github.com/ros-perception/image_pipeline/issues/1008>)
  Change camera info message to lower case since message type had been
  change in rolling and humble.
  [](https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/CameraInfo.msg)<hr>This
  is an automatic backport of pull request #1005 <https://github.com/ros-perception/image_pipeline/issues/1005> done by
  [Mergify](https://mergify.com).
  ---------
  Co-authored-by: SFhmichael <mailto:146928033+SFhmichael@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* [backport humble] Fix spelling error for cv2.aruco.DICT from 6x6_50 to 7x7_1000 (#961 <https://github.com/ros-perception/image_pipeline/issues/961>) (#1004 <https://github.com/ros-perception/image_pipeline/issues/1004>)
  Backport #961 <https://github.com/ros-perception/image_pipeline/issues/961> fix to humble
  Co-authored-by: Vishal Balaji <mailto:vishalvichu45@gmail.com>
  Co-authored-by: Vishal Balaji <mailto:vishal.balaji@schanzer-racing.de>
* Contributors: Balint Rozgonyi, mergify[bot]
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

```
* [backport humble] Node namespace parameter (#963 <https://github.com/ros-perception/image_pipeline/issues/963>)
  Backport pull request #925 <https://github.com/ros-perception/image_pipeline/issues/925> which solves issue #952 <https://github.com/ros-perception/image_pipeline/issues/952> by adding the
  namespace parameter to the image_proc launch file
  Co-authored-by: Lucas Wendland <mailto:82680922+CursedRock17@users.noreply.github.com>
* Contributors: Alejandro Hernández Cordero
```

## image_publisher

```
* [humble] image_publisher: Fix loading of the camera info parameters on startup (backport #983 <https://github.com/ros-perception/image_pipeline/issues/983>) (#996 <https://github.com/ros-perception/image_pipeline/issues/996>)
  As described in
  https://github.com/ros-perception/image_pipeline/issues/965 camera info
  is not loaded from the file on node initialization, but only when the
  parameter is reloaded.
  This PR resolves this issue and should be straightforward to port it to
  Humble, Iron and Jazzy.<hr>This is an automatic backport of pull
  request #983 <https://github.com/ros-perception/image_pipeline/issues/983> done by [Mergify](https://mergify.com).
  ---------
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* image_publisher: add field of view parameter (backport #985 <https://github.com/ros-perception/image_pipeline/issues/985>) (#993 <https://github.com/ros-perception/image_pipeline/issues/993>)
  Currently, the default value for focal length when no camera info is
  provided defaults to 1.0 rendering whole approximate intrinsics and
  projection matrices useless. Based on [this
  article](https://learnopencv.com/approximate-focal-length-for-webcams-and-cell-phone-cameras/),
  I propose a better approximation of the focal length based on the field
  of view of the camera.
  For most of the use cases, users will either know the field of view of
  the camera the used, or they already calibrated it ahead of time.
  If there is some documentation to fill. please let me know.
  This PR should be straightforward to port it to Humble, Iron and
  Jazzy.
  <hr>This is an automatic backport of pull request #985 <https://github.com/ros-perception/image_pipeline/issues/985> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
* image_publisher: Fix image, constantly flipping when static image is published (backport #986 <https://github.com/ros-perception/image_pipeline/issues/986>) (#988 <https://github.com/ros-perception/image_pipeline/issues/988>)
  Continuation of
  https://github.com/ros-perception/image_pipeline/pull/984.
  When publishing video stream from a camera, the image was flipped
  correctly. Yet for a static image, which was loaded once, the flip
  function was applied every time ImagePublisher::doWork() was called,
  resulting in the published image being flipped back and forth all the
  time.
  This PR should be straightforward to port it to Humble, Iron and
  Jazzy.<hr>This is an automatic backport of pull request #986 <https://github.com/ros-perception/image_pipeline/issues/986> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Krzysztof Wojciechowski <mailto:49921081+Kotochleb@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
