### PR TITLE
azure-iot-sdk-c: 1.14.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -562,10 +562,12 @@ repositories:
       url: https://github.com/Azure/azure-iot-sdk-c.git
       version: main
     release:
+      packages:
+      - azure_iot_sdk_c
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/nobleo/azure-iot-sdk-c-release.git
-      version: 1.13.0-1
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `azure-iot-sdk-c` to `1.14.0-1`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/nobleo/azure-iot-sdk-c-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.13.0-1`
