### PR TITLE
ros2_controllers: 4.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5972,7 +5972,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.12.1-1
+      version: 4.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.12.1-1`

## ackermann_steering_controller

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## admittance_controller

```
* Fix segfault at reconfigure of AdmittanceController (#1248 <https://github.com/ros-controls/ros2_controllers/issues/1248>)
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Lennart Nachtigall, Sai Kishor Kothakota
```

## bicycle_steering_controller

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## diff_drive_controller

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## joint_state_broadcaster

```
* [Joint State Broadcaster] Publish the joint_states of joints present in the URDF (#1233 <https://github.com/ros-controls/ros2_controllers/issues/1233>)
* Contributors: Sai Kishor Kothakota
```

## joint_trajectory_controller

- No changes

## parallel_gripper_controller

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## pid_controller

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## tricycle_steering_controller

```
* Fixes tests to work with use_global_arguments NodeOptions parameter  (#1256 <https://github.com/ros-controls/ros2_controllers/issues/1256>)
* Contributors: Sai Kishor Kothakota
```

## velocity_controllers

- No changes
