### PR TITLE
tiago_robot: 4.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9918,7 +9918,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.3.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.5.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-1`

## tiago_bringup

```
* Use launch file directly from base controller_configuration
* Contributors: David ter Kuile
```

## tiago_controller_configuration

```
* Use launch file directly from base controller_configuration
* Don't load gravity compensation in public sim
* Contributors: David ter Kuile
```

## tiago_description

```
* Fix distances for old wrist + change default wrist + typo
* Fix distance of from the arm_7_link to arm_tool_link and the ft_sensor link placement
* Contributors: thomas.peyrucain
```

## tiago_robot

- No changes
