### PR TITLE
mrpt2: 2.13.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4677,7 +4677,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.13.4-1
+      version: 2.13.5-1
     status: end-of-life
     status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt2` to `2.13.5-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.13.4-1`
