### PR TITLE
ros2_control: 2.43.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7808,7 +7808,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.43.0-1
+      version: 2.43.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.43.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.43.0-1`

## controller_interface

- No changes

## controller_manager

```
* controller_manager: Add space to string literal concatenation (#1245 <https://github.com/ros-controls/ros2_control/issues/1245>) (#1747 <https://github.com/ros-controls/ros2_control/issues/1747>)
* fix: the print of the information in control node was in wrong order (#1726 <https://github.com/ros-controls/ros2_control/issues/1726>)
* Contributors: Manuel Muth, roscan-tech
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [ros2controlcli] fix list_controllers when no controllers are loaded (#1721 <https://github.com/ros-controls/ros2_control/issues/1721>) (#1722 <https://github.com/ros-controls/ros2_control/issues/1722>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
