### PR TITLE
rosdep: add python3-ikpy-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6576,6 +6576,10 @@ python3-ignition-math6:
   ubuntu:
     focal: [python3-ignition-math6]
     jammy: [python3-ignition-math6]
+python3-ikpy-pip:
+  '*':
+    pip:
+      packages: [ikpy]
 python3-imageio:
   debian: [python3-imageio]
   fedora: [python3-imageio]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`ikpy`

## Package Upstream Source:


https://github.com/Phylliade/ikpy

## Purpose of using this:

ikpy is a lightweight Python-based inverse kinematics library. It is used by eg [`hri_body_detect`](https://github.com/ros4hri/hri_body_detect) to create kinematically-consistent human models on the fly.

## Links to Distribution Packages

https://pypi.org/project/ikpy/
