### PR TITLE
Fix many of the arch linux packages in base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1,10 +1,12 @@
 ace:
-  arch: [ace]
+  arch:
+    aur: [ace]
   debian: [libace-dev]
   gentoo: [dev-libs/ace]
   nixos: [ace]
   ubuntu: [libace-dev]
 ack:
+  arch: [ack]
   debian: [ack]
   fedora: [ack]
   nixos: [ack]
@@ -28,6 +30,7 @@ acl:
   rhel: [acl, libacl-devel]
   ubuntu: [acl, libacl1-dev]
 acpi:
+  arch: [acpi]
   debian: [acpi]
   fedora: [acpi]
   gentoo: [sys-power/acpi]
@@ -56,7 +59,7 @@ alsa-utils:
   rhel: [alsa-utils]
   ubuntu: [alsa-utils]
 ant:
-  arch: [apache-ant]
+  arch: [ant]
   debian: [ant]
   fedora: [ant]
   gentoo: [dev-java/ant]
@@ -64,7 +67,7 @@ ant:
   rhel: [ant]
   ubuntu: [ant]
 antlr:
-  arch: [antlr]
+  arch: [antlr4, antlr4-runtime]
   debian: [antlr, libantlr-dev]
   fedora: [antlr3-C, antlr-C++]
   gentoo: [dev-java/antlr]
@@ -82,6 +85,7 @@ apache2-mpm-prefork:
   gentoo: ['www-servers/apache[apache2_mpms_prefork]']
   ubuntu: [apache2-mpm-prefork]
 apparmor:
+  arch: [apparmor]
   debian: [apparmor]
   fedora: null
   ubuntu: [apparmor]
@@ -128,12 +132,12 @@ arduino-core:
   nixos: [arduino]
   ubuntu: [arduino-core]
 arista:
-  arch: [arista-transcoder]
   debian:
     wheezy: [arista]
   ubuntu: [arista]
 armadillo:
-  arch: [armadillo]
+  arch:
+    aur: [armadillo]
   debian: [libarmadillo-dev]
   fedora: [armadillo-devel]
   gentoo: [sci-libs/armadillo]
@@ -190,7 +194,8 @@ at-spi2-core:
   rhel: [at-spi2-core]
   ubuntu: [at-spi2-core]
 atlas:
-  arch: [atlas-lapack]
+  arch:
+    aur: [atlas-lapack]
   debian: [libatlas-base-dev]
   fedora: [atlas-devel]
   gentoo: [sci-libs/atlas]
@@ -287,6 +292,7 @@ awscli:
   rhel: [awscli]
   ubuntu: [awscli]
 babeltrace:
+  arch: [babeltrace]
   debian: [babeltrace]
   fedora: [babeltrace]
   gentoo: [dev-util/babeltrace]
@@ -303,7 +309,7 @@ bandit:
       packages: [bandit]
   ubuntu: [bandit]
 bazaar:
-  arch: [bzr]
+  arch: [breezy]
   debian: [bzr]
   freebsd: [bazaar]
   gentoo: [dev-vcs/bzr]
@@ -448,7 +454,7 @@ can-utils:
   nixos: [can-utils]
   ubuntu: [can-utils]
 cargo:
-  archlinux: [rust]
+  arch: [rust]
   debian: [cargo]
   fedora: [cargo]
   gentoo: [virtual/rust]
@@ -458,7 +464,8 @@ cargo:
   rhel: [cargo]
   ubuntu: [cargo]
 castxml:
-  arch: [castxml]
+  arch:
+    aur: [castxml]
   debian: [castxml]
   fedora: [castxml]
   macports: [castxml]
@@ -510,7 +517,8 @@ cgal-qt5-dev:
   gentoo: ['sci-mathematics/cgal[qt5]']
   ubuntu: [libcgal-qt5-dev]
 checkinstall:
-  arch: [checkinstall]
+  arch:
+    aur: [checkinstall]
   debian: [checkinstall]
   nixos: [checkinstall]
   ubuntu: [checkinstall]
@@ -526,6 +534,7 @@ chromedriver:
   rhel: [chromedriver]
   ubuntu: [chromium-chromedriver]
 chromium-browser:
+  arch: [chromium]
   debian: [chromium]
   fedora: [chromium]
   gentoo: [www-client/chromium]
@@ -625,7 +634,6 @@ coinor-libcoinutils-dev:
     '7': [coin-or-CoinUtils-devel]
   ubuntu: [coinor-libcoinutils-dev]
 coinor-libipopt-dev:
-  arch: [coinor-all]
   debian: [coinor-libipopt-dev]
   fedora: [coin-or-Ipopt-devel]
   gentoo: [sci-libs/ipopt]
@@ -640,7 +648,8 @@ coinor-libosi-dev:
   nixos: [osi]
   ubuntu: [coinor-libosi-dev]
 collada-dom:
-  arch: [collada-dom]
+  arch:
+    aur: [collada-dom]
   debian:
     buster: [libcollada-dom2.4-dp-dev]
     stretch: [libcollada-dom2.4-dp-dev]
@@ -713,10 +722,12 @@ cppunit:
   slackware: [cppunit]
   ubuntu: [libcppunit-dev]
 cpuburn:
-  arch: [cpuburn]
+  arch:
+    aur: [cpuburn]
   debian: [cpuburn]
   ubuntu: [cpuburn]
 crypto++:
+  arch: [crypto++]
   debian: [libcrypto++-dev]
   fedora: [cryptopp-devel]
   gentoo: [dev-libs/crypto++]
@@ -754,21 +765,22 @@ cvs:
   nixos: [cvs]
   ubuntu: [cvs]
 cwiid:
-  arch: [cwiid]
+  arch:
+    aur: [cwiid-git]
   debian: [libcwiid1]
   gentoo: [app-misc/cwiid]
   nixos: [cwiid]
   opensuse: [libcwiid1]
   ubuntu: [libcwiid1]
 cwiid-dev:
-  arch: [cwiid]
+  arch:
+    aur: [cwiid-git]
   debian: [libcwiid-dev]
   gentoo: [app-misc/cwiid]
   nixos: [cwiid]
   opensuse: [libcwiid-devel]
   ubuntu: [libcwiid-dev]
 daemontools:
-  arch: [daemontools]
   debian: [daemontools]
   gentoo: [virtual/daemontools]
   nixos: [daemontools]
@@ -792,7 +804,8 @@ debtree:
   debian: [debtree]
   ubuntu: [debtree]
 devilspie2:
-  arch: [devilspie2]
+  arch:
+    aur: [devilspie2]
   debian: [devilspie2]
   fedora: [devilspie2]
   gentoo: [x11-misc/devilspie2]
@@ -805,6 +818,7 @@ devscripts:
   gentoo: [dev-util/checkbashisms]
   ubuntu: [devscripts]
 dfu-util:
+  arch: [dfu-util]
   debian: [dfu-util]
   fedora: [dfu-util]
   gentoo: [app-mobilephone/dfu-util]
@@ -825,6 +839,7 @@ dkms:
   rhel: [dkms]
   ubuntu: [dkms]
 dnsmasq:
+  arch: [dnsmasq]
   debian: [dnsmasq]
   fedora: [dnsmasq]
   gentoo: [net-dns/dnsmasq]
@@ -832,6 +847,7 @@ dnsmasq:
   openembedded: [dnsmasq@meta-networking]
   ubuntu: [dnsmasq]
 docker-compose:
+  arch: [docker-compose]
   debian: [docker-compose]
   fedora: [docker-compose]
   nixos: [docker-compose]
@@ -889,12 +905,14 @@ e2fsprogs:
   rhel: [e2fsprogs]
   ubuntu: [e2fsprogs]
 eclipse:
-  arch: [eclipse, eclipse-rcp, eclipse-emf, eclipse-pde]
+  arch:
+    aur: [eclipse-java-bin, eclipse-rcp, eclipse-emf, eclipse-pde]
   debian: [eclipse, eclipse-rcp, eclipse-xsd, eclipse-pde]
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
     karmic: [eclipse, eclipse-platform, eclipse-rcp, eclipse-pde]
 ed:
+  arch: [ed]
   debian: [ed]
   fedora: [ed]
   nixos: [ed]
@@ -916,7 +934,8 @@ eigen:
       packages: [eigen3]
   ubuntu: [libeigen3-dev]
 eigen2:
-  arch: [eigen2]
+  arch:
+    aur: [eigen2]
   debian:
     wheezy: [libeigen2-dev]
   freebsd: [eigen2]
@@ -943,12 +962,14 @@ embree:
     '*': [libembree-dev]
     bionic: null
 enblend:
+  arch: [enblend-enfuse]
   debian: [enblend]
   fedora: [enblend]
   gentoo: [media-gfx/enblend]
   nixos: [enblend-enfuse]
   ubuntu: [enblend]
 enet:
+  arch: [enet]
   debian: [libenet-dev]
   fedora: [enet-devel]
   gentoo: [net-libs/enet]
@@ -994,13 +1015,15 @@ exiv2:
   rhel: [exiv2]
   ubuntu: [exiv2]
 f2c:
-  arch: [f2c]
+  arch:
+    aur: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]
   fedora: [f2c, f2c-libs]
   gentoo: [dev-lang/f2c]
   nixos: [libf2c]
   ubuntu: [f2c, libf2c2, libf2c2-dev]
 fakeroot:
+  arch: [fakeroot]
   debian: [fakeroot]
   fedora: [fakeroot]
   gentoo: [sys-apps/fakeroot]
@@ -1021,6 +1044,7 @@ festival:
   openembedded: [festival@meta-ros1]
   ubuntu: [festival, festvox-kallpc16k]
 festival-dev:
+  arch: [festival]
   debian: [festival-dev]
   fedora: [festival-devel, festvox-kal-diphone]
   gentoo: [app-accessibility/festival]
@@ -1185,6 +1209,7 @@ freeimage:
   ubuntu: [libfreeimage-dev]
 freetype:
   alpine: [freetype]
+  arch: [freetype2]
   debian: [libfreetype6]
   fedora: [freetype]
   gentoo: [media-libs/freetype]
@@ -1296,7 +1321,7 @@ gazebo9:
   ubuntu:
     bionic: [gazebo9]
 gcc-arm-none-eabi:
-  arch: [gcc-arm-none-eabi]
+  arch: [arm-none-eabi-gcc]
   debian: [gcc-arm-none-eabi]
   fedora: [arm-none-eabi-gcc-cs]
   gentoo: [sys-devel/crossdev]
@@ -1328,6 +1353,7 @@ gcovr:
   gentoo: [dev-util/gcovr]
   ubuntu: [gcovr]
 gdal-bin:
+  arch: [gdal]
   debian: [gdal-bin]
   fedora: [gdal]
   gentoo: [sci-libs/gdal]
@@ -1370,7 +1396,8 @@ gettext-base:
   nixos: [gettext]
   ubuntu: [gettext-base]
 gforth:
-  arch: [gforth]
+  arch:
+    aur: [gforth]
   debian: [gforth]
   fedora: [gforth]
   gentoo: [dev-lang/gforth]
@@ -1399,6 +1426,7 @@ gifsicle:
   nixos: [gifsicle]
   ubuntu: [gifsicle]
 gimp:
+  arch: [gimp]
   debian: [gimp]
   fedora: [gimp]
   gentoo: [media-gfx/gimp]
@@ -1432,12 +1460,14 @@ git-lfs:
   rhel: [git-lfs]
   ubuntu: [git-lfs]
 gitg:
+  arch: [gitg]
   debian: [gitg]
   fedora: [gitg]
   gentoo: [dev-vcs/gitg]
   nixos: [gitg]
   ubuntu: [gitg]
 gitk:
+  arch: [git]
   debian: [gitk]
   fedora: [gitk]
   ubuntu: [gitk]
@@ -1451,7 +1481,7 @@ glc:
   gentoo: [media-libs/quesoglc]
   nixos: [quesoglc]
 glpk:
-  arch: [glpk-git]
+  arch: [glpk]
   debian: [libglpk-dev]
   fedora: [glpk-devel]
   gentoo: [sci-mathematics/glpk]
@@ -1525,6 +1555,7 @@ gnuplot-x11:
   debian: [gnuplot-x11]
   ubuntu: [gnuplot-x11]
 golang-go:
+  arch: [go]
   debian: [golang-go]
   fedora: [golang-bin]
   gentoo: [dev-lang/go]
@@ -1532,7 +1563,7 @@ golang-go:
   ubuntu: [golang-go]
 google-mock:
   alpine: [gmock]
-  arch: [gmock]
+  arch: [gtest]
   debian: [google-mock]
   fedora: [gmock-devel]
   freebsd: [googlemock]
@@ -1546,6 +1577,7 @@ google-mock:
   rhel: [gmock-devel]
   ubuntu: [google-mock]
 gpac:
+  arch: [gpac]
   debian: [gpac]
   fedora: [gpac]
   gentoo: [media-video/gpac]
@@ -1555,6 +1587,7 @@ gpac:
       packages: [gpac]
   ubuntu: [gpac]
 gperf:
+  arch: [gperf]
   debian: [gperf]
   fedora: [gperf]
   gentoo: [dev-util/gperf]
@@ -1564,12 +1597,14 @@ gperf:
   rhel: [gperf]
   ubuntu: [gperf]
 gperftools:
+  arch: [gperftools]
   debian: [google-perftools, libgoogle-perftools-dev]
   fedora: [gperftools, gperftools-devel]
   gentoo: [dev-util/gperf]
   nixos: [gperftools]
   ubuntu: [google-perftools, libgoogle-perftools-dev]
 gpg-agent:
+  arch: [gnupg]
   debian:
     '*': [gpg-agent]
   ubuntu:
@@ -1586,6 +1621,7 @@ gprbuild:
   fedora: [gprbuild]
   ubuntu: [gprbuild]
 gpsd:
+  arch: [gpsd]
   debian: [gpsd]
   fedora: [gpsd]
   gentoo: [sci-geosciences/gpsd]
@@ -1624,6 +1660,7 @@ graphviz:
   slackware: [graphviz]
   ubuntu: [graphviz]
 graphviz-dev:
+  arch: [graphviz]
   debian: [libgraphviz-dev]
   fedora: [graphviz-devel]
   nixos: [graphviz]
@@ -1634,13 +1671,11 @@ gringo:
   nixos: [gringo]
   ubuntu: [gringo]
 gstreamer0.10-plugins-good:
-  arch: [gstreamer0.10-good-plugins]
   debian:
     wheezy: [gstreamer0.10-plugins-good]
   gentoo: ['media-libs/gst-plugins-good:0.10']
   ubuntu: [gstreamer0.10-plugins-good]
 gstreamer0.10-plugins-ugly:
-  arch: [gstreamer0.10-ugly-plugins]
   debian:
     wheezy: [gstreamer0.10-plugins-ugly]
   gentoo: ['media-libs/gst-plugins-ugly:0.10']
@@ -1808,7 +1843,8 @@ gurumdds-3.0:
   ubuntu:
     jammy: [gurumdds-3.0]
 gv:
-  arch: [gv]
+  arch:
+    aur: [gv]
   debian: [gv]
   fedora: [gv]
   gentoo: [app-text/gv]
@@ -1962,6 +1998,7 @@ gz-utils2:
 gz-utils2-cli:
   gentoo: ['dev-libs/gz-utils:2']
 haproxy:
+  arch: [haproxy]
   debian: [haproxy]
   fedora: [haproxy]
   gentoo: [net-proxy/haproxy]
@@ -1983,7 +2020,7 @@ hddtemp:
     bionic: [hddtemp]
     focal: [hddtemp]
 hdf5:
-  arch: [hdf5-cpp-fortran]
+  arch: [hdf5]
   debian: [libhdf5-dev]
   fedora: [hdf5-devel]
   gentoo: [sci-libs/hdf5]
@@ -1992,6 +2029,7 @@ hdf5:
   openembedded: [hdf5@meta-oe]
   ubuntu: [libhdf5-dev]
 hdf5-tools:
