### PR TITLE
mrpt_navigation: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3910,11 +3910,12 @@ repositories:
       - mrpt_pointcloud_pipeline
       - mrpt_rawlog
       - mrpt_reactivenav2d
+      - mrpt_tps_astar_planner
       - mrpt_tutorials
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.1.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## mrpt_map_server

```
* docs: typos and clarifications
* map server: simplify publication policy. Using transient local only and never republishing them
* Merge branch 'ros2' into wip/port-tps-astar
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav_interfaces

```
* Add two new service definitions: MakePlanTo, MakePlanFromTo
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

```
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pf_localization

```
* Fix GNSS name typo
* Merge branch 'ros2' into wip/port-tps-astar
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

```
* Merge branch 'ros2' into wip/port-tps-astar
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_rawlog

```
* BUGFIX: Data stream ignored for sensors where fixed_sensor_pose was defined.
* Fix GNSS name typo
* Merge branch 'ros2' into wip/port-tps-astar
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* Hide example output into <details>
* Merge branch 'ros2' into wip/port-tps-astar
* rnav node now detects live changes in the parameter 'pure_pursuit_mode'
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tps_astar_planner

```
* Merge pull request #147 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/147> from r-aguilera/ros2
  mrpt_tps_astar_planner_node tf data availability
* added max duration to wait for tf data
* Merge pull request #146 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/146> from r-aguilera/ros2
  parameterized astar plan waypoints fields
* Merge pull request #145 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/145> from mrpt-ros-pkg/ros2_astar
  add WaypointSequence missing header
* Implement two services for making navigation plans; code clean up; delete "replan" topic
* FIX: transform point cloud observations
* add frame_id params
* reset planner obstacles between path plans
* Add param to create subscribers with map-like QoS
* Enable multiple obstacle sources (grids and points)
* delete old ros1 files
* Merge pull request #144 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/144> from mrpt-ros-pkg/wip/port-tps-astar
  Port TPS A* planner to ROS2
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera, SRai22
```

## mrpt_tutorials

```
* add basic astar launch demo
* Merge branch 'ros2' into wip/port-tps-astar
* Merge branch 'ros2' into wip/port-tps-astar
* Contributors: Jose Luis Blanco-Claraco
```
