### PR TITLE
feat: add python3-juliacall-pip and python3-juliapkg-pip to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6753,6 +6753,14 @@ python3-jsonschema:
     '*': [python3-jsonschema]
     '7': [python36-jsonschema]
   ubuntu: [python3-jsonschema]
+python3-juliacall-pip:
+  '*':
+    pip:
+      packages: [juliacall]
+python3-juliapkg-pip:
+  '*':
+    pip:
+      packages: [juliapkg]
 python3-junitparser:
   debian:
     '*': [python3-junitparser]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependencies to the rosdep database.

## Package names:
* `python3-juliacall-pip`
* `python3-juliapkg-pip`

No system level dependencies are currently available.

## Package Upstream Source:
* https://github.com/JuliaPy/PyJuliaPkg
* https://github.com/JuliaPy/PythonCall.jl

## Purpose of using this:
Setup and call [Julia (Programming Language)](https://julialang.org/) from within python. Essentially, this provides a quick way for ROS' python users to tap into the power of the Julia ecosystem:
* JuliaPkg allows setting up an isolated Julia environment from within python. This can be used e.g. in an `ament_python` package to install such an environment during `colcon build` (using setuptool hooks).
* JuliaCall uses a JuliaPkg environment to call Julia code / run libs from within python.

## Links to Distribution Packages
* PyPI: 
  * https://pypi.org/project/juliacall/
  * https://pypi.org/project/juliapkg/
