### PR TITLE
Add PySide6 to rosdep keys

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8544,8 +8544,8 @@ python3-pyside6:
     bullseye:
       pip:
         packages: [PySide6]
-    trixie: [libpyside6-dev]
     sid: [libpyside6-dev]
+    trixie: [libpyside6-dev]
   osx:
     pip:
       packages: [PySide6]
@@ -8569,56 +8569,56 @@ python3-pyside6:
     oracular: [libpyside6-dev]
 python3-pyside6.qtasyncio:
   debian:
-    trixie: [python3-pyside6.qtasyncio]
     sid: [python3-pyside6.qtasyncio]
+    trixie: [python3-pyside6.qtasyncio]
   ubuntu:
     oracular: [python3-pyside6.qtasyncio]
 python3-pyside6.qtcharts:
   debian:
-    trixie: [python3-pyside6.qtcharts]
     sid: [python3-pyside6.qtcharts]
+    trixie: [python3-pyside6.qtcharts]
   ubuntu:
     oracular: [python3-pyside6.qtcharts]
 python3-pyside6.qtconcurrent:
   debian:
-    trixie: [python3-pyside6.qtconcurrent]
     sid: [python3-pyside6.qtconcurrent]
+    trixie: [python3-pyside6.qtconcurrent]
   ubuntu:
     oracular: [python3-pyside6.qtconcurrent]
 python3-pyside6.qtcore:
   debian:
-    trixie: [python3-pyside6.qtcore]
     sid: [python3-pyside6.qtcore]
+    trixie: [python3-pyside6.qtcore]
   ubuntu:
     oracular: [python3-pyside6.qtcore]
 python3-pyside6.qtdatavisualization:
   debian:
-    trixie: [python3-pyside6.qtdatavisualization]
     sid: [python3-pyside6.qtdatavisualization]
+    trixie: [python3-pyside6.qtdatavisualization]
   ubuntu:
     oracular: [python3-pyside6.qtdatavisualization]
 python3-pyside6.qtgui:
   debian:
-    trixie: [python3-pyside6.qtgui]
     sid: [python3-pyside6.qtgui]
+    trixie: [python3-pyside6.qtgui]
   ubuntu:
     oracular: [python3-pyside6.qtgui]
 python3-pyside6.qtqml:
   debian:
-    trixie: [python3-pyside6.qtqml]
     sid: [python3-pyside6.qtqml]
+    trixie: [python3-pyside6.qtqml]
   ubuntu:
     oracular: [python3-pyside6.qtqml]
 python3-pyside6.qttest:
   debian:
-    trixie: [python3-pyside6.qttest]
     sid: [python3-pyside6.qttest]
+    trixie: [python3-pyside6.qttest]
   ubuntu:
     oracular: [python3-pyside6.qttest]
 python3-pyside6.qtwidgets:
   debian:
-    trixie: [python3-pyside6.qtwidgets]
     sid: [python3-pyside6.qtwidgets]
+    trixie: [python3-pyside6.qtwidgets]
   ubuntu:
     oracular: [python3-pyside6.qtwidgets]
 python3-pysnmp:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8536,7 +8536,7 @@ python3-pyside2.qtwidgets:
     '*': [python3-pyside2]
     '8': null
   ubuntu: [python3-pyside2.qtwidgets]
-python3-pyside6-pip:
+python3-pyside6:
   debian:
     bookworm:
       pip:
@@ -8544,6 +8544,7 @@ python3-pyside6-pip:
     bullseye:
       pip:
         packages: [PySide6]
+    sid: [libpyside6-dev]
   osx:
     pip:
       packages: [PySide6]
@@ -8564,6 +8565,52 @@ python3-pyside6-pip:
     noble:
       pip:
         packages: [PySide6]
