### PR TITLE
ur_robot_driver: 2.4.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8006,7 +8006,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.8-1
+      version: 2.4.9-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.9-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.8-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Added Jazzy migration notes for moveit_config (#1058 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1058>)
* Add ur_moveit.launch.py arguments to control whether the move_group node publishes robot semantic description (#1036 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1036>)
* Contributors: Felix Exner (fexner), Vincenzo Di Pentima, Haavard Pedersen Brandal
```

## ur_robot_driver

```
* Added dynamics tag when using mock_components/GenericSystem (#1075 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1075>)
* Updated the UR family photo on the readme (#1064 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1064>)
* Fix passing launch_dashboard_client launch argument (#1057 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1057>)
* [doc] Add more documentation regarding usage (#1055 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1055>)
* Add doc to custom URScript commands that it needs to be in headless mode (#1051 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1051>)
* Update reference to ros2_controllers test node (#1054 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1054>)
* [doc] Update required polyscope version (#1052 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1052>)
* Add migration notes for jazzy (#1045 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1045>)
* Contributors: Felix Exner (fexner), Rune Søe-Knudsen
```
