### PR TITLE
performance_test_fixture: 0.2.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4829,7 +4829,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.2.0-3
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.2.1-2`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.0-3`

## performance_test_fixture

```
* Fix a warning when building on Ubuntu Noble. (#26 <https://github.com/ros2/performance_test_fixture/issues/26>) (#27 <https://github.com/ros2/performance_test_fixture/issues/27>)
  In particular, gcc 13.2 was complaining that we were
  accessing a pointer after a free.  And that was technically
  true; the calls to DoNotOptimize(ptr) were after the
  free.  Just move this before the free (when the ptr is still
  valid) to remove the warning, but still ensure that we don't
  optimize the pointer away.
  (cherry picked from commit e406c3cf4a352ab3f89c43fcebe7503781be5905)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
