### PR TITLE
Prepare jazzy release for kuka drivers

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3625,7 +3625,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git
-      version: master
+      version: humble
     release:
       packages:
       - fri_configuration_controller
@@ -3649,7 +3649,7 @@ repositories:
     source:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git
-      version: master
+      version: humble
     status: developed
   kuka_external_control_sdk:
     doc:
@@ -3673,7 +3673,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/kroshu/kuka_robot_descriptions.git
-      version: master
+      version: humble
     release:
       packages:
       - kuka_agilus_support
@@ -3696,7 +3696,7 @@ repositories:
     source:
       type: git
       url: https://github.com/kroshu/kuka_robot_descriptions.git
-      version: master
+      version: humble
     status: developed
   lanelet2:
     doc:


### PR DESCRIPTION
`master` branch contained the the source code for `humble` distro, this was now moved to `humble` branch, `master` will be for the new `jazzy` distro