### PR TITLE
Add python3-easyocr

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5688,6 +5688,16 @@ python3-easydict:
     focal:
       pip:
         packages: [easydict]
+python3-easyocr:
+  debian:
+    pip:
+      packages: [easyocr]
+  fedora:
+    pip:
+      packages: [easyocr]
+  ubuntu:
+    pip:
+      packages: [easyocr]
 python3-elasticsearch:
   debian: [python3-elasticsearch]
   fedora: [python3-elasticsearch]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

python3-easyocr:
Package Upstream Source:
https://github.com/JaidedAI/EasyOCR

Purpose of using this:
Used for optical character detection and recognition.

Distro packaging links:

Links to Distribution Packages
pip https://pypi.org/project/easyocr/