### PR TITLE
Attempt to resolve armhf regressions by dowgrading eigenpy

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2512,7 +2512,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/stack-of-tasks/eigenpy-ros-release.git
-      version: 3.7.0-1
+      version: 3.1.4-5
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
I'm checking if ROS Noetic armhf regressions are fixed by downgrading to a version prior to [3.5.0](https://github.com/stack-of-tasks/eigenpy/blob/master/CHANGELOG.md#350---2024-04-14). This effectively reverts #41555 and #41600

@wxmerkt FYI

Alternative PR attempting to fix the regression upstream: https://github.com/stack-of-tasks/eigenpy/pull/488