### PR TITLE
Enable test_pull_request for mvsim

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3805,6 +3805,7 @@ repositories:
       url: https://github.com/ros2-gbp/mvsim-release.git
       version: 0.9.4-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/MRPT/mvsim.git
       version: develop


### PR DESCRIPTION
It was not enabled initially but it is important to check for regressions in PRs upstream.