### PR TITLE
pmb2_navigation: 4.0.23-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6037,7 +6037,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.0.21-1
+      version: 4.0.23-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.0.23-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.21-1`

## pmb2_2dnav

```
* Merge branch 'feat/aca/pipeline-substitution' into 'humble-devel'
  using variables laser pipeline
  See merge request robots/pmb2_navigation!91
* reorganized remappings file
* added device number laser
* Contributors: andreacapodacqua
```

## pmb2_laser_sensors

```
* Merge branch 'feat/aca/pipeline-substitution' into 'humble-devel'
  using variables laser pipeline
  See merge request robots/pmb2_navigation!91
* using variables laser pipeline
* Contributors: andreacapodacqua
```

## pmb2_navigation

- No changes
