### PR TITLE
simple_actions: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7532,7 +7532,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/simple_actions-release.git
-      version: 0.3.0-3
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_actions` to `0.4.0-1`:

- upstream repository: https://github.com/DLu/simple_actions.git
- release repository: https://github.com/ros2-gbp/simple_actions-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-3`
