### PR TITLE
hri_msgs: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3161,7 +3161,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros4hri/hri_msgs-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## hri_msgs

```
* bring back LiveSpeech/language while we transition to LiveSpeech/locale
* LiveSpeech: refactor from language to locale
* fix documentation
* add copyright and documentation
* [doc] reword ROS1/ROS2 README note
* [doc] add reference to ROS 1 in README
* Contributors: Luka Juricic, Séverin Lemaignan
```
