### PR TITLE
foxglove_bridge: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1781,7 +1781,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.9-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.8.0-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.9-1`

## foxglove_bridge

```
* Fix usage of deprecated AsyncParametersClient constructor (#319 <https://github.com/foxglove/ros-foxglove-bridge/issues/319>)
* Add ROS2 JSON publishing support (#307 <https://github.com/foxglove/ros-foxglove-bridge/issues/307>)
* Contributors: Davide Faconti, Hans-Joachim Krauch
```
