### PR TITLE
rclcpp: 16.0.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6786,7 +6786,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.9-1
+      version: 16.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.10-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `16.0.9-1`

## rclcpp

```
* Add test creating two content filter topics with the same topic name (#2546 <https://github.com/ros2/rclcpp/issues/2546>) (#2549 <https://github.com/ros2/rclcpp/issues/2549>) (#2551 <https://github.com/ros2/rclcpp/issues/2551>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* revert call shutdown in LifecycleNode destructor (Humble) (#2560 <https://github.com/ros2/rclcpp/issues/2560>)
* lifecycle node dtor shutdown should be called only in primary state. (#2544 <https://github.com/ros2/rclcpp/issues/2544>)
* rclcpp::shutdown should not be called before LifecycleNode dtor. (backport #2527 <https://github.com/ros2/rclcpp/issues/2527>) (#2538 <https://github.com/ros2/rclcpp/issues/2538>)
* Contributors: Tomoya Fujita, mergify[bot]
```
