### PR TITLE
pmb2_robot: 5.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6057,7 +6057,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.0.25-1
+      version: 5.1.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.1.1-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.25-1`

## pmb2_bringup

```
* Publish odom tf for public sim
* Contributors: David ter Kuile
```

## pmb2_controller_configuration

```
* Publish odom tf for public sim
* Contributors: David ter Kuile
```

## pmb2_description

- No changes

## pmb2_robot

- No changes
