### PR TITLE
Revert "aerostack2: 1.1.1-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -104,32 +104,29 @@ repositories:
       - as2_behavior
       - as2_behavior_tree
       - as2_behaviors_motion
-      - as2_behaviors_path_planning
       - as2_behaviors_perception
       - as2_behaviors_platform
       - as2_behaviors_trajectory_generation
       - as2_cli
       - as2_core
-      - as2_external_object_to_tf
       - as2_gazebo_assets
-      - as2_geozones
+      - as2_gazebo_classic_assets
       - as2_keyboard_teleoperation
-      - as2_map_server
       - as2_motion_controller
       - as2_motion_reference_handlers
       - as2_msgs
+      - as2_platform_crazyflie
+      - as2_platform_dji_osdk
       - as2_platform_gazebo
-      - as2_platform_multirotor_simulator
+      - as2_platform_tello
       - as2_python_api
       - as2_realsense_interface
-      - as2_rviz_plugins
       - as2_state_estimator
       - as2_usb_camera_interface
-      - as2_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.1.1-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#42502

It seems this introduces a few new build farm errors:
- https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__as2_behaviors_path_planning__ubuntu_jammy_amd64__binary/4/
- https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__as2_map_server__ubuntu_jammy_amd64__binary/4/

I think this is the relevant error:
```
01:26:44 CMake Error at CMakeLists.txt:37 (find_package):
01:26:44   By not providing "Findbackward_ros.cmake" in CMAKE_MODULE_PATH this project
01:26:44   has asked CMake to find a package configuration file provided by
01:26:44   "backward_ros", but CMake did not find one.
01:26:44 
01:26:44   Could not find a package configuration file provided by "backward_ros" with
01:26:44   any of the following names:
01:26:44 
01:26:44     backward_rosConfig.cmake
01:26:44     backward_ros-config.cmake
01:26:44 
01:26:44   Add the installation prefix of "backward_ros" to CMAKE_PREFIX_PATH or set
01:26:44   "backward_ros_DIR" to a directory containing one of the above files.  If
01:26:44   "backward_ros" provides a separate development package or SDK, be sure it
01:26:44   has been installed.
```

FYI @pariaspe.