### PR TITLE
fix Fedora/RHEL rosdep for `libudev-devel`

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6233,11 +6233,11 @@ libturbojpeg:
 libudev-dev:
   arch: [systemd]
   debian: [libudev-dev]
-  fedora: [libudev-devel]
+  fedora: [systemd-devel]
   gentoo: [virtual/libudev]
   nixos: [udev]
   openembedded: [udev@openembedded-core]
-  rhel: [libudev-devel]
+  rhel: [systemd-devel]
   ubuntu: [libudev-dev]
 libunittest++:
   arch: [unittestpp]


### PR DESCRIPTION
https://github.com/mcatalancid/libudev
The udev development has moved to systemd

## Links to Distribution Packages

- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/systemd/systemd-devel/
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=systemd-devel
