### PR TITLE
pal_robotiq_gripper: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5725,7 +5725,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_robotiq_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_robotiq_gripper` to `2.2.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_robotiq_gripper.git
- release repository: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## pal_robotiq_controller_configuration

```
* Use controller_type from the controllers config
* Contributors: Noel Jimenez
```

## pal_robotiq_description

- No changes

## pal_robotiq_gripper

- No changes
