### PR TITLE
ros_babel_fish: 0.9.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8046,6 +8046,20 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros_babel_fish:
+    release:
+      packages:
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_babel_fish-release.git
+      version: 0.9.1-1
+    source:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: humble
+    status: developed
   ros_canopen:
     release:
       packages:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8047,6 +8047,10 @@ repositories:
       version: main
     status: maintained
   ros_babel_fish:
+    doc:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: humble
     release:
       packages:
       - ros_babel_fish


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.1-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ros_babel_fish

```
* Updated dependencies.
* Added missing test depend and configured ament_cmake_clang_format.
* Formatting.
* Renamed package to ros_babel_fish as requested in ros/rosdistro#41540 <https://github.com/ros/rosdistro/issues/41540>
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Updated dependencies.
* Renamed package to ros_babel_fish as requested in ros/rosdistro#41540 <https://github.com/ros/rosdistro/issues/41540>
* Contributors: Stefan Fabian
```
