### PR TITLE
rosbag2: 0.26.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6716,7 +6716,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.4-1
+      version: 0.26.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.5-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.26.4-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>) (#1778 <https://github.com/ros2/rosbag2/issues/1778>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  (cherry picked from commit 25c3e1c2effdaea3b880c39ff7580b2f38a44b1c)
  Co-authored-by: Roman <mailto:rsokolkov@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>) (#1778 <https://github.com/ros2/rosbag2/issues/1778>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  (cherry picked from commit 25c3e1c2effdaea3b880c39ff7580b2f38a44b1c)
  Co-authored-by: Roman <mailto:rsokolkov@gmail.com>
* Bugfix for bag_split event callbacks called to early with file compression (#1643 <https://github.com/ros2/rosbag2/issues/1643>) (#1732 <https://github.com/ros2/rosbag2/issues/1732>)
  (cherry picked from commit 1877b53847bda4d1f2668187b79fa27a796c3438)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Bugfix for bag_split event callbacks called to early with file compression (#1643 <https://github.com/ros2/rosbag2/issues/1643>) (#1732 <https://github.com/ros2/rosbag2/issues/1732>)
  (cherry picked from commit 1877b53847bda4d1f2668187b79fa27a796c3438)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Added method to introspect QoS in Python (#1648 <https://github.com/ros2/rosbag2/issues/1648>) (#1790 <https://github.com/ros2/rosbag2/issues/1790>)
  (cherry picked from commit f0f3cc5f57ba9142b763247a68acc571d2500bb5)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>) (#1778 <https://github.com/ros2/rosbag2/issues/1778>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  (cherry picked from commit 25c3e1c2effdaea3b880c39ff7580b2f38a44b1c)
  Co-authored-by: Roman <mailto:rsokolkov@gmail.com>
* [jazzy] Update CI scripts to use Ubuntu Noble distros and bump action scripts to latest versions (backport #1709 <https://github.com/ros2/rosbag2/issues/1709>) (#1779 <https://github.com/ros2/rosbag2/issues/1779>)
  Co-authored-by: Roman <mailto:rsokolkov@gmail.com>
  (cherry picked from commit 27a6b600c2a813ec1f2154145fe77392c88b314b)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Bugfix for wrong timestamps in ros2 bag info (#1745 <https://github.com/ros2/rosbag2/issues/1745>) (#1752 <https://github.com/ros2/rosbag2/issues/1752>)
  (cherry picked from commit da28c9da82824b8ce5f6fc18935d1a954e52b636)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

```
* Fix incorrect zero size for sqlite storage (#1759 <https://github.com/ros2/rosbag2/issues/1759>) (#1761 <https://github.com/ros2/rosbag2/issues/1761>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  (cherry picked from commit 86f681d9f525a4b7c3b4133d6b657e342283aad8)
  Co-authored-by: Roman <mailto:rsokolkov@gmail.com>
* Fix for failing throws_on_invalid_pragma_in_config_file on Windows (#1742 <https://github.com/ros2/rosbag2/issues/1742>) (#1746 <https://github.com/ros2/rosbag2/issues/1746>)
  (cherry picked from commit 055935d33dd2fed2772657c9dc1f2173eaa7f752)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_test_common

```
* Small cleanups to the rosbag2 tests. (#1792 <https://github.com/ros2/rosbag2/issues/1792>) (#1793 <https://github.com/ros2/rosbag2/issues/1793>)
  (cherry picked from commit 604cebcf11775151efa94f7c30ba1aea68e90c5c)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Small cleanups to the rosbag2 tests. (#1792 <https://github.com/ros2/rosbag2/issues/1792>) (#1793 <https://github.com/ros2/rosbag2/issues/1793>)
  (cherry picked from commit 604cebcf11775151efa94f7c30ba1aea68e90c5c)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Bugfix for wrong timestamps in ros2 bag info (#1745 <https://github.com/ros2/rosbag2/issues/1745>) (#1752 <https://github.com/ros2/rosbag2/issues/1752>)
  (cherry picked from commit da28c9da82824b8ce5f6fc18935d1a954e52b636)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Fix for a false negative integration test with bag split in recorder (#1743 <https://github.com/ros2/rosbag2/issues/1743>) (#1750 <https://github.com/ros2/rosbag2/issues/1750>)
  (cherry picked from commit da1acb29646258899ba73a81c803383c07905613)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* Small cleanups to the rosbag2 tests. (#1792 <https://github.com/ros2/rosbag2/issues/1792>) (#1793 <https://github.com/ros2/rosbag2/issues/1793>)
  (cherry picked from commit 604cebcf11775151efa94f7c30ba1aea68e90c5c)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Add cli option compression-threads-priority (#1768 <https://github.com/ros2/rosbag2/issues/1768>) (#1778 <https://github.com/ros2/rosbag2/issues/1778>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  (cherry picked from commit 25c3e1c2effdaea3b880c39ff7580b2f38a44b1c)
  Co-authored-by: Roman <mailto:rsokolkov@gmail.com>
* Bugfix for bag_split event callbacks called to early with file compression (#1643 <https://github.com/ros2/rosbag2/issues/1643>) (#1732 <https://github.com/ros2/rosbag2/issues/1732>)
  (cherry picked from commit 1877b53847bda4d1f2668187b79fa27a796c3438)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
