### PR TITLE
neo_nav2_bringup: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5168,6 +5168,11 @@ repositories:
       type: git
       url: https://github.com/neobotix/neo_nav2_bringup.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/neobotix/neo_nav2_bringup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.0.1-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## neo_nav2_bringup

```
* updating package.xml
* Create LICENSE
* Update package.xml
* updating the depend tags
* updating package.xml
* updating launch (#23 <https://github.com/neobotix/neo_nav2_bringup/issues/23>)
* multi robot rviz update
* rviz config update
* update for multi robot rviz
* Humble develop (#18 <https://github.com/neobotix/neo_nav2_bringup/issues/18>)
  * map_server is used standalone for multi_robot navigation
  * fixes to the default config
  * updating the package description
* Humble update (#13 <https://github.com/neobotix/neo_nav2_bringup/issues/13>)
  * minor fixes
  * update readme
  * variable rename for better understanding
  * update recoveries to behaviors
* variable rename for better understanding
* update readme
* minor fixes
* namespace handling for single robot vs multi robot case
* removing the namespace tag
* adding rviz files
* Feature/multi robot (#4 <https://github.com/neobotix/neo_nav2_bringup/issues/4>)
  * adding a multi robot tag
  * update
* launch updated
* adding launch files
* adding configs and maps
* adding CMakelists and package
* Update README.md
* Initial commit
* Contributors: PRP, Pradheep, Pradheep Krishna, Pradheep-office
```
