### PR TITLE
ros2_tracing: 8.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6425,7 +6425,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.2.1-1
+      version: 8.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.2-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `8.2.1-1`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

```
* Run relevant test_tracetools tests with all instrumented rmw impls (#134 <https://github.com/ros2/ros2_tracing/issues/134>)
* Contributors: Christophe Bedard
```

## tracetools_trace

- No changes
