### PR TITLE
gz_fuel_tools_vendor: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2144,7 +2144,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_fuel_tools_vendor` to `0.1.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## gz_fuel_tools_vendor

```
* Bump version to 9.1.0 (#3 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/3>)
* Fix name of the underlying package so it matches name from package.xml (#2 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/2>)
* Contributors: Addisu Z. Taddese
```