+  arch: [hdf5]
   debian: [hdf5-tools]
   fedora: [hdf5]
   gentoo: [sci-libs/hdf5]
@@ -2022,12 +2060,14 @@ htop:
   nixos: [htop]
   ubuntu: [htop]
 hugin-tools:
+  arch: [hugin]
   debian: [hugin-tools]
   fedora: [hugin-base]
   gentoo: [media-gfx/hugin]
   nixos: [hugin]
   ubuntu: [hugin-tools]
 i2c-tools:
+  arch: [i2c-tools]
   debian: [i2c-tools]
   fedora: [i2c-tools]
   gentoo: [sys-apps/i2c-tools]
@@ -2289,6 +2329,7 @@ imagemagick:
   nixos: [imagemagick]
   ubuntu: [imagemagick]
 intel-opencl-icd:
+  arch: [intel-compute-runtime]
   debian:
     '*': [intel-opencl-icd]
     buster: null
@@ -2305,6 +2346,7 @@ intltool:
   opensuse: [intltool]
   ubuntu: [intltool]
 inxi:
+  arch: [inxi]
   debian: [inxi]
   fedora: [inxi]
   gentoo: [sys-apps/inxi]
@@ -2315,6 +2357,7 @@ inxi:
   rhel: [inxi]
   ubuntu: [inxi]
 iperf:
+  arch: [iperf]
   debian: [iperf]
   fedora: [iperf]
   gentoo: [net-misc/iperf]
@@ -2338,6 +2381,7 @@ iproute2:
   opensuse: [iproute2]
   ubuntu: [iproute2]
 iputils-ping:
+  arch: [iputils]
   debian: [iputils-ping]
   fedora: [iputils]
   nixos: [unixtools.ping]
@@ -2347,7 +2391,7 @@ iwyu:
   nixos: [include-what-you-use]
   ubuntu: [iwyu]
 jack:
-  arch: [jack]
+  arch: [jack2]
   debian: [libjack-jackd2-dev]
   fedora: [jack-audio-connection-kit-devel]
   gentoo: [virtual/jack]
@@ -2369,7 +2413,7 @@ jasper:
       packages: [jasper]
 java:
   alpine: [openjdk8-jre]
-  arch: [jdk7-openjdk]
+  arch: [jdk-openjdk]
   debian:
     '*': [default-jdk]
     wheezy: [openjdk-7-jdk]
@@ -2390,6 +2434,7 @@ joystick:
   rhel: [joystick]
   ubuntu: [joystick]
 jq:
+  arch: [jq]
   debian: [jq]
   fedora: [jq]
   gentoo: [app-misc/jq]
@@ -2398,7 +2443,8 @@ jq:
   rhel: [jq]
   ubuntu: [jq]
 julius-voxforge:
-  arch: [voxforge-am-julius]
+  arch:
+    aur: [voxforge-am-julius]
   fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]
 jython:
@@ -2415,6 +2461,7 @@ kakasi:
   nixos: [kakasi]
   ubuntu: [kakasi]
 kate:
+  arch: [kate]
   debian: [kate]
   fedora: [kate]
   gentoo: [kde-apps/kate]
@@ -2428,6 +2475,7 @@ kgraphviewer:
   nixos: [kgraphviewer]
   ubuntu: [kgraphviewer]
 konsole:
+  arch: [konsole]
   debian: [konsole]
   fedora: [konsole]
   gentoo: [kde-apps/konsole]
@@ -2440,6 +2488,7 @@ language-pack-en:
   fedora: [filesystem]
   ubuntu: [language-pack-en]
 lcov:
+  arch: [lcov]
   debian: [lcov]
   fedora: [lcov]
   gentoo: [dev-util/lcov]
@@ -2449,6 +2498,7 @@ lcov:
   rhel: [lcov]
   ubuntu: [lcov]
 leveldb:
+  arch: [leveldb]
   debian: [libleveldb-dev]
   fedora: [leveldb-devel]
   gentoo: [dev-libs/leveldb]
@@ -2484,24 +2534,28 @@ libadolc-dev:
   opensuse: [adolc-devel]
   ubuntu: [libadolc-dev]
 libalglib-dev:
+  arch: [alglib]
   debian: [libalglib-dev]
   fedora: [alglib-devel]
   gentoo: [sci-libs/alglib]
   ubuntu: [libalglib-dev]
 libann-dev:
-  arch: [ann]
+  arch:
+    aur: [ann]
   debian: [libann-dev]
   fedora: [ann-devel]
   ubuntu: [libann-dev]
 libao-dev:
   alpine: [libao-dev]
+  arch: [libao]
   debian: [libao-dev]
   fedora: [libao-devel]
   opensuse: [libao-devel]
   rhel: [libao-devel]
   ubuntu: [libao-dev]
 libapache2-mod-python:
-  arch: [mod_python]
+  arch:
+    aur: [mod_python]
   debian: [libapache2-mod-python]
   gentoo: [www-apache/mod_python]
   ubuntu: [libapache2-mod-python]
@@ -2542,7 +2596,7 @@ libatomic:
   rhel: [libatomic]
   ubuntu: [libatomic1]
 libav:
-  arch: [libav-git]
+  arch: [ffmpeg]
   debian: [libav-tools]
   fedora: []
   gentoo: [virtual/ffmpeg]
@@ -2566,6 +2620,7 @@ libavahi-core-dev:
   rhel: [avahi-devel]
   ubuntu: [libavahi-core-dev]
 libavdevice-dev:
+  arch: [ffmpeg]
   debian: [libavdevice-dev]
   fedora: [libavdevice-free-devel]
   nixos: [ffmpeg]
@@ -2592,6 +2647,7 @@ libbdd-dev:
   gentoo: [sci-libs/buddy]
   ubuntu: [libbdd-dev]
 libbison-dev:
+  arch: [bison]
   debian: [libbison-dev]
   fedora: [bison-devel]
   gentoo: [sys-devel/bison]
@@ -2608,6 +2664,7 @@ libblas-dev:
   ubuntu: [libblas-dev]
 libblosc-dev:
   alpine: [blosc-dev]
+  arch: [blosc]
   debian: [libblosc-dev]
   fedora: [blosc-devel]
   nixos: [c-blosc]
@@ -2631,6 +2688,7 @@ libbluetooth-dev:
   rhel: [bluez-libs-devel]
   ubuntu: [libbluetooth-dev]
 libboost-atomic:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-atomic1.74.0]
     buster: [libboost-atomic1.67.0]
@@ -2646,6 +2704,7 @@ libboost-atomic:
     jammy: [libboost-atomic1.74.0]
     noble: [libboost-atomic1.83.0]
 libboost-atomic-dev:
+  arch: [boost]
   debian: [libboost-atomic-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2655,6 +2714,7 @@ libboost-atomic-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-atomic-dev]
 libboost-chrono:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-chrono1.74.0]
     buster: [libboost-chrono1.67.0]
@@ -2670,6 +2730,7 @@ libboost-chrono:
     jammy: [libboost-chrono1.74.0]
     noble: [libboost-chrono1.83.0]
 libboost-chrono-dev:
+  arch: [boost]
   debian: [libboost-chrono-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2680,6 +2741,7 @@ libboost-chrono-dev:
   ubuntu: [libboost-chrono-dev]
 libboost-coroutine:
   alpine: [boost-dev]
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-coroutine1.74.0]
     buster: [libboost-coroutine1.67.0]
@@ -2698,6 +2760,7 @@ libboost-coroutine:
     noble: [libboost-coroutine1.83.0]
 libboost-coroutine-dev:
   alpine: [boost-dev]
+  arch: [boost]
   debian: [libboost-coroutine-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2707,6 +2770,7 @@ libboost-coroutine-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-coroutine-dev]
 libboost-date-time:
+  arch: [boost-libs]
   debian:
     bookworm: [libboost-date-time1.81.0]
     bullseye: [libboost-date-time1.74.0]
@@ -2723,6 +2787,7 @@ libboost-date-time:
     jammy: [libboost-date-time1.74.0]
     noble: [libboost-date-time1.83.0]
 libboost-date-time-dev:
+  arch: [boost]
   debian: [libboost-date-time-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2732,6 +2797,7 @@ libboost-date-time-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-date-time-dev]
 libboost-dev:
+  arch: [boost]
   debian: [libboost-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2741,6 +2807,7 @@ libboost-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-dev]
 libboost-filesystem:
+  arch: [boost-libs]
   debian:
     bookworm: [libboost-filesystem-dev]
     bullseye: [libboost-filesystem1.74.0]
@@ -2757,6 +2824,7 @@ libboost-filesystem:
     jammy: [libboost-filesystem1.74.0]
     noble: [libboost-filesystem1.83.0]
 libboost-filesystem-dev:
+  arch: [boost]
   debian: [libboost-filesystem-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
@@ -2766,6 +2834,7 @@ libboost-filesystem-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-filesystem-dev]
 libboost-iostreams:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-iostreams1.74.0]
     buster: [libboost-iostreams1.67.0]
@@ -2781,6 +2850,7 @@ libboost-iostreams:
     jammy: [libboost-iostreams1.74.0]
     noble: [libboost-iostreams1.83.0]
 libboost-iostreams-dev:
+  arch: [boost]
   debian: [libboost-iostreams-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2790,6 +2860,7 @@ libboost-iostreams-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-iostreams-dev]
 libboost-math:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-math1.74.0]
     buster: [libboost-math1.67.0]
@@ -2804,6 +2875,7 @@ libboost-math:
     jammy: [libboost-math1.74.0]
     noble: [libboost-math1.83.0]
 libboost-math-dev:
+  arch: [boost]
   debian: [libboost-math-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2812,6 +2884,7 @@ libboost-math-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-math-dev]
 libboost-numpy-dev:
+  arch: [boost]
   debian: [libboost-numpy-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2820,6 +2893,7 @@ libboost-numpy-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-numpy-dev]
 libboost-program-options:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-program-options1.74.0]
     buster: [libboost-program-options1.67.0]
@@ -2835,6 +2909,7 @@ libboost-program-options:
     jammy: [libboost-program-options1.74.0]
     noble: [libboost-program-options1.83.0]
 libboost-program-options-dev:
+  arch: [boost]
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2845,6 +2920,7 @@ libboost-program-options-dev:
   ubuntu: [libboost-program-options-dev]
 libboost-python:
   alpine: [boost-python2]
+  arch: [boost-libs]
   debian:
     bookworm: [libboost-python1.81.0]
     bullseye: [libboost-python1.74.0]
@@ -2864,6 +2940,7 @@ libboost-python:
     noble: [libboost-python1.83.0]
 libboost-python-dev:
   alpine: [boost-python2]
+  arch: [boost]
   debian: [libboost-python-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
@@ -2875,6 +2952,7 @@ libboost-python-dev:
     '7': [boost-devel, 'boost-python%{python3_pkgversion}-devel']
   ubuntu: [libboost-python-dev]
 libboost-random:
+  arch: [boost-libs]
   debian:
     bookworm: [libboost-random1.81.0]
     bullseye: [libboost-random1.74.0]
@@ -2891,6 +2969,7 @@ libboost-random:
     jammy: [libboost-random1.74.0]
     noble: [libboost-random1.83.0]
 libboost-random-dev:
+  arch: [boost]
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2900,6 +2979,7 @@ libboost-random-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-random-dev]
 libboost-regex:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-regex1.74.0]
     buster: [libboost-regex1.67.0]
@@ -2915,6 +2995,7 @@ libboost-regex:
     jammy: [libboost-regex1.74.0]
     noble: [libboost-regex1.83.0]
 libboost-regex-dev:
+  arch: [boost]
   debian: [libboost-regex-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2924,6 +3005,7 @@ libboost-regex-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-regex-dev]
 libboost-serialization:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-serialization1.74.0]
     buster: [libboost-serialization1.67.0]
@@ -2939,6 +3021,7 @@ libboost-serialization:
     jammy: [libboost-serialization1.74.0]
     noble: [libboost-serialization1.83.0]
 libboost-serialization-dev:
+  arch: [boost]
   debian: [libboost-serialization-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2948,6 +3031,7 @@ libboost-serialization-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-serialization-dev]
 libboost-system:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-system1.74.0]
     buster: [libboost-system1.67.0]
@@ -2963,6 +3047,7 @@ libboost-system:
     jammy: [libboost-system1.74.0]
     noble: [libboost-system1.83.0]
 libboost-system-dev:
+  arch: [boost]
   debian: [libboost-system-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -2972,6 +3057,7 @@ libboost-system-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-system-dev]
 libboost-thread:
+  arch: [boost-libs]
   debian:
     bookworm: [libboost-thread1.81.0]
     bullseye: [libboost-thread1.74.0]
@@ -2988,6 +3074,7 @@ libboost-thread:
     jammy: [libboost-thread1.74.0]
     noble: [libboost-thread1.83.0]
 libboost-thread-dev:
+  arch: [boost]
   debian: [libboost-thread-dev]
   fedora: [boost-devel]
   gentoo: ['dev-libs/boost[threads]']
@@ -2997,6 +3084,7 @@ libboost-thread-dev:
   rhel: [boost-devel]
   ubuntu: [libboost-thread-dev]
 libboost-timer:
+  arch: [boost-libs]
   debian:
     bullseye: [libboost-timer1.74.0]
     buster: [libboost-timer1.67.0]
@@ -3011,6 +3099,7 @@ libboost-timer:
     jammy: [libboost-timer1.74.0]
     noble: [libboost-timer1.83.0]
 libboost-timer-dev:
+  arch: [boost]
   debian: [libboost-timer-dev]
   fedora: [boost-devel]
   gentoo: [dev-libs/boost]
@@ -3049,17 +3138,20 @@ libcap-dev:
   opensuse: [libcap-devel]
   ubuntu: [libcap-dev]
 libcap-ng-dev:
+  arch: [libcap-ng]
   debian: [libcap-ng-dev]
   fedora: [libcap-ng-devel]
   nixos: [libcap_ng]
   rhel: [libcap-ng-devel]
   ubuntu: [libcap-ng-dev]
 libcap-ng0:
+  arch: [libcap-ng]
   debian: [libcap-ng0]
   gentoo: [sys-libs/libcap-ng]
   nixos: [libcap_ng]
   ubuntu: [libcap-ng0]
 libcap2:
+  arch: [libcap]
   debian: [libcap2]
   nixos: [libcap]
   ubuntu: [libcap2]
@@ -3071,7 +3163,8 @@ libcap2-bin:
   nixos: [libcap]
   ubuntu: [libcap2-bin]
 libccd-dev:
-  arch: [libccd]
+  arch:
+    aur: [libccd]
   debian: [libccd-dev]
   fedora: [libccd]
   gentoo: [sci-libs/libccd]
@@ -3096,18 +3189,21 @@ libcdd-dev:
   nixos: [cddlib]
   ubuntu: [libcdd-dev]
 libcegui-mk2-dev:
-  arch: [cegui]
+  arch:
+    aur: [cegui]
   debian: [libcegui-mk2-dev]
   fedora: [cegui]
   gentoo: [dev-games/cegui]
   nixos: [cegui]
   ubuntu: [libcegui-mk2-dev]
 libcereal-dev:
+  arch: [cereal]
   debian: [libcereal-dev]
   fedora: [cereal-devel]
   gentoo: [dev-libs/cereal]
   ubuntu: [libcereal-dev]
 libceres-dev:
