### PR TITLE
turtlebot4: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8317,6 +8317,26 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
       version: ros2
     status: maintained
+  turtlebot4:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4.git
+      version: jazzy
+    release:
+      packages:
+      - turtlebot4_description
+      - turtlebot4_msgs
+      - turtlebot4_navigation
+      - turtlebot4_node
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4.git
+      version: jazzy
+    status: developed
   tuw_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `2.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot4_description

```
* Add base_footprint link to URDF
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Update the SLAM launch file so it works with the latest version of slam_toolbox. Rather than re-impementing all of the launch file, just include the online_sync or online_async launch files as appropriate
* Update nav2 launch configuration to work with the latest jazzy: syntax changes (/ -> ::)
* Use TwistStamped messages for velocity controllers
* Use MPPIController for path follower plugin instead of DWMLocalPlanner
* Assorted minor yaml formatting fixes (e.g. consistent caps for true & false)
* Use base_footprint link as the tf base for slam & localization
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_node

- No changes
