### PR TITLE
gz_ros2_control: 1.2.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2492,7 +2492,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.6-1
+      version: 1.2.7-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.7-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.6-1`

## gz_ros2_control

```
* Parse position_proportional_gain parameter from URDF and update docs (#393 <https://github.com/ros-controls/gz_ros2_control//issues/393>) (#410 <https://github.com/ros-controls/gz_ros2_control//issues/410>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 8cecc69b7aa698dfd996ae545c186a42b6799d87)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* propagate gazebo remapping and other arguments to the controller node (#396 <https://github.com/ros-controls/gz_ros2_control//issues/396>) (#397 <https://github.com/ros-controls/gz_ros2_control//issues/397>)
  (cherry picked from commit cbdd3a3fc6dcb49072b501984c3294a20872dcd8)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Use spawner with --params-file argument instead of cli verbs (#399 <https://github.com/ros-controls/gz_ros2_control//issues/399>) (#409 <https://github.com/ros-controls/gz_ros2_control//issues/409>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 30e67055bcd76e198805926997d01fefcc347255)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```
