### PR TITLE
Add python3-owslib to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7643,6 +7643,7 @@ python3-owlready2-pip:
 python3-owslib:
   arch: [python-owslib]
   debian: [python3-owslib]
+  fedora: [python3-OWSLib]
   gentoo: [dev-python/owslib]
   nixos: [python312Packages.owslib]
   opensuse: [python3-OWSLib]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7640,6 +7640,14 @@ python3-owlready2-pip:
   ubuntu:
     pip:
       packages: [owlready2]
+python3-owslib:
+  arch: [python-owslib]
+  debian: [python3-owslib]
+  gentoo: [dev-python/owslib]
+  nixos: [python312Packages.owslib]
+  opensuse: [python3-OWSLib]
+  rhel: [python3-OWSLib]
+  ubuntu: [python3-owslib]
 python3-packaging:
   alpine: [py3-packaging]
   arch: [python-packaging]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7646,7 +7646,6 @@ python3-owslib:
   fedora: [python3-OWSLib]
   gentoo: [dev-python/owslib]
   nixos: [python312Packages.owslib]
-  opensuse: [python3-OWSLib]
   rhel: [python3-OWSLib]
   ubuntu: [python3-owslib]
 python3-packaging:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

OWSLib

## Package Upstream Source:

https://github.com/geopython/OWSLib

## Purpose of using this:

This is a popular Python package that provides a client API for programming against Open Geospatial Consortium (OGC) compliant web services which is why I think it would be a valuable addition to the rosdep index.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-owslib
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/python3-owslib
  - https://packages.ubuntu.com/jammy/python3-owslib
  - https://packages.ubuntu.com/mantic/python3-owslib
  - https://packages.ubuntu.com/noble/python3-owslib
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-owslib/
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-OWSLib/python3-OWSLib/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/owslib
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=owslib
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-aarch64/python3-OWSLib-0.28.1-1.el9.noarch.rpm.html
  - https://rhel.pkgs.org/9/epel-x86_64/python3-OWSLib-0.28.1-1.el9.noarch.rpm.html
  - https://rhel.pkgs.org/8/epel-aarch64/python3-OWSLib-0.28.1-1.el8.noarch.rpm.html
  - https://rhel.pkgs.org/8/epel-x86_64/python3-OWSLib-0.28.1-1.el9.noarch.rpm.html
 