### PR TITLE
mola: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3475,7 +3475,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.0.8-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.8-1`

## kitti_metrics_eval

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* change ament linters to apply in test builds
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* Merge pull request #65 <https://github.com/MOLAorg/mola/issues/65> from MOLAorg/add-more-srvs
  Add more Services
* Offer ROS2 services for the new MOLA MapServer interface
* clang-format: switch to 100 columns
* ros2bridge: offer ROS2 services for relocalization
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* change ament linters to apply in test builds
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* add <mola_kernel/version.h> with a version-checking macro
* Merge pull request #65 <https://github.com/MOLAorg/mola/issues/65> from MOLAorg/add-more-srvs
  Add more Services
* Avoid cmake file glob expressions
* mola_kernel: add MapServer interface
* mola_kernel: add public symbols MOLA_{MAJOR,MINOR,PATCH}_VERSION
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

```
* Merge pull request #65 <https://github.com/MOLAorg/mola/issues/65> from MOLAorg/add-more-srvs
  Add more Services
* mola_msgs: add map save & load services
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fg

```
* Update test-navstate-basic.cpp: less noisy test data for more predictable results
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fuse

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Update clang-format style; add reformat bash script
* Merge pull request #62 <https://github.com/MOLAorg/mola/issues/62> from MOLAorg/docs-fixes
  Docs fixes
* Fix ament_xmllint warnings in package.xml
* Contributors: Jose Luis Blanco-Claraco
```
