### PR TITLE
Adding lm_sensors for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6759,6 +6759,7 @@ lm-sensors:
   gentoo: [sys-apps/lm_sensors]
   nixos: [lm_sensors]
   openembedded: [lmsensors@meta-oe]
+  rhel: [lm_sensors]
   ubuntu: [lm-sensors]
 log4cplus:
   arch: [log4cplus]


### PR DESCRIPTION
Needed for https://github.com/ros/diagnostics/blob/ros2/diagnostic_common_diagnostics/package.xml

It is available in CentOS: https://pkgs.org/download/lm_sensors