### PR TITLE
rosdep: added python3-rsa

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8896,6 +8896,19 @@ python3-rospkg-modules:
     pip:
       packages: [rospkg]
   ubuntu: [python3-rospkg-modules]
+python3-rsa:
+  alpine: [py3-rsa]
+  arch: [python-rsa]
+  debian: [python3-rsa]
+  fedora: [python3-rsa]
+  gentoo: [dev-python/rsa]
+  nixos: [python3Packages.rsa]
+  opensuse: [python3-rsa]
+  osx:
+    pip:
+      packages: [rsa]
+  rhel: [python3-rsa]
+  ubuntu: [python3-rsa]
 python3-rtree:
   debian: [python3-rtree]
   fedora: [python3-rtree]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-rsa

## Package Upstream Source:

http://stuvel.eu/rsa

## Purpose of using this:

Useful cryptographical library. Used e.g. when performing login to various web APIs.

## Links to Distribution Packages

- Debian: https://packages.debian.org/stable/python/python3-rsa
- Ubuntu: https://packages.ubuntu.com/noble/python3-rsa
- Fedora: https://packages.fedoraproject.org/pkgs/python-rsa/python3-rsa/
- Arch: https://archlinux.org/packages/extra/any/python-rsa/
- Gentoo: https://packages.gentoo.org/packages/dev-python/rsa
- macOS: pip
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-rsa
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=python312Packages.rsa&from=0&size=50&sort=relevance&type=packages&query=rsa
- openSUSE: https://software.opensuse.org/package/python3-rsa
- rhel: https://rhel.pkgs.org/9/epel-aarch64/python3-rsa-4.9-2.el9.noarch.rpm.html