### PR TITLE
rviz: 11.2.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8788,7 +8788,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.12-1
+      version: 11.2.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.13-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `11.2.12-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Migrate some security-related changes from iron to humble (#1238 <https://github.com/ros2/rviz/issues/1238>)
* Contributors: xueying
```

## rviz_common

```
* Correclty load icons of panels with whitespaces in their name (#1241 <https://github.com/ros2/rviz/issues/1241>) (#1243 <https://github.com/ros2/rviz/issues/1243>)
* Replace ESC shortcut for exiting full screen with solution from https://github.com/ros-visualization/rviz/pull/1416 (#1205 <https://github.com/ros2/rviz/issues/1205>) (#1210 <https://github.com/ros2/rviz/issues/1210>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* Migrate some security-related changes from iron to humble (#1238 <https://github.com/ros2/rviz/issues/1238>)
* Contributors: xueying
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
