### PR TITLE
hri_actions_msgs: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3152,6 +3152,20 @@ repositories:
       url: https://github.com/ros4hri/libhri.git
       version: humble-devel
     status: developed
+  hri_actions_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: humble-devel
   hri_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_actions_msgs` to `2.2.0-1`:

- upstream repository: https://github.com/ros4hri/hri_actions_msgs.git
- release repository: https://github.com/ros4hri/hri_actions_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_actions_msgs

```
2.2.0 (2024-08-01)
------------------
* add closed caption message
* Contributors: Luka Juricic

2.1.0 (2024-07-30)
------------------
* add wakeup and suspend intents
* add copyright to CMakeLists
* [doc] add reference to ROS 1 in README
* Contributors: Luka Juricic, Séverin Lemaignan

2.0.1 (2023-11-13)
------------------
* add missing dep on action_msgs
* Contributors: Séverin Lemaignan

2.0.0 (2023-11-13)
------------------
* porting to humble
* Contributors: Luka Juricic
```
