### PR TITLE
pmb2_robot: 5.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6268,7 +6268,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.1.2-1
+      version: 5.3.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.3.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.2-1`

## pmb2_bringup

```
* Merge branch 'fix/add_slash_to_nodes' into 'humble-devel'
  Add slash to node names on parameter files
  See merge request robots/pmb2_robot!146
* Add slash to node names on parameter files
* Contributors: Jordan Palacios, Noel Jimenez
```

## pmb2_controller_configuration

- No changes

## pmb2_description

```
* Merge branch 'man/feat/docking' into 'humble-devel'
  added docking link in urdf
  See merge request robots/pmb2_robot!145
* added docking link in urdf
* Merge branch 'fix/add_slash_to_nodes' into 'humble-devel'
  Add slash to node names on parameter files
  See merge request robots/pmb2_robot!146
* Add slash to node names on parameter files
* Contributors: Jordan Palacios, Noel Jimenez, josegarcia, martinaannicelli
```

## pmb2_robot

- No changes
