### PR TITLE
aerostack2: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -104,29 +104,32 @@ repositories:
       - as2_behavior
       - as2_behavior_tree
       - as2_behaviors_motion
+      - as2_behaviors_path_planning
       - as2_behaviors_perception
       - as2_behaviors_platform
       - as2_behaviors_trajectory_generation
       - as2_cli
       - as2_core
+      - as2_external_object_to_tf
       - as2_gazebo_assets
-      - as2_gazebo_classic_assets
+      - as2_geozones
       - as2_keyboard_teleoperation
+      - as2_map_server
       - as2_motion_controller
       - as2_motion_reference_handlers
       - as2_msgs
-      - as2_platform_crazyflie
-      - as2_platform_dji_osdk
       - as2_platform_gazebo
-      - as2_platform_tello
+      - as2_platform_multirotor_simulator
       - as2_python_api
       - as2_realsense_interface
+      - as2_rviz_plugins
       - as2_state_estimator
       - as2_usb_camera_interface
+      - as2_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.0.9-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.1.1-1`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.9-1`

## aerostack2

```
* [as2_keyboard_teleoperation] context is modified manually from generated config file
* [as2_msgs] add sensor msgs dependency
* [as2_python_api] License fix using ament copyright
* [as2_state_estimator] Fix gtest warning: publisher already registered
* [as2_usb_camera_interface] Fix gtest warning: publisher already registered
* Contributors: Rafael Perez-Segui, pariaspe, Miguel Fernandez-Cortizas, Javilinos
```

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors_motion

- No changes

## as2_behaviors_path_planning

- No changes

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

- No changes

## as2_core

- No changes

## as2_external_object_to_tf

- No changes

## as2_gazebo_assets

- No changes

## as2_geozones

- No changes

## as2_keyboard_teleoperation

```
* [as2_keyboard_teleoperation] context is modified manually from generated config file
* Contributors: Javilinos, pariaspe
```

## as2_map_server

- No changes

## as2_motion_controller

- No changes

## as2_motion_reference_handlers

- No changes

## as2_msgs

```
* [as2_msgs] add sensor msgs dependency
* Contributors: Miguel Fernandez-Cortizas
```

## as2_platform_gazebo

- No changes

## as2_platform_multirotor_simulator

- No changes

## as2_python_api

```
* [as2_python_api] License fix using ament copyright
* Contributors: Rafael Perez-Segui, pariaspe
```

## as2_realsense_interface

- No changes

## as2_rviz_plugins

- No changes

## as2_state_estimator

```
* [as2_state_estimator] Fix gtest warning: publisher already registered
* Contributors: Rafael Perez-Segui, pariaspe
```

## as2_usb_camera_interface

```
* [as2_usb_camera_interface] Fix gtest warning: publisher already registered
* Contributors: Rafael Perez-Segui, pariaspe
```

## as2_visualization

- No changes
