### PR TITLE
teleop_tools: 1.5.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8004,7 +8004,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
-      version: 1.5.0-3
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7993,7 +7993,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: foxy-devel
+      version: master
     release:
       packages:
       - joy_teleop
@@ -8008,7 +8008,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: foxy-devel
+      version: master
     status: maintained
   teleop_twist_joy:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.5.1-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros2-gbp/teleop_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.0-3`

## joy_teleop

```
* Removed action tutorials interfaces dependency (#88 <https://github.com/ros-teleop/teleop_tools/issues/88>)
* Contributors: Alejandro Hernández Cordero
```

## key_teleop

- No changes

## mouse_teleop

- No changes

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
