### PR TITLE
ffmpeg_encoder_decoder: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1560,6 +1560,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
       version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_encoder_decoder` to `1.0.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
- release repository: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ffmpeg_encoder_decoder

```
* initial commit
* Contributors: Bernd Pfrommer
```
