### PR TITLE
urdf: 2.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10490,7 +10490,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.6.0-2
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.6.1-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.0-2`

## urdf

```
* Provide copy and move constructors for model (#33 <https://github.com/ros2/urdf/issues/33>) (#41 <https://github.com/ros2/urdf/issues/41>)
  In 4b73ae2998bec0db24aca07b0bf7fc37b8e4dae7 the copy and move
  constructors were accidentally disabled.
  This means that one must always wrap a urdf::Model into some form of
  pointer in order to pass it around or have it as a member.
  This commit restores the copy and move constructors, such that one is
  able to pass the urdf::Model around as a normal variable.
  See also:
  https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rc-five
  Co-authored-by: Daniel Reuter <mailto:daniel.robin.reuter@googlemail.com>
  Co-authored-by: Shane Loretz <mailto:sloretz@osrfoundation.org>
* Contributors: Kenji Brameld (TRACLabs)
```

## urdf_parser_plugin

- No changes
