### PR TITLE
snmp_diagnostics: 0.1.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11533,6 +11533,21 @@ repositories:
       url: https://github.com/robosoft-ai/smacc.git
       version: noetic-devel
     status: developed
+  snmp_diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/snmp_diagnostics.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/snmp_diagnostics.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/snmp_diagnostics.git
+      version: master
+    status: developed
   snmp_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `snmp_diagnostics` to `0.1.1-1`:

- upstream repository: https://github.com/ctu-vras/snmp_diagnostics.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/snmp_diagnostics.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## snmp_diagnostics

```
* Initial release with the IF-MIB module. Do not consider any API stable yet.
* Contributors: Martin Pecka
```
