### PR TITLE
Add python3-minimalmodbus-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7066,6 +7066,19 @@ python3-meson-pip:
   ubuntu:
     pip:
       packages: [meson]
+python3-minimalmodbus-pip:
+  debian:
+    pip:
+      packages: [minimalmodbus]
+  fedora:
+    pip:
+      packages: [minimalmodbus]
+  osx:
+    pip:
+      packages: [minimalmodbus]
+  ubuntu:
+    pip:
+      packages: [minimalmodbus]
 python3-mistune:
   alpine:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

minimalmodbus

## Package Upstream Source:

https://github.com/pyhys/minimalmodbus

## Purpose of using this:

This dependency is being used for modbus RTU and modbus ASCII communication for Python. This is why I think it's valuable to be added to the rosdep database.

Distro packaging links:

## Links to Distribution Packages

PyPi: [https://pypi.org/project/minimalmodbus/](https://pypi.org/project/minimalmodbus/)