### PR TITLE
privacy_msgs: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6412,6 +6412,20 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  privacy_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/privacy_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/privacy_msgs-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/privacy_msgs.git
+      version: humble-devel
   proxsuite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `privacy_msgs` to `1.1.0-1`:

- upstream repository: https://github.com/ros4hri/privacy_msgs.git
- release repository: https://github.com/ros4hri/privacy_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## privacy_msgs

```
1.1.0 (2024-09-16)
------------------
* {privacy_centre -> privacy_msgs}
* [doc] cleanup README
* Contributors: Séverin Lemaignan

1.0.0 (2024-02-16)
------------------
* {SensitiveData->PersonalDataProcessor}
* initial commit of privacy_msgs
* Contributors: Séverin Lemaignan
```
