### PR TITLE
demos: 0.34.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1113,7 +1113,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.34.1-1
+      version: 0.34.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.34.2-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.34.1-1`

## action_tutorials_cpp

```
* Removed outdated comment (#699 <https://github.com/ros2/demos/issues/699>)
* Contributors: Alejandro Hernández Cordero
```

## action_tutorials_interfaces

- No changes

## action_tutorials_py

```
* Change all of the demos to use the new rclpy context manager. (#694 <https://github.com/ros2/demos/issues/694>)
* Contributors: Chris Lalancette
```

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Change all of the demos to use the new rclpy context manager. (#694 <https://github.com/ros2/demos/issues/694>)
* Contributors: Chris Lalancette
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

```
* Removed pre-compiler check for opencv3 (#695 <https://github.com/ros2/demos/issues/695>)
* Contributors: Alejandro Hernández Cordero
```

## lifecycle

- No changes

## lifecycle_py

```
* Change all of the demos to use the new rclpy context manager. (#694 <https://github.com/ros2/demos/issues/694>)
* Contributors: Chris Lalancette
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

```
* Change all of the demos to use the new rclpy context manager. (#694 <https://github.com/ros2/demos/issues/694>)
* Contributors: Chris Lalancette
```

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
