### PR TITLE
ros2_ouster_drivers: 0.4.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7827,7 +7827,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_ouster_drivers` to `0.4.3-1`:

- upstream repository: https://github.com/SteveMacenski/ros2_ouster_drivers.git
- release repository: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.2-1`
