### PR TITLE
mapviz: 2.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3089,7 +3089,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.2.2-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.2-1`

## mapviz

```
* Configurable qos (#818 <https://github.com/swri-robotics/mapviz/issues/818>)
  * Adding configurable QoS to UI
  * Changing lookup duration to reduce lag
  ---------
  Co-authored-by: Robert Brothers <mailto:33141599+rjb0026@users.noreply.github.com>
* Changing QoS settings on TF to reduce lag (#815 <https://github.com/swri-robotics/mapviz/issues/815>)
* Do not attempt to transform point if a target frame is not specified (#793 <https://github.com/swri-robotics/mapviz/issues/793>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Configurable qos (#818 <https://github.com/swri-robotics/mapviz/issues/818>)
  * Adding configurable QoS to UI
  * Changing lookup duration to reduce lag
  ---------
  Co-authored-by: Robert Brothers <mailto:33141599+rjb0026@users.noreply.github.com>
* Improve Font Selection Error Handling (#794 <https://github.com/swri-robotics/mapviz/issues/794>)
* Contributors: David Anthony
```

## multires_image

- No changes

## tile_map

```
* Fix unitialized bing source (#800 <https://github.com/swri-robotics/mapviz/issues/800>)
  Co-authored-by: Alex Youngs <mailto:alexyoungs@hatchbed.com>
* Contributors: agyoungs
```
