### PR TITLE
ur_description: 2.3.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8254,7 +8254,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.3.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## ur_description

```
* Added dynamics tag when using mock_components/GenericSystem (#175 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/175>)
* Remove ros2_control limit params (#167 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/167>)
* Add Jazzy to the README (#164 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/164>)
* Contributors: Felix Exner, Niccolo
```
