### PR TITLE
Remove mrpt2 package

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3947,14 +3947,6 @@ repositories:
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
       version: main
     status: maintained
-  mrpt2:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.13.5-1
-    status: end-of-life
-    status_description: Deprecated by packages mrpt_ros and python_mrpt_ros
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
Deprecated by packages mrpt_ros and python_mrpt_ros.  There are now no packages depending on mrpt2 (checked in Jenkins, "downstream projects"), all are ported to mrpt_ros.
