### PR TITLE
ros2_control: 3.28.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5966,7 +5966,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.28.0-1
+      version: 3.28.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.28.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.28.0-1`

## controller_interface

- No changes

## controller_manager

```
* fix: the print of the information in control node was in wrong order (#1726 <https://github.com/ros-controls/ros2_control/issues/1726>) (#1727 <https://github.com/ros-controls/ros2_control/issues/1727>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [ros2controlcli] fix list_controllers when no controllers are loaded (#1721 <https://github.com/ros-controls/ros2_control/issues/1721>) (#1723 <https://github.com/ros-controls/ros2_control/issues/1723>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