+  arch: [ceres-solver]
   debian: [libceres-dev]
   fedora: [ceres-solver-devel, suitesparse-devel, flexiblas-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
@@ -3140,6 +3236,7 @@ libcoin60-dev:
   gentoo: [=media-libs/coin-3.1.3*]
   ubuntu: [libcoin60-dev]
 libcoin80-dev:
+  arch: [coin]
   debian:
     '*': [libcoin-dev]
     stretch: [libcoin80-dev]
@@ -3148,6 +3245,7 @@ libcoin80-dev:
     '*': [libcoin-dev]
     bionic: [libcoin80-dev]
 libconfig++-dev:
+  arch: [libconfig]
   debian: [libconfig++-dev]
   fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
@@ -3155,6 +3253,7 @@ libconfig++-dev:
   rhel: [libconfig-devel]
   ubuntu: [libconfig++-dev]
 libconfig-dev:
+  arch: [libconfig]
   debian: [libconfig-dev]
   fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
@@ -3226,7 +3325,7 @@ libcurl-dev:
   rhel: [libcurl-devel]
   ubuntu: [libcurl4-openssl-dev]
 libdbus-dev:
-  arch: [dbus-core]
+  arch: [dbus]
   debian: [libdbus-1-dev]
   fedora: [dbus-devel]
   gentoo: [sys-apps/dbus]
@@ -3276,6 +3375,7 @@ libdmtx-dev:
   nixos: [libdmtx]
   ubuntu: [libdmtx-dev]
 libdpkg-dev:
+  arch: [dpkg]
   debian: [libdpkg-dev]
   fedora: [dpkg-devel]
   nixos: [dpkg]
@@ -3356,6 +3456,7 @@ libespeak-dev:
   nixos: [espeak]
   ubuntu: [libespeak-dev]
 libespeak-ng1:
+  arch: [espeak-ng]
   debian: [libespeak-ng1]
   fedora: [espeak-ng]
   opensuse: [libespeak-ng1]
@@ -3403,13 +3504,15 @@ libexpat1-dev:
   ubuntu: [libexpat1-dev]
 libext2fs-dev:
   alpine: [e2fsprogs-dev]
+  arch: [e2fsprogs]
   debian: [libext2fs-dev]
   fedora: [e2fsprogs-devel]
   opensuse: [libext2fs-devel]
   rhel: [e2fsprogs-devel]
   ubuntu: [libext2fs-dev]
 libfcl-dev:
-  arch: [fcl]
+  arch:
+    aur: [fcl]
   debian: [libfcl-dev]
   fedora: [fcl-devel]
   gentoo: [sci-libs/fcl]
@@ -3421,6 +3524,7 @@ libfcl-dev:
   ubuntu:
     '*': [libfcl-dev]
 libffi-dev:
+  arch: [libffi]
   debian: [libffi-dev]
   fedora: [libffi-devel]
   gentoo: [virtual/libffi]
@@ -3501,6 +3605,7 @@ libfltk-dev:
   slackware: [fltk]
   ubuntu: [libfltk1.3-dev]
 libfontconfig1-dev:
+  arch: [fontconfig]
   debian: [libfontconfig1-dev]
   fedora: [fontconfig-devel]
   gentoo: [media-libs/fontconfig]
@@ -3523,7 +3628,8 @@ libfreeimage-dev:
   rhel: [freeimage-devel]
   ubuntu: [libfreeimage-dev]
 libfreenect-dev:
-  arch: [libfreenect]
+  arch:
+    aur: [libfreenect]
   debian: [libfreenect-dev]
   fedora: [libfreenect-devel]
   nixos: [freenect]
@@ -3653,13 +3759,15 @@ libgazebo9-dev:
   ubuntu:
     bionic: [libgazebo9-dev]
 libgconf2:
-  arch: [gconf]
+  arch:
+    aur: [gconf]
   debian: [libgconf-2-4]
   fedora: [GConf2]
   gentoo: ['gnome-base/gconf:2']
   nixos: [gnome2.GConf]
   ubuntu: [libgconf-2-4]
 libgdal-dev:
+  arch: [gdal]
   debian: [libgdal-dev]
   fedora: [gdal-devel]
   nixos: [gdal]
@@ -3705,6 +3813,7 @@ libgfortran3:
   gentoo: ['sys-devel/gcc[fortran]']
   ubuntu: [libgfortran3]
 libgif-dev:
+  arch: [giflib]
   debian: [libgif-dev]
   fedora: [giflib-devel]
   gentoo: [media-libs/giflib]
@@ -3721,6 +3830,7 @@ libglew-dev:
   rhel: [glew-devel]
   ubuntu: [libglew-dev]
 libglfw3-dev:
+  arch: [glfw]
   debian: [libglfw3-dev]
   fedora: [glfw-devel]
   gentoo: [media-libs/glfw]
@@ -3745,19 +3855,19 @@ libglm-dev:
   rhel: [glm-devel]
   ubuntu: [libglm-dev]
 libglui-dev:
-  arch: [glui]
+  arch:
+    aur: [glui]
   debian: [libglui-dev]
   fedora: [glui-devel]
   ubuntu: [libglui-dev]
 libglw1-mesa:
-  arch: [glw]
   debian: [libglw1-mesa]
   fedora: [mesa-libGLw]
   gentoo: [x11-libs/libGLw]
   ubuntu: [libglw1-mesa]
 libgmock-dev:
   alpine: [gmock]
-  arch: [gmock]
+  arch: [gtest]
   debian: [libgmock-dev]
   fedora: [gmock-devel]
   freebsd: [googlemock]
@@ -3770,6 +3880,7 @@ libgmock-dev:
     '*': [libgmock-dev]
     bionic: null
 libgmp:
+  arch: [gmp]
   debian: [libgmp-dev]
   fedora: [gmp-devel]
   gentoo: [dev-libs/gmp]
@@ -3780,12 +3891,14 @@ libgmp:
   ubuntu: [libgmp-dev]
 libgnutls28-dev:
   alpine: [gnutls-dev]
+  arch: [gnutls]
   debian: [libgnutls28-dev]
   fedora: [gnutls-devel]
   opensuse: [libgnutls-devel]
   rhel: [gnutls-devel]
   ubuntu: [libgnutls28-dev]
 libgomp1:
+  arch: [gcc-libs]
   debian: [libgomp1]
   gentoo: [sys-libs/gcc]
   ubuntu: [libgomp1]
@@ -3823,6 +3936,7 @@ libgphoto-dev:
   ubuntu:
     '*': [libgphoto2-dev]
 libgpiod-dev:
+  arch: [libgpiod]
   debian: [libgpiod-dev]
   fedora: [libgpiod-devel]
   gentoo: [dev-libs/libgpiod]
@@ -3874,19 +3988,18 @@ libgsl:
   ubuntu:
     '*': [libgsl-dev]
 libgstreamer-plugins-bad1.0-dev:
+  arch: [gst-plugins-bad]
   debian: [libgstreamer-plugins-bad1.0-dev]
   fedora: [gstreamer1-plugins-bad-free-devel]
   gentoo: ['media-libs/gst-plugins-bad:1.0']
   nixos: [gst_all_1.gst-plugins-bad]
   ubuntu: [libgstreamer-plugins-bad1.0-dev]
 libgstreamer-plugins-base0.10-0:
-  arch: [gstreamer0.10-base-plugins]
   debian:
     wheezy: [libgstreamer-plugins-base0.10-0]
   gentoo: ['media-libs/gst-plugins-base:0.10']
   ubuntu: [libgstreamer-plugins-base0.10-0]
 libgstreamer-plugins-base0.10-dev:
-  arch: [gstreamer0.10-base-plugins]
   debian:
     wheezy: [libgstreamer-plugins-base0.10-dev]
   gentoo: ['media-libs/gst-plugins-base:0.10']
@@ -3902,13 +4015,11 @@ libgstreamer-plugins-base1.0-dev:
   rhel: [gstreamer1-plugins-base-devel]
   ubuntu: [libgstreamer-plugins-base1.0-dev]
 libgstreamer0.10-0:
-  arch: [gstreamer0.10]
   debian:
     wheezy: [libgstreamer0.10-0]
   gentoo: ['media-libs/gstreamer:0.10']
   ubuntu: [libgstreamer0.10-0]
 libgstreamer0.10-dev:
-  arch: [gstreamer0.10]
   debian:
     wheezy: [libgstreamer0.10-dev]
   gentoo: ['media-libs/gstreamer:0.10']
@@ -3924,11 +4035,13 @@ libgstreamer1.0-dev:
   rhel: [gstreamer1-devel]
   ubuntu: [libgstreamer1.0-dev]
 libgstrtspserver-1.0-0:
+  arch: [gst-rtsp-server]
   debian: [libgstrtspserver-1.0-0]
   fedora: [gstreamer1-rtsp-server]
   nixos: [gst_all_1.gst-rtsp-server]
   ubuntu: [libgstrtspserver-1.0-0]
 libgstrtspserver-1.0-dev:
+  arch: [gst-rtsp-server]
   debian: [libgstrtspserver-1.0-dev]
   fedora: [gstreamer1-rtsp-server-devel]
   nixos: [gst_all_1.gst-rtsp-server]
@@ -3961,6 +4074,7 @@ libhal-dev:
   debian: [libhal-dev]
   ubuntu: [libhal-dev]
 libhdf5-dev:
+  arch: [hdf5]
   debian: [libhdf5-dev]
   fedora: [hdf5-devel]
   gentoo: [sci-libs/hdf5]
@@ -3969,6 +4083,7 @@ libhdf5-dev:
   rhel: [hdf5-devel]
   ubuntu: [libhdf5-dev]
 libhidapi-dev:
+  arch: [hidapi]
   debian: [libhidapi-dev]
   fedora: [hidapi-devel]
   gentoo: [dev-libs/hidapi]
@@ -3985,6 +4100,7 @@ libi2c-dev:
   nixos: [i2c-tools]
   ubuntu: [libi2c-dev]
 libicu-dev:
+  arch: [icu]
   debian: [libicu-dev]
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
@@ -4107,6 +4223,7 @@ libignition-utils1:
   ubuntu:
     focal: [libignition-utils1]
 libiio-dev:
+  arch: [libiio]
   debian: [libiio-dev]
   fedora: [libiio-devel]
   gentoo: [net-libs/libiio]
@@ -4124,12 +4241,14 @@ libirrlicht-dev:
   nixos: [irrlicht]
   ubuntu: [libirrlicht-dev]
 libiw-dev:
+  arch: [wireless_tools]
   debian: [libiw-dev]
   fedora: [wireless-tools-devel]
   gentoo: [net-wireless/wireless-tools]
   nixos: [wirelesstools]
   ubuntu: [libiw-dev]
 libjack-dev:
+  arch: [jack2]
   debian: [libjack-dev]
   fedora: [jack-audio-connection-kit-devel]
   rhel: [jack-audio-connection-kit-devel]
@@ -4139,6 +4258,7 @@ libjackson-json-java:
   gentoo: [dev-java/jackson]
   ubuntu: [libjackson-json-java]
 libjansson-dev:
+  arch: [jansson]
   debian: [libjansson-dev]
   fedora: [jansson-devel]
   gentoo: [dev-libs/jansson]
@@ -4183,6 +4303,7 @@ libjson0-dev:
   rhel: [json-c-devel]
   ubuntu: [libjson0-dev]
 libjsoncpp:
+  arch: [jsoncpp]
   debian: [libjsoncpp1]
   fedora: [jsoncpp]
   gentoo: [dev-libs/jsoncpp]
@@ -4227,7 +4348,8 @@ libkdtree++-dev:
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]
 libkml-dev:
-  arch: [libkml]
+  arch:
+    aur: [libkml]
   debian: [libkml-dev]
   fedora: [libkml-devel]
   nixos: [libkml]
@@ -4246,6 +4368,7 @@ liblapack-dev:
   rhel: [lapack-devel]
   ubuntu: [liblapack-dev]
 liblapacke-dev:
+  arch: [lapacke]
   debian: [liblapacke-dev]
   fedora: [lapack-devel]
   ubuntu: [liblapacke-dev]
@@ -4305,6 +4428,7 @@ liblttng-ust-dev:
   rhel: [lttng-ust-devel]
   ubuntu: [liblttng-ust-dev]
 liblz4:
+  arch: [lz4]
   debian: [liblz4-1]
   fedora: [lz4-libs]
   nixos: [lz4]
@@ -4314,6 +4438,7 @@ liblz4:
   rhel: [lz4-libs]
   ubuntu: [liblz4-1]
 liblz4-dev:
+  arch: [lz4]
   debian: [liblz4-dev]
   fedora: [lz4-devel]
   nixos: [lz4]
@@ -4323,6 +4448,7 @@ liblz4-dev:
   rhel: [lz4-devel]
   ubuntu: [liblz4-dev]
 liblzma-dev:
+  arch: [xz]
   debian: [liblzma-dev]
   fedora: [xz-devel]
   nixos: [xz]
@@ -4335,15 +4461,17 @@ libmagick:
   nixos: [imagemagick]
   ubuntu: [libmagick++-dev]
 libmarble-dev:
-  arch: [kdeedu-marble]
+  arch: [marble]
   debian: [libmarble-dev]
   fedora: [marble-widget-qt5-devel]
   gentoo: [kde-base/marble]
   ubuntu: [libmarble-dev]
 libmbedtls-dev:
+  arch: [mbedtls]
   debian: [libmbedtls-dev]
   ubuntu: [libmbedtls-dev]
 libmicrohttpd:
+  arch: [libmicrohttpd]
   debian: [libmicrohttpd-dev]
   fedora: [libmicrohttpd-devel]
   gentoo: [net-libs/libmicrohttpd]
@@ -4357,36 +4485,44 @@ libmlpack-dev:
   ubuntu: [libmlpack-dev]
 libmnl-dev:
   alpine: [libmnl-dev]
+  arch: [libmnl]
   debian: [libmnl-dev]
   fedora: [libmnl-devel]
   opensuse: [libmnl-devel]
   rhel: [libmnl-devel]
   ubuntu: [libmnl-dev]
 libmockito-java:
-  arch: [mockito]
+  arch:
+    aur: [mockito]
   debian: [libmockito-java]
   fedora: [mockito]
   gentoo: [dev-java/mockito]
   rhel: [mockito]
   ubuntu: [libmockito-java]
 libmodbus-dev:
+  arch:
+    aur: [libmodbus]
   debian: [libmodbus-dev]
   fedora: [libmodbus-devel]
   nixos: [libmodbus]
   openembedded: [libmodbus@meta-oe]
   ubuntu: [libmodbus-dev]
 libmodbus5:
+  arch:
+    aur: [libmodbus]
   debian: [libmodbus5]
   fedora: [libmodbus]
   gentoo: [dev-libs/libmodbus]
   nixos: [libmodbus]
   ubuntu: [libmodbus5]
 libmongoc-1.0-0:
+  arch: [mongo-c-driver]
   debian: [libmongoc-1.0-0]
   gentoo: [dev-libs/mongo-c-driver]
   nixos: [mongoc]
   ubuntu: [libmongoc-1.0-0]
 libmongoc-dev:
+  arch: [mongo-c-driver]
   debian: [libmongoc-dev]
   nixos: [mongoc]
   ubuntu: [libmongoc-dev]
@@ -4411,17 +4547,22 @@ libmp3lame-dev:
   rhel: [lame-devel]
   ubuntu: [libmp3lame-dev]
 libmpg123-dev:
+  arch: [mpg123]
   debian: [libmpg123-dev]
   fedora: [mpg123-devel]
   nixos: [mpg123]
   ubuntu: [libmpg123-dev]
 libmpich-dev:
+  arch:
+    aur: [mpich]
   debian: [libmpich-dev]
   fedora: [mpich-devel]
   gentoo: [sys-cluster/mpich]
   nixos: [mpich]
   ubuntu: [libmpich-dev]
 libmpich2-dev:
+  arch:
+    aur: [mpich2]
   debian: [libmpich2-dev]
   gentoo: [sys-cluster/mpich2]
   nixos: [mpich]
@@ -4434,10 +4575,12 @@ libmsgsl-dev:
   gentoo: [dev-cpp/ms-gsl]
   ubuntu: [libmsgsl-dev]
 libmysql++-dev:
+  arch: [mysql++]
   debian: [libmysql++-dev]
   fedora: [mysql++-devel]
   ubuntu: [libmysql++-dev]
 libmysql++3v5:
+  arch: [mysql++]
   debian: [libmysql++3v5]
   fedora: [mysql++]
   ubuntu:
