### PR TITLE
depthai-ros: 2.10.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1238,6 +1238,10 @@ repositories:
       version: ros-release
     status: developed
   depthai-ros:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: jazzy
     release:
       packages:
       - depthai-ros
@@ -1251,6 +1255,12 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
       version: 2.10.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: jazzy
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1237,6 +1237,20 @@ repositories:
       url: https://github.com/luxonis/depthai-core.git
       version: ros-release
     status: developed
+  depthai-ros:
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 2.10.0-1
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.10.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## depthai-ros

```
## What's Changed
* Adding stl files for SR and LR models by @danilo-pejovic in https://github.com/luxonis/depthai-ros/pull/491
* No imu fix Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/500
* Tracking converter for ROS2 Humble by @daniqsilva25 in https://github.com/luxonis/depthai-ros/pull/505
* Added Env Hooks so that depthai xacro can be used with gazebo sim by @r4hul77 in https://github.com/luxonis/depthai-ros/pull/507
* Fix resource paths for Ignition Gazebo by @Nibanovic in https://github.com/luxonis/depthai-ros/pull/511
* Use simulation flag to decide how to load meshes. by @destogl in https://github.com/luxonis/depthai-ros/pull/524
* Add new launch file for starting multiple rgbd cameras on robots. by @destogl in https://github.com/luxonis/depthai-ros/pull/532
* Missing fields in detection messages Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/574
* Ip autodiscovery fix Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/561
* RS Mode & Sync - Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/578
* Compressed image publishers by @Serafadam in https://github.com/luxonis/depthai-ros/pull/580
* ToF Support Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/581
* WLS fix humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/582
* Syncing & RS updates Humble by @Serafadam in https://github.com/luxonis/depthai-ros/pull/586
## New Contributors
* @r4hul77 made their first contribution in https://github.com/luxonis/depthai-ros/pull/507
* @Nibanovic made their first contribution in https://github.com/luxonis/depthai-ros/pull/511
* @destogl made their first contribution in https://github.com/luxonis/depthai-ros/pull/524
**Full Changelog**: https://github.com/luxonis/depthai-ros/compare/v2.9.0-humble...v2.10.0-humble
```
