### PR TITLE
Add in chrony key for RHEL.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -538,6 +538,7 @@ chrony:
   gentoo: [net-misc/chrony]
   nixos: [chrony]
   opensuse: [chrony]
+  rhel: [chrony]
   ubuntu: [chrony]
 clang:
   arch: [clang]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please update the following dependency to the rosdep database.

## Package name:

chrony

## Package Upstream Source:

https://gitlab.com/chrony/chrony

## Purpose of using this:

This is being used by the turtlebot4_setup package, among others.

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=chrony