### PR TITLE
rcutils: 6.7.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5669,7 +5669,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.7.1-1
+      version: 6.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.7.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.7.1-1`

## rcutils

```
* Add new API to set envar while specifying overwrite (#473 <https://github.com/ros2/rcutils/issues/473>) (#480 <https://github.com/ros2/rcutils/issues/480>)
  (cherry picked from commit ea3675f63b0ce95dc81dc4a4aa3e263a75615c22)
  Co-authored-by: Yadu <mailto:yadunund@intrinsic.ai>
* Contributors: mergify[bot]
```
