### PR TITLE
ros2_controllers: 2.37.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7787,7 +7787,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.37.1-1
+      version: 2.37.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.37.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.37.1-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Fix segfault at reconfigure of AdmittanceController (#1248 <https://github.com/ros-controls/ros2_controllers/issues/1248>) (#1265 <https://github.com/ros-controls/ros2_controllers/issues/1265>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## pid_controller

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
