### PR TITLE
ros_gz: 1.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6540,7 +6540,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.4-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* feat: override_timestamps_with_wall_time parameter (backport #562 <https://github.com/gazebosim/ros_gz/issues/562>) (#584 <https://github.com/gazebosim/ros_gz/issues/584>)
  Co-authored-by: Rein Appeldoorn <mailto:rein.appeldoorn@nobleo.nl>
* Use memcpy instead of std::copy when bridging images (#565 <https://github.com/gazebosim/ros_gz/issues/565>) (#585 <https://github.com/gazebosim/ros_gz/issues/585>)
  While testing ros <-> gz communication using the bridge I noticed that the bridge was talking quite a bit of time copying images from Gazebo to ROS. I found that the std::copy operation that we're doing is substantially slower than the memcpy alternative. I think that in principle this shouldn't happen but the numbers are quite clear. Perhaps std::copy is doing something that doesn't use cache effectively
  ---------
  Co-authored-by: Jose Luis Rivero <jrivero@osrfoundation.org>
  (cherry picked from commit a781b78852112246245c05481db6335388d4f736)
  Co-authored-by: Carlos Agüero <caguero@openrobotics.org>
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
