### PR TITLE
mola_test_datasets: 0.3.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3676,7 +3676,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_test_datasets-release.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_test_datasets` to `0.3.4-1`:

- upstream repository: https://github.com/MOLAorg/mola_test_datasets.git
- release repository: https://github.com/ros2-gbp/mola_test_datasets-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.3-1`

## mola_test_datasets

```
* Add new warehouse RSLidar test dataset with XYZIR channels
* add MVSim warehouse 01 dataset resulting simplemaps
* Add tree index for html version
* Contributors: Jose Luis Blanco-Claraco
```
