### PR TITLE
add as2_platforms to humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -578,6 +578,72 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: developed
+  as2_platform_crazyflie:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/as2_platform_crazyflie.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/as2_platform_crazyflie.git
+      version: main
+    status: developed
+  as2_platform_dji_osdk:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/as2_platform_dji_osdk.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/as2_platform_dji_osdk.git
+      version: main
+    status: developed
+  as2_platform_dji_psdk:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/as2_platform_dji_psdk.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/as2_platform_dji_psdk.git
+      version: main
+    status: developed
+  as2_platform_mavlink:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/as2_platform_mavlink.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/as2_platform_mavlink.git
+      version: main
+    status: developed
+  as2_platform_pixhawk:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/as2_platform_pixhawk.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/as2_platform_pixhawk.git
+      version: main
+    status: developed
+  as2_platform_tello:
+    doc:
+      type: git
+      url: https://github.com/aerostack2/as2_platform_tello.git
+      version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/aerostack2/as2_platform_tello.git
+      version: main
+    status: developed
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

as2_platform_crazyflie
as2_platform_dji_osdk
as2_platform_dji_psdk
as2_platform_mavlink
as2_platform_pixhawk
as2_platform_tello

# The source is here:

https://github.com/aerostack2/as2_platform_crazyflie.git
https://github.com/aerostack2/as2_platform_dji_osdk.git
https://github.com/aerostack2/as2_platform_dji_psdk.git
https://github.com/aerostack2/as2_platform_mavlink.git
https://github.com/aerostack2/as2_platform_pixhawk.git
https://github.com/aerostack2/as2_platform_tello.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
