### PR TITLE
aerostack2: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -104,29 +104,32 @@ repositories:
       - as2_behavior
       - as2_behavior_tree
       - as2_behaviors_motion
+      - as2_behaviors_path_planning
       - as2_behaviors_perception
       - as2_behaviors_platform
       - as2_behaviors_trajectory_generation
       - as2_cli
       - as2_core
+      - as2_external_object_to_tf
       - as2_gazebo_assets
-      - as2_gazebo_classic_assets
+      - as2_geozones
       - as2_keyboard_teleoperation
+      - as2_map_server
       - as2_motion_controller
       - as2_motion_reference_handlers
       - as2_msgs
-      - as2_platform_crazyflie
-      - as2_platform_dji_osdk
       - as2_platform_gazebo
-      - as2_platform_tello
+      - as2_platform_multirotor_simulator
       - as2_python_api
       - as2_realsense_interface
+      - as2_rviz_plugins
       - as2_state_estimator
       - as2_usb_camera_interface
+      - as2_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.9-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.1.0-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.9-1`

## aerostack2

```
* [aerostack2] Update package dependencies and CI with new aerostack2 packages
* [aerostack2] many platforms extracted from main repo
* [aerostack2] Generate all aerostack2 doxygen together
* [as2_gazebo_classic] EOL - removing from aerostack2
* [as2_platform_gazebo] Use sim time true by default in gazebo platform
* [as2_platform_gazebo] Migrate to ament_lint_auto and use as2_core param utils
* [as2_platform_multirotor_simulator] Enable control using odometry as state instead of ground truth
* [as2_platform_multirotor_simulator] Update platform to use world.yaml and rename some params
* [as2_platform_multirotor_simulator] New launch utils to declare parameters from a config file, update launchers at multirotor simulation
* [as2_platform_multirotor_simulator] Add basic fly gtest mock
* [as2_platform_multirotor_simulator] Add ament_cmake_gtest to package.xml
* [as2_platform_multirotor_simulator] Add as2_multirotor_simulator package
* [as2_behavior_tree] Use ament_lint
* [as2_behavior] ament format, passing all tests
* [as2_behaviors_motion] Not overwritting behavior config file if user config file is empty
* [as2_behaviors_motion] Update to ament lint auto and use as2_core launch param utils
* [as2_behaviors_motion] Fix warning about service client access
* [as2_behaviors_path_planning] New behavior for navigation with basic a_star plugin working
* [as2_behaviors_perception] as2::sensors::Camera change to load parameters from ROS 2 parameters
* [as2_behaviors_perception] New launch utils to declare parameters from a config file
* [as2_behaviors_perception] migrate deprecated api from cv::aruco::drawAxis to cv::drawFrameAxes
* [as2_behaviors_perception] Update launchers to Flake8
* [as2_behaviors_perception] List launch arguments from parameter config file
* [as2_behaviors_platform] as2_behaviors_platform passing ament tests
* [as2_behaviors_platform] Fix warning about service client access
* [as2_cli] improvement in as2_list and as2_test
* [as2_core] Extended params utils with new capabilities
* [as2_core] Make SensorData public to access getData and getTopicName
* [as2_core] Don't call ownSendCommand until new ref arrives after control mode change
* [as2_core] AS2 Sensors Camera read encoding from ROS param
* [as2_core] as2::sensors::Camera change to load parameters from ROS 2 parameters
* [as2_core] New launch utils to declare parameters from a config file
* [as2_core] Add sync methods call in platform mocks
* [as2_core] Add mock library. Add a mock for aerial platform
* [as2_core] Refactor sensors and add gimbal sensor
* [as2_core] Add launch params utils
* [as2_core] Add GroundTruth to handler ground truth publish
* [as2_core] Change as2_aerial_platform methods visibility
* [as2_core] adding as2_core tests
* [as2_realsense_interface] Fix timestamp
* [as2_realsense_interface] Update real sense camera sensor constructor and methods
* [as2_realsense_interface] node passes ament, pep257 and flake8 tests
* [as2_usb_camera_interface] Add camera calibration file param
* [as2_usb_camera_interface] as2::sensors::Camera change to load parameters from ROS 2 parameters
* [as2_usb_camera_interface] as2 usb interface should pass ament tests format
* [as2_map_server] New map server with 2d mapping plugin
* [as2_motion_controller] update controller launcher with launch utils and particular launchers for each plugin
* [as2_motion_controller] Update launch using as2_core launch params utils
* [as2_motion_controller] Fix library exports and add simple gtest
* [as2_motion_controller_manager] Publish speed limits when bypassing and control mode is Position
* [as2_motion_controller] Use ament_lint_auto
* [as2_motion_reference_handlers] Ament common tests compliance
* [as2_msgs] New action for path planning behavior
* [as2_msgs] move interfaces from as2_utilities to as2_msgs package
* [as2_msgs] Add lint tests
* [as2_python_api] Deactivating drone interface tests
* [as2_python_api] Return bool service response when using ServiceBoolHandler (arm, offboard and manual)
* [as2_python_api] Fix using spin rate as a rate and not as an time interval
* [as2_python_api] Added class argument spin rate
* [as2_python_api] New navigate to behavior and module
* [as2_python_api] Behavior Status updated after call methods correctly
* [as2_python_api] ament lint auto compliance
* [as2_python_api] Add goal accepted/rejected return when call behavior method
* [as2_python_api] Continue using Pydantic V1
* [as2_gazebo_assets] Improve crazyflie model: controller tuned and added IMU
* [as2_gazebo_assets] Added crazyflie viz MODEL
* [as2_gazebo_assets] Updated Crazyflie Gazebo model
* [as2_gazebo_assets] Add optical frames to cameras
* [as2_gazebo_assets] Fix model templates for sensor naming
* [as2_gazebo_assets] Support yaml files for gazebo world configuration
* [as2_gazebo_assets] Fix malformed bridges
* [as2_gazebo_assets] ament lint auto compliance
* [as2_gazebo_assets] Continue using Pydantic V1
* [as2_gazebo_assets] environment variable IGN_GAZEBO_RESOURCE_PATH changed to GZ_SIM_RESOURCE_PATH
* [as2_gazebo_assets] Add actuators bridge
* [as2_gazebo_assets] Add Gazebo Harmonic launcher by env variable GZ_VERSION
* [as2_gazebo_assets] Add actuators bridge and disable velocity controller with a param
* [as2_gazebo_assets] Fix gimbal_bridge on Gazebo Harmonic
* [as2_gazebo_assets] Gz harmonic support
* [as2_gazebo_assets] Sensor model name and sensor link name were swapped in camera bridges
* [as2_state_estimator] map frame generates at the drone initial position
* [as2_state_estimator] Change gazebo tf parameter name
* [as2_state_estimator] update state estimator with new launch utils and new launchers for each plugin
* [as2_state_estimator] Code refactor, adding individually CMakeLists.txt and config for each plugin
* [as2_state_estimator] Migrate to ament lint
* [as2_state_estimator] mocap_pose plugin changed to work with mocap4ros2
* [as2_alphanumeric_viewer] Battery status problem fixed
* [as2_alphanumeric_viewer] alphanumeric viewer passing every ament test
* [as2_keyboard_teleoperation] extend default behaviors from argument
* [as2_keyboard_teleoperation] ability to load modules into interface to control behaviors
* [as2_keyboard_teleoperation] drone_frequency param added
* [as2_keyboard_teleoperation] ament lint compliance
* [as2_keyboard_teleoperation] add ros 2 parameters with config file using as2 launch utils
* [as2_keyboard_teleoperation] launcher improved to load namespace with different dividers, config file and speed behavior
* [as2_rviz_plugins] add as2_rviz_plugins package
* [as2_visualization] add as2_visualization package
* [as2_external_object_tf_tf] fix mocap source data
* [as2_external_object_to_tf] default config file within the node, added description
* [as2_external_object_to_tf] removed interface generation dependencies from external object to tf
* [as2_external_object_to_tf] as2_utilities package created, external object to tf node added to aerostack2
* [as2_geozones] Create a utilities folder, as2_geozones package added
* Contributors: pariaspe, Rafael Perez-Segui, Javilinos, Miguel Fernandez-Cortizas, keikei014, Sakura286
```

## as2_alphanumeric_viewer

```
* [as2_alphanumeric_viewer] Battery status problem fixed
* [as2_alphanumeric_viewer] alphanumeric viewer passing every ament test
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_behavior

