### PR TITLE
hri_face_detect: 2.0.10-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3171,6 +3171,20 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_actions_msgs.git
       version: humble-devel
+  hri_face_detect:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_face_detect.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_face_detect-release.git
+      version: 2.0.10-2
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_face_detect.git
+      version: humble-devel
   hri_msgs:
     doc:
       type: git


### PR DESCRIPTION
Import package in `hri_face_detect` `2.0.10-2`:

- upstream repository: https://github.com/ros4hri/hri_face_detect.git
- release repository: https://github.com/ros4hri/hri_face_detect-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_face_detect

`hri_face_detect` is  a ROS4HRI-compliant face detector. *It relies on `python3-mediapipe-pip`*, which means debian can not be automatically generated.

See [CHANGELOG](https://github.com/ros4hri/hri_face_detect/blob/humble-devel/CHANGELOG.rst) for full history.
