### PR TITLE
robot_upstart: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7710,8 +7710,8 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/clearpath-gbp/robot_upstart-release.git
-      version: 1.0.3-1
+      url: git@github.com:clearpath-gbp/robot_upstart-release.git
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/robot_upstart.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7710,7 +7710,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: git@github.com:clearpath-gbp/robot_upstart-release.git
+      url: https://github.com/clearpath-gbp/robot_upstart-release.git
       version: 1.0.4-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_upstart` to `1.0.4-1`:

- upstream repository: https://github.com/clearpathrobotics/robot_upstart.git
- release repository: git@github.com:clearpath-gbp/robot_upstart-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## robot_upstart

```
* Make tests pass on ROS 2 (#124 <https://github.com/clearpathrobotics/robot_upstart/issues/124>)
* Add Github CI
* Contributors: Chris Iverach-Brereton
```
