### PR TITLE
lusb: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3281,6 +3281,21 @@ repositories:
       url: https://github.com/hatchbed/log_view.git
       version: ros2
     status: developed
+  lusb:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    status: maintained
   magic_enum:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.2-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## lusb

```
* Fix include
* Contributors: Kevin Hallenbeck
```
