### PR TITLE
diagnostics: 4.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1151,7 +1151,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.3.0-1
+      version: 4.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.3.1-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-1`

## diagnostic_aggregator

- No changes

## diagnostic_common_diagnostics

```
* fixing pep257 problems introduced by #334 <https://github.com/ros/diagnostics/issues/334> (#384 <https://github.com/ros/diagnostics/issues/384>)
* Port hd_monitor to ROS2 (#334 <https://github.com/ros/diagnostics/issues/334>)
* Contributors: Antoine Lima, Christian Henkel
```

## diagnostic_updater

```
* Fix correctly exporting the library (#388 <https://github.com/ros/diagnostics/issues/388>) (#393 <https://github.com/ros/diagnostics/issues/393>)
* Minimize header includes by moving impl to .cpp files (#331 <https://github.com/ros/diagnostics/issues/331>) and Fix usage of rclcpp::ok with a non-default context (#352 <https://github.com/ros/diagnostics/issues/352>)  (#390 <https://github.com/ros/diagnostics/issues/390>)
* Contributors: Christian Henkel, Ramon Wijnands, Hervé Audren
```

## diagnostics

- No changes

## self_test

- No changes
