### PR TITLE
add python3-pyotp

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8252,6 +8252,9 @@ python3-pyotp:
   debian: [python3-pyotp]
   fedora: [python3-pyotp]
   freebsd: [py311-pyotp]
+  rhel:
+    '*': [python3-pyotp]
+    '8': null
   opensuse: [python3-pyotp]
   ubuntu: [python3-pyotp]
 python3-pyparsing:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8308,10 +8308,10 @@ python3-pyotp:
   debian: [python3-pyotp]
   fedora: [python3-pyotp]
   freebsd: [py311-pyotp]
+  opensuse: [python3-pyotp]
   rhel:
     '*': [python3-pyotp]
     '8': null
-  opensuse: [python3-pyotp]
   ubuntu: [python3-pyotp]
 python3-pyparsing:
   arch: [python-pyparsing]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8247,6 +8247,16 @@ python3-pyosmium:
   fedora: [python3-osmium]
   nixos: [python3Packages.pyosmium]
   ubuntu: [python3-pyosmium]
+python3-pyotp-pip:
+  debian:
+    pip:
+      packages: [pyotp]
+  fedora:
+    pip:
+      packages: [pyotp]
+  ubuntu:
+    pip:
+      packages: [pyotp]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8247,16 +8247,13 @@ python3-pyosmium:
   fedora: [python3-osmium]
   nixos: [python3Packages.pyosmium]
   ubuntu: [python3-pyosmium]
-python3-pyotp-pip:
-  debian:
-    pip:
-      packages: [pyotp]
-  fedora:
-    pip:
-      packages: [pyotp]
-  ubuntu:
-    pip:
-      packages: [pyotp]
+python3-pyotp:
+  arch: [python-pyotp]
+  debian: [python3-pyotp]
+  fedora: [python3-pyotp]
+  freebsd: [py311-pyotp]
+  opensuse: [python3-pyotp]
+  ubuntu: [python3-pyotp]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]


### PR DESCRIPTION


Please add the following dependency to the rosdep database.

## Package name:

python3-pyotp

## Package Upstream Source:

(https://github.com/pyotp/pyotp)

## Purpose of using this:

This dependency is being used to add a one time password creation package for python.

Distro packaging links:

## Links to Distribution Packages


- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-pyotp
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/jammy/python-pyotp
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-pyotp/python3-pyotp/fedora-40.html
- Arch: https://www.archlinux.org/packages/
  - https://gitlab.archlinux.org/archlinux/packaging/packages/python-pyotp
- FreeBSD: https://pkg.freebsd.org/
  - https://cgit.freebsd.org/ports/tree/security/py-pyotp
- OpenSUSE: https://software.opensuse.org/
  - https://build.opensuse.org/package/show/openSUSE:Leap:15.6/python3-pyotp



