### PR TITLE
Add in networkmanager key for RHEL.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7227,6 +7227,7 @@ network-manager:
   gentoo: [net-misc/networkmanager]
   nixos: [networkmanager]
   opensuse: [NetworkManager]
+  rhel: [NetworkManager]
   ubuntu: [network-manager]
 ninja-build:
   arch: [ninja]


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

## Package name:

NetworkManager

## Package Upstream Source:

https://github.com/NetworkManager/NetworkManager

## Purpose of using this:

NetworkManager is a widely-used network management utility.  It is being used by turtlebot4_setup, among other packages.

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=networkmanager