### PR TITLE
ros2_control: 2.43.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7750,7 +7750,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.42.0-1
+      version: 2.43.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.43.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.42.0-1`

## controller_interface

- No changes

## controller_manager

```
* Infrom user why rt policy could not be set, infrom if is set. (backport #1705 <https://github.com/ros-controls/ros2_control/issues/1705>) (#1708 <https://github.com/ros-controls/ros2_control/issues/1708>)
* Make list controller and list hardware components immediately visualize the state. (backport #1606 <https://github.com/ros-controls/ros2_control/issues/1606>) (#1690 <https://github.com/ros-controls/ros2_control/issues/1690>)
* Robustify spawner (backport #1501 <https://github.com/ros-controls/ros2_control/issues/1501>) (#1686 <https://github.com/ros-controls/ros2_control/issues/1686>)
* [CI] Backport #1636 <https://github.com/ros-controls/ros2_control/issues/1636> #1668 <https://github.com/ros-controls/ros2_control/issues/1668> and fix coverage on jammy (#1677 <https://github.com/ros-controls/ros2_control/issues/1677>)
* Handle on waiting (backport #1562 <https://github.com/ros-controls/ros2_control/issues/1562>) (#1680 <https://github.com/ros-controls/ros2_control/issues/1680>)
* refactor SwitchParams to fix the incosistencies in the spawner tests (backport #1638 <https://github.com/ros-controls/ros2_control/issues/1638>) (#1659 <https://github.com/ros-controls/ros2_control/issues/1659>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Make list controller and list hardware components immediately visualize the state. (backport #1606 <https://github.com/ros-controls/ros2_control/issues/1606>) (#1690 <https://github.com/ros-controls/ros2_control/issues/1690>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix flaky transmission_interface tests by making them deterministic. (backport #1665 <https://github.com/ros-controls/ros2_control/issues/1665>) (#1670 <https://github.com/ros-controls/ros2_control/issues/1670>)
* Contributors: mergify[bot]
```
