### PR TITLE
ament_black: 0.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -104,7 +104,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
-      version: 0.2.4-2
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/botsandus/ament_black.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.5-1`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/ros2-gbp/ament_black-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.4-2`

## ament_black

```
* Fix ament_black for new get_sources API (#13 <https://github.com/botsandus/ament_black/issues/13>)
  * Fix ament_black for new get_sources API
  * Fix import order
  * Add backward compatibility with older black versions
  * style
  * Move global variables inside method to fix flake8
  * Import only for newer versions
  * Last tweak
  ---------
  Co-authored-by: Ignacio Vizzo <mailto:ignacio@dexory.com>
* Contributors: Błażej Sowa
```

## ament_cmake_black

```
* Add ament_cmake_black_CONFIG_FILE option. (#11 <https://github.com/botsandus/ament_black/issues/11>)
  ament_cmake_black_CONFIG_FILE mimics the options available in other ament lint packages like ament_cmake_flake8
* Contributors: gstorer
```
