### PR TITLE
Noetic: mark mrpt2 as deprecated and remove source & doc

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6340,20 +6340,13 @@ repositories:
       version: main
     status: maintained
   mrpt2:
-    doc:
-      type: git
-      url: https://github.com/mrpt/mrpt.git
-      version: master
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt2-release.git
       version: 2.13.5-1
-    source:
-      type: git
-      url: https://github.com/mrpt/mrpt.git
-      version: develop
-    status: developed
+    status: end-of-life
+    status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
It is being replaced by smaller, more modular, mrpt_lib* packages.

The change was already done in all ROS 2 distros, Noetic was left behind.
