### PR TITLE
Adds vector_pursuit_controller to humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10661,6 +10661,16 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: humble
     status: maintained
+  vector_pursuit_controller:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
+      version: master
+    status: developed
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

package name: `vector_pursuit_controller`
distro name: `humble`

# The source is here:

https://github.com/blackcoffeerobotics/vector_pursuit_controller

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
