### PR TITLE
sick_safetyscanners_base: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9098,7 +9098,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners_base` to `1.0.3-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners_base.git
- release repository: https://github.com/SICKAG/sick_safetyscanners_base-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## sick_safetyscanners_base

```
* Adding missing includes for ubuntu24 compiler
* Adding dependencies on specific boost libraries, exporting dep to chrono
* Fix Sync example
* Fix read checksums
* UDPPacketMerger: fixing missing include
* Contributors: Carl Morgan, Denis Taniguchi, Lennart Puck, Marco Bassa, Matthias Schoepfer, Rein Appeldoorn, Soren Holm, 张天宇
```
