### PR TITLE
Removing Mapviz

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3359,27 +3359,6 @@ repositories:
       url: https://github.com/Neargye/magic_enum.git
       version: master
     status: maintained
-  mapviz:
-    doc:
-      type: git
-      url: https://github.com/swri-robotics/mapviz.git
-      version: ros2-devel
-    release:
-      packages:
-      - mapviz
-      - mapviz_interfaces
-      - mapviz_plugins
-      - multires_image
-      - tile_map
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.1-1
-    source:
-      type: git
-      url: https://github.com/swri-robotics/mapviz.git
-      version: ros2-devel
-    status: developed
   marine_msgs:
     doc:
       type: git


### PR DESCRIPTION
I'm removing Mapviz from Jazzy until we release some of its dependencies so that I don't get spammed about failing builds from the buildfarm.
