### PR TITLE
adding python3-nep-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7232,6 +7232,13 @@ python3-nclib-pip:
   ubuntu:
     pip:
       packages: [nclib]
+python3-nep-pip:
+  osx:
+    pip:
+      packages: [nep]
+  ubuntu:
+    pip:
+      packages: [nep]
 python3-nest-asyncio:
   alpine: [py3-nest_asyncio]
   arch: [python-nest-asyncio]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7233,6 +7233,9 @@ python3-nclib-pip:
     pip:
       packages: [nclib]
 python3-nep-pip:
+  debian:
+    pip:
+      packages: [nep]
   osx:
     pip:
       packages: [nep]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

NEP

## Package Upstream Source:

* Source: [https://github.com/enriquecoronadozu/NEP](https://github.com/enriquecoronadozu/NEP)
* PIP: [https://pypi.org/project/nep/](https://pypi.org/project/nep/)
* Documentation: [https://enriquecoronadozu.github.io/NEP/](https://enriquecoronadozu.github.io/NEP/) and [https://enrique-coronado.gitbook.io/nep-docs](https://enrique-coronado.gitbook.io/nep-docs)

## Purpose of using this:

This package is used to communicate between two devices regardless of the OS. It uses the same publisher/subscriber system as ROS and can be used in several languages (Python, C#, Javascript, C++...). It can be an alternative to ROS when just the communication is required or with a language not available with ROS.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PyPi: https://pypi.org/project/nep/

NB: I ran the `pytest` and it returned `9 passed, 1 warning`. I also tried to do `rosdep install --from-paths src -y --ignore-src` and it worked (but I only tried on Ubuntu 22.04). The package also works on Windows but I didn't add it since it is not supported on rosdep.