### PR TITLE
as2_platform_dji_osdk: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -602,6 +602,11 @@ repositories:
       type: git
       url: https://github.com/aerostack2/as2_platform_dji_osdk.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/as2_platform_dji_osdk-release.git
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `as2_platform_dji_osdk` to `1.1.0-1`:

- upstream repository: https://github.com/aerostack2/as2_platform_dji_osdk.git
- release repository: https://github.com/ros2-gbp/as2_platform_dji_osdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## as2_platform_dji_osdk

```
* [test] Migrate to ament_lint_auto
* [feat] Update launcher with param utils
* [fix] publising gimbal attitude at any cb hit
* [refactor] repo extracted from main track
* Contributors: Miguel Fernandez-Cortizas, Rafael Perez-Segui, pariaspe
```
