### PR TITLE
rviz: 14.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7036,7 +7036,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.2.4-1
+      version: 14.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.2.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.2.4-1`

## rviz2

```
* Detect wayland and make sure X rendering is used. (#1253 <https://github.com/ros2/rviz/issues/1253>)
* Contributors: Matthew Elwin
```

## rviz_assimp_vendor

```
* Revert "Update ASSIMP_VENDOR CMakeLists.txt (#1226 <https://github.com/ros2/rviz/issues/1226>)" (#1249 <https://github.com/ros2/rviz/issues/1249>)
* Contributors: Chris Lalancette
```

## rviz_common

```
* Added more time to copyright on Windwos (#1252 <https://github.com/ros2/rviz/issues/1252>)
* Added common test for rviz_common (#1232 <https://github.com/ros2/rviz/issues/1232>)
* Set ContentsMargins for RenderPanel to 0 to avoid borders in fullscreen mode. Fixes #1024 <https://github.com/ros2/rviz/issues/1024> (#1228 <https://github.com/ros2/rviz/issues/1228>)
* Contributors: Alejandro Hernández Cordero, Bo Chen
```

## rviz_default_plugins

```
* Added more time to copyright on Windwos (#1252 <https://github.com/ros2/rviz/issues/1252>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Added more time to copyright on Windwos (#1252 <https://github.com/ros2/rviz/issues/1252>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
