### PR TITLE
mrpt_sensors: 0.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4043,7 +4043,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.2.3-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.2-1`

## mrpt_generic_sensor

```
* Update copyright comment blocks to try to make ament linter happy
* Update to package XML format 3
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_bumblebee_stereo

```
* Update copyright comment blocks to try to make ament linter happy
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Update to package XML format 3
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_nmea

```
* Update copyright comment blocks to try to make ament linter happy
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Update to package XML format 3
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_novatel

```
* Update copyright comment blocks to try to make ament linter happy
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Update to package XML format 3
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_imu_taobotics

```
* Update copyright comment blocks to try to make ament linter happy
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Update to package XML format 3
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* Update copyright comment blocks to try to make ament linter happy
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Update to package XML format 3
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

- No changes
