### PR TITLE
robotraconteur: 1.2.2-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9345,7 +9345,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/robotraconteur-packaging/robotraconteur-ros-release.git
-      version: 1.1.1-1
+      version: 1.2.2-3
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `1.2.2-3`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`
