### PR TITLE
nixos: protobuf-compiler-grpc provided by grpc

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7717,6 +7717,7 @@ protobuf-compiler-grpc:
   arch: [grpc]
   debian: [protobuf-compiler-grpc]
   fedora: [grpc-plugins]
+  nixos: [grpc]
   rhel:
     '8': null
     '9': [grpc-plugins]


### PR DESCRIPTION
https://search.nixos.org/packages?channel=24.05&show=grpc&from=0&size=50&sort=relevance&type=packages&query=grpc provides the same binaries as https://packages.ubuntu.com/noble/amd64/protobuf-compiler-grpc/filelist so `grpc` is a suitable package.