### PR TITLE
ur_robot_driver: 2.2.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10248,7 +10248,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.14-1
+      version: 2.2.15-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.15-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.14-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Updated scaled JTC to latest upstream updates (#1067 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1067>)
* Contributors: Felix Exner (fexner)
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Fix passing launch_dashobard_client launch argument (backport of #1057 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1057>)
* Updated the UR family photo on the readme (backport of #1064 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1064>)
* Contributors: Rune Søoe-Knudsen, Felix Exner
```
