### PR TITLE
message_filters: 6.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3324,7 +3324,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 6.0.3-1
+      version: 6.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `6.0.4-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.3-1`

## message_filters

```
* Apply some simplifications and deduplications to ExactTime sync policy (#142 <https://github.com/ros2/message_filters/issues/142>)
* Minor fixes for #93 <https://github.com/ros2/message_filters/issues/93> (#143 <https://github.com/ros2/message_filters/issues/143>)
* Bugfix/segfault when getting surrounding interval of empty cache (#116 <https://github.com/ros2/message_filters/issues/116>)
* Contributors: Christopher Wecht, Matthias Holoch
```
