### PR TITLE
mrpt_navigation: 1.0.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6380,7 +6380,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.6-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.5-1`

## mrpt_local_obstacles

```
* port to new mrpt_lib ROS packages as dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_localization

```
* port to new mrpt_lib ROS packages as dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_map

```
* port to new mrpt_lib ROS packages as dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* port to new mrpt_lib ROS packages as dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

- No changes

## mrpt_rawlog

```
* port to new mrpt_lib ROS packages as dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* port to new mrpt_lib ROS packages as dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

- No changes
