### PR TITLE
robotraconteur: 1.2.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5914,8 +5914,8 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/robotraconteur-release.git
-      version: 1.1.1-1
+      url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5914,7 +5914,7 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/robotraconteur-ros2-release.git
+      url: https://github.com/ros2-gbp/robotraconteur-release.git
       version: 1.2.2-1
     source:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5914,7 +5914,7 @@ repositories:
     release:
       tags:
         release: release/iron/{package}/{version}
-      url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
+      url: https://github.com/ros2-gbp/robotraconteur-ros2-release.git
       version: 1.2.2-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `1.2.2-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`
