### PR TITLE
add mrpt_ros for indexing in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3748,6 +3748,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
     status: developed
+  mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    status: developed
   mrpt_sensors:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4862,6 +4862,16 @@ repositories:
       url: https://github.com/ros2/python_cmake_module.git
       version: rolling
     status: developed
+  python_mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    status: developed
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/MRPT/mrpt_ros
https://github.com/MRPT/python_mrpt_ros

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
