### PR TITLE
mvsim: 0.10.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6540,7 +6540,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.10.0-1
+      version: 0.10.0-2
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.10.0-2`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.10.0-1`

## mvsim

```
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Merge pull request #52 <https://github.com/MRPT/mvsim/issues/52> from finani/fix-fake-amcl
  Fix fake amcl topic (QoS Durability)
* Update outdated copyright years in source files
* Merge pull request #51 <https://github.com/MRPT/mvsim/issues/51> from finani/nav2-compatible
  Nav2 compatible
* Update codebase to new clang-format style
* Merge pull request #48 <https://github.com/MRPT/mvsim/issues/48> from finani/refactoring-node
  Refactoring node
* Merge pull request #45 <https://github.com/MRPT/mvsim/issues/45> from finani/develop
  Add tf pub for each robot (support namespace)
* Merge pull request #43 <https://github.com/MRPT/mvsim/issues/43> from kr-jschoi/fix-bug
  Fix namespace switching bug between mvsim.chassis_shape and mvsim.chassis_shape.wheel3 in /chassis_markers
* Contributors: Inhwan Wee, Jose Luis Blanco-Claraco, finani, kr-jschoi
```
