### PR TITLE
foxglove_compressed_video_transport: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1807,6 +1807,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_compressed_video_transport` to `1.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
- release repository: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## foxglove_compressed_video_transport

```
* initial commit
* Contributors: Bernd Pfrommer
```