```
* [as2_behavior] ament format, passing all tests
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_behavior_tree

```
* [as2_behavior_tree] Use ament_lint
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_behaviors_motion

```
* [as2_behaviors_motion] Not overwritting behavior config file if user config file is empty
* [as2_behaviors_motion] Update to ament lint auto and use as2_core launch param utils
* [as2_behaviors_motion] Fix warning about service client access
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_behaviors_path_planning

```
* [as2_behaviors_path_planning] New behavior for navigation with basic a_star plugin working
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_behaviors_perception

```
* [as2_behaviors_perception] as2::sensors::Camera change to load parameters from ROS 2 parameters
* [as2_behaviors_perception] New launch utils to declare parameters from a config file
* [as2_behaviors_perception] migrate deprecated api from cv::aruco::drawAxis to cv::drawFrameAxes
* [as2_behaviors_perception] Update launchers to Flake8
* [as2_behaviors_perception] List launch arguments from parameter config file
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, Sakura286, pariaspe
```

## as2_behaviors_platform

```
* [as2_behaviors_platform] as2_behaviors_platform passing ament tests
* [as2_behaviors_platform] Fix warning about service client access
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_behaviors_trajectory_generation

```
* [as2_behaviors_trajectory_generation ] as2_behaviors_trajectory_generation pass ament tests
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_cli

