### PR TITLE
Adding kinematics_interface_pinocchio to documentation index for distro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3402,6 +3402,11 @@ repositories:
       url: https://github.com/ros-controls/kinematics_interface.git
       version: humble
     status: developed
+  kinematics_interface_pinocchio:
+    doc:
+      type: git
+      url: https://github.com/justagist/kinematics_interface_pinocchio
+      version: main
   kobuki_core:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME: humble

# The source is here:

https://github.com/justagist/kinematics_interface_pinocchio

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
