### PR TITLE
ros_battery_monitoring: 1.0.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6141,6 +6141,14 @@ repositories:
       type: git
       url: https://github.com/ipa320/ros_battery_monitoring.git
       version: main
+    release:
+      packages:
+      - battery_state_broadcaster
+      - battery_state_rviz_overlay
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_battery_monitoring` to `1.0.0-1`:

- upstream repository: https://github.com/ipa320/ros_battery_monitoring.git
- release repository: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## battery_state_broadcaster

```
* initial release
* Contributors: Jonas Otto
```

## battery_state_rviz_overlay

```
* initial release
* Contributors: Jonas Otto
```
