### PR TITLE
robotraconteur: 1.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6098,7 +6098,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/robotraconteur-ros2-release.git
+      url: https://github.com/ros2-gbp/robotraconteur-release.git
       version: 1.2.2-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6098,7 +6098,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
+      url: https://github.com/ros2-gbp/robotraconteur-ros2-release.git
       version: 1.2.2-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6095,6 +6095,11 @@ repositories:
       version: jazzy
     status: maintained
   robotraconteur:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `1.2.2-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
