### PR TITLE
Add mrpt_ros for index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4741,6 +4741,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
     status: developed
+  mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    status: developed
   mrpt_sensors:
     doc:
       type: git
@@ -6350,6 +6360,16 @@ repositories:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
       version: humble
+    status: developed
+  python_mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
     status: developed
   python_qt_binding:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3653,6 +3653,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
     status: developed
+  mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    status: developed
   mrpt_sensors:
     doc:
       type: git
@@ -4896,6 +4906,16 @@ repositories:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
       version: iron
+    status: developed
+  python_mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
     status: developed
   python_qt_binding:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3914,6 +3914,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_path_planning.git
       version: develop
     status: developed
+  mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    status: developed
   mrpt_sensors:
     doc:
       type: git
@@ -5105,6 +5115,16 @@ repositories:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
       version: jazzy
+    status: developed
+  python_mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
     status: developed
   python_qt_binding:
     doc:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble, iron, jazzy

(Rolling was already merged in #42230 )

# The source is here:

https://github.com/MRPT/mrpt_ros
https://github.com/MRPT/python_mrpt_ros

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
