### PR TITLE
rmw: 7.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5640,7 +5640,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.4.2-1
+      version: 7.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.4.3-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.4.2-1`

## rmw

```
* remove rmw_localhost_only_t. (#376 <https://github.com/ros2/rmw/issues/376>)
* Fix typo with RMW_DURATION_UNSPECIFIED (#375 <https://github.com/ros2/rmw/issues/375>)
* Fix typo in rmw_validate_*_with_size() doc (#374 <https://github.com/ros2/rmw/issues/374>)
* Contributors: Christophe Bedard, Tomoya Fujita
```

## rmw_implementation_cmake

- No changes
