### PR TITLE
marti_common: 3.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4268,7 +4268,6 @@ repositories:
       - swri_image_util
       - swri_math_util
       - swri_opencv_util
-      - swri_prefix_tools
       - swri_roscpp
       - swri_route_util
       - swri_serial_util
@@ -4277,7 +4276,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.6.1-1
+      version: 3.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.7.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.1-1`

## swri_cli_tools

```
* Fix Unit Test Failures (#740 <https://github.com/swri-robotics/marti_common/issues/740>)
  * Fixing inverse transform
  * Fixing various CI build failures.
* Contributors: David Anthony
```

## swri_console_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Fully specifying type to avoid warnings on Arm platforms (#717 <https://github.com/swri-robotics/marti_common/issues/717>)
* Contributors: David Anthony
```

## swri_dbw_interface

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_geometry_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_image_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_math_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_opencv_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_roscpp

```
* Simplify Cmake by linking to the library target (#742 <https://github.com/swri-robotics/marti_common/issues/742>)
  By linking to the library target, we can reuse the include paths and libraries from it. This will
  simplify the Cmake a bit.
  It also fixes a bug when linking to the ros2-jazzy branch of diagnostic_updater.
* Sanity checking time before performing duration calculation (#735 <https://github.com/swri-robotics/marti_common/issues/735>)
* Add definitions for subscribers with unique_ptr callback arguments (#731 <https://github.com/swri-robotics/marti_common/issues/731>)
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony, Ramon Wijnands, Veronica Knisley
```

## swri_route_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_serial_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_system_util

```
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony
```

## swri_transform_util

```
* Fix Test Failures (#745 <https://github.com/swri-robotics/marti_common/issues/745>)
  * Checking if increasing timeout value will fix test failure
  * Making default origin all NaN
* Updating Tests With New Error Bounds (#741 <https://github.com/swri-robotics/marti_common/issues/741>)
* Replaced local projection math with geographiclib (#739 <https://github.com/swri-robotics/marti_common/issues/739>)
  * Replaced local projection math with geographiclib
  * Updated unit tests with new values
* Fix Unit Test Failures (#740 <https://github.com/swri-robotics/marti_common/issues/740>)
  * Fixing inverse transform
  * Fixing various CI build failures.
* changed from python-transforms3d-pip dep to python3-transforms3d dep. (#730 <https://github.com/swri-robotics/marti_common/issues/730>)
* Fix UTM Utils and Get Tests to Build in ROS 2 (#729 <https://github.com/swri-robotics/marti_common/issues/729>)
  * Fix north and south projections
  * Enable tests and fix coordinate types
  * Updating test condition to match ROS 1 condition
  * Format build files like on other in-progress branch
  * Got a couple of the swri_transform_util unit tests working.
  * Got a few more transform manager tests to work. Loss of precision somewhere causing existing test to fail.
  * Uncommented all swri_transform_util::TransformManager tests.
  * Update tests for ROS 2 except pytests
  * Port python tests
  * Update navsatfix test to match gpsfix test
  ---------
  Co-authored-by: robert.brothers <mailto:robert.brothers@swri.org>
* Adding better initialization of origin (#725 <https://github.com/swri-robotics/marti_common/issues/725>)
* Adding Adelaide UTM <-> WGS84 test case (#723 <https://github.com/swri-robotics/marti_common/issues/723>)
* Fixing wrapping around negative/positive lat/lon changes (#722 <https://github.com/swri-robotics/marti_common/issues/722>)
* Cleaning up package maintainer (#721 <https://github.com/swri-robotics/marti_common/issues/721>)
* Contributors: David Anthony, JayHerpin, Robert Brothers, Veronica Knisley
```