@@ -4516,11 +4659,13 @@ libnl-3-dev:
   openembedded: [libnl@openembedded-core]
   ubuntu: [libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev]
 libnl-dev:
-  arch: [libnl1]
+  arch:
+    aur: [libnl1]
   debian: [libnl-dev]
   gentoo: [dev-libs/libnl]
   ubuntu: [libnl-dev]
 libnlopt-cxx-dev:
+  arch: [nlopt]
   debian:
     '*': [libnlopt-cxx-dev]
     stretch: null
@@ -4531,24 +4676,28 @@ libnlopt-cxx-dev:
     '*': [libnlopt-cxx-dev]
     bionic: null
 libnlopt-dev:
+  arch: [nlopt]
   debian: [libnlopt-dev]
   fedora: [NLopt-devel]
   gentoo: [sci-libs/nlopt]
   nixos: [nlopt]
   ubuntu: [libnlopt-dev]
 libnlopt0:
+  arch: [nlopt]
   debian: [libnlopt0]
   fedora: [NLopt]
   gentoo: [sci-libs/nlopt]
   nixos: [nlopt]
   ubuntu: [libnlopt0]
 libnotify:
+  arch: [libnotify]
   debian: [libnotify-dev]
   fedora: [libnotify-devel]
   gentoo: [x11-libs/libnotify]
   nixos: [libnotify]
   ubuntu: [libnotify-dev]
 libnss3-dev:
+  arch: [nss]
   debian: [libnss3-dev]
   fedora: [nss-devel]
   gentoo: [=dev-libs/nss-3*]
@@ -4574,7 +4723,7 @@ libogg:
   slackware: [libogg]
   ubuntu: [libogg-dev]
 libogre:
-  arch: [ogre-1.9]
+  arch: [ogre]
   debian:
     bookworm: [libogre-1.12-dev]
     buster: [libogre-1.9.0v5]
@@ -4596,7 +4745,7 @@ libogre-1.12-dev:
     focal: [libogre-1.12-dev]
     jammy: [libogre-1.12-dev]
 libogre-dev:
-  arch: [ogre-1.9]
+  arch: [ogre]
   debian:
     buster: [libogre-1.9-dev]
     stretch: [libogre-1.9-dev]
@@ -4654,6 +4803,7 @@ libopenal-dev:
   rhel: [openal-soft-devel]
   ubuntu: [libopenal-dev]
 libopenblas-dev:
+  arch: [openblas]
   debian: [libopenblas-dev]
   fedora: [openblas-devel]
   gentoo: [sci-libs/openblas]
@@ -4662,7 +4812,7 @@ libopenblas-dev:
   rhel: [openblas-devel]
   ubuntu: [libopenblas-dev]
 libopencv-contrib-dev:
-  arch: [opencv-contrib]
+  arch: [opencv]
   debian: [libopencv-contrib-dev]
   fedora: [opencv-contrib]
   gentoo: [media-libs/opencv]
@@ -4698,23 +4848,25 @@ libopenexr-dev:
   rhel: [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
-  arch: [openni]
+  arch:
+    aur: [openni]
   debian: [libopenni-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
   rhel: [openni-devel]
   ubuntu: [libopenni-dev]
 libopenni-nite-dev:
-  arch: [primesense-nite]
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
 libopenni-sensor-primesense-dev:
-  arch: [sensorkinect]
+  arch:
+    aur: [sensorkinect]
   debian: [libopenni-sensor-primesense-dev]
   fedora: [openni-primesense]
   ubuntu: [libopenni-sensor-primesense-dev]
 libopenni2-dev:
-  arch: [openni2]
+  arch:
+    aur: [openni2]
   debian: [libopenni2-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI2]
@@ -4868,9 +5020,7 @@ libpaho-mqttpp-dev:
     bionic: null
     focal: null
 libpcap:
-  arch:
-    pacman:
-      packages: [libpcap]
+  arch: [libpcap]
   debian: [libpcap0.8-dev]
   fedora: [libpcap-devel]
   gentoo: [net-libs/libpcap]
@@ -4880,7 +5030,8 @@ libpcap:
   rhel: [libpcap-devel]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
-  arch: [pcl]
+  arch:
+    aur: [pcl]
   debian:
     bookworm: [libpcl-apps1.13, libpcl-common1.13, libpcl-features1.13, libpcl-filters1.13, libpcl-io1.13, libpcl-kdtree1.13, libpcl-keypoints1.13, libpcl-ml1.13, libpcl-octree1.13, libpcl-outofcore1.13, libpcl-people1.13, libpcl-recognition1.13, libpcl-registration1.13, libpcl-sample-consensus1.13, libpcl-search1.13, libpcl-segmentation1.13, libpcl-stereo1.13, libpcl-surface1.13, libpcl-tracking1.13, libpcl-visualization1.13]
     bullseye: [libpcl-apps1.11, libpcl-common1.11, libpcl-features1.11, libpcl-filters1.11, libpcl-io1.11, libpcl-kdtree1.11, libpcl-keypoints1.11, libpcl-ml1.11, libpcl-octree1.11, libpcl-outofcore1.11, libpcl-people1.11, libpcl-recognition1.11, libpcl-registration1.11, libpcl-sample-consensus1.11, libpcl-search1.11, libpcl-segmentation1.11, libpcl-stereo1.11, libpcl-surface1.11, libpcl-tracking1.11, libpcl-visualization1.11]
@@ -4900,7 +5051,8 @@ libpcl-all:
     jammy: [libpcl-apps1.12, libpcl-common1.12, libpcl-features1.12, libpcl-filters1.12, libpcl-io1.12, libpcl-kdtree1.12, libpcl-keypoints1.12, libpcl-ml1.12, libpcl-octree1.12, libpcl-outofcore1.12, libpcl-people1.12, libpcl-recognition1.12, libpcl-registration1.12, libpcl-sample-consensus1.12, libpcl-search1.12, libpcl-segmentation1.12, libpcl-stereo1.12, libpcl-surface1.12, libpcl-tracking1.12, libpcl-visualization1.12]
     noble: [libpcl-apps1.14, libpcl-common1.14, libpcl-features1.14, libpcl-filters1.14, libpcl-io1.14, libpcl-kdtree1.14, libpcl-keypoints1.14, libpcl-ml1.14, libpcl-octree1.14, libpcl-outofcore1.14, libpcl-people1.14, libpcl-recognition1.14, libpcl-registration1.14, libpcl-sample-consensus1.14, libpcl-search1.14, libpcl-segmentation1.14, libpcl-stereo1.14, libpcl-surface1.14, libpcl-tracking1.14, libpcl-visualization1.14]
 libpcl-all-dev:
-  arch: [pcl]
+  arch:
+    aur: [pcl]
   debian: [libpcl-dev]
   fedora: [pcl-devel]
   freebsd: [libpcl]
@@ -5287,6 +5439,7 @@ libpcsclite-dev:
   nixos: [pcsclite]
   ubuntu: [libpcsclite-dev]
 libpcsclite1:
+  arch: [pcsclite]
   debian: [libpcsclite1]
   fedora: [pcsc-lite-libs]
   opensuse: [libpcsclite1]
@@ -5303,6 +5456,7 @@ libphonon-dev:
   gentoo: [media-libs/phonon]
   ubuntu: [libphonon-dev]
 libpng++-dev:
+  arch: [png++]
   debian: [libpng++-dev]
   gentoo: [dev-cpp/pngpp]
   nixos: [pngpp]
@@ -5322,7 +5476,7 @@ libpng-dev:
   ubuntu:
     '*': [libpng-dev]
 libpng12-dev:
-  arch: [libpng]
+  arch: [libpng12]
   debian: [libpng12-dev]
   fedora: [libpng12-devel]
   freebsd: [png]
@@ -5367,6 +5521,7 @@ libpq-dev:
   nixos: [postgresql]
   ubuntu: [libpq-dev]
 libpqxx:
+  arch: [libpqxx]
   debian:
     buster: [libpqxx-6.2]
     stretch: [libpqxx-4.0v5]
@@ -5378,12 +5533,14 @@ libpqxx:
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
 libpqxx-dev:
+  arch: [libpqxx]
   debian: [libpqxx-dev]
   fedora: [libpqxx-devel]
   gentoo: [dev-libs/libpqxx]
   nixos: [libpqxx]
   ubuntu: [libpqxx-dev]
 libprocps-dev:
+  arch: [libprocps]
   debian: [libprocps-dev]
   fedora: [procps-ng-devel]
   nixos: [procps]
@@ -5409,6 +5566,7 @@ libpulse-dev:
   openembedded: [pulseaudio@openembedded-core]
   ubuntu: [libpulse-dev]
 libqcustomplot-dev:
+  arch: [qcustomplot]
   debian:
     bookworm: [libqcustomplot-dev]
     bullseye: [libqcustomplot-dev]
@@ -5418,6 +5576,7 @@ libqcustomplot-dev:
   gentoo: [dev-libs/qcustomplot]
   ubuntu: [libqcustomplot-dev]
 libqd-dev:
+  arch: [qd]
   debian: [libqd-dev]
   fedora: [qd-devel]
   gentoo: [sci-libs/qd]
@@ -5434,7 +5593,6 @@ libqglviewer-dev-qt5:
     '7': null
   ubuntu: [libqglviewer-dev-qt5]
 libqglviewer-qt4:
-  arch: [libqglviewer-qt4]
   debian:
     buster: [libqglviewer2-qt4]
     stretch: [libqglviewer2-qt4]
@@ -5445,7 +5603,6 @@ libqglviewer-qt4:
   ubuntu:
     bionic: [libqglviewer2-qt4]
 libqglviewer-qt4-dev:
-  arch: [libqglviewer-qt4]
   debian:
     buster: [libqglviewer-dev-qt4]
     stretch: [libqglviewer-dev-qt4]
@@ -5478,24 +5635,26 @@ libqhull:
   ubuntu: [libqhull-dev]
 libqmi-glib-dev:
   alpine: [libqmi-dev]
+  arch: [libqmi]
   debian: [libqmi-glib-dev]
   fedora: [libqmi-devel]
   opensuse: [libqmi-devel]
   ubuntu: [libqmi-glib-dev]
 libqrencode:
+  arch: [qrencode]
   debian: [libqrencode3]
   fedora: [qrencode]
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [libqrencode3]
 libqrencode-dev:
+  arch: [qrencode]
   debian: [libqrencode-dev]
   fedora: [qrencode-devel]
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [libqrencode-dev]
 libqt4:
-  arch: [qt4]
   debian: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
   fedora: [qt]
   freebsd: [qt4-corelib]
@@ -5507,7 +5666,6 @@ libqt4:
     '7': [qt]
   ubuntu: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
 libqt4-dev:
-  arch: [qt4]
   debian: [libqt4-dev]
   fedora: [qt-devel]
   freebsd: [qt4-corelib]
@@ -5519,7 +5677,6 @@ libqt4-dev:
     '7': [qt-devel]
   ubuntu: [libqt4-dev]
 libqt4-opengl:
-  arch: [qt4]
   debian: [libqt4-opengl]
   fedora: [qt]
   gentoo: ['dev-qt/qtopengl:4']
@@ -5528,7 +5685,6 @@ libqt4-opengl:
     '7': [qt]
   ubuntu: [libqt4-opengl]
 libqt4-opengl-dev:
-  arch: [qt4]
   debian: [libqt4-opengl-dev]
   fedora: [qt-devel]
   gentoo: ['dev-qt/qtopengl:4']
@@ -5539,7 +5695,6 @@ libqt4-opengl-dev:
     '7': [qt-devel]
   ubuntu: [libqt4-opengl-dev]
 libqt4-sql-psql:
-  arch: [qt4]
   debian: [libqt4-sql-psql]
   fedora: [qt-postgresql]
   gentoo: ['dev-qt/qtsql:4']
@@ -5547,6 +5702,7 @@ libqt4-sql-psql:
   nixos: [qt4]
   ubuntu: [libqt4-sql-psql]
 libqt5-charts-dev:
+  arch: [qt5-charts]
   debian: [libqt5charts5-dev]
   ubuntu: [libqt5charts5-dev]
 libqt5-concurrent:
@@ -5590,6 +5746,7 @@ libqt5-gui:
   slackware: [qt5]
   ubuntu: [libqt5gui5]
 libqt5-multimedia:
+  arch: [qt5-multimedia]
   debian: [libqt5multimedia5]
   nixos: [qt5.qtmultimedia]
   ubuntu: [libqt5multimedia5]
@@ -5637,6 +5794,7 @@ libqt5-printsupport:
   nixos: [qt5.qtbase]
   ubuntu: [libqt5printsupport5]
 libqt5-qml:
+  arch: [qt5-declarative]
   debian: [libqt5qml5]
   gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
@@ -5644,6 +5802,7 @@ libqt5-qml:
   rhel: [qt5-qtdeclarative]
   ubuntu: [libqt5qml5]
 libqt5-quick:
+  arch: [qt5-declarative]
   debian: [libqt5quick5]
   gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
@@ -5720,6 +5879,7 @@ libqt5-widgets:
   slackware: [qt5]
   ubuntu: [libqt5widgets5]
 libqt5-xml:
+  arch: [qt5-base]
   debian: [libqt5xml5]
   nixos: [qt5.qtbase]
   ubuntu: [libqt5xml5]
@@ -5741,7 +5901,6 @@ libqt5x11extras5-dev:
   rhel: [qt5-qtx11extras-devel]
   ubuntu: [libqt5x11extras5-dev]
 libqtgui4:
-  arch: [qt4]
   debian: [libqtgui4]
   fedora: [qt-x11]
   gentoo: ['dev-qt/qtgui:4']
@@ -5750,7 +5909,8 @@ libqtgui4:
     '7': [qt-x11]
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
-  arch: [qt5-webkit]
+  arch:
+    aur: [qt5-webkit]
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]
@@ -5769,7 +5929,8 @@ libqwt-qt5-dev:
   ubuntu:
     '*': [libqwt-qt5-dev]
 libqwt5-qt4-dev:
-  arch: [qwt5]
+  arch:
+    aur: [qwt5]
   debian: [libqwt5-qt4-dev]
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:5[qt4]']
@@ -5782,12 +5943,14 @@ libqwt6:
   nixos: [libsForQt5.qwt]
   ubuntu: [libqwt-dev]
 libqwtplot3d-qt4-dev:
-  arch: [qwtplot3d]
+  arch:
+    aur: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]
   fedora: [qwtplot3d-qt4-devel]
   gentoo: [x11-libs/qwtplot3d]
   ubuntu: [libqwtplot3d-qt4-dev]
 librabbitmq-dev:
+  arch: [librabbitmq-c]
   debian: [librabbitmq-dev]
   fedora: [librabbitmq-devel]
   rhel: [librabbitmq-devel]
@@ -5818,6 +5981,7 @@ libraw1394-dev:
   rhel: [libraw1394-devel]
   ubuntu: [libraw1394-dev]
 librdkafka-dev:
+  arch: [librdkafka]
   debian: [librdkafka-dev]
   fedora: [librdkafka-devel]
   gentoo: [dev-libs/librdkafka]
@@ -5843,7 +6007,6 @@ libreadline-dev:
   openembedded: [readline@openembedded-core]
   ubuntu: [libreadline-dev]
 libreadline-java:
-  arch: [java-readline]
   debian: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
@@ -5857,6 +6020,7 @@ librtaudio-dev:
   opensuse: [rtaudio-devel]
   ubuntu: [librtaudio-dev]
 libsecp256k1-dev:
+  arch: [libsecp256k1]
   debian: [libsecp256k1-dev]
   fedora: [libsecp256k1-devel]
   ubuntu: [libsecp256k1-dev]
@@ -5891,11 +6055,11 @@ libshaderc-dev:
     focal: null
     jammy: null
 libsimage-dev:
-  arch: [simage]
   debian: [libsimage-dev]
   gentoo: [media-libs/simage]
   ubuntu: [libsimage-dev]
 libsndfile1-dev:
