### PR TITLE
added python3 noisereduce

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7352,7 +7352,7 @@ python3-nmcli-pip:
     pip:
       depends: [network-manager]
       packages: [nmcli]
-python3-noisereduce:
+python3-noisereduce-pip:
   '*':
     pip:
       packages: [noisereduce]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7352,6 +7352,10 @@ python3-nmcli-pip:
     pip:
       depends: [network-manager]
       packages: [nmcli]
+python3-noisereduce:
+  '*':
+    pip:
+      packages: [noisereduce]
 python3-nose:
   arch: [python-nose]
   debian: [python3-nose]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- `noisereduce`

## Package Upstream Source:

- https://github.com/timsainb/noisereduce

## Purpose of using this:

Noise reduction in python using spectral gating (speech, bioacoustics, audio, time-domain signals).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->
- Python: https://pypi.org/project/noisereduce/


