### PR TITLE
add foxglove_compressed_video_transport package to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2556,6 +2556,16 @@ repositories:
       url: https://github.com/foxglove/ros-foxglove-bridge.git
       version: main
     status: developed
+  foxglove_compressed_video_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    status: developed
   foxglove_msgs:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1798,6 +1798,16 @@ repositories:
       url: https://github.com/foxglove/ros-foxglove-bridge.git
       version: main
     status: developed
+  foxglove_compressed_video_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    status: developed
   foxglove_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1927,6 +1927,16 @@ repositories:
       url: https://github.com/foxglove/ros-foxglove-bridge.git
       version: main
     status: developed
+  foxglove_compressed_video_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    status: developed
   foxglove_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1797,6 +1797,16 @@ repositories:
       url: https://github.com/foxglove/ros-foxglove-bridge.git
       version: main
     status: developed
+  foxglove_compressed_video_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    status: developed
   foxglove_msgs:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please add foxglove_compressed_video_transport to be indexed in the rosdistro.

ROSDISTRO NAME: humble, iron, jazzy, rolling

This is an image transport plugin that uses libav/ffmpeg to produce Foxglove CompressedVideo messages.

# The source is here:

https://github.com/ros-misc-utilities/foxglove_compressed_video_transport


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
