### PR TITLE
Add python3-antlr4 to python.yaml 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4890,6 +4890,8 @@ python3-ansible-runner-pip:
   ubuntu:
     pip:
       packages: [ansible-runner]
+python3-antlr4:
+  ubuntu: [python3-antlr4]
 python3-anytree-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4892,7 +4892,9 @@ python3-ansible-runner-pip:
       packages: [ansible-runner]
 python3-antlr4:
   debian: [python3-antlr4]
-  ubuntu: [python3-antlr4]
+  ubuntu: 
+    '*': [python3-antlr4]
+    focal: null
 python3-anytree-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4892,7 +4892,7 @@ python3-ansible-runner-pip:
       packages: [ansible-runner]
 python3-antlr4:
   debian: [python3-antlr4]
-  ubuntu: 
+  ubuntu:
     '*': [python3-antlr4]
     focal: null
 python3-anytree-pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4891,6 +4891,7 @@ python3-ansible-runner-pip:
     pip:
       packages: [ansible-runner]
 python3-antlr4:
+  debian: [python3-antlr4]
   ubuntu: [python3-antlr4]
 python3-anytree-pip:
   debian:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-antlr4

## Package Upstream Source:

https://github.com/antlr/antlr4


## Purpose of using this:

The python 3 runtime of antlr4 is used within parsers that are generated by [antlr4](https://www.antlr.org/),  a powerful parser generator for reading, processing, executing, or translating structured text or binary files.


## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: 
  - https://packages.debian.org/bookworm/python3-antlr4
- Ubuntu: 
  - https://packages.ubuntu.com/source/jammy/python3-antlr4
  - https://packages.ubuntu.com/noble/python3-antlr4

