### PR TITLE
mapviz: 2.4.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3089,7 +3089,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.2-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.1-1`

## mapviz

```
* Plugin shortcuts (#824 <https://github.com/swri-robotics/mapviz/issues/824>)
  * Added hotkey for plugin remove (Ctrl + X)
  * Added key shortcut for plugin rename (CTRL + R)
  * Added Ctrl + N shortcut for adding new plugin.
* Fixed qos_dpeth to qos_depth in MapvizPlugin::LoadQosConfig (#823 <https://github.com/swri-robotics/mapviz/issues/823>)
* Contributors: Robert Brothers
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

- No changes
