### PR TITLE
rviz: 14.2.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7097,7 +7097,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.2.5-1
+      version: 14.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.2.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.2.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fully handle Tool::processKeyEvent return value (#1270 <https://github.com/ros2/rviz/issues/1270>)
* Handle Tool::Finished returned by processKeyEvent (#1257 <https://github.com/ros2/rviz/issues/1257>)
* Contributors: Patrick Roncagliolo
```

## rviz_default_plugins

```
* Update urdf model.h deprecation (#1266 <https://github.com/ros2/rviz/issues/1266>)
* Enabling manual space width for TextViewFacingMarker (#1261 <https://github.com/ros2/rviz/issues/1261>)
* Contributors: Alejandro Hernández Cordero, Tom Moore
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
