### PR TITLE
play_motion2: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6168,7 +6168,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.1.2-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.3.0-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.2-1`

## play_motion2

```
* Remove error log from exists function
* Check the motion exists for isMotionReady service
* Add missing option to overwrite when adding motion
* Add option to run motions asynchronously
* Create service functions for the PlayMotion2Client
* Add run_motion executable
* Add simple client for PlayMotion2
* Add new motion key only if is not overwritten
* Create services to add and remove motions
* Add service to get the info of a motion
* Contributors: Noel Jimenez
```

## play_motion2_msgs

```
* Create services to add and remove motions
* Add service to get the info of a motion
* Contributors: Noel Jimenez
```
