### PR TITLE
gz_ros2_control: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2302,7 +2302,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.0-3
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.1-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-3`

## gz_ros2_control

```
* Parse position_proportional_gain parameter from URDF and update docs (#393 <https://github.com/ros-controls/gz_ros2_control/issues/393>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* propagate gazebo remapping and other arguments to the controller node (#396 <https://github.com/ros-controls/gz_ros2_control/issues/396>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## gz_ros2_control_demos

```
* Use spawner with --params-file argument instead of cli verbs (#399 <https://github.com/ros-controls/gz_ros2_control/issues/399>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Christoph Fröhlich
```
