### PR TITLE
rt_usb_9axisimu_driver: 2.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8869,7 +8869,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
-      version: 2.0.2-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/rt-net/rt_usb_9axisimu_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `2.1.0-2`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## rt_usb_9axisimu_driver

```
* Fix to get the latest data (#58 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/58>)
* Add test for readSensorData() (#57 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/57>)
* checkDataFormat() and unit test updates (#54 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/54>)
* Add unit tests (#52 <https://github.com/rt-net/rt_usb_9axisimu_driver/issues/52>)
  Co-authored-by: ShotaAk <mailto:s.aoki@rt-net.jp>
* Contributors: YusukeKato
```
