### PR TITLE
Remove the octomap package from Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4113,25 +4113,6 @@ repositories:
       url: https://github.com/wg-perception/object_recognition_msgs.git
       version: ros2
     status: maintained
-  octomap:
-    doc:
-      type: git
-      url: https://github.com/octomap/octomap.git
-      version: devel
-    release:
-      packages:
-      - dynamic_edt_3d
-      - octomap
-      - octovis
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/octomap-release.git
-      version: 1.10.0-3
-    source:
-      type: git
-      url: https://github.com/octomap/octomap.git
-      version: devel
-    status: maintained
   octomap_mapping:
     doc:
       type: git


### PR DESCRIPTION
This is essentially a vendor package; upstream is not a ROS package, even though it has some things in it to interoperate with ROS.

The problem is that it is *also* packaged in debian as a system package.  In Ubuntu 24.04, the system version of the package has a different ABI than this "vendored" version.

So it turns out that we don't need this version at all.  All downstream sources have been updated to use the system version of the package, rather than this vendor.  All but Moveit have done releases into Rolling as of this writing, so everything should continue to work with the exception of Moveit.

This should fix https://github.com/ros/rosdistro/issues/41622 .

@nuclearsandwich @wxmerkt FYI