### PR TITLE
image_pipeline: 3.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3280,7 +3280,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.5-1
+      version: 3.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `3.0.6-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.5-1`

## camera_calibration

```
* [backport] use correct synchronous service call (#1006 <https://github.com/ros-perception/image_pipeline/issues/1006>)
  Backport from https://github.com/ros-perception/image_pipeline/pull/792
  to fix https://github.com/ros-perception/image_pipeline/pull/838
  Co-authored-by: Christian Rauch <mailto:Rauch.Christian@gmx.de>
* Contributors: Balint Rozgonyi
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
