### PR TITLE
rviz: 14.1.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7544,7 +7544,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.4-1
+      version: 14.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `14.1.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Handle Tool::Finished returned by processKeyEvent (#1257 <https://github.com/ros2/rviz/issues/1257>) (#1263 <https://github.com/ros2/rviz/issues/1263>)
  (cherry picked from commit 37cf8051a4dec9bbaddd17ca07d846b3e5016a99)
  Co-authored-by: Patrick Roncagliolo <mailto:ronca.pat@gmail.com>
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Enabling manual space width for TextViewFacingMarker (#1261 <https://github.com/ros2/rviz/issues/1261>) (#1267 <https://github.com/ros2/rviz/issues/1267>)
  (cherry picked from commit db7e7f8e8e3e1d848c24d8430bb66e3d79a1e50f)
  Co-authored-by: Tom Moore <mailto:tmoore@locusrobotics.com>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
