### PR TITLE
warehouse_ros: 2.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10961,7 +10961,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.4-3
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.5-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros2-gbp/warehouse_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-3`

## warehouse_ros

```
* Add constructor taking a NodeParametersInterface (#97 <https://github.com/ros-planning/warehouse_ros/issues/97>)
* Refactor processing of parameters in loadDatabase() (#94 <https://github.com/ros-planning/warehouse_ros/issues/94>)
* Fix public OpenSSL dependency (#86 <https://github.com/ros-planning/warehouse_ros/issues/86>)
* Contributors: Bjar Ne, Calen Robinson, Robert Haschke, Sebastian Jahr, Vatan Aksoy Tezer
```
