### PR TITLE
etsi_its_messages: 2.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2663,6 +2663,9 @@ repositories:
       - etsi_its_cam_coding
       - etsi_its_cam_conversion
       - etsi_its_cam_msgs
+      - etsi_its_cam_ts_coding
+      - etsi_its_cam_ts_conversion
+      - etsi_its_cam_ts_msgs
       - etsi_its_coding
       - etsi_its_conversion
       - etsi_its_cpm_ts_coding
@@ -2679,7 +2682,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
-      version: 2.1.0-3
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `2.2.0-1`:
- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-3`