### PR TITLE
mp2p_icp: 1.5.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4749,7 +4749,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.5.2-1
+      version: 1.5.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.5.3-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.2-1`

## mp2p_icp

```
* Re-add ROS1 Noetic as supported distribution
* Generator sanity check asserts: more informative error messages
* sm-cli: new command 'join' to merge simplemaps
* icp-log-viewer UI: new keybind 'I' to switch initial/final pose
* icp-log-viewer UI: add option to visualize voxelmaps empty space
* Contributors: Jose Luis Blanco-Claraco
```
