### PR TITLE
Add python3-pyopt-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8247,6 +8247,16 @@ python3-pyosmium:
   fedora: [python3-osmium]
   nixos: [python3Packages.pyosmium]
   ubuntu: [python3-pyosmium]
+python3-pyotp-pip:
+  debian:
+    pip:
+      packages: [pyotp]
+  fedora:
+    pip:
+      packages: [pyotp]
+  ubuntu:
+    pip:
+      packages: [pyotp]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]


### PR DESCRIPTION


Please add the following dependency to the rosdep database.

## Package name:

pyotp

## Package Upstream Source:

https://github.com/pyauth/pyotp
PIP: https://pypi.org/project/pyotp

## Purpose of using this:

This dependency is being used to create one time passwords in python

Distro packaging links:

## Links to Distribution Packages

https://pypi.org/project/pyotp
- Debian: https://packages.debian.org/
  - PIP: https://pypi.org/project/pyotp
- Ubuntu: https://packages.ubuntu.com/
  - PIP: https://pypi.org/project/pyotp
- Fedora: https://packages.fedoraproject.org/
  - PIP: https://pypi.org/project/pyotp
- macOS: https://formulae.brew.sh/
  -PIP: https://pypi.org/project/pyotp


