### PR TITLE
realtime_tools: 2.6.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5375,7 +5375,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.5.0-3
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.6.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-3`

## realtime_tools

```
* Add Async Function Handler  (#168 <https://github.com/ros-controls/realtime_tools/issues/168>)
* Bump version of pre-commit hooks (#167 <https://github.com/ros-controls/realtime_tools/issues/167>)
* [CI] Add jazzy :rocket:  (#165 <https://github.com/ros-controls/realtime_tools/issues/165>)
* [CI] Specify runner/container images (#163 <https://github.com/ros-controls/realtime_tools/issues/163>)
* Add custom rosdoc2 config (#161 <https://github.com/ros-controls/realtime_tools/issues/161>)
* Added a new implementation of the RealtimeBox with added best effort behaviour (#139 <https://github.com/ros-controls/realtime_tools/issues/139>)
* [CI] Code coverage and pre-commit (#154 <https://github.com/ros-controls/realtime_tools/issues/154>)
* [CI] Use reusable workflows and matrix strategy (#151 <https://github.com/ros-controls/realtime_tools/issues/151>)
* Bump ros-tooling/action-ros-ci from 0.3.5 to 0.3.6 (#148 <https://github.com/ros-controls/realtime_tools/issues/148>)
* Fix RHEL workflows (#144 <https://github.com/ros-controls/realtime_tools/issues/144>)
* update unlock method to also include the part of the NON_POLLING (#142 <https://github.com/ros-controls/realtime_tools/issues/142>)
* Bump actions/upload-artifact from 4.1.0 to 4.2.0 (#143 <https://github.com/ros-controls/realtime_tools/issues/143>)
* [CI] Add debian workflows (#145 <https://github.com/ros-controls/realtime_tools/issues/145>)
* Test fix: initialize the global context to avoid runtime_error upon destruction (#128 <https://github.com/ros-controls/realtime_tools/issues/128>)
* Contributors: Christoph Fröhlich, Felix Exner (fexner), Lennart Nachtigall, Sai Kishor Kothakota, dependabot[bot], github-actions[bot]
```
