### PR TITLE
robot_localization: 3.7.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5885,7 +5885,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.7.0-1
+      version: 3.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.7.1-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.0-1`

## robot_localization

```
* Fix mixing of UTM and catesian transforms with in use_local_catesian mode (#884 <https://github.com/cra-ros-pkg/robot_localization/issues/884>)
* Spam the logs a little bit less (#879 <https://github.com/cra-ros-pkg/robot_localization/issues/879>)
* Contributors: JayHerpin, Tim Clephas
```
