### PR TITLE
mp2p_icp: 1.5.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3684,7 +3684,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.5.3-1
+      version: 1.5.5-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.5.5-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.3-1`

## mp2p_icp

```
* Explicitly add tbb as dependency in package.xml
* Depend on new mrpt_lib packages (deprecate mrpt2)
* FIX: build errors in armhf arch
* Contributors: Jose Luis Blanco-Claraco
```
