### PR TITLE
mapviz: 2.4.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3089,7 +3089,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.2.2-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.1-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.2-1`

## mapviz

```
* Code cleanup (#820 <https://github.com/swri-robotics/mapviz/issues/820>)
  * Applying code changes that should have gone in previous release
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Code cleanup (#820 <https://github.com/swri-robotics/mapviz/issues/820>)
  * Switching to plus sign for concatenation
  * Applying code changes that should have gone in previous release
* Contributors: David Anthony
```

## multires_image

- No changes

## tile_map

- No changes
