### PR TITLE
examples: 0.15.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2093,7 +2093,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.15.1-1
+      version: 0.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.15.2-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.1-1`

## examples_rclcpp_async_client

- No changes

## examples_rclcpp_cbg_executor

- No changes

## examples_rclcpp_minimal_action_client

- No changes

## examples_rclcpp_minimal_action_server

- No changes

## examples_rclcpp_minimal_client

- No changes

## examples_rclcpp_minimal_composition

- No changes

## examples_rclcpp_minimal_publisher

- No changes

## examples_rclcpp_minimal_service

- No changes

## examples_rclcpp_minimal_subscriber

- No changes

## examples_rclcpp_minimal_timer

- No changes

## examples_rclcpp_multithreaded_executor

- No changes

## examples_rclcpp_wait_set

- No changes

## examples_rclpy_executors

- No changes

## examples_rclpy_guard_conditions

- No changes

## examples_rclpy_minimal_action_client

- No changes

## examples_rclpy_minimal_action_server

```
* Add guard on Python single goal action server example (#380 <https://github.com/ros2/examples/issues/380>) (#383 <https://github.com/ros2/examples/issues/383>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_client

- No changes

## examples_rclpy_minimal_publisher

- No changes

## examples_rclpy_minimal_service

- No changes

## examples_rclpy_minimal_subscriber

- No changes

## examples_rclpy_pointcloud_publisher

- No changes

## launch_testing_examples

- No changes
