### PR TITLE
pmb2_navigation: 4.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6248,7 +6248,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.1.1-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.2.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.1-1`

## pmb2_2dnav

```
* Merge branch 'man/feat/docking' into 'humble-devel'
  added docking link
  See merge request robots/pmb2_navigation!97
* added docking link
* Contributors: josegarcia, martinaannicelli
```

## pmb2_laser_sensors

- No changes

## pmb2_navigation

- No changes
