### PR TITLE
ros2_control: 4.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5934,7 +5934,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.15.0-1
+      version: 4.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.15.0-1`

## controller_interface

```
* Fix params_file typo in spawner and update release notes for use_global_arguments (#1701 <https://github.com/ros-controls/ros2_control/issues/1701>)
* Avoid using the global arguments for internal controller nodes (#1694 <https://github.com/ros-controls/ros2_control/issues/1694>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* inform user what reason is for not setting rt policy, inform is policy (#1705 <https://github.com/ros-controls/ros2_control/issues/1705>)
* Fix params_file typo in spawner and update release notes for use_global_arguments (#1701 <https://github.com/ros-controls/ros2_control/issues/1701>)
* Fix spawner tests timeout (#1692 <https://github.com/ros-controls/ros2_control/issues/1692>)
* Refactor spawner to be able to reuse code for ros2controlcli (#1661 <https://github.com/ros-controls/ros2_control/issues/1661>)
* Robustify controller spawner and add integration test with many controllers (#1501 <https://github.com/ros-controls/ros2_control/issues/1501>)
* Handle waiting in Spawner and align Hardware Spawner functionality (#1562 <https://github.com/ros-controls/ros2_control/issues/1562>)
* Make list controller and list hardware components immediately visualize the state. (#1606 <https://github.com/ros-controls/ros2_control/issues/1606>)
* [CI] Add coveragepy and remove ignore: test (#1668 <https://github.com/ros-controls/ros2_control/issues/1668>)
* Fix spawner unload on kill test (#1675 <https://github.com/ros-controls/ros2_control/issues/1675>)
* [CM] Add more logging for easier debugging (#1645 <https://github.com/ros-controls/ros2_control/issues/1645>)
* refactor SwitchParams to fix the incosistencies in the spawner tests (#1638 <https://github.com/ros-controls/ros2_control/issues/1638>)
* Contributors: Bence Magyar, Christoph Fröhlich, Dr. Denis, Felix Exner (fexner), Manuel Muth, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Use handle_name_ variable instead of allocating for every get_name call (#1706 <https://github.com/ros-controls/ros2_control/issues/1706>)
* Introduce Creation of Handles with InterfaceDescription (variant support) (#1679 <https://github.com/ros-controls/ros2_control/issues/1679>)
* Preparation of Handles for Variant Support (#1678 <https://github.com/ros-controls/ros2_control/issues/1678>)
* [RM] Decouple read/write cycles of each component with mutex to not block other components (#1646 <https://github.com/ros-controls/ros2_control/issues/1646>)
* Contributors: Manuel Muth, Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Refactor spawner to be able to reuse code for ros2controlcli (#1661 <https://github.com/ros-controls/ros2_control/issues/1661>)
* Make list controller and list hardware components immediately visualize the state. (#1606 <https://github.com/ros-controls/ros2_control/issues/1606>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Preparation of Handles for Variant Support (#1678 <https://github.com/ros-controls/ros2_control/issues/1678>)
* Fix flaky transmission_interface tests by making them deterministic. (#1665 <https://github.com/ros-controls/ros2_control/issues/1665>)
* Contributors: Manuel Muth, sgmurray
```