```
* [as2_cli] improvement in as2_list and as2_test
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_core

```
* [as2_core] Extended params utils with new capabilities
* [as2_core] Make SensorData public to access getData and getTopicName
* [as2_core] Don't call ownSendCommand until new ref arrives after control mode change
* [as2_core] AS2 Sensors Camera read encoding from ROS param
* [as2_core] as2::sensors::Camera change to load parameters from ROS 2 parameters
* [as2_core] New launch utils to declare parameters from a config file
* [as2_core] Add sync methods call in platform mocks
* [as2_core] Add mock library. Add a mock for aerial platform
* [as2_core] Refactor sensors and add gimbal sensor
* [as2_core] Add launch params utils
* [as2_core] Add GroundTruth to handler ground truth publish
* [as2_core] Change as2_aerial_platform methods visibility
* [as2_core] Fix adding as2_core tests
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_external_object_to_tf

```
* [as2_external_object_to_tf] quick fix flake8
* [as2_external_object_tf_tf] fix mocap source data
* [as2_external_object_to_tf] default config file within the node, added description
* [as2_external_object_to_tf] move interfaces from utilities to as2 interface packages
* [as2_external_object_to_tf] removed interface generation dependencies from external object to tf
* [as2_external_object_to_tf] as2_utilities package created, external object to tf node added to aerostack2
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Pérez, pariaspe
```

## as2_gazebo_assets

```
* [as2_gazebo_assets] Improve crazyflie model: controller tuned and added IMU
* [as2_gazebo_assets] Added crazyflie viz MODEL
* [as2_gazebo_assets] Updated Crazyflie Gazebo model
* [as2_gazebo_assets] Add optical frames to cameras
* [as2_gazebo_assets] Fix for flake8.
* [as2_gazebo_assets] Fix model templates for sensor naming
* [as2_gazebo_assets] Support yaml files for gazebo world configuration
* [as2_gazebo_assets] Fix malformed bridges
* [as2_gazebo_assets] ament lint auto compliance
* [as2_gazebo_assets] Continue using Pydantic V1
* [as2_gazebo_assets] environment variable IGN_GAZEBO_RESOURCE_PATH changed to GZ_SIM_RESOURCE_PATH
* [as2_gazebo_assets] Add actuators bridge
* [as2_gazebo_assets] Add Gazebo Harmonic launcher by env variable GZ_VERSION
* [as2_gazebo_assets] Add actuators bridge and disable velocity controller with a param
* [as2_gazebo_assets] Fix gimbal_bridge on Gazebo Harmonic
* [as2_gazebo_assets] Gz harmonic support
* [as2_gazebo_assets] Sensor model name and sensor link name were swapped in camera bridges
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui, keikei014, pariaspe
```

## as2_geozones

```
* [as2_geozones] as2 geozones intefaces moved to Aerostack2 interfaces package
* [as2_geozones] Create a utilities package, as2_geozones added
* Contributors: Javilinos, Miguel Fernandez-Cortizas
```

## as2_keyboard_teleoperation

