### PR TITLE
rmw_connextdds: 0.24.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5660,7 +5660,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.24.0-1
+      version: 0.24.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.24.1-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.24.0-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* remove rmw_localhost_only_t. (#156 <https://github.com/ros2/rmw_connextdds/issues/156>)
* Contributors: Tomoya Fujita
```

## rti_connext_dds_cmake_module

- No changes
