### PR TITLE
Add python3-lgpio

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6844,6 +6844,32 @@ python3-lark-parser:
   ubuntu:
     '*': [python3-lark]
     bionic: [python3-lark-parser]
+python3-lgpio:
+  alpine:
+    pip:
+      packages: [lgpio]
+  arch:
+    pip:
+      packages: [lgpio]
+  debian:
+     pip:
+      packages: [lgpio]
+  fedora:
+     pip:
+      packages: [lgpio]
+  gentoo:
+     pip:
+      packages: [lgpio]
+  nixos:
+     pip:
+      packages: [lgpio]
+  openembedded:
+     pip:
+      packages: [lgpio]
+  rhel:
+     pip:
+      packages: [lgpio]
+  ubuntu: [python3-lgpio]
 python3-libgpiod:
   alpine: [py3-libgpiod]
   arch: [libgpiod]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6870,10 +6870,10 @@ python3-lgpio:
     pip:
       packages: [lgpio]
   ubuntu:
-  '*': [python3-lgpio]
-  focal:
-    pip:
-      packages: [lgpio]
+    '*': [python3-lgpio]
+    focal:
+      pip:
+        packages: [lgpio]
 python3-libgpiod:
   alpine: [py3-libgpiod]
   arch: [libgpiod]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6869,7 +6869,11 @@ python3-lgpio:
   rhel:
     pip:
       packages: [lgpio]
-  ubuntu: [python3-lgpio]
+  ubuntu:
+  '*': [python3-lgpio]
+  focal:
+    pip:
+      packages: [lgpio]
 python3-libgpiod:
   alpine: [py3-libgpiod]
   arch: [libgpiod]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6852,22 +6852,22 @@ python3-lgpio:
     pip:
       packages: [lgpio]
   debian:
-     pip:
+    pip:
       packages: [lgpio]
   fedora:
-     pip:
+    pip:
       packages: [lgpio]
   gentoo:
-     pip:
+    pip:
       packages: [lgpio]
   nixos:
-     pip:
+    pip:
       packages: [lgpio]
   openembedded:
-     pip:
+    pip:
       packages: [lgpio]
   rhel:
-     pip:
+    pip:
       packages: [lgpio]
   ubuntu: [python3-lgpio]
 python3-libgpiod:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## python3-lgpio:

## Package Upstream Source:

https://github.com/joan2937/lg

## Purpose of using this:

Another useful wrapper for Raspberry Pi IO including serial, i2c, etc.

Distro packaging links:

## Links to Distribution Packages

pip https://pypi.org/project/lgpio/

- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-lgpio

I was originally going to make this `python3-lgpio-pip` but noticed Ubuntu has binaries.