### PR TITLE
hri: 2.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3151,7 +3151,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
-      version: 2.5.1-1
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/ros4hri/libhri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri` to `2.6.1-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.1-1`

## hri

```
2.6.1 (2024-09-10)
------------------
* bring back dependencies on tf2 and cv_bridge as <depends> so that <build_export_depend> is implied
* Contributors: Séverin Lemaignan

2.6.0 (2024-09-09)
------------------
* add face expression
* change build to ament_cmake_auto
* Contributors: Luka Juricic

```

## pyhri

```
2.6.1 (2024-09-10)
------------------
* bring back dependencies on python3-opencv as <depends> so that <build_export_depend> is implied
* Contributors: Séverin Lemaignan

2.6.0 (2024-09-09)
------------------
* add face expression
* change build to ament_cmake_auto
* Contributors: Luka Juricic

```
