### PR TITLE
ros2cli: 0.34.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6044,7 +6044,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.34.0-1
+      version: 0.34.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.34.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.34.0-1`

## ros2action

```
* Switch to using rclpy.init context manager. (#918 <https://github.com/ros2/ros2cli/issues/918>)
* support 'ros2 action find'. (#917 <https://github.com/ros2/ros2cli/issues/917>)
* Contributors: Chris Lalancette, Tomoya Fujita
```

## ros2cli

```
* Switch to using the rclpy.init context manager. (#920 <https://github.com/ros2/ros2cli/issues/920>)
* Contributors: Chris Lalancette
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Switch to using rclpy.init context manager. (#918 <https://github.com/ros2/ros2cli/issues/918>)
* Contributors: Chris Lalancette
```

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

```
* Switch to using rclpy.init context manager. (#918 <https://github.com/ros2/ros2cli/issues/918>)
* Contributors: Chris Lalancette
```

## ros2param

```
* Switch to using rclpy.init context manager. (#918 <https://github.com/ros2/ros2cli/issues/918>)
* Contributors: Chris Lalancette
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

```
* Switch to using the rclpy.init context manager. (#920 <https://github.com/ros2/ros2cli/issues/920>)
* Switch to using rclpy.init context manager. (#918 <https://github.com/ros2/ros2cli/issues/918>)
* Contributors: Chris Lalancette
```

## ros2topic

```
* Switch to using rclpy.init context manager. (#918 <https://github.com/ros2/ros2cli/issues/918>)
* Contributors: Chris Lalancette
```
