### PR TITLE
Update branches for ros_gz

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6248,7 +6248,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: humble
+      version: iron
     release:
       packages:
       - ros_gz
@@ -6272,7 +6272,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: humble
+      version: iron
     status: developed
   ros_image_to_qimage:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6563,7 +6563,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: humble
+      version: jazzy
     release:
       packages:
       - ros_gz
@@ -6581,7 +6581,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: humble
+      version: jazzy
     status: developed
   ros_image_to_qimage:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6231,7 +6231,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: humble
+      version: ros2
     release:
       packages:
       - ros_gz
@@ -6249,7 +6249,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: humble
+      version: ros2
     status: developed
   ros_image_to_qimage:
     doc:


### PR DESCRIPTION
At one point, the `ros_gz` package used the `humble` branch to make releases for `iron` and `rolling`. That has since changed and there' snow a branch for each ROS 2 release.