+    oracular: [libpyside6-dev]
+python3-pyside6.qtasyncio:
+  debian:
+    sid: [python3-pyside6.qtasyncio]
+  ubuntu:
+    oracular: [python3-pyside6.qtasyncio]
+python3-pyside6.qtcharts:
+  debian:
+    sid: [python3-pyside6.qtcharts]
+  ubuntu:
+    oracular: [python3-pyside6.qtcharts]
+python3-pyside6.qtconcurrent:
+  debian:
+    sid: [python3-pyside6.qtconcurrent]
+  ubuntu:
+    oracular: [python3-pyside6.qtconcurrent]
+python3-pyside6.qtcore:
+  debian:
+    sid: [python3-pyside6.qtcore]
+  ubuntu:
+    oracular: [python3-pyside6.qtcore]
+python3-pyside6.qtdatavisualization:
+  debian:
+    sid: [python3-pyside6.qtdatavisualization]
+  ubuntu:
+    oracular: [python3-pyside6.qtdatavisualization]
+python3-pyside6.qtgui:
+  debian:
+    sid: [python3-pyside6.qtgui]
+  ubuntu:
+    oracular: [python3-pyside6.qtgui]
+python3-pyside6.qtqml:
+  debian:
+    sid: [python3-pyside6.qtqml]
+  ubuntu:
+    oracular: [python3-pyside6.qtqml]
+python3-pyside6.qttest:
+  debian:
+    sid: [python3-pyside6.qttest]
+  ubuntu:
+    oracular: [python3-pyside6.qttest]
+python3-pyside6.qtwidgets:
+  debian:
+    sid: [python3-pyside6.qtwidgets]
+  ubuntu:
+    oracular: [python3-pyside6.qtwidgets]
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8538,10 +8538,10 @@ python3-pyside2.qtwidgets:
   ubuntu: [python3-pyside2.qtwidgets]
 python3-pyside6-pip:
   debian:
-    bullseye:
+    bookworm:
       pip:
         packages: [PySide6]
-    bookworm:
+    bullseye:
       pip:
         packages: [PySide6]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8539,7 +8539,7 @@ python3-pyside2.qtwidgets:
 python3-pyside6-pip:
   '*':
     pip:
-      packages: ["PySide6"]
+      packages: [PySide6]
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8545,7 +8545,9 @@ python3-pyside6:
     bullseye:
       pip:
         packages: [PySide6]
-  fedora: [python3-pyside6]
+  fedora:
+    '*': [python3-pyside6]
+    '39': null
   osx:
     pip:
       packages: [PySide6]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8538,25 +8538,23 @@ python3-pyside2.qtwidgets:
   ubuntu: [python3-pyside2.qtwidgets]
 python3-pyside6:
   debian:
+    '*': [libpyside6-dev]
     bookworm:
       pip:
         packages: [PySide6]
     bullseye:
       pip:
         packages: [PySide6]
-    sid: [libpyside6-dev]
-    trixie: [libpyside6-dev]
+  fedora: [python3-pyside6]
   osx:
     pip:
       packages: [PySide6]
   rhel:
-    '8':
-      pip:
-        packages: [PySide6]
-    '9':
+    '*':
       pip:
         packages: [PySide6]
   ubuntu:
+    '*': [libpyside6-dev]
     focal:
       pip:
         packages: [PySide6]
@@ -8566,61 +8564,96 @@ python3-pyside6:
     noble:
       pip:
         packages: [PySide6]
-    oracular: [libpyside6-dev]
 python3-pyside6.qtasyncio:
   debian:
-    sid: [python3-pyside6.qtasyncio]
-    trixie: [python3-pyside6.qtasyncio]
+    '*': [python3-pyside6.qtasyncio]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtasyncio]
+    '*': [python3-pyside6.qtasyncio]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtcharts:
   debian:
-    sid: [python3-pyside6.qtcharts]
-    trixie: [python3-pyside6.qtcharts]
+    '*': [python3-pyside6.qtcharts]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtcharts]
+    '*': [python3-pyside6.qtcharts]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtconcurrent:
   debian:
