### PR TITLE
hri_face_body_matcher: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3171,6 +3171,20 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_actions_msgs.git
       version: humble-devel
+  hri_face_body_matcher:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_face_body_matcher.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_face_body_matcher-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_face_body_matcher.git
+      version: humble-devel
   hri_msgs:
     doc:
       type: git


### PR DESCRIPTION
Import package(s) in repository `hri_face_body_matcher` `2.0.3-1`:

- upstream repository: https://github.com/ros4hri/hri_face_body_matcher.git
- release repository: https://github.com/ros4hri/hri_face_body_matcher-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_face_body_matcher

`hri_face_body_matcher` is a ROS4HRI -compliant node that attempts to match people faces to their detected bodies.

Check here for the complete [CHANGELOG](https://github.com/ros4hri/hri_face_body_matcher/blob/humble-devel/CHANGELOG.rst).