### PR TITLE
teleop_twist_joy: 2.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7600,7 +7600,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.6.1-1
+      version: 2.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.6.2-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.1-1`

## teleop_twist_joy

```
* Update the launch file to work with modern joy. (#52 <https://github.com/ros2/teleop_twist_joy/issues/52>)
  It should use "device_id" (not "dev") as the parameter,
  and the parameter should be a number, not a path (this is
  effectively the SDL device number, which is cross-platform).
* Contributors: Chris Lalancette
```
