### PR TITLE
robot_upstart: 1.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6220,7 +6220,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `1.0.4-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: https://github.com/clearpath-gbp/robot_upstart-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## robot_upstart

```
* Make tests pass on ROS 2 (#124 <https://github.com/clearpathrobotics/robot_upstart/issues/124>)
* Add Github CI
* Contributors: Chris Iverach-Brereton
```
