### PR TITLE
mola: 1.0.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3626,6 +3626,7 @@ repositories:
       - mola_kernel
       - mola_launcher
       - mola_metric_maps
+      - mola_msgs
       - mola_navstate_fg
       - mola_navstate_fuse
       - mola_pose_list
@@ -3636,7 +3637,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.0.8-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.7-1`

## kitti_metrics_eval

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola

- No changes

## mola_bridge_ros2

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* mola_kernel: add C++ virtual interface for relocalization methods
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Update robin-map to latest version (Fix cmake < 3.5 compatibility warning)
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

```
* Add mola_msgs package with ROS service definitions
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fg

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fuse

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* BUGFIX: Add missing cmake dependency on mrpt-slam
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* ament_lint_cmake: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```
