### PR TITLE
warehouse_ros_sqlite: 1.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8774,7 +8774,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.3-4
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.4-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-4`

## warehouse_ros_sqlite

```
* Fix column name escaping (#44 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/44>)
* Update CI (#41 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/41>)
* Contributors: Bjar Ne, Henning Kayser, Tyler Weaver, Vatan Aksoy Tezer
```
