### PR TITLE
qml_ros2_plugin: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6650,6 +6650,21 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbshin-ros.git
       version: production-humble
     status: developed
+  qml_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml_ros2_plugin.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml_ros2_plugin.git
+      version: master
+    status: developed
   qpoases_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `qml_ros2_plugin` to `1.0.1-1`:

- upstream repository: https://github.com/StefanFabian/qml_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## qml_ros2_plugin

```
* Added missing dependencies.
* Contributors: Stefan Fabian
```
