### PR TITLE
ros2_control: 3.28.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5957,7 +5957,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.27.0-1
+      version: 3.28.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.28.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.27.0-1`

## controller_interface

- No changes

## controller_manager

```
* Inform user why rt policy could not be set, inform if is set. (backport #1705 <https://github.com/ros-controls/ros2_control/issues/1705>) (#1709 <https://github.com/ros-controls/ros2_control/issues/1709>)
* [CI] Backport #1636 <https://github.com/ros-controls/ros2_control/issues/1636> #1668 <https://github.com/ros-controls/ros2_control/issues/1668> and fix coverage on jammy (#1677 <https://github.com/ros-controls/ros2_control/issues/1677>) (#1693 <https://github.com/ros-controls/ros2_control/issues/1693>)
* Make list controller and list hardware components immediately visualize the state. (#1606 <https://github.com/ros-controls/ros2_control/issues/1606>) (#1691 <https://github.com/ros-controls/ros2_control/issues/1691>)
* Robustify spawner (backport #1501 <https://github.com/ros-controls/ros2_control/issues/1501>) (#1687 <https://github.com/ros-controls/ros2_control/issues/1687>)
* Handle on waiting (backport #1562 <https://github.com/ros-controls/ros2_control/issues/1562>) (#1681 <https://github.com/ros-controls/ros2_control/issues/1681>)
* refactor SwitchParams to fix the incosistencies in the spawner tests (backport #1638 <https://github.com/ros-controls/ros2_control/issues/1638>) (#1660 <https://github.com/ros-controls/ros2_control/issues/1660>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Make list controller and list hardware components immediately visualize the state. (#1606 <https://github.com/ros-controls/ros2_control/issues/1606>) (#1691 <https://github.com/ros-controls/ros2_control/issues/1691>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix flaky transmission_interface tests by making them deterministic. (#1665 <https://github.com/ros-controls/ros2_control/issues/1665>) (#1671 <https://github.com/ros-controls/ros2_control/issues/1671>)
* Contributors: mergify[bot]
```
