### PR TITLE
sros2: 0.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7358,7 +7358,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.15.0-1
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.15.1-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.0-1`

## sros2

```
* Give more time to generate policies in tests (#323 <https://github.com/ros2/sros2/issues/323>)
* Switch to context manager for rclpy tests. (#322 <https://github.com/ros2/sros2/issues/322>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```

## sros2_cmake

- No changes
