### PR TITLE
omni_base_robot: 2.0.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5441,7 +5441,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.0.18-1
+      version: 2.0.19-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.0.19-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.18-1`

## omni_base_bringup

```
* Add warning for pal_module_cmake not found
* Contributors: Noel Jimenez
```

## omni_base_controller_configuration

```
* Add warning for pal_module_cmake not found
* Contributors: Noel Jimenez
```

## omni_base_description

```
* Add warning for pal_module_cmake not found
* Contributors: Noel Jimenez
```

## omni_base_robot

- No changes
