### PR TITLE
ompl: 1.6.0-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4247,11 +4247,20 @@ repositories:
       version: master
     status: maintained
   ompl:
+    doc:
+      type: git
+      url: https://github.com/ompl/ompl.git
+      version: main
     release:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.6.0-1
+      version: 1.6.0-2
+    source:
+      type: git
+      url: https://github.com/ompl/ompl.git
+      version: main
+    status: developed
   openeb_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.6.0-2`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-1`
