### PR TITLE
rqt_bag: 1.5.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7070,7 +7070,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.5.3-1
+      version: 1.5.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.5.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.3-1`

## rqt_bag

```
* Updated player QoS (backport #164 <https://github.com/ros-visualization/rqt_bag/issues/164>) (#167 <https://github.com/ros-visualization/rqt_bag/issues/167>)
  Updated player QoS (#164 <https://github.com/ros-visualization/rqt_bag/issues/164>)
  (cherry picked from commit 4a9a69617e439140771a2b292aaa4aa93a213a03)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rqt_bag_plugins

- No changes
