### PR TITLE
autoware_lanelet2_extension: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -581,7 +581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.6.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-1`

## autoware_lanelet2_extension

```
* feat(lanelet2_extension)!: release format_v2 (#26 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/26>)
* docs(autoware_lanelet2_extension): refactor document (#25 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/25>)
  * refactor doc
  * Update autoware_lanelet2_extension/docs/lanelet2_format_extension.md
  Co-authored-by: Ryohsuke Mitsudome <mailto:43976834+mitsudome-r@users.noreply.github.com>
  ---------
  Co-authored-by: Ryohsuke Mitsudome <mailto:43976834+mitsudome-r@users.noreply.github.com>
* feat(lanelet2_extension): format v2 bicycle lane doc (#24 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/24>)
* feat(lanelet2_extension): update documentation for bus_stop_area to be introduced in format_version2 (#21 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/21>)
* feat(lanelet2_extension): add bus_stop_area implementation (#22 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/22>)
* Contributors: Mamoru Sobue
```

## autoware_lanelet2_extension_python

- No changes