-    sid: [python3-pyside6.qtconcurrent]
-    trixie: [python3-pyside6.qtconcurrent]
+    '*': [python3-pyside6.qtconcurrent]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtconcurrent]
+    '*': [python3-pyside6.qtconcurrent]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtcore:
   debian:
-    sid: [python3-pyside6.qtcore]
-    trixie: [python3-pyside6.qtcore]
+    '*': [python3-pyside6.qtcore]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtcore]
+    '*': [python3-pyside6.qtcore]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtdatavisualization:
   debian:
-    sid: [python3-pyside6.qtdatavisualization]
-    trixie: [python3-pyside6.qtdatavisualization]
+    '*': [python3-pyside6.qtdatavisualization]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtdatavisualization]
+    '*': [python3-pyside6.qtdatavisualization]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtgui:
   debian:
-    sid: [python3-pyside6.qtgui]
-    trixie: [python3-pyside6.qtgui]
+    '*': [python3-pyside6.qtgui]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtgui]
+    '*': [python3-pyside6.qtgui]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtqml:
   debian:
-    sid: [python3-pyside6.qtqml]
-    trixie: [python3-pyside6.qtqml]
+    '*': [python3-pyside6.qtqml]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtqml]
+    '*': [python3-pyside6.qtqml]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qttest:
   debian:
-    sid: [python3-pyside6.qttest]
-    trixie: [python3-pyside6.qttest]
+    '*': [python3-pyside6.qttest]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qttest]
+    '*': [python3-pyside6.qttest]
+    noble: null
+    jammy: null
+    focal: null
 python3-pyside6.qtwidgets:
   debian:
-    sid: [python3-pyside6.qtwidgets]
-    trixie: [python3-pyside6.qtwidgets]
+    '*': [python3-pyside6.qtwidgets]
+    bookworm: null
+    bullseye: null
   ubuntu:
-    oracular: [python3-pyside6.qtwidgets]
+    '*': [python3-pyside6.qtwidgets]
+    noble: null
+    jammy: null
+    focal: null
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8573,6 +8573,9 @@ python3-pyside6.qtasyncio:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtasyncio]
+    focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtcharts:
   debian:
     '*': [python3-pyside6.qtcharts]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8537,9 +8537,33 @@ python3-pyside2.qtwidgets:
     '8': null
   ubuntu: [python3-pyside2.qtwidgets]
 python3-pyside6-pip:
-  '*':
+  debian:
+    bullseye:
+      pip:
+        packages: [PySide6]
+    bookworm:
+      pip:
+        packages: [PySide6]
+  osx:
     pip:
       packages: [PySide6]
+  rhel:
+    '8':
+      pip:
+        packages: [PySide6]
+    '9':
+      pip:
+        packages: [PySide6]
+  ubuntu:
+    focal:
+      pip:
+        packages: [PySide6]
+    jammy:
+      pip:
+        packages: [PySide6]
+    noble:
+      pip:
+        packages: [PySide6]
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8573,9 +8573,6 @@ python3-pyside6.qtasyncio:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtasyncio]
-    noble: null
-    jammy: null
-    focal: null
 python3-pyside6.qtcharts:
   debian:
     '*': [python3-pyside6.qtcharts]
@@ -8583,9 +8580,9 @@ python3-pyside6.qtcharts:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtcharts]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtconcurrent:
   debian:
     '*': [python3-pyside6.qtconcurrent]
@@ -8593,9 +8590,9 @@ python3-pyside6.qtconcurrent:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtconcurrent]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtcore:
   debian:
     '*': [python3-pyside6.qtcore]
@@ -8603,9 +8600,9 @@ python3-pyside6.qtcore:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtcore]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtdatavisualization:
   debian:
     '*': [python3-pyside6.qtdatavisualization]
@@ -8613,9 +8610,9 @@ python3-pyside6.qtdatavisualization:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtdatavisualization]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtgui:
   debian:
     '*': [python3-pyside6.qtgui]