+  arch: [libsndfile]
   debian: [libsndfile1-dev]
   fedora: [libsndfile-devel]
   gentoo: [media-libs/libsndfile]
@@ -5937,6 +6101,7 @@ libsoup2-dev:
   opensuse: [libsoup-2_4-1]
   ubuntu: [libsoup2.4-dev]
 libspatialindex-dev:
+  arch: [spatialindex]
   debian: [libspatialindex-dev]
   fedora: [spatialindex-devel]
   nixos: [libspatialindex]
@@ -5969,11 +6134,13 @@ libsqlite3-dev:
   rhel: [libsq3-devel]
   ubuntu: [libsqlite3-dev]
 libsrtp0-dev:
+  arch: [libsrtp]
   debian: [libsrtp0-dev]
   fedora: [libsrtp-devel]
   gentoo: ['net-libs/libsrtp:0']
   ubuntu: [libsrtp0-dev]
 libssh-dev:
+  arch: [libssh]
   debian: [libssh-dev]
   fedora: [libssh-devel]
   gentoo: [net-libs/libssh]
@@ -6006,7 +6173,8 @@ libssl-dev:
   rhel: [openssl-devel]
   ubuntu: [libssl-dev]
 libstdc++5:
-  arch: [libstdc++5]
+  arch:
+    aur: [libstdc++5]
   debian: [libstdc++5]
   freebsd: [builtin]
   gentoo: [virtual/libstdc++]
@@ -6019,18 +6187,21 @@ libstdc++6:
   nixos: []
   ubuntu: [libstdc++6]
 libsvm-dev:
+  arch: [libsvm]
   debian: [libsvm-dev]
   fedora: [libsvm-devel]
   gentoo: [sci-libs/libsvm]
   nixos: [libsvm]
   ubuntu: [libsvm-dev]
 libsvm3:
+  arch: [libsvm]
   debian: [libsvm3]
   fedora: [libsvm]
   gentoo: [=sci-libs/libsvm-3*]
   nixos: [libsvm]
   ubuntu: [libsvm3]
 libsvn-dev:
+  arch: [subversion]
   debian: [libsvn-dev]
   fedora: [subversion-devel]
   ubuntu: [libsvn-dev]
@@ -6045,6 +6216,7 @@ libswscale-dev:
     '8': null
   ubuntu: [libswscale-dev]
 libsystemd-dev:
+  arch: [systemd-libs]
   debian: [libsystemd-dev]
   fedora: [systemd-devel]
   ubuntu:
@@ -6058,6 +6230,7 @@ libtclap-dev:
   nixos: [tclap]
   ubuntu: [libtclap-dev]
 libtesseract:
+  arch: [tesseract]
   debian: [libtesseract-dev]
   fedora: [tesseract-devel]
   gentoo: [app-text/tesseract]
@@ -6101,7 +6274,8 @@ libtiff4-dev:
   ubuntu: [libtiff4-dev]
 libtins-dev:
   alpine: [libtins-dev]
-  arch: [libtins]
+  arch:
+    aur: [libtins]
   debian: [libtins-dev]
   fedora: [libtins-devel]
   nixos: [libtins]
@@ -6157,6 +6331,7 @@ libunittest++:
   rhel: [unittest-cpp-devel]
   ubuntu: [libunittest++-dev]
 libunwind:
+  arch: [libunwind]
   debian:
     '*': [libunwind8]
     wheezy: [libunwind7]
@@ -6166,6 +6341,7 @@ libunwind:
   ubuntu:
     '*': [libunwind8]
 libunwind-dev:
+  arch: [libunwind]
   debian:
     buster: [libunwind8-dev]
     stretch: [libunwind8-dev]
@@ -6176,7 +6352,8 @@ libunwind-dev:
   ubuntu:
     '*': [libunwind-dev]
 liburdfdom-dev:
-  arch: [urdfdom]
+  arch:
+    aur: [urdfdom]
   debian: [liburdfdom-dev]
   fedora: [urdfdom-devel]
   freebsd: [ros-urdfdom]
@@ -6200,7 +6377,8 @@ liburdfdom-headers-dev:
   slackware: [urdfdom_headers]
   ubuntu: [liburdfdom-headers-dev]
 liburdfdom-tools:
-  arch: [urdfdom]
+  arch:
+    aur: [urdfdom]
   debian: [liburdfdom-tools]
   fedora: [urdfdom]
   freebsd: [ros-urdfdom]
@@ -6220,7 +6398,7 @@ libusb:
   rhel: [libusb]
   ubuntu: [libusb-0.1-4]
 libusb-1.0:
-  arch: [libusbx]
+  arch: [libusb]
   debian: [libusb-1.0-0]
   fedora: [libusbx]
   gentoo: ['virtual/libusb:1']
@@ -6230,7 +6408,7 @@ libusb-1.0:
   rhel: [libusbx]
   ubuntu: [libusb-1.0-0]
 libusb-1.0-dev:
-  arch: [libusbx]
+  arch: [libusb]
   debian: [libusb-1.0-0-dev]
   fedora: [libusbx-devel]
   gentoo: ['virtual/libusb:1']
@@ -6286,6 +6464,7 @@ libv4l-dev:
       packages: [v4l-utils]
   ubuntu: [libv4l-dev]
 libvlc:
+  arch: [vlc]
   debian:
     '*': [libvlc5, vlc-bin]
   fedora: [vlc-core]
@@ -6296,6 +6475,7 @@ libvlc:
   ubuntu:
     '*': [libvlc5, vlc-bin]
 libvlc-dev:
+  arch: [vlc]
   debian: [libvlc-dev]
   fedora: [vlc-devel]
   gentoo: [media-video/vlc]
@@ -6310,12 +6490,14 @@ libvlccore-dev:
   ubuntu: [libvlccore-dev]
 libvorbis-dev:
   alpine: [libvorbis-dev]
+  arch: [libvorbis]
   debian: [libvorbis-dev]
   fedora: [libvorbis-devel]
   opensuse: [libvorbis-devel]
   rhel: [libvorbis-devel]
   ubuntu: [libvorbis-dev]
 libvpx-dev:
+  arch: [libvpx]
   debian: [libvpx-dev]
   fedora: [libvpx-devel]
   gentoo: [media-libs/libvpx]
@@ -6373,6 +6555,7 @@ libvtk9-dev:
     bionic: null
     focal: null
 libvulkan-dev:
+  arch: [vulkan-icd-loader, vulkan-headers]
   debian: [libvulkan-dev]
   fedora: [vulkan-devel]
   gentoo: [media-libs/vulkan-loader]
@@ -6384,6 +6567,7 @@ libvulkan-dev:
   ubuntu:
     '*': [libvulkan-dev]
 libwebp-dev:
+  arch: [libwebp]
   debian: [libwebp-dev]
   fedora: [libwebp-devel]
   freebsd: [webp]
@@ -6443,6 +6627,7 @@ libx11-xcb-dev:
   rhel: [libX11-devel]
   ubuntu: [libx11-xcb-dev]
 libx264-dev:
+  arch: [x264]
   debian: [libx264-dev]
   fedora: [x264-devel]
   gentoo: [media-libs/x264]
@@ -6470,6 +6655,7 @@ libxcb-randr0-dev:
   nixos: [xorg.libxcb]
   ubuntu: [libxcb-randr0-dev]
 libxcursor-dev:
+  arch: [libxcursor]
   debian: [libxcursor-dev]
   fedora: [libXcursor-devel]
   nixos: [xorg.libXcursor]
@@ -6491,6 +6677,7 @@ libxext:
   rhel: [libXext-devel]
   ubuntu: [libxext-dev]
 libxft-dev:
+  arch: [libxft]
   debian: [libxft-dev]
   fedora: [libXft-devel]
   gentoo: [x11-libs/libXft]
@@ -6513,6 +6700,7 @@ libxinerama-dev:
   nixos: [xorg.libXinerama]
   ubuntu: [libxinerama-dev]
 libxkbcommon-dev:
+  arch: [libxkbcommon]
   debian: [libxkbcommon-dev]
   fedora: [libxkbcommon-devel]
   nixos: [libxkbcommon]
@@ -6548,7 +6736,7 @@ libxml2-utils:
   rhel: [libxml2]
   ubuntu: [libxml2-utils]
 libxmlrpc-c++:
-  arch: [xmlrpc-c]
+  arch: [libxmlrpc]
   debian: [libxmlrpc-c++8-dev]
   fedora: [xmlrpc-c-devel]
   gentoo: [dev-libs/xmlrpc-c]
@@ -6640,6 +6828,7 @@ libyaml-dev:
   rhel: [libyaml-devel]
   ubuntu: [libyaml-dev]
 libzip-dev:
+  arch: [libzip]
   debian: [libzip-dev]
   fedora: [libzip-devel]
   gentoo: [dev-libs/libzip]
@@ -6679,10 +6868,12 @@ libzstd-dev:
   ubuntu:
     '*': [libzstd-dev]
 light-locker:
+  arch: [light-locker]
   debian: [light-locker]
   fedora: [light-locker]
   ubuntu: [light-locker]
 lighttpd:
+  arch: [lighttpd]
   debian: [lighttpd]
   fedora: [lighttpd]
   nixos: [lighttpd]
@@ -6804,12 +6995,14 @@ lsb-release:
   slackware: [lsb-release]
   ubuntu: [lsb-release]
 lttng-modules:
-  arch: [lttng-modules]
+  arch:
+    aur: [lttng-modules]
   debian: [lttng-modules-dkms]
   gentoo: [dev-util/lttng-modules]
   ubuntu: [lttng-modules-dkms]
 lttng-tools:
-  arch: [lttng-tools]
+  arch:
+    aur: [lttng-tools]
   debian: [lttng-tools]
   fedora: [lttng-tools]
   gentoo: [dev-util/lttng-tools]
@@ -6880,6 +7073,7 @@ m4:
   opensuse: [m4]
   ubuntu: [m4]
 mapnik-utils:
+  arch: [mapnik]
   debian: [mapnik-utils]
   fedora: [mapnik-utils]
   ubuntu: [mapnik-utils]
@@ -6905,6 +7099,7 @@ mayavi:
   gentoo: [sci-visualization/mayavi]
   ubuntu: [mayavi2]
 meld:
+  arch: [meld]
   debian: [meld]
   fedora: [meld]
   gentoo: [dev-util/meld]
@@ -6927,12 +7122,14 @@ mesa-common-dev:
   gentoo: [media-libs/mesa]
   ubuntu: [mesa-common-dev]
 mesa-utils:
+  arch: [mesa-utils]
   debian: [mesa-utils]
   fedora: [glx-utils]
   gentoo: [x11-apps/mesa-progs]
   ubuntu: [mesa-utils]
 meshlab:
-  arch: [meshlab]
+  arch:
+    aur: [meshlab]
   debian: [meshlab]
   fedora: [meshlab]
   gentoo: [media-gfx/meshlab]
@@ -6986,6 +7183,7 @@ mono-complete:
   gentoo: [dev-lang/mono]
   ubuntu: [mono-complete]
 mono-devel:
+  arch: [mono]
   debian: [mono-devel]
   fedora: [mono-devel]
   gentoo: [dev-lang/mono]
@@ -6997,14 +7195,17 @@ mosquitto:
   nixos: [mosquitto]
   ubuntu: [mosquitto]
 mosquitto-clients:
+  arch: [mosquitto]
   debian: [mosquitto-clients]
   fedora: [mosquitto]
   ubuntu: [mosquitto-clients]
 mosquitto-dev:
+  arch: [mosquitto]
   debian: [libmosquitto-dev]
   fedora: [mosquitto-devel]
   ubuntu: [libmosquitto-dev]
 mosquittopp-dev:
+  arch: [mosquitto]
   debian: [libmosquittopp-dev]
   fedora: [mosquitto-devel]
   nixos: [mosquitto]
@@ -7054,6 +7255,7 @@ multistrap:
   debian: [multistrap]
   ubuntu: [multistrap]
 muparser:
+  arch: [muparser]
   debian: [libmuparser-dev]
   fedora: [muParser-devel]
   gentoo: [dev-cpp/muParser]
@@ -7094,6 +7296,7 @@ net-tools:
   openembedded: [net-tools@openembedded-core]
   ubuntu: [net-tools]
 netcdf:
+  arch: [netcdf]
   debian: [libnetcdf-dev]
   fedora: [netcdf]
   gentoo: [sci-libs/netcdf, sci-libs/netcdf-cxx, sci-libs/netcdf-fortran]
@@ -7111,6 +7314,7 @@ netpbm:
   rhel: [netpbm-devel]
   ubuntu: [libnetpbm10-dev]
 network-manager:
+  arch: [networkmanager]
   debian: [network-manager]
   fedora: [NetworkManager]
   gentoo: [net-misc/networkmanager]
@@ -7137,6 +7341,7 @@ nkf:
   rhel: [nkf]
   ubuntu: [nkf]
 nlohmann-json-dev:
+  arch: [nlohmann-json]
   debian:
     '*': [nlohmann-json3-dev]
     stretch: [nlohmann-json-dev]
@@ -7149,13 +7354,14 @@ nlohmann-json-dev:
     '*': [nlohmann-json3-dev]
     bionic: [nlohmann-json-dev]
 nmap:
-  archlinux: [nmap]
+  arch: [nmap]
   debian: [nmap]
   fedora: [nmap]
   gentoo: [net-analyzer/nmap]
   nixos: [nmap]
   ubuntu: [nmap]
 nodejs:
+  arch: [nodejs]
   debian: [nodejs]
   fedora: [nodejs]
   gentoo: [net-libs/nodejs]
@@ -7163,11 +7369,13 @@ nodejs:
   openembedded: [nodejs@meta-oe]
   ubuntu: [nodejs]
 nodejs-legacy:
+  arch: [nodejs]
   debian: [nodejs-legacy]
   fedora: [nodejs]
   nixos: [nodejs]
   ubuntu: [nodejs-legacy]
 npm:
+  arch: [npm]
   debian: [npm]
   fedora: [npm]
   gentoo: ['net-libs/nodejs[npm]']
@@ -7192,19 +7400,23 @@ nvidia-cg:
   gentoo: [media-gfx/nvidia-cg-toolkit]
   ubuntu: [nvidia-cg-toolkit]
 nvidia-cuda:
+  arch: [cuda]
   debian: [nvidia-cuda-toolkit]
   gentoo: [dev-util/nvidia-cuda-toolkit]
   ubuntu: [nvidia-cuda-toolkit]
 nvidia-cuda-dev:
+  arch: [cuda]
   debian: [nvidia-cuda-dev]
   gentoo: [dev-util/nvidia-cuda-sdk, dev-util/nvidia-cuda-gdk]
   ubuntu: [nvidia-cuda-dev]
 nvidia-cudnn:
+  arch: [cudnn]
   debian: [nvidia-cudnn]
   ubuntu:
     '*': [nvidia-cudnn]
     focal: null
 ocl-icd-opencl-dev:
+  arch: [ocl-icd]
   debian: [ocl-icd-opencl-dev]
   fedora: [ocl-icd-devel]
   gentoo: [virtual/opencl]
@@ -7225,13 +7437,15 @@ odb:
   ubuntu:
     '*': [odb]
 omniidl:
-  arch: [omniorb]
+  arch:
+    aur: [omniorb]
   debian: [omniidl, omniorb-idl]
   fedora: [omniORB-devel]
   nixos: [omniorb]
   ubuntu: [omniidl, omniorb-idl]
 omniorb:
-  arch: [omniorb]
+  arch:
+    aur: [omniorb]
   debian: [omniorb, omniidl, omniorb-idl, omniorb-nameserver, libomniorb4-dev]
   fedora: [omniORB, omniORB-devel, omniORB-servers]
   gentoo: [net-misc/omniORB]
@@ -7239,6 +7453,7 @@ omniorb:
   nixos: [omniorb]
   ubuntu: [omniorb, omniidl, omniorb-idl, omniorb-nameserver, libomniorb4-dev]
 opencascade:
