### PR TITLE
rosbag2: 0.29.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6355,7 +6355,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.28.0-1
+      version: 0.29.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.29.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.28.0-1`

## liblz4_vendor

- No changes

## mcap_vendor

```
* Update mcap (#1774 <https://github.com/ros2/rosbag2/issues/1774>)
  Update mcap cpp to last version
* Contributors: mosfet80
```

## ros2bag

```
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>)
* Add computation of size contribution to info verb (#1726 <https://github.com/ros2/rosbag2/issues/1726>)
* Contributors: Nicola Loi, Roman
```

## rosbag2

- No changes

## rosbag2_compression

```
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>)
* Bugfix for bag_split event callbacks called to early with file compression (#1643 <https://github.com/ros2/rosbag2/issues/1643>)
* Contributors: Michael Orlov, Roman
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add computation of size contribution to info verb (#1726 <https://github.com/ros2/rosbag2/issues/1726>)
* [WIP] Remove rcpputils::fs dependencies in rosbag2 packages (#1740 <https://github.com/ros2/rosbag2/issues/1740>)
* Removed deprecated write method (#1738 <https://github.com/ros2/rosbag2/issues/1738>)
* Bugfix for bag_split event callbacks called to early with file compression (#1643 <https://github.com/ros2/rosbag2/issues/1643>)
* Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1725 <https://github.com/ros2/rosbag2/issues/1725>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov, Nicola Loi, Tomoya Fujita
```

## rosbag2_examples_cpp

```
* Add rosbag2_examples_cpp/simple_bag_reader.cpp. (#1683 <https://github.com/ros2/rosbag2/issues/1683>)
* Contributors: Tomoya Fujita
```

## rosbag2_examples_py

```
* simple_bag_reader.py should publish the data for each timer callback. (#1767 <https://github.com/ros2/rosbag2/issues/1767>)
* Change the python examples to use the rclpy context manager. (#1758 <https://github.com/ros2/rosbag2/issues/1758>)
* Add rosbag2_examples_cpp/simple_bag_reader.cpp. (#1683 <https://github.com/ros2/rosbag2/issues/1683>)
* Contributors: Chris Lalancette, Tomoya Fujita
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Added method to introspect QoS in Python (#1648 <https://github.com/ros2/rosbag2/issues/1648>)
* Update CI scripts to use Ubuntu Noble distros and bump action scripts to latest versions (#1709 <https://github.com/ros2/rosbag2/issues/1709>)
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>)
* Add computation of size contribution to info verb (#1726 <https://github.com/ros2/rosbag2/issues/1726>)
* Bugfix for wrong timestamps in ros2 bag info (#1745 <https://github.com/ros2/rosbag2/issues/1745>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov, Nicola Loi, Roman
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

```
* Fix incorrect zero size for sqlite storage (#1759 <https://github.com/ros2/rosbag2/issues/1759>)
* Fix for failing throws_on_invalid_pragma_in_config_file on Windows (#1742 <https://github.com/ros2/rosbag2/issues/1742>)
* Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1725 <https://github.com/ros2/rosbag2/issues/1725>)
* Contributors: Michael Orlov, Roman, Tomoya Fujita
```

## rosbag2_test_common

```
* Small cleanups to the rosbag2 tests. (#1792 <https://github.com/ros2/rosbag2/issues/1792>)
* [WIP] Remove rcpputils::fs dependencies in rosbag2 packages (#1740 <https://github.com/ros2/rosbag2/issues/1740>)
* Contributors: Chris Lalancette, Michael Orlov
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Small cleanups to the rosbag2 tests. (#1792 <https://github.com/ros2/rosbag2/issues/1792>)
* Add computation of size contribution to info verb (#1726 <https://github.com/ros2/rosbag2/issues/1726>)
* Bugfix for wrong timestamps in ros2 bag info (#1745 <https://github.com/ros2/rosbag2/issues/1745>)
* Fix for a false negative integration test with bag split in recorder (#1743 <https://github.com/ros2/rosbag2/issues/1743>)
* Contributors: Chris Lalancette, Michael Orlov, Nicola Loi
```

## rosbag2_transport

```
* Removed warnings (#1794 <https://github.com/ros2/rosbag2/issues/1794>)
* Small cleanups to the rosbag2 tests. (#1792 <https://github.com/ros2/rosbag2/issues/1792>)
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>)
* [WIP] Remove rcpputils::fs dependencies in rosbag2 packages (#1740 <https://github.com/ros2/rosbag2/issues/1740>)
* Bugfix for bag_split event callbacks called to early with file compression (#1643 <https://github.com/ros2/rosbag2/issues/1643>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Michael Orlov, Roman
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

```
* Bump sqlite3 to 3.45.1 (#1737 <https://github.com/ros2/rosbag2/issues/1737>)
* Contributors: Christophe Bedard
```

## zstd_vendor

- No changes
