### PR TITLE
add pytest-pylint plugin in 'rosdep/python.yml'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8608,6 +8608,19 @@ python3-pytest-mock:
       packages: [pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
+python3-pytest-pylint:
+  arch:
+    pip:
+      packages: [pytest-pylint]
+  debian: [python3-pytest-pylint]
+  fedora:
+    pip:
+      packages: [pytest-pylint]
+  opensuse: [python3-pytest-pylint]
+  osx:
+    pip:
+      packages: [pytest-pylint]
+  ubuntu: [python3-pytest-pylint]
 python3-pytest-ruff-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8616,7 +8616,7 @@ python3-pytest-pylint:
   fedora:
     pip:
       packages: [pytest-pylint]
-  opensuse: [python3-pytest-pylint]
+  opensuse: [python-pytest-pylint]
   osx:
     pip:
       packages: [pytest-pylint]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8616,7 +8616,6 @@ python3-pytest-pylint:
   fedora:
     pip:
       packages: [pytest-pylint]
-  opensuse: [python-pytest-pylint]
   osx:
     pip:
       packages: [pytest-pylint]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- `pytest-pylint`

## Package Upstream Source:

- https://github.com/carsongee/pytest-pylint

## Purpose of using this:

This plugin is a connector to allow you to run a pylint test with pytest tool which allows you, to retrieve xml reports to feed a pipeline

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

  
- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-pytest-pylint
  - https://packages.debian.org/trixie/python3-pytest-pylint
  - https://packages.debian.org/bookworm/python3-pytest-pylint
  - https://packages.debian.org/bullseye/python3-pytest-pylint
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-pytest-pylint
  - https://packages.ubuntu.com/jammy/python3-pytest-pylint
  - https://packages.ubuntu.com/noble/python3-pytest-pylint
- Fedora: https://packages.fedoraproject.org/
  - PIP Method
- Arch: https://www.archlinux.org/packages/
  - PIP Method
- macOS: https://formulae.brew.sh/
  - PIP Method
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pytest-pylint
- pip: https://pypi.org/project/pytest-pylint/

