### PR TITLE
aerostack2: 1.1.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -129,7 +129,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
-      version: 1.1.1-1
+      version: 1.1.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `aerostack2` to `1.1.2-2`:

- upstream repository: https://github.com/aerostack2/aerostack2.git
- release repository: https://github.com/ros2-gbp/aerostack2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## aerostack2

```
* [as2_behaviors_path_planning, as2_map_server] Remove backward_ros dependency
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_alphanumeric_viewer

- No changes

## as2_behavior

- No changes

## as2_behavior_tree

- No changes

## as2_behaviors_motion

- No changes

## as2_behaviors_path_planning

```
* Remove backward_ros dependency
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_behaviors_perception

- No changes

## as2_behaviors_platform

- No changes

## as2_behaviors_trajectory_generation

- No changes

## as2_cli

- No changes

## as2_core

- No changes

## as2_external_object_to_tf

- No changes

## as2_gazebo_assets

- No changes

## as2_geozones

- No changes

## as2_keyboard_teleoperation

- No changes

## as2_map_server

```
* Remove backward_ros dependency
* Contributors: Miguel Fernandez-Cortizas, pariaspe
```

## as2_motion_controller

- No changes

## as2_motion_reference_handlers

- No changes

## as2_msgs

- No changes

## as2_platform_gazebo

- No changes

## as2_platform_multirotor_simulator

- No changes

## as2_python_api

- No changes

## as2_realsense_interface

- No changes

## as2_rviz_plugins

- No changes

## as2_state_estimator

- No changes

## as2_usb_camera_interface

- No changes

## as2_visualization

- No changes
