### PR TITLE
turtlebot4_desktop: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8353,6 +8353,24 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4.git
       version: jazzy
     status: developed
+  turtlebot4_desktop:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_desktop.git
+      version: jazzy
+    release:
+      packages:
+      - turtlebot4_desktop
+      - turtlebot4_viz
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_desktop.git
+      version: jazzy
+    status: developed
   tuw_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_desktop` to `2.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_desktop.git
- release repository: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot4_desktop

- No changes

## turtlebot4_viz

```
* Add new view_navigation launch file
* Remove Nav2 plugins from view_robot launch file
* Load the description when using view_model launch file
* Update Github CI to use Jazzy and ROS testing
* Linter fixes for Jazzy
* Initial Jazzy implementation (#9 <https://github.com/turtlebot/turtlebot4_desktop/issues/9>)
* Contributors: Chris Iverach-Brereton
```
