### PR TITLE
rclpy: 7.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5611,7 +5611,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.1.1-2
+      version: 7.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `7.1.1-2`

## rclpy

```
* Fixes spin_until_future_complete inside callback (#1316 <https://github.com/ros2/rclpy/issues/1316>) (#1341 <https://github.com/ros2/rclpy/issues/1341>)
  Closes rclpy:#1313 <https://github.com/ros2/rclpy/issues/1313>
  Current if spin_unitl_future_complete is called inside a nodes callback it removes the node from the executor
  This results in any subsiquent waitables to never be checked by the node since the node is no longer in the executor
  This aims to fix that by only removing the node from the executor if it wasn't already present
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  (cherry picked from commit 47346ef9688039b890ae19c499d4b51587a7305b)
  Co-authored-by: Jonathan <mailto:jmblixt3@gmail.com>
* Install signal handlers after context is initialized. (#1333 <https://github.com/ros2/rclpy/issues/1333>)
  Co-authored-by: Shane Loretz <mailto:shane.loretz@gmail.com>
* Fix a bad bug in fetching the lifecycle transitions. (#1321 <https://github.com/ros2/rclpy/issues/1321>) (#1322 <https://github.com/ros2/rclpy/issues/1322>)
  We were fetching one more lifecycle transition than existed
  in the source list (i.e. we should use < instead of <=).
  In turn, this allows us to enable the test_lifecycle.py test,
  and to fix the spurious "empty" string in the expected states.
  (cherry picked from commit 2a8f23ed1b52ea2355658cce09d7045b955f417a)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Tomoya Fujita, mergify[bot]
```
