### PR TITLE
mrpt_ros: 2.13.7-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3796,7 +3796,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.13.7-1
+      version: 2.13.7-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.13.7-2`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.13.7-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libros_bridge

```
* Change ros bridge package name so it works with both ROS1 and ROS2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
