### PR TITLE
xacro: 2.0.11-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8835,7 +8835,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.9-3
+      version: 2.0.11-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.11-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.9-3`

## xacro

```
* Allow substitution args without ROS (#340 <https://github.com/ros/xacro/issues/340>)
* Add more unit tags for yaml files  (#331 <https://github.com/ros/xacro/issues/331>)
* Resolve $(find ...) as a result of a substitution argument (#339 <https://github.com/ros/xacro/issues/339>)
* Mark regexes as raw strings (#336 <https://github.com/ros/xacro/issues/336>)
* Add pyproject.toml for direct installation via pip (#329 <https://github.com/ros/xacro/issues/329>)
* Contributors: Adam Heins, Bruno-Pier, Carlo Rizzardo, Lukas Huber, Robert Haschke
```
