### PR TITLE
diagnostics: 4.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1247,7 +1247,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 3.1.2-3
+      version: 4.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.2.1-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.2-3`

## diagnostic_aggregator

- No changes

## diagnostic_common_diagnostics

```
* fixing pep257 problems introduced by #334 <https://github.com/ros/diagnostics/issues/334> (#384 <https://github.com/ros/diagnostics/issues/384>) (#392 <https://github.com/ros/diagnostics/issues/392>)
* Fixing ntp launchtest (#330 <https://github.com/ros/diagnostics/issues/330>) (#391 <https://github.com/ros/diagnostics/issues/391>)
* Port hd_monitor to ROS2 (#334 <https://github.com/ros/diagnostics/issues/334>) (#383 <https://github.com/ros/diagnostics/issues/383>)
* Contributors: Christian Henkel, Richardvdketterij, Richard
```

## diagnostic_updater

```
* Fix correctly exporting the library (#388 <https://github.com/ros/diagnostics/issues/388>)
* Contributors: Ramon Wijnands
```

## diagnostics

- No changes

## self_test

- No changes
