### PR TITLE
added ffmpeg_encoder_decoder

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2253,6 +2253,16 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
     status: maintained
+  ffmpeg_encoder_decoder:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    status: developed
   ffmpeg_image_transport:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1556,6 +1556,16 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.10.x
     status: maintained
+  ffmpeg_encoder_decoder:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    status: developed
   ffmpeg_image_transport:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1685,6 +1685,16 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.14.x
     status: maintained
+  ffmpeg_encoder_decoder:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    status: developed
   ffmpeg_image_transport:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1555,6 +1555,16 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.14.x
     status: maintained
+  ffmpeg_encoder_decoder:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    status: developed
   ffmpeg_image_transport:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add ffmpeg_encoder_decoder to be indexed in the rosdistro.

ROSDISTRO NAME: humble, iron, jazzy, rolling

This package contains the core encoder/decoder wrapper around libav (aka ffmpeg) that is currently part of the ffmpeg-image-transport package. I am moving this into a separate package so it can be shared with the forthcoming foxglove-compressed-video-transport.

# The source is here:

https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
