### PR TITLE
Iron: Use the right branch in image_transport_plugins 

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2407,7 +2407,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: iron
     release:
       packages:
       - compressed_depth_image_transport
@@ -2422,7 +2422,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: iron
     status: maintained
   imu_pipeline:
     doc:


### PR DESCRIPTION
I just noticed that we are not using the right branch in `image_transport_plugins` in `iron`.