### PR TITLE
tiago_simulation: 4.1.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9685,7 +9685,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.1.8-1
+      version: 4.1.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_simulation` to `4.1.9-1`:

- upstream repository: https://github.com/pal-robotics/tiago_simulation
- release repository: https://github.com/pal-gbp/tiago_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.8-1`

## tiago_gazebo

```
* added tuck arm arg and condition
* Contributors: sergiacosta
```

## tiago_simulation

- No changes