+  arch: [opencascade]
   debian:
     buster: [libocct-data-exchange-dev, libocct-draw-dev]
     stretch: [liboce-visualization-dev]
@@ -7283,7 +7498,6 @@ opengl:
       packages: [mesa]
   ubuntu: [libgl1-mesa-dev, libglu1-mesa-dev]
 openjdk-6-jdk:
-  arch: [openjdk6]
   debian:
     wheezy: [openjdk-6-jdk]
   freebsd: [openjdk6]
@@ -7305,6 +7519,7 @@ openni-dev:
   rhel: [openni-devel]
   ubuntu: [libopenni-dev]
 openocd:
+  arch: [openocd]
   debian: [openocd]
   fedora: [openocd]
   gentoo: [dev-embedded/openocd]
@@ -7313,12 +7528,14 @@ openocd:
 opensplice:
   gentoo: [sci-libs/opensplice]
 openssh-client:
+  arch: [openssh]
   debian: [openssh-client]
   fedora: [openssh-clients]
   gentoo: [net-misc/openssh]
   nixos: [openssh]
   ubuntu: [openssh-client]
 openssh-server:
+  arch: [openssh]
   debian: [openssh-server]
   fedora: [openssh-server]
   gentoo: [net-misc/openssh]
@@ -7336,23 +7553,27 @@ openssl:
   rhel: [openssl]
   ubuntu: [openssl]
 optipng:
+  arch: [optipng]
   debian: [optipng]
   fedora: [optipng]
   gentoo: [media-gfx/optipng]
   nixos: [optipng]
   ubuntu: [optipng]
 osm2pgsql:
+  arch: [osm2pgsql]
   debian: [osm2pgsql]
   fedora: [osm2pgsql]
   gentoo: [sci-geosciences/osm2pgsql]
   nixos: [osm2pgsql]
   ubuntu: [osm2pgsql]
 osmium:
+  arch: [libosmium]
   debian: [libosmium-dev]
   fedora: [libosmium-devel]
   nixos: [libosmium]
   ubuntu: [libosmium-dev]
 pandoc:
+  arch: [pandoc-cli]
   debian: [pandoc]
   fedora: [pandoc]
   gentoo: [app-text/pandoc]
@@ -7419,13 +7640,14 @@ php:
   gentoo: [dev-lang/php]
   nixos: [php]
 pigz:
+  arch: [pigz]
   debian: [pigz]
   fedora: [pigz]
   gentoo: [app-arch/pigz]
   ubuntu: [pigz]
 pkg-config:
   alpine: [pkgconf]
-  arch: [pkg-config]
+  arch: [pkgconf]
   cygwin: [pkg-config]
   debian: [pkg-config]
   fedora: [pkgconfig]
@@ -7476,6 +7698,7 @@ polyclipping-dev:
   fedora: [polyclipping-devel]
   ubuntu: [libpolyclipping-dev]
 poppler-utils:
+  arch: [poppler]
   debian: [poppler-utils]
   fedora: [poppler-utils]
   gentoo: [app-text/poppler]
@@ -7504,6 +7727,7 @@ postfix:
   rhel: [postfix]
   ubuntu: [postfix]
 postgresql:
+  arch: [postgresql, postgresql-libs, postgresql-docs]
   debian: [postgresql, postgresql-contrib]
   fedora: [postgresql-server, postgresql-contrib]
   nixos: [postgresql]
@@ -7531,6 +7755,7 @@ postgresql-postgis:
     bionic: [postgresql-10-postgis-2.4, postgresql-contrib, postgresql-server-dev-all]
     focal: [postgresql-12-postgis-3, postgresql-contrib, postgresql-server-dev-all]
 potrace:
+  arch: [potrace]
   debian: [potrace]
   fedora: [potrace]
   rhel: [potrace]
@@ -7582,6 +7807,7 @@ protobuf:
     jammy: [libprotobuf23]
     noble: [libprotobuf32]
 protobuf-compiler-grpc:
+  arch: [grpc]
   debian: [protobuf-compiler-grpc]
   fedora: [grpc-plugins]
   rhel:
@@ -7607,6 +7833,7 @@ ps-engine:
   fedora: [openni-primesense]
   ubuntu: [ps-engine]
 pstoedit:
+  arch: [pstoedit]
   debian: [pstoedit]
   fedora: [pstoedit]
   gentoo: [media-gfx/pstoedit]
@@ -7614,12 +7841,14 @@ pstoedit:
   rhel: [pstoedit]
   ubuntu: [pstoedit]
 psutils:
+  arch: [psutils]
   debian: [psutils]
   fedora: [psutils]
   gentoo: [app-text/psutils]
   nixos: [psutils]
   ubuntu: [psutils]
 pugixml-dev:
+  arch: [pugixml]
   debian: [libpugixml-dev]
   fedora: [pugixml-devel]
   gentoo: [dev-libs/pugixml]
@@ -7648,6 +7877,7 @@ pybind11-json-dev:
     '*': [pybind11-json-dev]
     focal: null
 python-dev:
+  arch: [python]
   debian: [python-dev]
   fedora: [python2-devel]
   nixos: [pythonPackages.python]
@@ -7658,6 +7888,7 @@ python-dev:
     '*': [python-dev]
     focal: [python2-dev]
 qemu-user-static:
+  arch: [qemu-user-static]
   debian: [qemu-user-static]
   fedora: [qemu-user-static]
   ubuntu: [qemu-user-static]
@@ -7669,6 +7900,7 @@ qhull-bin:
   nixos: [qhull]
   ubuntu: [qhull-bin]
 qml-module-qt-labs-folderlistmodel:
+  arch: [qt5-declarative]
   debian: [qml-module-qt-labs-folderlistmodel]
   nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qt-labs-folderlistmodel]
@@ -7680,6 +7912,7 @@ qml-module-qt-labs-platform:
   nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qt-labs-platform]
 qml-module-qt-labs-settings:
+  arch: [qt5-declarative]
   debian: [qml-module-qt-labs-settings]
   nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qt-labs-settings]
@@ -7691,6 +7924,7 @@ qml-module-qtcharts:
   nixos: [qt5.qtcharts]
   ubuntu: [qml-module-qtcharts]
 qml-module-qtgraphicaleffects:
+  arch: [qt5-graphicaleffects]
   debian: [qml-module-qtgraphicaleffects]
   nixos: [qt5.qtgraphicaleffects]
   ubuntu: [qml-module-qtgraphicaleffects]
@@ -7702,6 +7936,7 @@ qml-module-qtlocation:
   nixos: [qt5.qtlocation]
   ubuntu: [qml-module-qtlocation]
 qml-module-qtmultimedia:
+  arch: [qt5-multimedia]
   debian: [qml-module-qtmultimedia]
   nixos: [qt5.qtmultimedia]
   ubuntu: [qml-module-qtmultimedia]
@@ -7713,19 +7948,23 @@ qml-module-qtpositioning:
   nixos: [qt5.qtpositioning]
   ubuntu: [qml-module-qtpositioning]
 qml-module-qtquick-controls:
+  arch: [qt5-quickcontrols]
   debian: [qml-module-qtquick-controls]
   gentoo: [dev-qt/qtquickcontrols]
   nixos: [qt5.qtquickcontrols]
   ubuntu: [qml-module-qtquick-controls]
 qml-module-qtquick-controls2:
+  arch: [qt5-quickcontrols2]
   debian: [qml-module-qtquick-controls2]
   nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qtquick-controls2]
 qml-module-qtquick-dialogs:
+  arch: [qt5-quickcontrols]
   debian: [qml-module-qtquick-dialogs]
   nixos: [qt5.qtquickcontrols]
   ubuntu: [qml-module-qtquick-dialogs]
 qml-module-qtquick-extras:
+  arch: [qt5-quickcontrols]
   debian: [qml-module-qtquick-extras]
   fedora: [qt5-qtquickcontrols]
   gentoo: [dev-qt/qtquickcontrols]
@@ -7733,18 +7972,22 @@ qml-module-qtquick-extras:
   rhel: [qt5-qtquickcontrols]
   ubuntu: [qml-module-qtquick-extras]
 qml-module-qtquick-layouts:
+  arch: [qt5-declarative]
   debian: [qml-module-qtquick-layouts]
   nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qtquick-layouts]
 qml-module-qtquick-templates2:
+  arch: [qt5-quickcontrols2]
   debian: [qml-module-qtquick-templates2]
   nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qtquick-templates2]
 qml-module-qtquick-window2:
+  arch: [qt5-declarative]
   debian: [qml-module-qtquick-window2]
   nixos: [qt5.qtdeclarative]
   ubuntu: [qml-module-qtquick-window2]
 qml-module-qtquick2:
+  arch: [qt5-quickcontrols2]
   debian: [qml-module-qtquick2]
   nixos: [qt5.qtquickcontrols2]
   ubuntu: [qml-module-qtquick2]
@@ -7756,7 +7999,6 @@ qrencode:
   nixos: [qrencode]
   ubuntu: [qrencode]
 qt4-dev-tools:
-  arch: [qt4]
   debian: [qt4-dev-tools]
   fedora: [qt-devel]
   gentoo: ['dev-qt/assistant:4', 'dev-qt/linguist:4', 'dev-qt/pixeltool:4']
@@ -7771,7 +8013,6 @@ qt4-linguist-tools:
     '*': null
     bionic: [qt4-linguist-tools]
 qt4-qmake:
-  arch: [qt4]
   debian: [qt4-qmake]
   fedora: [qt-devel]
   freebsd: [qt4-qmake]
@@ -7814,6 +8055,7 @@ qtbase5-dev:
   slackware: [qt5]
   ubuntu: [qtbase5-dev]
 qtbase5-private-dev:
+  arch: [qt5-base]
   debian: [qtbase5-private-dev]
   fedora: [qt5-qtbase-private-devel]
   rhel: [qt5-qtbase-private-devel]
@@ -7828,7 +8070,6 @@ qtdeclarative5-dev:
   openembedded: [qtdeclarative@meta-qt5]
   ubuntu: [qtdeclarative5-dev]
 qtmobility-dev:
-  arch: [qtmobility]
   debian: [qtmobility-dev]
   fedora: [qt-mobility-devel]
   gentoo: [dev-qt/qt-mobility]
@@ -7843,6 +8084,7 @@ qtmultimedia5-dev:
   openembedded: [qtmultimedia@meta-qt5]
   ubuntu: [qtmultimedia5-dev]
 qtpositioning5-dev:
+  arch: [qt5-location]
   debian: [qtpositioning5-dev]
   nixos: [qt5.qtpositioning]
   ubuntu: [qtpositioning5-dev]
@@ -7854,12 +8096,14 @@ qtquickcontrols2-5-dev:
   nixos: [qt5.qtquickcontrols]
   ubuntu: [qtquickcontrols2-5-dev]
 qttools5-dev:
+  arch: [qt5-tools]
   debian: [qttools5-dev]
   fedora: [qt5-qttools-devel]
   nixos: [qt5.qttools]
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev]
 qttools5-dev-tools:
+  arch: [qt5-tools]
   debian: [qttools5-dev-tools]
   fedora: [qt5-qttools-devel]
   nixos: [qt5.qttools.dev]
@@ -7867,6 +8111,7 @@ qttools5-dev-tools:
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
 qtwebengine5-dev:
+  arch: [qt5-webengine]
   debian: [qtwebengine5-dev]
   fedora: [qt5-qtwebengine-devel]
   gentoo: [dev-qt/qtwebengine]
@@ -7874,16 +8119,19 @@ qtwebengine5-dev:
   rhel: [qt5-qtwebengine-devel]
   ubuntu: [qtwebengine5-dev]
 r-base:
+  arch: [r]
   debian: [r-base]
   fedora: [R]
   gentoo: [dev-lang/R]
   ubuntu: [r-base]
 r-base-dev:
+  arch: [r]
   debian: [r-base-dev]
   fedora: [R-devel]
   gentoo: [dev-lang/R]
   ubuntu: [r-base-dev]
 range-v3:
+  arch: [range-v3]
   debian:
     '*': [librange-v3-dev]
     stretch: null
@@ -7899,6 +8147,7 @@ range-v3:
   ubuntu:
     '*': [librange-v3-dev]
 rapidjson-dev:
+  arch: [rapidjson]
   debian: [rapidjson-dev]
   fedora: [rapidjson]
   gentoo: [dev-libs/rapidjson]
@@ -7978,12 +8227,13 @@ rti-connext-dds-6.0.1:
     '*': [rti-connext-dds-6.0.1]
     bionic: null
 rtmidi:
+  arch: [rtmidi]
   debian: [librtmidi-dev]
   fedora: [rtmidi-devel]
   nixos: [rtmidi]
   ubuntu: [librtmidi-dev]
 rustc:
-  archlinux: [rust]
+  arch: [rust]
   debian: [rustc]
   fedora: [rust]
   opensuse: [rust]
@@ -8023,7 +8273,8 @@ screen:
   openembedded: [screen@openembedded-core]
   ubuntu: [screen]
 sdformat:
-  arch: [sdformat-hg]
+  arch:
+    aur: [sdformat]
   debian: [libsdformat-dev]
   fedora: [sdformat-devel]
   gentoo: [dev-libs/sdformat]
@@ -8048,7 +8299,7 @@ sdformat12:
 sdformat13:
   gentoo: ['dev-libs/sdformat:13']
 sdl:
-  arch: [sdl]
+  arch: [sdl12-compat]
   debian: [libsdl1.2-dev]
   fedora: [SDL-devel]
   gentoo: [media-libs/libsdl]
@@ -8094,6 +8345,7 @@ sdl-ttf:
   nixos: [SDL_ttf]
   ubuntu: [libsdl-ttf2.0-dev]
 sdl2:
+  arch: [sdl2]
   debian: [libsdl2-dev]
   fedora: [SDL2-devel]
   gentoo: [media-libs/libsdl2]
@@ -8102,16 +8354,19 @@ sdl2:
   rhel: [SDL2-devel]
   ubuntu: [libsdl2-dev]
 sdl2-image:
+  arch: [sdl2_image]
   debian: [libsdl2-image-dev]
   fedora: [SDL2_image-devel]
   rhel:
     '7': [SDL2_image-devel]
   ubuntu: [libsdl2-image-dev]
 sdl2-mixer:
+  arch: [sdl2_mixer]
   debian: [libsdl2-mixer-dev]
   fedora: [SDL2_mixer-devel]
   ubuntu: [libsdl2-mixer-dev]
 sdl2-ttf:
+  arch: [sdl2_ttf]
   debian: [libsdl2-ttf-dev]
   fedora: [SDL2_ttf-devel]
   gentoo: [media-libs/sdl2-ttf]
@@ -8141,6 +8396,7 @@ sfml-dev:
   nixos: [sfml]
   ubuntu: [libsfml-dev]
 simde:
+  arch: [simde]
   debian:
     '*': [libsimde-dev]
     buster: null
@@ -8156,6 +8412,7 @@ simde:
 sixad:
   ubuntu: [sixad]
 slime:
+  arch: [emacs-slime]
   debian: [slime]
   fedora: [emacs-slime]
   gentoo: [app-emacs/slime]
@@ -8192,18 +8449,21 @@ socat:
   rhel: [socat]
   ubuntu: [socat]
 sound-theme-freedesktop:
+  arch: [sound-theme-freedesktop]
   debian: [sound-theme-freedesktop]
   fedora: [sound-theme-freedesktop]
   gentoo: [x11-themes/sound-theme-freedesktop]
   ubuntu: [sound-theme-freedesktop]
 sox:
+  arch: [sox]
   debian: [sox]
   fedora: [sox]
   gentoo: [media-sound/sox]
   nixos: [sox]
   ubuntu: [sox]
 spacenavd:
-  arch: [spacenavd]
+  arch:
+    aur: [spacenavd]
   debian: [spacenavd]
   fedora: [spacenavd]
   gentoo: [app-misc/spacenavd]
