### PR TITLE
Revert "ros_gz: 0.244.16-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7862,7 +7862,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.16-1
+      version: 0.244.15-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Reverts ros/rosdistro#42152

FYI @ahcorde 

Here is the failing build job: https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__ros_gz_bridge__ubuntu_jammy_amd64__binary/69/console