### PR TITLE
as2_platform_mavlink: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -621,6 +621,11 @@ repositories:
       type: git
       url: https://github.com/aerostack2/as2_platform_mavlink.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/as2_platform_mavlink-release.git
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `as2_platform_mavlink` to `1.1.0-1`:

- upstream repository: https://github.com/aerostack2/as2_platform_mavlink.git
- release repository: https://github.com/ros2-gbp/as2_platform_mavlink-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## as2_platform_mavlink

```
* [feat] updated params for multi-vehicle simulation
* [fix] passing tests
* [feat] new launchers
* [feat] add mavros dependencies
* [feat] external odom
* [docs] update readme
* [feat] kill switch
* [feat] enable odom, battery and gps
* [feat] remaps in launcher
* [feat] command enabled
* Contributors: Miguel Fernandez Cortizas
```
