### PR TITLE
as2_platform_dji_psdk: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -610,6 +610,11 @@ repositories:
       type: git
       url: https://github.com/aerostack2/as2_platform_dji_psdk.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/as2_platform_dji_psdk-release.git
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `as2_platform_dji_psdk` to `1.1.0-1`:

- upstream repository: https://github.com/aerostack2/as2_platform_dji_psdk.git
- release repository: https://github.com/ros2-gbp/as2_platform_dji_psdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## as2_platform_dji_psdk

```
* [fix] psdk_wrapper.launch.py by removing tab in default config files
* [feat] Update changes in launcher and params to psdk_ros2 v1.3.0
* [feat] Update launcher with param utils
* [test] flake8 passing
* [ci] new ci added
* [fix] velocity sub topic
* [feat] Add tf_frame_prefix param
* [feat] Improve gimbal using TF
* [fix] Avoid sending duplicated gimbal command
* [fix] platform take off
* [feat] Add gimbal
* [refactor] Code refractor without impl
* [feat] Add HMS file
* [feat] Add gimbal and camera intialization flags
* [fix] speed state and yaw reference frames
* [feat] obtain ctrl authority
* [feat] change to SynchronousServiceClient
* [test] enable test dir
* [docs] add copyright
* [style] add hints to platform virtual methods
* [test] Use ament_lint_auto
* [build] Add psdk_interfaces dependency
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, Santiago Tapia-Fernández, pariaspe
```
