### PR TITLE
[python.yaml] add python3-pyside2.qtqml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8418,6 +8418,13 @@ python3-pyside2.qtopengl:
   ubuntu:
     '*': [python3-pyside2.qtopengl]
     bionic: null
+python3-pyside2.qtqml:
+  debian: [python3-pyside2.qtqml]
+  gentoo: [dev-python/pyside2]
+  rhel:
+    '*': [python3-pyside2]
+    '8': null
+  ubuntu: [python3-pyside2.qtqml]
 python3-pyside2.qtquick:
   arch: [pyside2]
   debian: [python3-pyside2.qtquick]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pyside2.qtqml

## Purpose of using this:

To release PySide + QML based GUI package.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/amd64/python3-pyside2.qtqml
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-pyside2.qtqml
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pyside2
- rhel: https://rhel.pkgs.org/
  - python3-pyside2

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