@@ -8211,6 +8471,7 @@ spacenavd:
   rhel: [spacenavd]
   ubuntu: [spacenavd]
 sparsehash:
+  arch: [sparsehash]
   debian: [libsparsehash-dev]
   fedora: [sparsehash-devel]
   gentoo: [dev-cpp/sparsehash]
@@ -8227,11 +8488,13 @@ spdlog:
   rhel: [spdlog-devel]
   ubuntu: [libspdlog-dev]
 speech-dispatcher:
+  arch: [speech-dispatcher]
   debian: [speech-dispatcher]
   fedora: [speech-dispatcher]
   gentoo: [app-accessibility/speech-dispatcher]
   ubuntu: [speech-dispatcher]
 speex:
+  arch: [speex]
   debian: [speex]
   fedora: [speex, speex-tools, speexdsp]
   gentoo: [media-libs/speex]
@@ -8268,6 +8531,7 @@ sqlite3:
   rhel: [sqlite]
   ubuntu: [sqlite3]
 ssh-askpass:
+  arch: [x11-ssh-askpass]
   debian: [ssh-askpass]
   fedora: [x11-ssh-askpass]
   gentoo: [net-misc/x11-ssh-askpass]
@@ -8293,6 +8557,7 @@ stress:
   ubuntu: [stress]
 stress-ng:
   alpine: [stress-ng]
+  arch: [stress-ng]
   debian: [stress-ng]
   fedora: [stress-ng]
   gentoo: [app-benchmarks/stress-ng]
@@ -8350,6 +8615,7 @@ swi-prolog-http:
     lenny: [swi-prolog-http]
   fedora: [pl]
 swi-prolog-java:
+  arch: [swi-prolog]
   debian: [swi-prolog-java]
   fedora: [pl-jpl]
   gentoo: ['dev-lang/swi-prolog[java]']
@@ -8374,6 +8640,7 @@ swi-prolog-xpce:
     woody: [swi-prolog-xpce]
   fedora: [pl-xpce]
 swig:
+  arch: [swig]
   debian: [swig]
   fedora: [swig]
   gentoo: [dev-lang/swig]
@@ -8417,7 +8684,8 @@ systemd:
   ubuntu: [systemd]
 tango-icon-theme:
   alpine: [tango-icon-theme]
-  arch: [tango-icon-theme]
+  arch:
+    aur: [tango-icon-theme]
   debian: [tango-icon-theme]
   fedora: [tango-icon-theme]
   freebsd: [icons-tango]
@@ -8449,7 +8717,7 @@ tar:
     '7': [libtar-devel]
   ubuntu: [libtar-dev]
 tbb:
-  arch: [intel-tbb]
+  arch: [intel-oneapi-tbb]
   debian: [libtbb-dev]
   fedora: [tbb-devel]
   gentoo: [dev-cpp/tbb]
@@ -8467,12 +8735,14 @@ tcsh:
   nixos: [tcsh]
   ubuntu: [tcsh]
 terminator:
+  arch: [terminator]
   debian: [terminator]
   fedora: [terminator]
   gentoo: [x11-terms/terminator]
   nixos: [terminator]
   ubuntu: [terminator]
 tesseract-ocr:
+  arch: [tesseract]
   debian: [tesseract-ocr]
   fedora: [tesseract-devel]
   gentoo: [app-text/tesseract]
@@ -8491,7 +8761,7 @@ texlive-fonts-extra:
   macports: [texlive-fonts-extra]
   ubuntu: [texlive-fonts-extra]
 texlive-fonts-recommended:
-  arch: [texlive-core]
+  arch: [texlive-fontsrecommended]
   debian: [texlive-fonts-recommended]
   fedora: [texlive-times, texlive-helvetic]
   gentoo: [dev-texlive/texlive-fontsrecommended]
@@ -8502,7 +8772,7 @@ texlive-full:
   gentoo: [app-text/texlive]
   ubuntu: [texlive-full]
 texlive-latex-base:
-  arch: [texlive-core]
+  arch: [texlive-basic]
   debian: [texlive-latex-base]
   fedora: [texlive-latex, texlive-parskip]
   gentoo: [dev-texlive/texlive-latex]
@@ -8517,7 +8787,7 @@ texlive-latex-extra:
   opensuse: [texlive-titlesec, texlive-wrapfig, texlive-multirow, texlive-fancybox]
   ubuntu: [texlive-latex-extra]
 texlive-latex-recommended:
-  arch: [texlive-core]
+  arch: [texlive-latexrecommended]
   debian: [texlive-latex-recommended]
   fedora: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
   gentoo: [dev-texlive/texlive-latexrecommended]
@@ -8525,6 +8795,7 @@ texlive-latex-recommended:
   opensuse: [texlive-framed, texlive-threeparttable, texlive-ec, texlive-mdwtools]
   ubuntu: [texlive-latex-recommended]
 texmaker:
+  arch: [texmaker]
   debian: [texmaker]
   fedora: [texmaker]
   gentoo: [app-office/texmaker]
@@ -8574,13 +8845,15 @@ tinyxml2:
   rhel: [tinyxml2-devel]
   ubuntu: [libtinyxml2-dev]
 tix:
-  arch: [tix]
+  arch:
+    aur: [tix]
   debian: [tix]
   fedora: [tix]
   gentoo: [dev-tcltk/tix]
   nixos: [tix]
   ubuntu: [tix]
 tmux:
+  arch: [tmux]
   debian: [tmux]
   fedora: [tmux]
   gentoo: [app-misc/tmux]
@@ -8598,6 +8871,7 @@ trang:
     '7': [trang]
   ubuntu: [trang]
 tree:
+  arch: [tree]
   debian: [tree]
   fedora: [tree]
   gentoo: [app-text/tree]
@@ -8611,17 +8885,16 @@ tshark:
   rhel: [wireshark-cli]
   ubuntu: [tshark]
 ttf-kochi-gothic:
-  arch: [ttf-togoshi-gothic]
   debian: [ttf-kochi-gothic]
   gentoo: [media-fonts/kochi-substitute]
   ubuntu: [ttf-kochi-gothic]
 ttf-kochi-mincho:
-  arch: [ttf-togoshi-mincho]
   debian: [ttf-kochi-mincho]
   gentoo: [media-fonts/kochi-substitute]
   ubuntu: [ttf-kochi-mincho]
 ttf-mscorefonts-installer:
-  arch: [ttf-ms-fonts]
+  arch:
+    aur: [ttf-ms-fonts]
   debian: [ttf-mscorefonts-installer]
   gentoo: [media-fonts/corefonts]
 ttf-sazanami-gothic:
@@ -8646,7 +8919,8 @@ udev:
   rhel: [systemd]
   ubuntu: [udev]
 udhcpc:
-  arch: [udhcp]
+  arch:
+    aur: [udhcp]
   debian: [udhcpc]
   ubuntu: [udhcpc]
 unclutter:
@@ -8706,6 +8980,7 @@ unzip:
       packages: [infozip]
   ubuntu: [unzip]
 usbutils:
+  arch: [usbutils]
   debian: [usbutils]
   fedora: [usbutils]
   gentoo: [sys-apps/usbutils]
@@ -8760,12 +9035,14 @@ v4l-utils:
     '7': [v4l-utils]
   ubuntu: [v4l-utils]
 valgrind:
+  arch: [valgrind]
   debian: [valgrind]
   fedora: [valgrind]
   gentoo: [dev-debug/valgrind]
   nixos: [valgrind]
   ubuntu: [valgrind]
 vim:
+  arch: [vim]
   debian: [vim]
   fedora: [vim-enhanced]
   gentoo: [app-editors/vim]
@@ -8818,6 +9095,7 @@ wget:
   rhel: [wget]
   ubuntu: [wget]
 wireguard:
+  arch: [wireguard-tools]
   debian:
     '*': [wireguard]
     buster: null
@@ -8829,24 +9107,28 @@ wireguard:
     '*': [wireguard]
     bionic: null
 wireless-tools:
+  arch: [wireless_tools]
   debian: [wireless-tools]
   fedora: [wireless-tools]
   gentoo: [net-wireless/wireless-tools]
   nixos: [wirelesstools]
   ubuntu: [wireless-tools]
 wireshark:
+  arch: [wireshark-qt]
   debian: [wireshark]
   fedora: [wireshark]
   gentoo: [net-analyzer/wireshark]
   nixos: [wireshark]
   ubuntu: [wireshark]
 wireshark-common:
+  arch: [wireshark-cli]
   debian: [wireshark-common]
   fedora: [wireshark-cli]
   nixos: [wireshark-cli]
   ubuntu: [wireshark-common]
 wkhtmltopdf:
-  arch: [wkhtmltopdf]
+  arch:
+    aur: [wkhtmltopdf]
   debian: [wkhtmltopdf]
   fedora: [wkhtmltopdf]
   gentoo: [media-gfx/wkhtmltopdf]
@@ -8860,12 +9142,13 @@ wmctrl:
   rhel: [wmctrl]
   ubuntu: [wmctrl]
 workrave:
+  arch: [workrave]
   debian: [workrave]
   fedora: [workrave]
   gentoo: [app-misc/workrave]
   ubuntu: [workrave, workrave-data]
 wx-common:
-  arch: [wxgtk]
+  arch: [wxwidgets-gtk3]
   debian: [wx-common]
   fedora: [wxGTK3-devel]
   gentoo: [x11-libs/wxGTK]
@@ -8876,7 +9159,7 @@ wx-common:
     '7': [wxGTK-devel]
   ubuntu: [wx-common]
 wxwidgets:
-  arch: [wxgtk]
+  arch: [wxwidgets-gtk3]
   debian:
     '*': [libwxgtk3.2-dev]
     bullseye: [libwxgtk3.0-gtk3-dev]
@@ -8897,17 +9180,16 @@ wxwidgets:
     focal: [libwxgtk3.0-gtk3-dev]
     jammy: [libwxgtk3.0-gtk3-dev]
 x11proto-dri2-dev:
-  arch: [dri2proto]
+  arch: [xorgproto]
   debian: [x11proto-dri2-dev]
   fedora: [xorg-x11-proto-devel]
   ubuntu: [x11proto-dri2-dev]
 x11proto-gl-dev:
-  arch: [glproto]
+  arch: [xorgproto]
   debian: [x11proto-gl-dev]
   fedora: [xorg-x11-proto-devel]
   ubuntu: [x11proto-gl-dev]
 x11proto-print-dev:
-  arch: [printproto]
   debian: [x11proto-print-dev]
   fedora: [xorg-x11-proto-devel]
   ubuntu: [x11proto-print-dev]
@@ -8970,6 +9252,7 @@ xpath-perl:
   ubuntu: [libxml-xpath-perl]
 xsimd:
   alpine: [xsimd]
+  arch: [xsimd]
   debian:
     '*': [libxsimd-dev]
     bullseye: null
@@ -8992,7 +9275,8 @@ xsltproc:
   nixos: [libxslt]
   ubuntu: [xsltproc]
 xtensor:
-  arch: [xtensor]
+  arch:
+    aur: [xtensor]
   fedora: [xtensor-devel]
   nixos: [xtensor]
   rhel:
@@ -9012,12 +9296,10 @@ xterm:
   rhel: [xterm]
   ubuntu: [xterm]
 xulrunner-1.9.2:
-  arch: [xulrunner]
   debian: []
   ubuntu:
     karmic: [xulrunner-1.9.2]
 xulrunner-dev:
-  arch: [xulrunner]
   debian: [libv8-dev]
   ubuntu: [libv8-dev]
 xvfb:
@@ -9113,6 +9395,7 @@ zeromq3:
   nixos: [zeromq]
   ubuntu: [libzmq5]
 zip:
+  arch: [zip]
   debian: [zip]
   fedora: [zip]
   gentoo: [app-arch/zip]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1,6 +1,4 @@
 ace:
-  arch:
-    aur: [ace]
   debian: [libace-dev]
   gentoo: [dev-libs/ace]
   nixos: [ace]
@@ -136,8 +134,6 @@ arista:
     wheezy: [arista]
   ubuntu: [arista]
 armadillo:
-  arch:
-    aur: [armadillo]
   debian: [libarmadillo-dev]
   fedora: [armadillo-devel]
   gentoo: [sci-libs/armadillo]
@@ -194,8 +190,6 @@ at-spi2-core:
   rhel: [at-spi2-core]
   ubuntu: [at-spi2-core]
 atlas:
-  arch:
-    aur: [atlas-lapack]
   debian: [libatlas-base-dev]
   fedora: [atlas-devel]
   gentoo: [sci-libs/atlas]
@@ -464,8 +458,6 @@ cargo:
   rhel: [cargo]
   ubuntu: [cargo]
 castxml:
-  arch:
-    aur: [castxml]
   debian: [castxml]
   fedora: [castxml]
   macports: [castxml]
@@ -517,8 +509,6 @@ cgal-qt5-dev:
   gentoo: ['sci-mathematics/cgal[qt5]']
   ubuntu: [libcgal-qt5-dev]
 checkinstall:
-  arch:
-    aur: [checkinstall]
   debian: [checkinstall]
   nixos: [checkinstall]
   ubuntu: [checkinstall]
@@ -648,8 +638,6 @@ coinor-libosi-dev:
   nixos: [osi]
   ubuntu: [coinor-libosi-dev]
 collada-dom:
-  arch:
-    aur: [collada-dom]
   debian:
     buster: [libcollada-dom2.4-dp-dev]
     stretch: [libcollada-dom2.4-dp-dev]
@@ -722,8 +710,6 @@ cppunit:
   slackware: [cppunit]
   ubuntu: [libcppunit-dev]
 cpuburn:
-  arch:
-    aur: [cpuburn]
   debian: [cpuburn]
   ubuntu: [cpuburn]
 crypto++:
@@ -765,16 +751,12 @@ cvs:
   nixos: [cvs]
   ubuntu: [cvs]
 cwiid:
-  arch:
-    aur: [cwiid-git]
   debian: [libcwiid1]
   gentoo: [app-misc/cwiid]
   nixos: [cwiid]
   opensuse: [libcwiid1]
   ubuntu: [libcwiid1]
 cwiid-dev:
-  arch:
-    aur: [cwiid-git]
   debian: [libcwiid-dev]
   gentoo: [app-misc/cwiid]
   nixos: [cwiid]
@@ -804,8 +786,6 @@ debtree:
   debian: [debtree]
   ubuntu: [debtree]
 devilspie2:
-  arch:
-    aur: [devilspie2]
   debian: [devilspie2]
   fedora: [devilspie2]
   gentoo: [x11-misc/devilspie2]
@@ -905,8 +885,6 @@ e2fsprogs:
   rhel: [e2fsprogs]
   ubuntu: [e2fsprogs]
 eclipse:
-  arch:
-    aur: [eclipse-java-bin, eclipse-rcp, eclipse-emf, eclipse-pde]
   debian: [eclipse, eclipse-rcp, eclipse-xsd, eclipse-pde]
   gentoo: [dev-java/ant-eclipse-ecj, dev-java/eclipse-ecj]
   ubuntu:
@@ -934,8 +912,6 @@ eigen:
       packages: [eigen3]
   ubuntu: [libeigen3-dev]
 eigen2:
-  arch:
-    aur: [eigen2]
   debian:
     wheezy: [libeigen2-dev]
   freebsd: [eigen2]
@@ -1015,8 +991,6 @@ exiv2:
   rhel: [exiv2]
   ubuntu: [exiv2]
 f2c:
-  arch:
-    aur: [f2c]
   debian: [f2c, libf2c2, libf2c2-dev]
   fedora: [f2c, f2c-libs]
   gentoo: [dev-lang/f2c]
@@ -1396,8 +1370,6 @@ gettext-base:
   nixos: [gettext]
   ubuntu: [gettext-base]
 gforth:
-  arch:
-    aur: [gforth]
   debian: [gforth]
   fedora: [gforth]
   gentoo: [dev-lang/gforth]
@@ -1843,8 +1815,6 @@ gurumdds-3.0:
   ubuntu:
     jammy: [gurumdds-3.0]
 gv:
