### PR TITLE
robot_localization: 3.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5828,7 +5828,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.9.0-1
+      version: 3.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.9.1-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.9.0-1`

## robot_localization

```
* Switch robot_localization to modern CMake idioms. (#895 <https://github.com/cra-ros-pkg/robot_localization/issues/895>)
* Fix warnings when building against Rolling. (#896 <https://github.com/cra-ros-pkg/robot_localization/issues/896>)
* Resolve mixing of UTM and local transforms in local cartesian mode (#886 <https://github.com/cra-ros-pkg/robot_localization/issues/886>)
* Spam the logs a little bit less (#880 <https://github.com/cra-ros-pkg/robot_localization/issues/880>)
* Contributors: Chris Lalancette, JayHerpin, Tim Clephas
```
