### PR TITLE
add libfranka package

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3909,6 +3909,12 @@ repositories:
       url: https://github.com/AutonomyLab/libcreate.git
       version: master
     status: maintained
+  libfranka:
+    source:
+      type: git
+      url: https://github.com/frankaemika/libfranka.git
+      version: main
+    status: developed
   libg2o:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

distribution: `humble`
package name: `libfranka`

This package is required to control [Franka Robotics research robots](https://franka.de/research).

# The source is here:

[https://github.com/frankaemika/libfranka.git](https://github.com/frankaemika/libfranka.git) 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
