### PR TITLE
nixos: libgpiod-dev needs to point to libgpiod_1

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3893,7 +3893,7 @@ libgpiod-dev:
   debian: [libgpiod-dev]
   fedora: [libgpiod-devel]
   gentoo: [dev-libs/libgpiod]
-  nixos: [libgpiod]
+  nixos: [libgpiod_1]
   opensuse: [libgpiod-devel]
   rhel:
     '*': [libgpiod-devel]


### PR DESCRIPTION
`libgpiod-dev` on Ubuntu points to 1.6.3: https://packages.ubuntu.com/noble/libgpiod-dev while `libgpiod` on nixos is currently at 2.1.2 which is incompatible with the 1.x series.

Change the value to `libgiod_1` which currently points to 1.6.4:
https://search.nixos.org/packages?channel=24.05&show=libgpiod_1&from=0&size=50&sort=relevance&type=packages&query=libgpiod