### PR TITLE
mp2p_icp: 1.5.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6280,7 +6280,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mp2p_icp-release.git
-      version: 1.5.3-1
+      version: 1.5.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.5.4-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/mrpt-ros-pkg-release/mp2p_icp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.3-1`

## mp2p_icp

```
* Do not use Eigen::Vector for compatibility with Eigen3 <3.4 in ROS Noetic
* Contributors: Jose Luis Blanco-Claraco
```
