### PR TITLE
image_pipeline: 5.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2690,7 +2690,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.3-1
+      version: 5.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.4-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.3-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Finish QoS updates (backport #1019 <https://github.com/ros-perception/image_pipeline/issues/1019>) (#1024 <https://github.com/ros-perception/image_pipeline/issues/1024>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* fix signature issue from #943 <https://github.com/ros-perception/image_pipeline/issues/943> (backport #1018 <https://github.com/ros-perception/image_pipeline/issues/1018>) (#1023 <https://github.com/ros-perception/image_pipeline/issues/1023>)
  Without this, we get
  ```
  symbol lookup error: /home/ubr/jazzy/install/depth_image_proc/lib/libdepth_image_proc.so: undefined symbol: _ZN16depth_image_proc10convertRgbERKSt10shared_ptrIKN11sensor_msgs3msg6Image_ISaIvEEEES0_INS2_12PointCloud2_IS4_EEEiiii
  c++filt _ZN16depth_image_proc10convertRgbERKSt10shared_ptrIKN11sensor_msgs3msg6Image_ISaIvEEEES0_INS2_12PointCloud2_IS4_EEEiiii
  depth_image_proc::convertRgb(std::shared_ptr<sensor_msgs::msg::Image\_<std::allocator<void> > const> const&, std::shared_ptr<sensor_msgs::msg::PointCloud2\_<std::allocator<void> > >, int, int, int, int)
  ```
  This is an automatic backport of pull request #1018 <https://github.com/ros-perception/image_pipeline/issues/1018> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Contributors: mergify[bot]
```

## image_pipeline

```
* Finish QoS updates (backport #1019 <https://github.com/ros-perception/image_pipeline/issues/1019>) (#1024 <https://github.com/ros-perception/image_pipeline/issues/1024>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: mergify[bot]
```

## image_proc

```
* Finish QoS updates (backport #1019 <https://github.com/ros-perception/image_pipeline/issues/1019>) (#1024 <https://github.com/ros-perception/image_pipeline/issues/1024>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: mergify[bot]
```

## image_publisher

```
* Finish QoS updates (backport #1019 <https://github.com/ros-perception/image_pipeline/issues/1019>) (#1024 <https://github.com/ros-perception/image_pipeline/issues/1024>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: mergify[bot]
```

## image_rotate

```
* Finish QoS updates (backport #1019 <https://github.com/ros-perception/image_pipeline/issues/1019>) (#1024 <https://github.com/ros-perception/image_pipeline/issues/1024>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: mergify[bot]
```

## image_view

```
* Finish QoS updates (backport #1019 <https://github.com/ros-perception/image_pipeline/issues/1019>) (#1024 <https://github.com/ros-perception/image_pipeline/issues/1024>)
  This implements the remainder of #847 <https://github.com/ros-perception/image_pipeline/issues/847>:
  - Make sure publishers default to system defaults (reliable)
  - Add QoS overriding where possible (some of the image_transport /
  message_filters stuff doesn't really support that)
  - Use the matching heuristic for subscribers consistently
* Contributors: mergify[bot]
```

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
