### PR TITLE
Remove mrpt2 from doc and source, set as EOL with recommended upgrade

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4672,20 +4672,13 @@ repositories:
       version: main
     status: maintained
   mrpt2:
-    doc:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
       version: 2.13.4-1
-    source:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
-    status: developed
+    status: end-of-life
+    status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3584,20 +3584,13 @@ repositories:
       version: main
     status: maintained
   mrpt2:
-    doc:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
       version: 2.13.4-1
-    source:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
-    status: developed
+    status: end-of-life
+    status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3845,20 +3845,13 @@ repositories:
       version: main
     status: maintained
   mrpt2:
-    doc:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
     release:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
       version: 2.13.4-1
-    source:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
-    status: developed
+    status: end-of-life
+    status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3679,20 +3679,13 @@ repositories:
       version: main
     status: maintained
   mrpt2:
-    doc:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
       version: 2.13.4-1
-    source:
-      type: git
-      url: https://github.com/MRPT/mrpt.git
-      version: develop
-    status: developed
+    status: end-of-life
+    status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
- Disable mrpt2 `dev` builds.
- Mark as EOL, with recommended upgrade in #42230
- I think the binaries (`release` tag) should be left untouched until all packages downstream are updated to use the new ones.

