### PR TITLE
as2_platform_crazyflie: 1.1.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -591,6 +591,11 @@ repositories:
       type: git
       url: https://github.com/aerostack2/as2_platform_crazyflie.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/as2_platform_crazyfile-release.git
+      version: 1.1.0-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `as2_platform_crazyflie` to `1.1.0-3`:

- upstream repository: https://github.com/aerostack2/as2_platform_crazyflie.git
- release repository: https://github.com/ros2-gbp/as2_platform_crazyfile-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## as2_platform_crazyflie

```
* Update LICENSE to BSD-3
* Fix camera frame tf
* [fix] flake8 test
* [feat] move parameters to ROS 2 standard
* Fix AIDeckPublisher spin
* Enable main node in swarm launch
* Add camera calibration file param
* [feat] add camera info
* [feat] launch aideck node depending on params
* [feat] pass ament_common tests
* [CI] add CIs
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```
