### PR TITLE
remove the 'pybind11-dev' key for RHEL8

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7773,6 +7773,7 @@ pybind11-dev:
   rhel:
     '*': [pybind11-devel]
     '7': null
+    '8': null
   ubuntu: [pybind11-dev]
 pybind11-json-dev:
   debian: [pybind11-json-dev]


### PR DESCRIPTION
Remove the `pybind11-dev` key for RHEL8 since the package `pybind11-devel` is not available any more: https://bugzilla.redhat.com/show_bug.cgi?id=2151596.

Fixes https://github.com/ros/rosdistro/issues/42698. (@cottsay)