### PR TITLE
audio_common: 0.3.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -368,7 +368,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/audio_common-release.git
-      version: 0.3.17-1
+      version: 0.3.18-1
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.3.18-1`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros-gbp/audio_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.17-1`

## audio_capture

- No changes

## audio_common

- No changes

## audio_common_msgs

- No changes

## audio_play

```
* Merge pull request #238 <https://github.com/ros-drivers/audio_common/issues/238> from Kanazawanaoaki/add-record-to-file-launch
* Add record to file launch
* Contributors: Kanazawanaoaki, Shingo Kitagawa
```

## sound_play

```
* Merge pull request #249 <https://github.com/ros-drivers/audio_common/issues/249> from peci1/patch-1
  festival_plugin: add support for different encodings
* festival_plugin: add support for different encodings
* Contributors: Martin Pecka, Shingo Kitagawa
```
