### PR TITLE
mola: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3403,7 +3403,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.1.3-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.3-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* sort <depend> entries
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_imu_preintegration

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* Merge pull request #70 <https://github.com/MOLAorg/mola/issues/70> from MOLAorg/fix/rosbag2-memory-free
  BUGFIX: read ahead cache memory for rosbag2 was not freed
* BUGFIX: read ahead cache memory for rosbag2 was not freed if invoked via Dataset access API only
* sort <depend> entries
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Update RTTI macros for upcoming MRPT 2.14.0
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

```
* gcc warning fix
* Avoid gcc warning
* Merge pull request #69 <https://github.com/MOLAorg/mola/issues/69> from MOLAorg/new-map-ndt
  New NDT-3D metric map
* Add NDT-3D map class
* Remove leftover dead .cpp file from MOLA package template
* FIX BUG: missing cmake dependency on robin_map in exported targets
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_navstate_fg

- No changes

## mola_navstate_fuse

- No changes

## mola_pose_list

- No changes

## mola_relocalization

```
* Fix cmake warning on missing mola_test_datasets for non-test builds
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

- No changes

## mola_viz

```
* mola_viz: do not add a XY ground grid by default to all GUIs
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
