### PR TITLE
hri: 2.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3146,7 +3146,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 2.3.0-1
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
cd Increasing version of package(s) in repository `hri` to `2.5.1-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.3.0-1`

## hri

```
2.5.1 (2024-08-21)
------------------

2.5.0 (2024-08-02)
------------------
* readd deprecated function signatures
* add voice locale
* add tests for gaze transform
* Contributors: Luka Juricic

2.4.1 (2024-06-19)
------------------
* [doc] minor fixes
* Contributors: Séverin Lemaignan

2.4.0 (2024-05-13)
------------------
* adding doxygen documentation
* adding body description support for Body objects
* Contributors: lorenzoferrini
```

## pyhri

```
2.5.1 (2024-08-21)
------------------
* disable some CMAKE optimization
  avoid parallel compilation warning with pybind
* add use_sim_time option to pyhri
* Contributors: Luka Juricic, Séverin Lemaignan

2.5.0 (2024-08-02)
------------------
* readd deprecated function signatures
* add voice locale
* add tests for gaze transform
* fix thread joining in pyhri listener destructor
* Contributors: Luka Juricic

2.4.1 (2024-06-19)
------------------
* add PyHRIListener destructor
* [doc] minor fixes
* various improvement to the pyhri documentation
  running  should yield a correct API documentation
* Contributors: Luka Juricic, Séverin Lemaignan

2.4.0 (2024-05-13)
------------------
```
