### PR TITLE
mola_common: 0.3.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5974,6 +5974,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/mrpt-ros-pkg-release/mola_common-release.git
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_common` to `0.3.3-1`:

- upstream repository: https://github.com/MOLAorg/mola_common.git
- release repository: https://github.com/mrpt-ros-pkg-release/mola_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## mola_common

```
* make the package to build on ROS 1 too
* Contributors: Jose Luis Blanco-Claraco
```
