### PR TITLE
lusb: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3996,7 +3996,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/lusb-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/lusb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.2-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## lusb

```
* Fix include
* Contributors: Kevin Hallenbeck
```
