### PR TITLE
mrpt_navigation: 1.0.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6380,7 +6380,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
-      version: 1.0.6-2
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `1.0.7-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.6-2`

## mrpt_local_obstacles

```
* Remove git submodules; depend on mp2p_icp Noetic package instead
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_localization

- No changes

## mrpt_map

- No changes

## mrpt_msgs_bridge

- No changes

## mrpt_navigation

- No changes

## mrpt_rawlog

- No changes

## mrpt_reactivenav2d

- No changes

## mrpt_tutorials

- No changes
