### PR TITLE
openni2_camera: 2.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4499,7 +4499,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.2.0-2
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.2.1-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-2`

## openni2_camera

```
* rename depth/image_raw to depth_raw/image (#140 <https://github.com/ros-drivers/openni2_camera/issues/140>)
  Without this change, both depth/image and depth/image_raw publish the
  same camera_info topic (depth/camera_info) - this has several issues:
  * subscribing to either image causes both to be published along with
  their respective camera_info
  * remapping either camera_info, remaps both
  * In Jazzy, it appears that the double camera_info also causes minor
  issues with message_filters in downstream packages
* Contributors: Michael Ferguson
```
