### PR TITLE
teleop_twist_joy: 2.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8073,7 +8073,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.6.0-3
+      version: 2.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.6.1-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.0-3`

## teleop_twist_joy

```
* Added Github action (#48 <https://github.com/ros2/teleop_twist_joy/issues/48>)
* Add an option to publish TwistStamped (#42 <https://github.com/ros2/teleop_twist_joy/issues/42>)
* Add support for PDP joysticks (#41 <https://github.com/ros2/teleop_twist_joy/issues/41>)
  * Add support for PDP joysticks
* Contributors: Alejandro Hernández Cordero, Bonolo Mathibela, Tamaki Nishino
```
