### PR TITLE
libstatistics_collector: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3108,7 +3108,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.8.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `2.0.0-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`

## libstatistics_collector

```
* Removed deprecated classes (#200 <https://github.com/ros-tooling/libstatistics_collector/issues/200>)
* fix: add void annotation (#194 <https://github.com/ros-tooling/libstatistics_collector/issues/194>)
* Contributors: Alejandro Hernández Cordero, Daisuke Nishimatsu, dependabot[bot]
```
