### PR TITLE
geometry2: 0.31.8-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2019,7 +2019,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.31.7-1
+      version: 0.31.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.31.8-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.31.7-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Enable Twist interpolator (backport #646 <https://github.com/ros2/geometry2/issues/646>) (#685 <https://github.com/ros2/geometry2/issues/685>)
* Contributors: mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Enable Twist interpolator (backport #646 <https://github.com/ros2/geometry2/issues/646>) (#685 <https://github.com/ros2/geometry2/issues/685>)
* Contributors: mergify[bot]
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Enable Twist interpolator (backport #646 <https://github.com/ros2/geometry2/issues/646>) (#685 <https://github.com/ros2/geometry2/issues/685>)
* Contributors: mergify[bot]
```

## tf2_ros

```
* Enable Twist interpolator (backport #646 <https://github.com/ros2/geometry2/issues/646>) (#685 <https://github.com/ros2/geometry2/issues/685>)
* Contributors: mergify[bot]
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
