### PR TITLE
rslidar_sdk: 1.5.14-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7233,7 +7233,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
-      version: dev
+      version: main
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -7242,7 +7242,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
-      version: dev
+      version: main
     status: maintained
   rt_manipulators_cpp:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7229,6 +7229,21 @@ repositories:
       url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
       version: master
     status: maintained
+  rslidar_sdk:
+    doc:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+      version: dev
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rslidar_sdk-release.git
+      version: 1.5.14-3
+    source:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
+      version: dev
+    status: maintained
   rt_manipulators_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_sdk` to `1.5.14-3`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_sdk.git
- release repository: https://github.com/ros2-gbp/rslidar_sdk-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
