### PR TITLE
Add PyRoboSim to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8343,6 +8343,10 @@ python3-pyro-ppl-pip:
   ubuntu:
     pip:
       packages: [pyro-ppl]
+python3-pyrobosim-pip:
+  '*':
+    pip:
+      packages: [pyrobosim]
 python3-pyrr-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Python package : `pyrobosim`
rosdep entry : `python3-pyrobosim-pip`

## Package Upstream Source:

https://github.com/sea-bass/pyrobosim
https://github.com/sea-bass/pyrobosim_ros

## Purpose of using this:

PyRoboSim has existed as a Python package with a ROS 2 wrapper for about 2 years. However, the ROS 2 wrapper lives within the source code and thus is not well-integrated into the ROS 2 ecosystem for distribution.

I am now working on breaking up the `pyrobosim` repo into a ROS-free package (the one on PyPi below) and its ROS 2 wrappers will be officially bloomed soon.

So, this PR handles only the Python package, and I will next break out a new `pyrobosim_ros` repo and bloom that.

## Links to Distribution Packages

This is available on PyPi here: https://pypi.org/project/pyrobosim/
