### PR TITLE
cras_ros_utils: 2.4.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1793,7 +1793,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.2-1
+      version: 2.4.4-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.4.4-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.2-1`

## cras_cpp_common

```
* Fixed build with ros_comm 0.17.0.
* Contributors: Martin Pecka
```

## cras_docs_common

- No changes

## cras_py_common

- No changes

## cras_topic_tools

- No changes

## image_transport_codecs

- No changes
