### PR TITLE
marti_messages: 1.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3447,7 +3447,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.5.2-3
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.6.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/ros2-gbp/marti_messages-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.2-3`

## marti_can_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_common_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_dbw_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_introspection_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_nav_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_perception_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_sensor_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_status_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```

## marti_visualization_msgs

```
* Updating CI for Rolling and Jazzy. No functional changes.
* Contributors: David Anthony
```
