### PR TITLE
omni_base_robot: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5652,7 +5652,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.2.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.4.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## omni_base_bringup

```
* Add slash to node names on parameter files
* Contributors: Noel Jimenez
```

## omni_base_controller_configuration

```
* Only relay cmd_vel topic in simulation
* Contributors: David ter Kuile
```

## omni_base_description

```
* Add slash to node names on parameter files
* Contributors: Noel Jimenez
```

## omni_base_robot

- No changes
