### PR TITLE
googletest: 1.10.9006-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2746,7 +2746,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.10.9004-4
+      version: 1.10.9006-1
     source:
       type: git
       url: https://github.com/ament/googletest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.10.9006-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.10.9004-4`
