### PR TITLE
mola_common: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4581,7 +4581,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_common-release.git
-      version: 0.3.2-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_common` to `0.4.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_common.git
- release repository: https://github.com/ros2-gbp/mola_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.2-1`

## mola_common

```
* Reorganize cmake scripts to make them compatible with both ROS1 catkin and ROS2 ament
* Contributors: Jose Luis Blanco-Claraco
```
