### PR TITLE
timed_roslaunch: 0.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12075,6 +12075,21 @@ repositories:
       url: https://github.com/ThundeRatz/thunder_line_follower_pmr3100.git
       version: master
     status: developed
+  timed_roslaunch:
+    doc:
+      type: git
+      url: https://github.com/Tiryoh/timed_roslaunch.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/Tiryoh/timed_roslaunch-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/Tiryoh/timed_roslaunch.git
+      version: noetic-devel
+    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
I am preparing a release for Noetic on behalf of the original author because the project is not active over 4 years. If the original author wishes to maintain it in the future, I am willing to hand it over at that time.
https://github.com/MoriKen254/timed_roslaunch/issues/21

Increasing version of package(s) in repository `timed_roslaunch` to `0.2.0-1`:

- upstream repository: https://github.com/Tiryoh/timed_roslaunch.git
- release repository: https://github.com/Tiryoh/timed_roslaunch-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## timed_roslaunch

```
* Update maintainer
* Use GitHub Actions
* Add "output" option to launch #20 <https://github.com/MoriKen254/timed_roslaunch/pull/20>
```
