### PR TITLE
turtlebot4_simulator: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8371,6 +8371,26 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_desktop.git
       version: jazzy
     status: developed
+  turtlebot4_simulator:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_simulator.git
+      version: jazzy
+    release:
+      packages:
+      - turtlebot4_gz_bringup
+      - turtlebot4_gz_gui_plugins
+      - turtlebot4_gz_toolbox
+      - turtlebot4_simulator
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_simulator.git
+      version: jazzy
+    status: developed
   tuw_geometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `2.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot4_gz_bringup

```
* Ignition/ign rename to gz
* Update launch files to remove deprecations
* Use new view_navigation launch for the rviz argument
* Update dependencies for Gazebo Harmonic
* Enable OSRF testing packages for Github CI
* Initial Jazzy implementation (#80 <https://github.com/turtlebot/turtlebot4_simulator/issues/80>)
* Linting & formatting fixes
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_gz_gui_plugins

```
* Ignition/ign rename to gz
* Update launch files to remove deprecations
* Update dependencies for Gazebo Harmonic
* Enable OSRF testing packages for Github CI
* Initial Jazzy implementation (#80 <https://github.com/turtlebot/turtlebot4_simulator/issues/80>)
* Linting & formatting fixes
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_gz_toolbox

```
* Ignition/ign rename to gz
* Update dependencies for Gazebo Harmonic
* Enable OSRF testing packages for Github CI
* Initial Jazzy implementation (#80 <https://github.com/turtlebot/turtlebot4_simulator/issues/80>)
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_simulator

```
* Ignition/ign rename to gz
* Update dependencies for Gazebo Harmonic
* Enable OSRF testing packages for Github CI
* Initial Jazzy implementation (#80 <https://github.com/turtlebot/turtlebot4_simulator/issues/80>)
* Contributors: Chris Iverach-Brereton
```
