### PR TITLE
omni_base_simulation: 2.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5459,7 +5459,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_simulation-release.git
-      version: 2.0.3-1
+      version: 2.0.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_simulation` to `2.0.9-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_simulation.git
- release repository: https://github.com/pal-gbp/omni_base_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## omni_base_gazebo

```
* Merge branch 'abr/feat/advanced-navigation' into 'humble-devel'
  added advanced navigation
  See merge request robots/omni_base_simulation!20
* added advanced navigation
* Contributors: antoniobrandi, davidterkuile
```

## omni_base_simulation

- No changes
