### PR TITLE
teleop_twist_joy: 2.4.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9794,7 +9794,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.6-1
+      version: 2.4.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.7-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.6-1`

## teleop_twist_joy

```
* Update the launch file to work with modern joy. (#52 <https://github.com/ros2/teleop_twist_joy/issues/52>) (#53 <https://github.com/ros2/teleop_twist_joy/issues/53>)
  It should use "device_id" (not "dev") as the parameter,
  and the parameter should be a number, not a path (this is
  effectively the SDL device number, which is cross-platform).
  (cherry picked from commit e4856e4afeda704547bdb43edc29d008b07f15d9)
  # Conflicts:
  #     README.md
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
