### PR TITLE
Jazzy: Use the right branch image_transport_plugins

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2692,7 +2692,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: jazzy
     release:
       packages:
       - compressed_depth_image_transport
@@ -2708,7 +2708,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: jazzy
     status: maintained
   imu_pipeline:
     doc:


### PR DESCRIPTION
Use the right branch in `Jazzy` for `image_transport_plugins`