### PR TITLE
Add webpy to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10190,7 +10190,6 @@ python3-webargs:
 python3-webpy:
   debian: [python3-webpy]
   fedora: [python3-webpy]
-  rhel: [py3-webpy]
   ubuntu: [python3-webpy]
 python3-websocket:
   debian: [python3-websocket]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10187,6 +10187,11 @@ python3-webargs:
     focal:
       pip:
         packages: [webargs]
+python3-webpy:
+  debian: [python3-webpy]
+  fedora: [python3-webpy]
+  rhel: [py3-webpy]
+  ubuntu: [python3-webpy]
 python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]


### PR DESCRIPTION
## Package name:

webpy (python3-webpy)

## Package Upstream Source:

https://github.com/webpy/webpy

## Purpose of using this:

A simple web server implementation available in the public domain. Python 2 version (python-webpy) already in python.yaml.

## Links to Distribution Packages

- Debian: https://packages.debian.org/bookworm/python3-webpy
- Ubuntu: https://packages.ubuntu.com/jammy/python3-webpy
- Fedora: https://packages.fedoraproject.org/pkgs/python-webpy/python3-webpy/