-  arch:
-    aur: [gv]
   debian: [gv]
   fedora: [gv]
   gentoo: [app-text/gv]
@@ -2443,8 +2413,6 @@ jq:
   rhel: [jq]
   ubuntu: [jq]
 julius-voxforge:
-  arch:
-    aur: [voxforge-am-julius]
   fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]
 jython:
@@ -2540,8 +2508,6 @@ libalglib-dev:
   gentoo: [sci-libs/alglib]
   ubuntu: [libalglib-dev]
 libann-dev:
-  arch:
-    aur: [ann]
   debian: [libann-dev]
   fedora: [ann-devel]
   ubuntu: [libann-dev]
@@ -2554,8 +2520,6 @@ libao-dev:
   rhel: [libao-devel]
   ubuntu: [libao-dev]
 libapache2-mod-python:
-  arch:
-    aur: [mod_python]
   debian: [libapache2-mod-python]
   gentoo: [www-apache/mod_python]
   ubuntu: [libapache2-mod-python]
@@ -3163,8 +3127,6 @@ libcap2-bin:
   nixos: [libcap]
   ubuntu: [libcap2-bin]
 libccd-dev:
-  arch:
-    aur: [libccd]
   debian: [libccd-dev]
   fedora: [libccd]
   gentoo: [sci-libs/libccd]
@@ -3189,8 +3151,6 @@ libcdd-dev:
   nixos: [cddlib]
   ubuntu: [libcdd-dev]
 libcegui-mk2-dev:
-  arch:
-    aur: [cegui]
   debian: [libcegui-mk2-dev]
   fedora: [cegui]
   gentoo: [dev-games/cegui]
@@ -3511,8 +3471,6 @@ libext2fs-dev:
   rhel: [e2fsprogs-devel]
   ubuntu: [libext2fs-dev]
 libfcl-dev:
-  arch:
-    aur: [fcl]
   debian: [libfcl-dev]
   fedora: [fcl-devel]
   gentoo: [sci-libs/fcl]
@@ -3628,8 +3586,6 @@ libfreeimage-dev:
   rhel: [freeimage-devel]
   ubuntu: [libfreeimage-dev]
 libfreenect-dev:
-  arch:
-    aur: [libfreenect]
   debian: [libfreenect-dev]
   fedora: [libfreenect-devel]
   nixos: [freenect]
@@ -3759,8 +3715,6 @@ libgazebo9-dev:
   ubuntu:
     bionic: [libgazebo9-dev]
 libgconf2:
-  arch:
-    aur: [gconf]
   debian: [libgconf-2-4]
   fedora: [GConf2]
   gentoo: ['gnome-base/gconf:2']
@@ -3855,8 +3809,6 @@ libglm-dev:
   rhel: [glm-devel]
   ubuntu: [libglm-dev]
 libglui-dev:
-  arch:
-    aur: [glui]
   debian: [libglui-dev]
   fedora: [glui-devel]
   ubuntu: [libglui-dev]
@@ -4348,8 +4300,6 @@ libkdtree++-dev:
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]
 libkml-dev:
-  arch:
-    aur: [libkml]
   debian: [libkml-dev]
   fedora: [libkml-devel]
   nixos: [libkml]
@@ -4492,24 +4442,18 @@ libmnl-dev:
   rhel: [libmnl-devel]
   ubuntu: [libmnl-dev]
 libmockito-java:
-  arch:
-    aur: [mockito]
   debian: [libmockito-java]
   fedora: [mockito]
   gentoo: [dev-java/mockito]
   rhel: [mockito]
   ubuntu: [libmockito-java]
 libmodbus-dev:
-  arch:
-    aur: [libmodbus]
   debian: [libmodbus-dev]
   fedora: [libmodbus-devel]
   nixos: [libmodbus]
   openembedded: [libmodbus@meta-oe]
   ubuntu: [libmodbus-dev]
 libmodbus5:
-  arch:
-    aur: [libmodbus]
   debian: [libmodbus5]
   fedora: [libmodbus]
   gentoo: [dev-libs/libmodbus]
@@ -4553,16 +4497,12 @@ libmpg123-dev:
   nixos: [mpg123]
   ubuntu: [libmpg123-dev]
 libmpich-dev:
-  arch:
-    aur: [mpich]
   debian: [libmpich-dev]
   fedora: [mpich-devel]
   gentoo: [sys-cluster/mpich]
   nixos: [mpich]
   ubuntu: [libmpich-dev]
 libmpich2-dev:
-  arch:
-    aur: [mpich2]
   debian: [libmpich2-dev]
   gentoo: [sys-cluster/mpich2]
   nixos: [mpich]
@@ -4595,8 +4535,6 @@ libmysqlclient-dev:
   opensuse: [libmysqlclient-devel]
   ubuntu: [libmysqlclient-dev]
 libmysqlcppconn-dev:
-  arch:
-    aur: [mysql-connector-c++]
   debian: [libmysqlcppconn-dev]
   gentoo: [dev-db/mysql-connector-c++]
   opensuse: [libmysqlcppconn-devel]
@@ -4659,8 +4597,6 @@ libnl-3-dev:
   openembedded: [libnl@openembedded-core]
   ubuntu: [libnl-3-dev, libnl-genl-3-dev, libnl-route-3-dev]
 libnl-dev:
-  arch:
-    aur: [libnl1]
   debian: [libnl-dev]
   gentoo: [dev-libs/libnl]
   ubuntu: [libnl-dev]
@@ -4848,8 +4784,6 @@ libopenexr-dev:
   rhel: [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
-  arch:
-    aur: [openni]
   debian: [libopenni-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
@@ -4859,14 +4793,10 @@ libopenni-nite-dev:
   debian: [libopenni-nite-dev]
   fedora: [openni-nite-devel]
 libopenni-sensor-primesense-dev:
-  arch:
-    aur: [sensorkinect]
   debian: [libopenni-sensor-primesense-dev]
   fedora: [openni-primesense]
   ubuntu: [libopenni-sensor-primesense-dev]
 libopenni2-dev:
-  arch:
-    aur: [openni2]
   debian: [libopenni2-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI2]
@@ -5030,8 +4960,6 @@ libpcap:
   rhel: [libpcap-devel]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
-  arch:
-    aur: [pcl]
   debian:
     bookworm: [libpcl-apps1.13, libpcl-common1.13, libpcl-features1.13, libpcl-filters1.13, libpcl-io1.13, libpcl-kdtree1.13, libpcl-keypoints1.13, libpcl-ml1.13, libpcl-octree1.13, libpcl-outofcore1.13, libpcl-people1.13, libpcl-recognition1.13, libpcl-registration1.13, libpcl-sample-consensus1.13, libpcl-search1.13, libpcl-segmentation1.13, libpcl-stereo1.13, libpcl-surface1.13, libpcl-tracking1.13, libpcl-visualization1.13]
     bullseye: [libpcl-apps1.11, libpcl-common1.11, libpcl-features1.11, libpcl-filters1.11, libpcl-io1.11, libpcl-kdtree1.11, libpcl-keypoints1.11, libpcl-ml1.11, libpcl-octree1.11, libpcl-outofcore1.11, libpcl-people1.11, libpcl-recognition1.11, libpcl-registration1.11, libpcl-sample-consensus1.11, libpcl-search1.11, libpcl-segmentation1.11, libpcl-stereo1.11, libpcl-surface1.11, libpcl-tracking1.11, libpcl-visualization1.11]
@@ -5051,8 +4979,6 @@ libpcl-all:
     jammy: [libpcl-apps1.12, libpcl-common1.12, libpcl-features1.12, libpcl-filters1.12, libpcl-io1.12, libpcl-kdtree1.12, libpcl-keypoints1.12, libpcl-ml1.12, libpcl-octree1.12, libpcl-outofcore1.12, libpcl-people1.12, libpcl-recognition1.12, libpcl-registration1.12, libpcl-sample-consensus1.12, libpcl-search1.12, libpcl-segmentation1.12, libpcl-stereo1.12, libpcl-surface1.12, libpcl-tracking1.12, libpcl-visualization1.12]
     noble: [libpcl-apps1.14, libpcl-common1.14, libpcl-features1.14, libpcl-filters1.14, libpcl-io1.14, libpcl-kdtree1.14, libpcl-keypoints1.14, libpcl-ml1.14, libpcl-octree1.14, libpcl-outofcore1.14, libpcl-people1.14, libpcl-recognition1.14, libpcl-registration1.14, libpcl-sample-consensus1.14, libpcl-search1.14, libpcl-segmentation1.14, libpcl-stereo1.14, libpcl-surface1.14, libpcl-tracking1.14, libpcl-visualization1.14]
 libpcl-all-dev:
-  arch:
-    aur: [pcl]
   debian: [libpcl-dev]
   fedora: [pcl-devel]
   freebsd: [libpcl]
@@ -5909,8 +5835,6 @@ libqtgui4:
     '7': [qt-x11]
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
-  arch:
-    aur: [qt5-webkit]
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]
@@ -5929,8 +5853,6 @@ libqwt-qt5-dev:
   ubuntu:
     '*': [libqwt-qt5-dev]
 libqwt5-qt4-dev:
-  arch:
-    aur: [qwt5]
   debian: [libqwt5-qt4-dev]
   fedora: [qwt-devel]
   gentoo: ['x11-libs/qwt:5[qt4]']
@@ -5943,8 +5865,6 @@ libqwt6:
   nixos: [libsForQt5.qwt]
   ubuntu: [libqwt-dev]
 libqwtplot3d-qt4-dev:
-  arch:
-    aur: [qwtplot3d]
   debian: [libqwtplot3d-qt4-dev]
   fedora: [qwtplot3d-qt4-devel]
   gentoo: [x11-libs/qwtplot3d]
@@ -6173,8 +6093,6 @@ libssl-dev:
   rhel: [openssl-devel]
   ubuntu: [libssl-dev]
 libstdc++5:
-  arch:
-    aur: [libstdc++5]
   debian: [libstdc++5]
   freebsd: [builtin]
   gentoo: [virtual/libstdc++]
@@ -6274,8 +6192,6 @@ libtiff4-dev:
   ubuntu: [libtiff4-dev]
 libtins-dev:
   alpine: [libtins-dev]
-  arch:
-    aur: [libtins]
   debian: [libtins-dev]
   fedora: [libtins-devel]
   nixos: [libtins]
@@ -6352,8 +6268,6 @@ libunwind-dev:
   ubuntu:
     '*': [libunwind-dev]
 liburdfdom-dev:
-  arch:
-    aur: [urdfdom]
   debian: [liburdfdom-dev]
   fedora: [urdfdom-devel]
   freebsd: [ros-urdfdom]
@@ -6377,8 +6291,6 @@ liburdfdom-headers-dev:
   slackware: [urdfdom_headers]
   ubuntu: [liburdfdom-headers-dev]
 liburdfdom-tools:
-  arch:
-    aur: [urdfdom]
   debian: [liburdfdom-tools]
   fedora: [urdfdom]
   freebsd: [ros-urdfdom]
@@ -6995,14 +6907,10 @@ lsb-release:
   slackware: [lsb-release]
   ubuntu: [lsb-release]
 lttng-modules:
-  arch:
-    aur: [lttng-modules]
   debian: [lttng-modules-dkms]
   gentoo: [dev-util/lttng-modules]
   ubuntu: [lttng-modules-dkms]
 lttng-tools:
-  arch:
-    aur: [lttng-tools]
   debian: [lttng-tools]
   fedora: [lttng-tools]
   gentoo: [dev-util/lttng-tools]
@@ -7128,8 +7036,6 @@ mesa-utils:
   gentoo: [x11-apps/mesa-progs]
   ubuntu: [mesa-utils]
 meshlab:
-  arch:
-    aur: [meshlab]
   debian: [meshlab]
   fedora: [meshlab]
   gentoo: [media-gfx/meshlab]
@@ -7437,15 +7343,11 @@ odb:
   ubuntu:
     '*': [odb]
 omniidl:
-  arch:
-    aur: [omniorb]
   debian: [omniidl, omniorb-idl]
   fedora: [omniORB-devel]
   nixos: [omniorb]
   ubuntu: [omniidl, omniorb-idl]
 omniorb:
-  arch:
-    aur: [omniorb]
   debian: [omniorb, omniidl, omniorb-idl, omniorb-nameserver, libomniorb4-dev]
   fedora: [omniORB, omniORB-devel, omniORB-servers]
   gentoo: [net-misc/omniORB]
@@ -7664,8 +7566,6 @@ pkg-config:
   ubuntu: [pkg-config]
 pmccabe:
   alpine: [pmccabe]
-  arch:
-    aur: [pmccabe]
   debian: [pmccabe]
   nixos: [pmccabe]
   opensuse:
@@ -7677,8 +7577,6 @@ pmccabe:
       packages: [pmccabe]
   ubuntu: [pmccabe]
 pmount:
-  arch:
-    aur: [pmount]
   debian: [pmount]
   fedora: [pmount]
   gentoo: [sys-apps/pmount]
@@ -8273,8 +8171,6 @@ screen:
   openembedded: [screen@openembedded-core]
   ubuntu: [screen]
 sdformat:
-  arch:
-    aur: [sdformat]
   debian: [libsdformat-dev]
   fedora: [sdformat-devel]
   gentoo: [dev-libs/sdformat]
@@ -8462,8 +8358,6 @@ sox:
   nixos: [sox]
   ubuntu: [sox]
 spacenavd:
-  arch:
-    aur: [spacenavd]
   debian: [spacenavd]
   fedora: [spacenavd]
   gentoo: [app-misc/spacenavd]
@@ -8684,8 +8578,6 @@ systemd:
   ubuntu: [systemd]
 tango-icon-theme:
   alpine: [tango-icon-theme]
-  arch:
-    aur: [tango-icon-theme]
   debian: [tango-icon-theme]
   fedora: [tango-icon-theme]
   freebsd: [icons-tango]
@@ -8845,8 +8737,6 @@ tinyxml2:
   rhel: [tinyxml2-devel]
   ubuntu: [libtinyxml2-dev]
 tix:
-  arch:
-    aur: [tix]
   debian: [tix]
   fedora: [tix]
   gentoo: [dev-tcltk/tix]
@@ -8893,8 +8783,6 @@ ttf-kochi-mincho:
   gentoo: [media-fonts/kochi-substitute]
   ubuntu: [ttf-kochi-mincho]
 ttf-mscorefonts-installer:
-  arch:
-    aur: [ttf-ms-fonts]
   debian: [ttf-mscorefonts-installer]
   gentoo: [media-fonts/corefonts]
 ttf-sazanami-gothic:
@@ -8919,8 +8807,6 @@ udev:
   rhel: [systemd]
   ubuntu: [udev]
 udhcpc:
-  arch:
-    aur: [udhcp]
   debian: [udhcpc]
   ubuntu: [udhcpc]
 unclutter:
@@ -9127,8 +9013,6 @@ wireshark-common:
   nixos: [wireshark-cli]
   ubuntu: [wireshark-common]
 wkhtmltopdf:
-  arch:
-    aur: [wkhtmltopdf]
   debian: [wkhtmltopdf]
   fedora: [wkhtmltopdf]
   gentoo: [media-gfx/wkhtmltopdf]
@@ -9275,8 +9159,6 @@ xsltproc:
   nixos: [libxslt]
   ubuntu: [xsltproc]
 xtensor:
-  arch:
-    aur: [xtensor]
   fedora: [xtensor-devel]
   nixos: [xtensor]
   rhel:


### PR DESCRIPTION
- Lots of missing arch packages are added
- Packages that are no longer exist in main repos (core, extra) but in aur placed in aur block
- Some incorrectly-named packages are fixed
- A few obsolete packages are removed (e.g. qt4 packages)

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

There are lots of them

## Package Upstream Source:

There are lots of them

## Purpose of using this:

Most of the arch packages were either missing or wrong.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Arch: https://www.archlinux.org/packages/
- AUR: https://aur.archlinux.org/