### PR TITLE
mapviz: 1.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5501,7 +5501,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/mapviz-release.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `1.4.3-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/swri-robotics-gbp/mapviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.2-1`

## mapviz

```
* Restore and refactor use_latest_transforms option for point drawing plugins like Odometry. (#705 <https://github.com/swri-robotics/mapviz/issues/705>)
* Avoid deprecated GLUT_LIBRARY variable (#755 <https://github.com/swri-robotics/mapviz/issues/755>)
  GLUT_LIBRARY is deprecated, and, more importantly, is not normally set
  since CMake 3.22. This looks like a CMake bug, but it is good to not use
  deprecated things anyway.
* Contributors: Ben Wolsieffer, Marc Alban
```

## mapviz_plugins

```
* Adding rotation to image_plugin (#682 <https://github.com/swri-robotics/mapviz/issues/682>)
  * Adding rotation to image_plugin
  ---------
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* fixed button connect (#807 <https://github.com/swri-robotics/mapviz/issues/807>)
* Restore and refactor use_latest_transforms option for point drawing plugins like Odometry. (#705 <https://github.com/swri-robotics/mapviz/issues/705>)
* Contributors: Anthony Jiang, Marc Alban, TobinHall
```

## multires_image

- No changes

## tile_map

```
* Fix unitialized bing source (#799 <https://github.com/swri-robotics/mapviz/issues/799>)
  Co-authored-by: Alex Youngs <mailto:alexyoungs@hatchbed.com>
* Contributors: agyoungs
```
