### PR TITLE
ros_gz: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6260,7 +6260,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Remove default_value for required arguments (#602 <https://github.com/gazebosim/ros_gz//issues/602>)
  * Remove default_value for config_file
* Fix errors with name of bridge not being given (#600 <https://github.com/gazebosim/ros_gz//issues/600>)
  * Add argument bridge_name to fix errors
* Use optional parameters in actions (#601 <https://github.com/gazebosim/ros_gz//issues/601>)
* Contributors: Amronos, Carlos Agüero
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Change world_string to model_string in gz_spawn_model files (#606 <https://github.com/gazebosim/ros_gz//issues/606>)
  * Change world_string to model_string
  Also changed description from XML string to XML(SDF) string
* Use model string in ros_gz_spawn_model.launch.py (#605 <https://github.com/gazebosim/ros_gz//issues/605>)
* Remove default_value for required arguments (#602 <https://github.com/gazebosim/ros_gz//issues/602>)
  * Remove default_value for config_file
* Fix errors with name of bridge not being given (#600 <https://github.com/gazebosim/ros_gz//issues/600>)
  * Add argument bridge_name to fix errors
* Restore launch file (#603 <https://github.com/gazebosim/ros_gz//issues/603>)
* Use optional parameters in actions (#601 <https://github.com/gazebosim/ros_gz//issues/601>)
* Contributors: Amronos, Carlos Agüero
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
