### PR TITLE
mrt_cmake_modules: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6436,7 +6436,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
-      version: 1.0.4-1
+      version: 1.0.10-1
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrt_cmake_modules` to `1.0.10-1`:

- upstream repository: https://github.com/KIT-MRT/mrt_cmake_modules.git
- release repository: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.4-1`

## mrt_cmake_modules

```
* FindGeographicLib: Fix for GeographicLib 2.* and Windows
  Since GeographicLib version 2, the library name changed from libGeographic.so to libGeographicLib.so, see https://github.com/geographiclib/geographiclib/blob/5e4425da84a46eb70e59656d71b4c99732a570ec/NEWS#L208 .
  To ensure that GeographicLib 2.* is found correcty, I think we should add also GeographicLib to the names used by find_library.
  Furthermore, on Windows the import library is called GeographicLib-i.lib (see https://github.com/geographiclib/geographiclib/blob/v2.3/src/CMakeLists.txt#L119), so to find the library correctly on Windows we also look for GeographicLib-i .
* add ortools
* Revert "mrt_add_library now adds a compilation tests for all headers used by the library"
  This reverts commit b05cac0200ce6b8de8e8a18789dbd58cd9d8d1eb.
* Merge branch 'master' into HEAD
* Changes how the check for formatting is done.
  Now the CI job uses the --check flag provided by cmake_format instead of
  the git diff check, because git caused some problems in this repo.
* format
* mrt_add_library now adds a compilation tests for all headers used by the library
* Add ZeroMQ
* Add zxing-cpp to cmake.yaml.
* hard coded ignore files which start with "mocs_compilation and delete the corresponding gcda file, because otherwise our current coverage pipeline fails.
* Contributors: Fabian Poggenhans, Jan-Hendrik Pauls, Johannes Beck, Kevin Rösch, Mrt Builder, Yinzhe Shen
```
