### PR TITLE
topic_tools: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7745,7 +7745,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.3.0-2
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.4.0-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-2`

## topic_tools

```
* Fix unsubscribing when switching to none topic (#111 <https://github.com/ros-tooling/topic_tools/issues/111>)
* Add demux (#106 <https://github.com/ros-tooling/topic_tools/issues/106>)
* Contributors: Adam Morrissett, Rufus Wong
```

## topic_tools_interfaces

```
* Add demux (#106 <https://github.com/ros-tooling/topic_tools/issues/106>)
* Contributors: Rufus Wong
```
