### PR TITLE
omni_base_navigation: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5416,12 +5416,12 @@ repositories:
       packages:
       - omni_base_2dnav
       - omni_base_laser_sensors
-      - omni_base_maps
       - omni_base_navigation
+      - omni_base_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_navigation-release.git
-      version: 2.0.7-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_navigation` to `2.1.1-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_navigation.git
- release repository: https://github.com/pal-gbp/omni_base_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.7-1`

## omni_base_2dnav

```
* fix laser frames
* Contributors: andreacapodacqua
```

## omni_base_laser_sensors

- No changes

## omni_base_navigation

- No changes

## omni_base_rgbd_sensors

- No changes
