### PR TITLE
ompl: 1.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4449,11 +4449,20 @@ repositories:
       version: master
     status: developed
   ompl:
+    doc:
+      type: git
+      url: https://github.com/ompl/ompl.git
+      version: main
     release:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.5.2-2
+      version: 1.6.0-1
+    source:
+      type: git
+      url: https://github.com/ompl/ompl.git
+      version: main
+    status: developed
   openeb_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.6.0-1`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.2-2`
