### PR TITLE
warehouse_ros: 2.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8461,7 +8461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.4-4
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.5-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros2-gbp/warehouse_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-4`

## warehouse_ros

```
* Add constructor taking a NodeParametersInterface (#97 <https://github.com/ros-planning/warehouse_ros/issues/97>)
* Refactor processing of parameters in loadDatabase() (#94 <https://github.com/ros-planning/warehouse_ros/issues/94>)
* Fix public OpenSSL dependency (#86 <https://github.com/ros-planning/warehouse_ros/issues/86>)
* Contributors: Bjar Ne, Calen Robinson, Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```