@@ -8623,9 +8620,9 @@ python3-pyside6.qtgui:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtgui]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtqml:
   debian:
     '*': [python3-pyside6.qtqml]
@@ -8633,9 +8630,9 @@ python3-pyside6.qtqml:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtqml]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qttest:
   debian:
     '*': [python3-pyside6.qttest]
@@ -8643,9 +8640,9 @@ python3-pyside6.qttest:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qttest]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pyside6.qtwidgets:
   debian:
     '*': [python3-pyside6.qtwidgets]
@@ -8653,9 +8650,9 @@ python3-pyside6.qtwidgets:
     bullseye: null
   ubuntu:
     '*': [python3-pyside6.qtwidgets]
-    noble: null
-    jammy: null
     focal: null
+    jammy: null
+    noble: null
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8544,6 +8544,7 @@ python3-pyside6:
     bullseye:
       pip:
         packages: [PySide6]
+    trixie: [libpyside6-dev]
     sid: [libpyside6-dev]
   osx:
     pip:
@@ -8568,46 +8569,55 @@ python3-pyside6:
     oracular: [libpyside6-dev]
 python3-pyside6.qtasyncio:
   debian:
+    trixie: [python3-pyside6.qtasyncio]
     sid: [python3-pyside6.qtasyncio]
   ubuntu:
     oracular: [python3-pyside6.qtasyncio]
 python3-pyside6.qtcharts:
   debian:
+    trixie: [python3-pyside6.qtcharts]
     sid: [python3-pyside6.qtcharts]
   ubuntu:
     oracular: [python3-pyside6.qtcharts]
 python3-pyside6.qtconcurrent:
   debian:
+    trixie: [python3-pyside6.qtconcurrent]
     sid: [python3-pyside6.qtconcurrent]
   ubuntu:
     oracular: [python3-pyside6.qtconcurrent]
 python3-pyside6.qtcore:
   debian:
+    trixie: [python3-pyside6.qtcore]
     sid: [python3-pyside6.qtcore]
   ubuntu:
     oracular: [python3-pyside6.qtcore]
 python3-pyside6.qtdatavisualization:
   debian:
+    trixie: [python3-pyside6.qtdatavisualization]
     sid: [python3-pyside6.qtdatavisualization]
   ubuntu:
     oracular: [python3-pyside6.qtdatavisualization]
 python3-pyside6.qtgui:
   debian:
+    trixie: [python3-pyside6.qtgui]
     sid: [python3-pyside6.qtgui]
   ubuntu:
     oracular: [python3-pyside6.qtgui]
 python3-pyside6.qtqml:
   debian:
+    trixie: [python3-pyside6.qtqml]
     sid: [python3-pyside6.qtqml]
   ubuntu:
     oracular: [python3-pyside6.qtqml]
 python3-pyside6.qttest:
   debian:
+    trixie: [python3-pyside6.qttest]
     sid: [python3-pyside6.qttest]
   ubuntu:
     oracular: [python3-pyside6.qttest]
 python3-pyside6.qtwidgets:
   debian:
+    trixie: [python3-pyside6.qtwidgets]
     sid: [python3-pyside6.qtwidgets]
   ubuntu:
     oracular: [python3-pyside6.qtwidgets]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8536,6 +8536,10 @@ python3-pyside2.qtwidgets:
     '*': [python3-pyside2]
     '8': null
   ubuntu: [python3-pyside2.qtwidgets]
+python3-pyside6-pip:
+  '*':
+    pip:
+      packages: ["PySide6"]
 python3-pysnmp:
   debian: [python3-pysnmp4]
   fedora: [python3-pysnmp]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

PySide6

## Package Upstream Source:

https://github.com/qtproject/pyside-pyside-setup

## Purpose of using this:

This package is a Python wrapper for Qt 6. It allows one to create Qt applications using Python.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PyPi: https://pypi.org/project/PySide6/
