### PR TITLE
mrpt_sensors: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3774,7 +3774,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.2.2-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.1-1`

## mrpt_generic_sensor

- No changes

## mrpt_sensor_bumblebee_stereo

- No changes

## mrpt_sensor_gnss_nmea

```
* Merge pull request #10 <https://github.com/mrpt-ros-pkg/mrpt_sensors/issues/10> from mrpt-ros-pkg/use-gnss-base-topic-name
  Use gnss base topic name
* Reuse base class publish topic name
  add missing getter
* Merge pull request #8 <https://github.com/mrpt-ros-pkg/mrpt_sensors/issues/8> from mrpt-ros-pkg/use-gnss-base-topic-name
  Reuse base class publish topic name
* Reuse base class publish topic name
* Merge pull request #6 <https://github.com/mrpt-ros-pkg/mrpt_sensors/issues/6> from r-aguilera/ros2
  fix uninitialized publishers in NMEA msg publishers
* fix uninitialized publishers
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera
```

## mrpt_sensor_gnss_novatel

- No changes

## mrpt_sensor_imu_taobotics

- No changes

## mrpt_sensorlib

```
* Merge pull request #10 <https://github.com/mrpt-ros-pkg/mrpt_sensors/issues/10> from mrpt-ros-pkg/use-gnss-base-topic-name
  Use gnss base topic name
* Reuse base class publish topic name
  add missing getter
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

- No changes
