### PR TITLE
ros_gz: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6232,7 +6232,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.0.1-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Stamp all outgoing headers with the wall time if parameter override_timestamps_with_wall_time is set to true (#562 <https://github.com/gazebosim/ros_gz/issues/562>)
* Contributors: Rein Appeldoorn
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Wait for create service to be available. (#588 <https://github.com/gazebosim/ros_gz/issues/588>)
* Contributors: Sebastian Kasperski
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
