### PR TITLE
ros2_control: 4.17.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6295,7 +6295,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.16.1-1
+      version: 4.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.16.1-1`

## controller_interface

```
* Rename get_state and set_state Functions to get/set_lifecylce_state (variant support) (#1683 <https://github.com/ros-controls/ros2_control/issues/1683>)
* Contributors: Manuel Muth
```

## controller_manager

```
* Log exception type when catching the exception (#1749 <https://github.com/ros-controls/ros2_control/issues/1749>)
* [CM] Handle other exceptions while loading the controller plugin (#1731 <https://github.com/ros-controls/ros2_control/issues/1731>)
* remove unnecessary log of the CM args (#1720 <https://github.com/ros-controls/ros2_control/issues/1720>)
* Fix unload of controllers when spawned with --unload-on-kill (#1717 <https://github.com/ros-controls/ros2_control/issues/1717>)
* Rename get_state and set_state Functions to get/set_lifecylce_state (variant support) (#1683 <https://github.com/ros-controls/ros2_control/issues/1683>)
* Contributors: Manuel Muth, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Log exception type when catching the exception (#1749 <https://github.com/ros-controls/ros2_control/issues/1749>)
* Fix spam of logs on failed hardware component initialization (#1719 <https://github.com/ros-controls/ros2_control/issues/1719>)
* [HWItfs] Add key-value-storage to the InterfaceInfo (#1421 <https://github.com/ros-controls/ros2_control/issues/1421>)
* Rename get_state and set_state Functions to get/set_lifecylce_state (variant support) (#1683 <https://github.com/ros-controls/ros2_control/issues/1683>)
* Contributors: Manuel Muth, Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* [HWItfs] Add key-value-storage to the InterfaceInfo (#1421 <https://github.com/ros-controls/ros2_control/issues/1421>)
* Contributors: Manuel Muth
```

## ros2controlcli

```
* [ros2controlcli] fix list_controllers when no controllers are loaded (#1721 <https://github.com/ros-controls/ros2_control/issues/1721>)
* Contributors: Sai Kishor Kothakota
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
