### PR TITLE
rosdep: added python3-pysnmp-mibs

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8442,6 +8442,22 @@ python3-pysnmp:
     '*': [python3-pysnmp]
     '7': [pysnmp]
   ubuntu: [python3-pysnmp4]
+python3-pysnmp-mibs:
+  debian: [python3-pysnmp4-mibs]
+  fedora: [python3-pysnmp-mibs]
+  gentoo: [dev-python/pysnmp-mibs]
+  nixos:
+    pip:
+      packages: [pysnmp-mibs]
+  opensuse:
+    '*': [python3-pysnmp-mibs]
+    '15.2':
+      pip:
+        packages: [pysnmp-mibs]
+  rhel:
+    pip:
+      packages: [pysnmp-mibs]
+  ubuntu: [python3-pysnmp4-mibs]
 python3-pystemd:
   debian:
     bullseye: [python3-pystemd]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pysnmp-mibs

## Package Upstream Source:

https://sourceforge.net/projects/pysnmp/

## Purpose of using this:

Adds MIB definitions of many known schemes to python3-pysnmp .

## Links to Distribution Packages

- Debian: https://packages.debian.org/bookworm/python3-pysnmp4-mibs
- Ubuntu: https://packages.ubuntu.com/noble/python3-pysnmp4-mibs
- Fedora: https://packages.fedoraproject.org/pkgs/python-pysnmp-mibs/python3-pysnmp-mibs/
- Arch: N/A
- Gentoo: https://packages.gentoo.org/packages/dev-python/pysnmp-mibs
- macOS: N/A
- Alpine: N/A
- NixOS/nixpkgs: pip
- openSUSE: https://software.opensuse.org/package/python3-pysnmp-mibs
- rhel: pip


I only added OSs supported by python3-pysnmp key.