### PR TITLE
image_pipeline: 6.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2515,7 +2515,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.2-1
+      version: 6.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.3-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.2-1`

## camera_calibration

```
* Refactoring calibration code (#1000 <https://github.com/ros-perception/image_pipeline/issues/1000>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Myron Rodrigues
```

## depth_image_proc

```
* Publish using unique ptr (#1016 <https://github.com/ros-perception/image_pipeline/issues/1016>)
  Prevents doing an extra copy of the data when using intra-process
  communication.
* Finish QoS updates (#1019 <https://github.com/ros-perception/image_pipeline/issues/1019>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* fix signature issue from #943 <https://github.com/ros-perception/image_pipeline/issues/943> (#1018 <https://github.com/ros-perception/image_pipeline/issues/1018>)
  Without this, we get
  ```
  symbol lookup error: /home/ubr/jazzy/install/depth_image_proc/lib/libdepth_image_proc.so: undefined symbol: _ZN16depth_image_proc10convertRgbERKSt10shared_ptrIKN11sensor_msgs3msg6Image_ISaIvEEEES0_INS2_12PointCloud2_IS4_EEEiiii
  c++filt _ZN16depth_image_proc10convertRgbERKSt10shared_ptrIKN11sensor_msgs3msg6Image_ISaIvEEEES0_INS2_12PointCloud2_IS4_EEEiiii
  depth_image_proc::convertRgb(std::shared_ptr<sensor_msgs::msg::Image\_<std::allocator<void> > const> const&, std::shared_ptr<sensor_msgs::msg::PointCloud2\_<std::allocator<void> > >, int, int, int, int)
  ```
* Contributors: Błażej Sowa, Michael Ferguson
```

## image_pipeline

```
* Finish QoS updates (#1019 <https://github.com/ros-perception/image_pipeline/issues/1019>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: Michael Ferguson
```

## image_proc

```
* Publish using unique ptr (#1016 <https://github.com/ros-perception/image_pipeline/issues/1016>)
  Prevents doing an extra copy of the data when using intra-process
  communication.
* Finish QoS updates (#1019 <https://github.com/ros-perception/image_pipeline/issues/1019>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Updated deprecated rcpputils::path (#1014 <https://github.com/ros-perception/image_pipeline/issues/1014>)
* Contributors: Alejandro Hernández Cordero, Błażej Sowa, Michael Ferguson
```

## image_publisher

```
* Publish using unique ptr (#1016 <https://github.com/ros-perception/image_pipeline/issues/1016>)
  Prevents doing an extra copy of the data when using intra-process
  communication.
* Finish QoS updates (#1019 <https://github.com/ros-perception/image_pipeline/issues/1019>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: Błażej Sowa, Michael Ferguson
```

## image_rotate

```
* Publish using unique ptr (#1016 <https://github.com/ros-perception/image_pipeline/issues/1016>)
  Prevents doing an extra copy of the data when using intra-process
  communication.
* Finish QoS updates (#1019 <https://github.com/ros-perception/image_pipeline/issues/1019>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: Błażej Sowa, Michael Ferguson
```

## image_view

```
* Finish QoS updates (#1019 <https://github.com/ros-perception/image_pipeline/issues/1019>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: Michael Ferguson
```

## stereo_image_proc

```
* Publish using unique ptr (#1016 <https://github.com/ros-perception/image_pipeline/issues/1016>)
  Prevents doing an extra copy of the data when using intra-process
  communication.
* Contributors: Błażej Sowa
```

## tracetools_image_pipeline

- No changes
