### PR TITLE
message_filters: 6.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3320,7 +3320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 6.0.1-1
+      version: 6.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `6.0.2-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.1-1`

## message_filters

```
* Fix cppcheck warning on Windwos (#138 <https://github.com/ros2/message_filters/issues/138>)
* Adding ament_lint_common (#120 <https://github.com/ros2/message_filters/issues/120>)
* Contributors: Alejandro Hernández Cordero, Lucas Wendland
```
