### PR TITLE
python_mrpt_ros: 2.13.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5254,7 +5254,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
-      version: 2.13.7-1
+      version: 2.13.8-1
     source:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_mrpt_ros` to `2.13.8-1`:

- upstream repository: https://github.com/MRPT/python_mrpt_ros.git
- release repository: https://github.com/ros2-gbp/python_mrpt_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.13.7-1`
