### PR TITLE
dataspeed_can: 2.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1527,11 +1527,13 @@ repositories:
       packages:
       - dataspeed_can
       - dataspeed_can_msg_filters
+      - dataspeed_can_msgs
+      - dataspeed_can_tools
       - dataspeed_can_usb
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 2.0.1-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `2.0.4-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

- No changes

## dataspeed_can_msgs

- No changes

## dataspeed_can_tools

```
* Added parameter declarations to DBC node
* Handle rosbag2_storage changes in Jazzy
* Contributors: Gabe, Kevin Hallenbeck
```

## dataspeed_can_usb

- No changes
