### PR TITLE
magic_enum: 0.9.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3353,7 +3353,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/magic_enum-release.git
-      version: 0.9.5-3
+      version: 0.9.6-1
     source:
       type: git
       url: https://github.com/Neargye/magic_enum.git


### PR DESCRIPTION
Increasing version of package(s) in repository `magic_enum` to `0.9.6-1`:

- upstream repository: https://github.com/Neargye/magic_enum.git
- release repository: https://github.com/ros2-gbp/magic_enum-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.5-3`
