### PR TITLE
launch_ros: 0.27.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2912,7 +2912,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.27.1-1
+      version: 0.27.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.27.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.27.1-1`

## launch_ros

- No changes

## launch_testing_ros

```
* Switch to use rclpy.init context manager. (#402 <https://github.com/ros2/launch_ros/issues/402>)
* Contributors: Chris Lalancette
```

## ros2launch

- No changes
