### PR TITLE
hri_rviz: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3167,6 +3167,20 @@ repositories:
       url: https://github.com/ros4hri/hri_msgs.git
       version: humble-devel
     status: developed
+  hri_rviz:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_rviz-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
   human_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_rviz` to `2.0.0-1`:

- upstream repository: https://github.com/ros4hri/hri_rviz.git
- release repository: https://github.com/ros4hri/hri_rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_rviz

```
* re-import CHANGELOG from ROS1
* general cleanup
  linting code + fixing wrong dependencies in package.xml
* reading body description from the new dedicated topic
* add LICENSE and CONTRIBUTING.md
* using rviz-ogre-vendor instead of native ogre libraries
  see https://github.com/ros2/rviz/issues/876
* documentation
* fixed icons
* added copyright
* TF (HRI) porting
* Skeletons3D porting
* Humans porting
* Contributors: Séverin Lemaignan, lorenzoferrini
```
