### PR TITLE
hpp-fcl: 2.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2427,7 +2427,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hpp_fcl-release.git
-      version: 2.4.4-2
+      version: 2.4.5-1
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hpp-fcl` to `2.4.5-1`:

- upstream repository: https://github.com/humanoid-path-planner/hpp-fcl.git
- release repository: https://github.com/ros2-gbp/hpp_fcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.4-2`
