### PR TITLE
dbw_ros: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1143,6 +1143,26 @@ repositories:
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
       version: ros2
     status: maintained
+  dbw_ros:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dbw_ros.git
+      version: ros2
+    release:
+      packages:
+      - ds_dbw
+      - ds_dbw_can
+      - ds_dbw_joystick_demo
+      - ds_dbw_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dbw_ros-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dbw_ros.git
+      version: ros2
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.2.0-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ds_dbw

```
* Remove some settings changes in ROS install script
* Better desktop startup launcher with ROS environment already sourced in bashrc
* Add support for Ubuntu Noble with ROS Jazzy in ROS install script
* Contributors: Gabe, Kevin Hallenbeck
```

## ds_dbw_can

```
* Bump firmware versions to match 2024/06/17 release package
* Add steering offset message
* Finish porting wheel_counts_per_km script to DBW2
* Add several new messages and signals
  New messages:
  - Battery
  - Low voltage battery state-of-charge/voltage/current/temperature
  - Vehicle ignition
  - BatteryTraction
  - High voltage battery state-of-charge/voltage/temperature
  - DriverAssist
  - ADAS deceleration value
  - FCW/AEB/ACC/BLIS/CTA statuses
  - FuelLevel
  - Fuel level
  - Odometer
  - GPS
  New signals in existing messages:
  - MiscReport
  - Wiper
  - Headlights (high and low beams)
  - Ambient light
  - Outside air temperature
  - ThrottleInfo
  - Drive mode
  - Transmission gear number
* Fix a few invalid signal checks
* Round all command values generated by user instead of truncating
* Separate turn signal messages with diagnostics
  Keep functionality in misc cmd/report for a while to ease the transition
* Contributors: Kevin Hallenbeck
```

## ds_dbw_joystick_demo

```
* Separate turn signal messages with diagnostics
  Keep functionality in misc cmd/report for a while to ease the transition
* Contributors: Kevin Hallenbeck
```

## ds_dbw_msgs

```
* Add steering offset message
* Add several new messages and signals
  New messages:
  - Battery
  - Low voltage battery state-of-charge/voltage/current/temperature
  - Vehicle ignition
  - BatteryTraction
  - High voltage battery state-of-charge/voltage/temperature
  - DriverAssist
  - ADAS deceleration value
  - FCW/AEB/ACC/BLIS/CTA statuses
  - FuelLevel
  - Fuel level
  - Odometer
  - GPS
  New signals in existing messages:
  - MiscReport
  - Wiper
  - Headlights (high and low beams)
  - Ambient light
  - Outside air temperature
  - ThrottleInfo
  - Drive mode
  - Transmission gear number
* Separate turn signal messages with diagnostics
  Keep functionality in misc cmd/report for a while to ease the transition
* Contributors: Kevin Hallenbeck
```
