### PR TITLE
topic_tools: 1.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8189,7 +8189,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.3.0-3
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.3.1-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-3`

## topic_tools

```
* Add demux (#106 <https://github.com/ros-tooling/topic_tools/issues/106>) (#109 <https://github.com/ros-tooling/topic_tools/issues/109>)
* Contributors: Rufus Wong
```

## topic_tools_interfaces

```
* Add demux (#106 <https://github.com/ros-tooling/topic_tools/issues/106>) (#109 <https://github.com/ros-tooling/topic_tools/issues/109>)
* Contributors: Rufus Wong <mailto:rcywongaa@gmail.com>
```
