### PR TITLE
Add hector_rviz_overlay to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2572,6 +2572,24 @@ repositories:
       url: https://github.com/tier4/heaphook.git
       version: main
     status: maintained
+  hector_rviz_overlay:
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
+      version: jazzy
+    status: maintained
+  hector_rviz_overlay_controls:
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
+      version: jazzy
+    status: maintained
+  hector_rviz_overlay_demo:
+    source:
+      type: git
+      url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
+      version: jazzy
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2578,18 +2578,6 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
       version: jazzy
     status: maintained
-  hector_rviz_overlay_controls:
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
-      version: jazzy
-    status: maintained
-  hector_rviz_overlay_demo:
-    source:
-      type: git
-      url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
-      version: jazzy
-    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

hector_rviz_overlay

# The source is here:
https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro