### PR TITLE
omni_base_robot: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5444,7 +5444,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.0.19-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.2.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.19-1`

## omni_base_bringup

```
* start mobile_base_controller only for real robot
* Contributors: antoniobrandi
```

## omni_base_controller_configuration

```
* Use unlesscondition
* start mobile_base_controller only for real robot
* Contributors: David ter Kuile, antoniobrandi
```

## omni_base_description

- No changes

## omni_base_robot

- No changes
