### PR TITLE
ros2cli: 0.18.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7769,7 +7769,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.10-1
+      version: 0.18.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.11-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.18.10-1`

## ros2action

- No changes

## ros2cli

```
* Update daemon.py for Python 3.8 compatibility (#912 <https://github.com/ros2/ros2cli/issues/912>)
* ros2cli.node.daemon : try getting fdsize from /proc for open fd limit (#888 <https://github.com/ros2/ros2cli/issues/888>) (#908 <https://github.com/ros2/ros2cli/issues/908>)
* Contributors: AhmedMoaz, mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
