### PR TITLE
sick_safetyscanners2_interfaces: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7668,21 +7668,6 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
     status: maintained
-  sick_safetyscanners_base:
-    doc:
-      type: git
-      url: https://github.com/SICKAG/sick_safetyscanners_base.git
-      version: ros2
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/sick_safetyscanners_base-release.git
-      version: 1.0.3-1
-    source:
-      type: git
-      url: https://github.com/SICKAG/sick_safetyscanners_base.git
-      version: ros2
-    status: developed
   sick_safetyscanners2_interfaces:
     doc:
       type: git
@@ -7697,6 +7682,21 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
       version: master
+    status: developed
+  sick_safetyscanners_base:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safetyscanners_base-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
     status: developed
   sick_safevisionary_base:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7690,7 +7690,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/SICKAG/sick_safetyscanners2_interfaces-release.git
+      url: https://github.com/ros2-gbp/sick_safetyscanners2_interfaces-release.git
       version: 1.0.0-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7682,6 +7682,20 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git
       version: ros2
+  sick_safetyscanners2_interfaces:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/SICKAG/sick_safetyscanners2_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
+      version: master
     status: developed
   sick_safevisionary_base:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7682,6 +7682,7 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git
       version: ros2
+    status: developed
   sick_safetyscanners2_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
- release repository: https://github.com/SICKAG/sick_safetyscanners2_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sick_safetyscanners2_interfaces

```
* Initial Release
```
