### PR TITLE
rviz: 14.1.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7425,7 +7425,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.3-1
+      version: 14.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.3-1`

## rviz2

```
* Detect wayland and make sure X rendering is used. (#1253 <https://github.com/ros2/rviz/issues/1253>) (#1254 <https://github.com/ros2/rviz/issues/1254>)
  rviz2 does not work under wayland unless using X compatibility.
  The current workaround on wayland is to set the QT_QPA_PLATFORM
  environment variable to xcb.  This patch now detects
  if rviz2 is started in a wayland session and if so sets that
  variable automatically.
  (cherry picked from commit 72c0826545b4cc173413699a381cc36da78437bf)
  Co-authored-by: Matthew Elwin <mailto:10161574+m-elwin@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Set ContentsMargins for RenderPanel to 0 to avoid borders in fullscreen mode. Fixes #1024 <https://github.com/ros2/rviz/issues/1024> (#1228 <https://github.com/ros2/rviz/issues/1228>) (#1250 <https://github.com/ros2/rviz/issues/1250>)
  (cherry picked from commit 642b1a34b1a50bfa8afa76817ec3fe0e2f9cf210)
  Co-authored-by: Bo Chen <mailto:bo@enway.ai>
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
