### PR TITLE
rosbag2: 0.15.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7999,7 +7999,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.11-1
+      version: 0.15.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.12-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.11-1`

## mcap_vendor

- No changes

## ros2bag

```
* [humble] Add option to prevent message loss while converting (backport #1058 <https://github.com/ros2/rosbag2/issues/1058>) (#1749 <https://github.com/ros2/rosbag2/issues/1749>)
* [humble] rosbag2_cpp: test more than one storage plugin (backport #1196 <https://github.com/ros2/rosbag2/issues/1196>) (#1721 <https://github.com/ros2/rosbag2/issues/1721>)
* [humble] rosbag2_storage: expose default storage ID as method (backport #1146 <https://github.com/ros2/rosbag2/issues/1146>) (#1724 <https://github.com/ros2/rosbag2/issues/1724>)
* [humble] Allow to specify start offset from CLI arguments equal to 0.0 for the rosbag2 player (backport #1682 <https://github.com/ros2/rosbag2/issues/1682>) (#1715 <https://github.com/ros2/rosbag2/issues/1715>)
* Contributors: mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* [humble] Bugfix for bag_split event callbacks called to early with file compression (backport #1643 <https://github.com/ros2/rosbag2/issues/1643>) (#1733 <https://github.com/ros2/rosbag2/issues/1733>)
* [humble] Add option to prevent message loss while converting (backport #1058 <https://github.com/ros2/rosbag2/issues/1058>) (#1749 <https://github.com/ros2/rosbag2/issues/1749>)
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* [Humble] Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1722 <https://github.com/ros2/rosbag2/issues/1722>)
* [humble] Bugfix for bag_split event callbacks called to early with file compression (backport #1643 <https://github.com/ros2/rosbag2/issues/1643>) (#1733 <https://github.com/ros2/rosbag2/issues/1733>)
* [humble] rosbag2_cpp: test more than one storage plugin (backport #1196 <https://github.com/ros2/rosbag2/issues/1196>) (#1721 <https://github.com/ros2/rosbag2/issues/1721>)
* [humble] Remove explicit sqlite3 from code (backport #1166 <https://github.com/ros2/rosbag2/issues/1166>) (#1723 <https://github.com/ros2/rosbag2/issues/1723>)
* [humble] rosbag2_storage: expose default storage ID as method (backport #1146 <https://github.com/ros2/rosbag2/issues/1146>) (#1724 <https://github.com/ros2/rosbag2/issues/1724>)
* Contributors: Michael Orlov, mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* [humble] Remove explicit sqlite3 from code (backport #1166 <https://github.com/ros2/rosbag2/issues/1166>) (#1723 <https://github.com/ros2/rosbag2/issues/1723>)
* Contributors: mergify[bot]
```

## rosbag2_py

```
* [Humble] Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1722 <https://github.com/ros2/rosbag2/issues/1722>)
* [humble] Bugfix for wrong timestamps in ros2 bag info (backport #1745 <https://github.com/ros2/rosbag2/issues/1745>) (#1754 <https://github.com/ros2/rosbag2/issues/1754>)
* [humble] Expose py Reader metadata, improve rosbag2_py.BagMetadata usability (backport #1082 <https://github.com/ros2/rosbag2/issues/1082>) (#1404 <https://github.com/ros2/rosbag2/issues/1404>)
* [humble] Remove explicit sqlite3 from code (backport #1166 <https://github.com/ros2/rosbag2/issues/1166>) (#1723 <https://github.com/ros2/rosbag2/issues/1723>)
* [humble] rosbag2_storage: expose default storage ID as method (backport #1146 <https://github.com/ros2/rosbag2/issues/1146>) (#1724 <https://github.com/ros2/rosbag2/issues/1724>)
* [rosbag2] Fix typo to properly restore SIGINT hanlder (#1687 <https://github.com/ros2/rosbag2/issues/1687>)
* [humble] Fix for false negative tests in rosbag2_py (backport #1592 <https://github.com/ros2/rosbag2/issues/1592>) (#1689 <https://github.com/ros2/rosbag2/issues/1689>)
* Contributors: Eric Cousineau, Michael Orlov, mergify[bot]
```

## rosbag2_storage

```
* [humble] Remove explicit sqlite3 from code (backport #1166 <https://github.com/ros2/rosbag2/issues/1166>) (#1723 <https://github.com/ros2/rosbag2/issues/1723>)
* [humble] rosbag2_storage: expose default storage ID as method (backport #1146 <https://github.com/ros2/rosbag2/issues/1146>) (#1724 <https://github.com/ros2/rosbag2/issues/1724>)
* Contributors: mergify[bot]
```

## rosbag2_storage_default_plugins

```
* [Humble] Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1722 <https://github.com/ros2/rosbag2/issues/1722>)
* [humble] Fix for failing throws_on_invalid_pragma_in_config_file test on Windows (backport #1742 <https://github.com/ros2/rosbag2/issues/1742>) (#1748 <https://github.com/ros2/rosbag2/issues/1748>)
* Contributors: Michael Orlov, mergify[bot]
```

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

```
* [humble] rosbag2_cpp: test more than one storage plugin (backport #1196 <https://github.com/ros2/rosbag2/issues/1196>) (#1721 <https://github.com/ros2/rosbag2/issues/1721>)
* Contributors: mergify[bot]
```

## rosbag2_tests

```
* [humble] Fix for a false negative integration test with bag split in recorder (backport #1743 <https://github.com/ros2/rosbag2/issues/1743>) (#1751 <https://github.com/ros2/rosbag2/issues/1751>)
* [humble] Bugfix for wrong timestamps in ros2 bag info (backport #1745 <https://github.com/ros2/rosbag2/issues/1745>) (#1754 <https://github.com/ros2/rosbag2/issues/1754>)
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* [humble] Bugfix for bag_split event callbacks called to early with file compression (backport #1643 <https://github.com/ros2/rosbag2/issues/1643>) (#1733 <https://github.com/ros2/rosbag2/issues/1733>)
* [humble] rosbag2_cpp: test more than one storage plugin (backport #1196 <https://github.com/ros2/rosbag2/issues/1196>) (#1721 <https://github.com/ros2/rosbag2/issues/1721>)
* [humble] Remove explicit sqlite3 from code (backport #1166 <https://github.com/ros2/rosbag2/issues/1166>) (#1723 <https://github.com/ros2/rosbag2/issues/1723>)
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
