### PR TITLE
ros2_control: 4.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5878,7 +5878,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.14.0-1
+      version: 4.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.14.0-1`

## controller_interface

- No changes

## controller_manager

```
* Add missing include for executors (#1653 <https://github.com/ros-controls/ros2_control/issues/1653>)
* Fix the namespaced controller_manager spawner + added tests (#1640 <https://github.com/ros-controls/ros2_control/issues/1640>)
* CM: Add missing includes (#1641 <https://github.com/ros-controls/ros2_control/issues/1641>)
* Fix rst markup (#1642 <https://github.com/ros-controls/ros2_control/issues/1642>)
* Add a pytest launch file to test ros2_control_node (#1636 <https://github.com/ros-controls/ros2_control/issues/1636>)
* [CM] Remove deprecated spawner args (#1639 <https://github.com/ros-controls/ros2_control/issues/1639>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [RM] Add get_hardware_info method to the Hardware Components (#1643 <https://github.com/ros-controls/ros2_control/issues/1643>)
* add missing rclcpp logging include for Humble compatibility build (#1635 <https://github.com/ros-controls/ros2_control/issues/1635>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface_testing

```
* [RM] Add get_hardware_info method to the Hardware Components (#1643 <https://github.com/ros-controls/ros2_control/issues/1643>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
