### PR TITLE
mrpt_navigation: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4892,7 +4892,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.1.1-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## mrpt_map_server

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* Fix duplicated deps
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* Fix duplicated deps
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav_interfaces

- No changes

## mrpt_navigation

- No changes

## mrpt_pf_localization

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_rawlog

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* rosbag2rawlog app: support generating CObservationOdometry from /tf odom->base_link msgs
* mrpt_rawlog: delete old ROS1 leftover files
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* rosbag2rawlog app: support generating CObservationOdometry from /tf odom->base_link msgs
* mrpt_rawlog: delete old ROS1 leftover files
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* Fix duplicated deps
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* Fix duplicated deps
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tps_astar_planner

```
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* Fix duplicated deps
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
* Remove temporary workaround in <depends> for buggy mrpt_libros_bridge package.xml
* Fix duplicated deps
* update dependencies
* Depend on new mrpt_lib packages (deprecate mrpt2)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

- No changes
