### PR TITLE
rcl: 9.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5084,7 +5084,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.4.0-1
+      version: 9.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.4.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.4.0-1`

## rcl

```
* Removed deprecated localhost_only (#1169 <https://github.com/ros2/rcl/issues/1169>)
* Fix typo in rcl_validate_enclave_name_with_size() doc (#1168 <https://github.com/ros2/rcl/issues/1168>)
* Removed deprecated rcl_init_timer() (#1167 <https://github.com/ros2/rcl/issues/1167>)
* Cleanup test_count_matched test to handle non-DDS RMWs (#1164 <https://github.com/ros2/rcl/issues/1164>)
  * Make check_state a class method in test_count_matched.
  This allows us to pass fewer parameters into each
  each invocation, and allows us to hide some more of
  the implementation inside the class.
  * Rename "ops" to "opts" in test_count_matched.
  It just better reflects what these structures are.
  * Cleanup pub/subs with a scope_exit in test_count_matched.
  This just ensures that they are always cleaned up, even
  if we exit early.  Note that we specifically do *not*
  use it for test_count_matched_functions, since the cleanup
  is intentionally interleaved with other tests.
  * Check with the RMW layer to see whether QoS is compatible.
  Some RMWs may have different compatibility than DDS, so
  check with the RMW layer to see what we should expect for
  the number of publishers and subscriptions.
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Christophe Bedard
```

## rcl_action

```
* Increase the test_action_interaction timeouts. (#1172 <https://github.com/ros2/rcl/issues/1172>)
  While I can't reproduce the problem locally, I suspect that
  waiting only 1 second for the entities to become ready isn't
  enough in all cases, particularly on Windows, with Connext,
  and when we are running in parallel with other tests.
  Thus, increase the timeout for the rcl_wait() in all of the
  test_action_interaction tests, which should hopefully be
  enough to make this always pass.
* Stop compiling rcl_action tests multiple times. (#1165 <https://github.com/ros2/rcl/issues/1165>)
  We don't need to compile the tests once for each RMW;
  we can just compile it once and then use the RMW_IMPLEMENTATION
  environment variable to run the tests on the different RMWs.
  This speeds up compilation.
* Contributors: Chris Lalancette
```

## rcl_lifecycle

```
* Fix a memory leak in test_rcl_lifecycle. (#1173 <https://github.com/ros2/rcl/issues/1173>)
  This one came about probably as a result of a bad merge.
  But essentially we were forcing the srv_change_state
  com_interface to be nullptr, but forgetting to save off
  the old pointer early enough.  Thus, we could never restore
  the old one before we went to "fini", and the memory would
  be leaked.  Fix this by remembering the impl pointer earlier.
* Contributors: Chris Lalancette
```

## rcl_yaml_param_parser

- No changes
