### PR TITLE
mrpt_path_planning: 0.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4915,7 +4915,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.1.5-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.4-1`

## mrpt_path_planning

```
* Update RTTI macros for upcoming MRPT 2.14.0
* Contributors: Jose Luis Blanco-Claraco
```