```
* [as2_keyboard_teleoperation] extend default behaviors from argument
* [as2_keyboard_teleoperation] Rename tests folder name
* [as2_keyboard_teleoperation] ability to load modules into interface to control behaviors
* [as2_keyboard_teleoperation] drone_frequency param added
* [as2_keyboard_teleoperation] ament lint compliance
* [as2_keyboard_teleoperation] add ros 2 parameters with config file using as2 launch utils
* [as2_keyboard_teleoperation] as2 keyboard teleoperations test compliance
* [as2_keyboard_teleoperation] launcher improved to load namespace with different dividers, config file and speed behavior
* [as2_keyboard_teleoperation] Update launchers to Flake8
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_map_server

```
* [as2_map_server] New map server with 2d mapping plugin
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_motion_controller

```
* [as2_motion_controller] Update motion_controller_default.yaml typo
* [as2_motion_controller] update controller launcher with launch utils and particular launchers for each plugin
* [as2_motion_controller] Update launch using as2_core launch params utils
* [as2_motion_controller] Fix library exports and add simple gtest
* [as2_motion_controller] Update launchers to Flake8
* [as2_motion_controller_manager] Publish speed limits when bypassing and control mode is Position
* [as2_motion_controller] Use ament_lint_auto
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_motion_reference_handlers

```
* [as2_motion_reference_handlers] Ament common tests compliance
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_msgs

```
* [as2_msgs] New action for path planning behavior
* [as2_msgs] move interfaces from utilities to as2 interface packages
* [as2_msgs] Add lint tests
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_platform_gazebo

```
* [as2_platform_gazebo] Use sim time true by default in gazebo platform
* [as2_platform_gazebo] Migrate to ament_lint_auto and use as2_core param utils
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_platform_multirotor_simulator

```
* [as2_platform_multirotor_simulator] Enable control using odometry as state instead of ground truth
* [as2_platform_multirotor_simulator] Update platform to use world.yaml and rename some params
* [as2_platform_multirotor_simulator] New launch utils to declare parameters from a config file, update launchers at multirotor simulation
* [as2_platform_multirotor_simulator] Change gtest to use as2 core mock
* [as2_platform_multirotor_simulator] Add basic fly gtest
* [as2_platform_multirotor_simulator] Add ament_cmake_gtest to package.xml
* [as2_platform_multirotor_simulator] Remove LICENCE and CONTRIBUTING to use the ones in the aerostack2
* [as2_platform_multirotor_simulator] Update launchers to Flake8
* [as2_multirotor_simulator] Add as2_multirotor_simulator package
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, keikei014
```

## as2_python_api

```
* [as2_python_api] Deactivating drone interface tests
* [as2_python_api] Rename tests folder name
* [as2_python_api] Ament_lint compliance
* [as2_python_api] Return bool service response when using ServiceBoolHandler (arm, offboard and manual)
* [as2_python_api] Fix using spin rate as a rate and not as an time interval
* [as2_python_api] Added class argument spin rate
* [as2_python_api] New navigate to behavior and module
* [as2_python_api] Behavior Status updated after call methods correctly
* [as2_python_api] ament lint auto compliance
* [as2_python_api] Add goal accepted/rejected return when call behavior method
* [as2_python_api] Continue using Pydantic V1
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_realsense_interface

```
* [as2_realsense_interface] Fix timestamp
* [as2_realsense_interface] Update real sense camera sensor constructor and methods
* [as2_realsense_interface] node passes ament, pep257 and flake8 tests
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_rviz_plugins

```
* [as2_user_interfaces] add as2_rviz_plugins package
* Contributors: Javilinos, Rafael Pérez, pariaspe
```

## as2_state_estimator

```
* [as2_state_estimator] map frame generates at the drone initial position
* [as2_state_estimator] Change gazebo tf parameter name
* [as2_state_estimator] update state estimator with new launch utils and new launchers for each plugin
* [as2_state_estimator] Code refactor, adding individually CMakeLists.txt and config for each plugin. Update launch using as2_core launch params utils
* [as2_state_estimator] Migrate to ament lint
* [as2_state_estimator] mocap_pose plugin changed to work with mocap4ros2
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```

## as2_usb_camera_interface

```
* [as2_usb_camera_interface] Add camera calibration file param
* [as2_realsense_interface] Fix timestamp
* [as2_usb_camera_interface] as2::sensors::Camera change to load parameters from ROS 2 parameters
* [as2_usb_camera_interface] as2 usb interface should pass ament tests format
* Contributors: Javilinos, Miguel Fernandez-Cortizas, Rafael Perez-Segui
```

## as2_visualization

```
* [as2_visualization] Rename as2_visulization tests folder
* [as2_visualization] add as2_visualization package
* Contributors: Javilinos, Rafael Pérez, pariaspe
```
