### PR TITLE
sick_safetyscanners_base: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7181,6 +7181,21 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
     status: maintained
+  sick_safetyscanners_base:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    status: developed
   sick_safevisionary_base:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7189,7 +7189,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/SICKAG/sick_safetyscanners_base-release.git
+      url: https://github.com/ros2-gbp/sick_safetyscanners_base-release.git
       version: 1.0.3-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners_base` to `1.0.3-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners_base.git
- release repository: https://github.com/SICKAG/sick_safetyscanners_base-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sick_safetyscanners_base

```
* Adding missing includes for ubuntu24 compiler
* Adding dependencies on specific boost libraries, exporting dep to chrono
* Fix Sync example
* Fix read checksums
* UDPPacketMerger: fixing missing include
* Contributors: Carl Morgan, Denis Taniguchi, Lennart Puck, Marco Bassa, Matthias Schoepfer, Rein Appeldoorn, Soren Holm, 张天宇
```
