### PR TITLE
raspimouse_ros2_examples: 2.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6748,7 +6748,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
-      version: 2.2.0-2
+      version: 2.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_ros2_examples` to `2.2.1-2`:

- upstream repository: https://github.com/rt-net/raspimouse_ros2_examples.git
- release repository: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-2`

## raspimouse_ros2_examples

```
* サービスクライアントでexecutorを使用しない (#59 <https://github.com/rt-net/raspimouse_ros2_examples/issues/59>)
* SubscriberとService Clientに別々のcallback_groupを設定 (#58 <https://github.com/rt-net/raspimouse_ros2_examples/issues/58>)
* Contributors: ShotaAk, YusukeKato
```
