### PR TITLE
vector_pursuit_controller: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10805,6 +10805,11 @@ repositories:
       type: git
       url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
       version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/vector_pursuit_controller-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vector_pursuit_controller` to `1.0.1-1`:

- upstream repository: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
- release repository: https://github.com/ros2-gbp/vector_pursuit_controller-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## vector_pursuit_controller

```
* Fixed liniting issues
* package manifest updated
* updated readme
* docs: Update README with detailed parameter descriptions and feature parameters
* Updated parameter descriptions and values. Changed p_gain to k. Readme updates.
* new tutorial added with launch and config in repo, readme updated
* updated readme and code coverage report
* Dyanmic parameter test
* Update README.md to add video and fix typo
* Merge pull request #1 <https://github.com/blackcoffeerobotics/vector_pursuit_controller/issues/1> from blackcoffeerobotics/devel-testing
  Improved test coverage and minor bug fixes
* Improved test coverage, fixed turning radius calculation, updated optimal p_gain value in README
* Linter updates
* readme update, code coverage added, package manifest update
* Added Screw calculation
  Updated the algorithm theory and added relevant diagrams for better understanding
* initial commit
* Contributors: Arthur, Arthur Gomes, Kostubh Khandelwal, exMachina316
```
