### PR TITLE
image_transport_plugins: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2537,7 +2537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 4.0.1-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `5.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-1`

## compressed_depth_image_transport

```
* Added common linters to compressed depth image transport (#168 <https://github.com/ros-perception/image_transport_plugins/issues/168>)
* Contributors: Alejandro Hernández Cordero
```

## compressed_image_transport

```
* Added common linters to compressed_image_transport (#167 <https://github.com/ros-perception/image_transport_plugins/issues/167>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Added common linters to theora_image_transport (#169 <https://github.com/ros-perception/image_transport_plugins/issues/169>)
* Contributors: Alejandro Hernández Cordero
```

## zstd_image_transport

- No changes
