### PR TITLE
mrpt_path_planning: 0.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3766,7 +3766,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.1.4-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.3-1`

## mrpt_path_planning

```
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```
