### PR TITLE
ur_description: 2.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10263,7 +10263,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.5-1
+      version: 2.1.6-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.6-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.5-1`

## ur_description

```
* Fixed typo in README.md (#176 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/176>)
* Added dynamics tag when using mock_components/GenericSystem (backport of #175 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/175>)
* Auto-update pre-commit hooks (#171 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/171>) (#172 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/172>)
* Remove ros2_control limit params (#168 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/168>)
* Add Jazzy to the README (#163 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/163>)
* Contributors: Filippo Bosi, Niccolo, Felix Exner
```
