### PR TITLE
mrpt_ros: 2.13.6-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3776,7 +3776,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.13.6-1
+      version: 2.13.6-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.13.6-2`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.13.6-1`

## mrpt_apps

```
* Add lib suffix to package names
* Disable ROS detection to save cmake configure time
* more packages
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libapps

```
* Add lib suffix to package names
* Disable ROS detection to save cmake configure time
* more packages
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libbase

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libgui

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libhwdrivers

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libmaps

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libmath

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libnav

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libobs

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libopengl

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libposes

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libros2bridge

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libslam

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libtclap

```
* Add lib suffix to package names
* Contributors: Jose Luis Blanco-Claraco
```
