### PR TITLE
ament_black: 0.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/botsandus/ament_black.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.6-1`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/ros2-gbp/ament_black-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.5-1`

## ament_black

```
* Add packaging as a required dependency (#14 <https://github.com/botsandus/ament_black/issues/14>)
  Follow up to:
  - https://github.com/botsandus/ament_black/pull/13
* Contributors: Ruffin
```

## ament_cmake_black

- No changes
