### PR TITLE
urdf: 2.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8078,7 +8078,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.12.0-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.11.0-1`

## urdf

```
* Added commom linters (#39 <https://github.com/ros2/urdf/issues/39>)
* Use rcutils to log (#37 <https://github.com/ros2/urdf/issues/37>)
* Enable test_robot_model_parser test (#38 <https://github.com/ros2/urdf/issues/38>)
* Contributors: Alejandro Hernández Cordero
```

## urdf_parser_plugin

```
* Added commom linters (#39 <https://github.com/ros2/urdf/issues/39>)
* Contributors: Alejandro Hernández Cordero
```
