### PR TITLE
ros_comm: 1.17.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9524,7 +9524,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.16.0-1
+      version: 1.17.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.17.0-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.16.0-1`

## message_filters

```
* Enable building with boost 1.73 (#2348 <https://github.com/ros/ros_comm/issues/2348>)
* Contributors: Robert Haschke
```

## ros_comm

- No changes

## rosbag

```
* Exposed record snapshot feature to command line. (#2254 <https://github.com/ros/ros_comm/issues/2254>)
* Fix rosbag calling uncallable signal handler object (#2236 <https://github.com/ros/ros_comm/issues/2236>)
* Add --min-space option to the python cli of rosbag record (#2298 <https://github.com/ros/ros_comm/issues/2298>)
* Fix latched topic not latched in splitted rosbags (#2351 <https://github.com/ros/ros_comm/issues/2351>)
* Enable building with boost 1.83.0 (#2354 <https://github.com/ros/ros_comm/issues/2354>)
* Contributors: Blake Anderson, Hugal31, Yannik Nager, Zijun Xu, daizhirui
```

## rosbag_storage

```
* Fix segfault with default-constructed rosbag::ChunkedFile::swap (#2363 <https://github.com/ros/ros_comm/issues/2363>)
* Contributors: Hugal31
```

## roscpp

```
* Make build compatible with boost 1.73 (#2348 <https://github.com/ros/ros_comm/issues/2348>)
* Added init_options::NoSimTime which disables subscribing to /clock (#2342 <https://github.com/ros/ros_comm/issues/2342>)
* Fix crash during shutdown when explicitly calling ros::start but not ros::shutdown (#2355 <https://github.com/ros/ros_comm/issues/2355>)
* Contributors: David Gossow, Martin Pecka, Robert Haschke
```

## rosgraph

```
* Fixed ROSCONSOLE_FORMAT with microseconds (#2370 <https://github.com/ros/ros_comm/issues/2370>)
* Contributors: Martin Pecka
```

## roslaunch

```
* Check if ignore_unset_args is set in xmlloader (#2217 <https://github.com/ros/ros_comm/issues/2217>)
* Remove Python 2 on Windows workaround (#2364 <https://github.com/ros/ros_comm/issues/2364>)
* Contributors: Griffin Tabor, Shingo Kitagawa
```

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

```
* Enable rosrun & roslaunch to find rosnode script (#2262 <https://github.com/ros/ros_comm/issues/2262>)
* Contributors: G.A. vd. Hoorn
```

## rosout

- No changes

## rosparam

- No changes

## rospy

```
* Stop using deprecated logger.warn (#2191 <https://github.com/ros/ros_comm/issues/2191>)
* Expose is_shutdown_requested in rospy module. (#2267 <https://github.com/ros/ros_comm/issues/2267>)
* Fix error "s is not defined" (#2328 <https://github.com/ros/ros_comm/issues/2328>)
* Contributors: Guglielmo Gemignani, Michael Grupp, vineet131
```

## rosservice

```
* Fixed uninitialized Time usage in rosservice call (#2369 <https://github.com/ros/ros_comm/issues/2369>)
* Contributors: Martin Pecka
```

## rostest

```
* Add new rostest utility subscribetest (#2184 <https://github.com/ros/ros_comm/issues/2184>)
* Fix use of undelcared variable t_start (#2183 <https://github.com/ros/ros_comm/issues/2183>)
* Fix rostest target names when build directory is inside source directory (#2361 <https://github.com/ros/ros_comm/issues/2361>)
* Contributors: Kei Okada, Michael Görner
```

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

```
* Add wait_publisher_initialization option in topic_tools mux (#2305 <https://github.com/ros/ros_comm/issues/2305>)
* Contributors: Shingo Kitagawa
```

## xmlrpcpp

```
* Fix printing XmlRpcValue with GTest (#2224 <https://github.com/ros/ros_comm/issues/2224>)
* Fix EINTR handling in XmlRpcDispatch::work (#2278 <https://github.com/ros/ros_comm/issues/2278>)
* Contributors: Hugal31, Martin Pecka
```
