### PR TITLE
create3_sim: 3.0.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1077,6 +1077,27 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  create3_sim:
+    release:
+      packages:
+      - irobot_create_common_bringup
+      - irobot_create_control
+      - irobot_create_description
+      - irobot_create_gz_bringup
+      - irobot_create_gz_plugins
+      - irobot_create_gz_sim
+      - irobot_create_gz_toolbox
+      - irobot_create_nodes
+      - irobot_create_toolbox
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/create3_sim-release.git
+      version: 3.0.2-2
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/create3_sim.git
+      version: main
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_sim` to `3.0.2-2`:

- upstream repository: https://github.com/iRobotEducation/create3_sim.git
- release repository: https://github.com/ros2-gbp/create3_sim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## irobot_create_common_bringup

- No changes

## irobot_create_control

- No changes

## irobot_create_description

- No changes

## irobot_create_gz_bringup

- No changes

## irobot_create_gz_plugins

```
* replace gz-gui8 with gz_gui_vendor
  back to what was used before, but as depend rather than buildtool_depend
* Contributors: Alberto Soragna
```

## irobot_create_gz_sim

- No changes

## irobot_create_gz_toolbox

- No changes

## irobot_create_nodes

- No changes

## irobot_create_toolbox

- No changes
