### PR TITLE
adding python3-requests-toolbelt, python3-imutils-pip and python3-simplekml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6649,6 +6649,10 @@ python3-importlib-resources:
     bionic:
       pip:
         packages: [importlib-resources]
+python3-imutils-pip:
+  '*':
+    pip:
+      packages: [imutils]
 python3-inflection:
   arch: [python-inflection]
   debian: [python3-inflection]
@@ -8780,6 +8784,7 @@ python3-reportlab:
 python3-requests:
   debian: [python3-requests]
   fedora: [python3-requests]
+  arch: [python-requests]
   gentoo: [dev-python/requests]
   nixos: [python3Packages.requests]
   openembedded: [python3-requests@meta-python]
@@ -8800,6 +8805,18 @@ python3-requests-oauthlib:
     '*': ['python%{python3_pkgversion}-requests-oauthlib']
     '7': null
   ubuntu: [python3-requests-oauthlib]
+python3-requests-toolbelt:
+  debian: [python3-requests-toolbelt]
+  ubuntu: [python3-requests-toolbelt]
+  arch: [python-requests-toolbelt]
+  gentoo: [dev-python/requests-toolbelt]
+  openembedded: [python3-requests-toolbelt@meta-python]
+  fedora: [python3-requests-toolbelt]
+  nixos: [python3Packages.requests-toolbelt]
+  opensuse: [python-requests-toolbelt]
+  rhel:
+    '8': ['python%{python3_pkgversion}-requests-toolbelt']
+    '9': ['python%{python3_pkgversion}-requests-toolbelt']
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]
@@ -9207,6 +9224,10 @@ python3-simplejpeg-pip:
   ubuntu:
     pip:
       packages: [simplejpeg]
+python3-simplekml-pip:
+  '*':
+    pip:
+      packages: [simplekml]
 python3-simplejson:
   arch: [python-simplejson]
   debian: [python3-simplejson]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8782,9 +8782,9 @@ python3-reportlab:
     '7': null
   ubuntu: [python3-reportlab]
 python3-requests:
+  arch: [python-requests]
   debian: [python3-requests]
   fedora: [python3-requests]
-  arch: [python-requests]
   gentoo: [dev-python/requests]
   nixos: [python3Packages.requests]
   openembedded: [python3-requests@meta-python]
@@ -8806,17 +8806,17 @@ python3-requests-oauthlib:
     '7': null
   ubuntu: [python3-requests-oauthlib]
 python3-requests-toolbelt:
-  debian: [python3-requests-toolbelt]
-  ubuntu: [python3-requests-toolbelt]
   arch: [python-requests-toolbelt]
-  gentoo: [dev-python/requests-toolbelt]
-  openembedded: [python3-requests-toolbelt@meta-python]
+  debian: [python3-requests-toolbelt]
   fedora: [python3-requests-toolbelt]
+  gentoo: [dev-python/requests-toolbelt]
   nixos: [python3Packages.requests-toolbelt]
+  openembedded: [python3-requests-toolbelt@meta-python]
   opensuse: [python-requests-toolbelt]
   rhel:
     '8': ['python%{python3_pkgversion}-requests-toolbelt']
     '9': ['python%{python3_pkgversion}-requests-toolbelt']
+  ubuntu: [python3-requests-toolbelt]
 python3-retrying:
   arch: [python-retrying]
   debian: [python3-retrying]
@@ -9224,10 +9224,6 @@ python3-simplejpeg-pip:
   ubuntu:
     pip:
       packages: [simplejpeg]
-python3-simplekml-pip:
-  '*':
-    pip:
-      packages: [simplekml]
 python3-simplejson:
   arch: [python-simplejson]
   debian: [python3-simplejson]
@@ -9236,6 +9232,10 @@ python3-simplejson:
   nixos: [python3Packages.simplejson]
   openembedded: [python3-simplejson@meta-python]
   ubuntu: [python3-simplejson]
+python3-simplekml-pip:
+  '*':
+    pip:
+      packages: [simplekml]
 python3-simplification-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

python3-requests-toolbelt

## Package Upstream Source:

[link to source repository](https://github.com/requests/toolbelt)

## Purpose of using this:

Makes working with python3-requests easier, which is already in rosdep.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/bookworm/python3-requests-toolbelt
- Ubuntu: https://packages.ubuntu.com/noble/python3-requests-toolbelt
- Fedora: https://packages.fedoraproject.org/pkgs/python-requests-toolbelt/python3-requests-toolbelt/
- Arch: https://archlinux.org/packages/extra/any/python-requests-toolbelt/
- Gentoo: https://packages.gentoo.org/packages/dev-python/requests-toolbelt
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=python311Packages.requests-toolbelt&from=0&size=50&sort=relevance&type=packages&query=requests-toolbelt
- openSUSE: https://software.opensuse.org/package/python-requests-toolbelt
- rhel: https://rhel.pkgs.org/9/epel-x86_64/python3-requests-toolbelt-0.9.1-16.el9.noarch.rpm.html

## Package name:

python3-imutils-pip

## Package Upstream Source:

[link to source repository](https://github.com/PyImageSearch/imutils)

## Purpose of using this:

Easier manipulation of images (rotation, translation, resizing)

## Links to Distribution Packages

- PyPi: https://pypi.org/project/imutils/

## Package name:

python3-simplekml-pip

## Package Upstream Source:

[link to source repository](https://github.com/eisoldt/simplekml)

## Purpose of using this:

Simplify saving/logging GPS coordinates as KML file

## Links to Distribution Packages

- PyPi: https://pypi.org/project/simplekml/

And I added the Arch Linux package for python3-requests