### PR TITLE
as2_platform_tello: 1.1.0-4 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -656,6 +656,11 @@ repositories:
       type: git
       url: https://github.com/aerostack2/as2_platform_tello.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/as2_platform_tello-release.git
+      version: 1.1.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `as2_platform_tello` to `1.1.0-4`:

- upstream repository: https://github.com/aerostack2/as2_platform_tello.git
- release repository: https://github.com/ros2-gbp/as2_platform_tello-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## as2_platform_tello

```
* [feat] Default camera name: camera
* [test] Update test to load camera calibration
* [feat] added optional calibration config file
* [feat] Create sensor camera using as2::core
* [feat] Local port config for multi-drone, port reconfiguration for state and video and temporary CamInfo to enable streaming.
* [test] Use ament_lint tests
* [ci] new ci added
* Contributors: Mickey Li, Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```
