### PR TITLE
dataspeed_can: 2.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1122,6 +1122,27 @@ repositories:
       url: https://github.com/PickNikRobotics/data_tamer.git
       version: main
     status: developed
+  dataspeed_can:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
+      version: ros2
+    release:
+      packages:
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_msgs
+      - dataspeed_can_tools
+      - dataspeed_can_usb
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
+      version: 2.0.4-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
+      version: ros2
+    status: maintained
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `2.0.4-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

- No changes

## dataspeed_can_msgs

- No changes

## dataspeed_can_tools

```
* Added parameter declarations to DBC node
* Handle rosbag2_storage changes in Jazzy
* Contributors: Gabe, Kevin Hallenbeck
```

## dataspeed_can_usb

- No changes
