### PR TITLE
Revert "perception_pcl: 2.4.4-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5964,7 +5964,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.4.4-1
+      version: 2.4.0-6
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#42460

This seems to create bugs in packages downstream that depend on PCL, for example:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__bosch_locator_bridge__ubuntu_jammy_amd64__binary/822/console

Here's a PR I made that hopefully fixes this issue:
https://github.com/ros-perception/perception_pcl/pull/465

FYI @SteveMacenski 