### PR TITLE
ros_babel_fish: 0.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6138,6 +6138,20 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros_babel_fish:
+    release:
+      packages:
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_babel_fish-release.git
+      version: 0.9.3-1
+    source:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: jazzy
+    status: developed
   ros_battery_monitoring:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.3-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ros_babel_fish

```
* Updated dependencies.
  Removed test node. Examples serve the purpose.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Removed unneeded dependency.
* Contributors: Stefan Fabian
```
