### PR TITLE
cras_ros_utils: 2.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1793,7 +1793,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1793,7 +1793,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.3.9-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.4.2-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.9-1`

## cras_cpp_common

```
* Added small_map and fixed concurrency problems in log_utils.
* Updated fast_float to 6.1.5.
* node_from_nodelet: Fixed error message
* Contributors: Martin Pecka
```

## cras_docs_common

```
* Fine-tuned appearance of inline code in Spinx docs and allowed to type inline code by single backticks.
* Contributors: Martin Pecka
```

## cras_py_common

```
* log_utils: Addded log_once_identical() functions.
* log_utils: Fixed stack information for cras.log().
* string_utils: Fixed iconv functions when running with LC_ALL=C or other weird locale.
* Added python_utils.
* string_utils: Added methods for iconv-like conversions of strings and sanitization or ROS names.
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* Little fixes suggested by linters.
* priority_mux: Added option to invert disable_topic.
* Contributors: Martin Pecka
```

## image_transport_codecs

- No changes
