### PR TITLE
launch_pal: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3638,7 +3638,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.1.15-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.2.0-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.15-1`

## launch_pal

```
* [test] make sure changing AMENT_PREFIX_PATH does not spill out of the tests
* PAPS-007: better logging for invalid user configuration files
* get_pal_parameters: improved logging
  In particular, list all the configuration files found for the node, by order of precedence
* PAPS-007 - get_pal_parameters: add support for user configuration in ~/.pal/config
  The location of user configuration can be overridden via envvar
  $PAL_USER_PARAMETERS_PATH.
* Contributors: Séverin Lemaignan
```
