### PR TITLE
Adding nmea_parser package to documentation index for distro<humble>

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5181,7 +5181,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/HundredGB/nmea_parser.git
-      version: 0.0.1
+      version: ros2
       status: maintained
   nodl:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5174,14 +5174,14 @@ repositories:
     doc:
       type: git
       url: https://github.com/HundredGB/nmea_parser.git
-      version: 0.0.1
+      version: main
     release:
     tags:
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/HundredGB/nmea_parser.git
-      version: ros2
+      version: main
       status: maintained
   nodl:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5170,6 +5170,19 @@ repositories:
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
       version: ros2
     status: maintained
+  nmea_parser:
+    doc:
+      type: git
+      url: https://github.com/HundredGB/nmea_parser.git
+      version: 0.0.1
+    release:
+    tags:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/HundredGB/nmea_parser.git
+      version: 0.0.1
+      status: maintained
   nodl:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name: nmea_parser

A node that receives nmea data (GGA, RMC, HDT), parses it, and then publishes it

## Package Upstream Source: https://github.com/HundredGB/nmea_parser

TODO link to source repository

## Purpose of using this: for education

TODO Replace. This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  -not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  -not available
- rhel: https://rhel.pkgs.org/
  - not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME : humble

# The source is here:

https://github.com/HundredGB/nmea_parser

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
