### PR TITLE
rcutils: 6.2.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5387,7 +5387,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.2.3-1
+      version: 6.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.2.4-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.2.3-1`

## rcutils

```
* Add new API to set envar while specifying overwrite (backport #473 <https://github.com/ros2/rcutils/issues/473>) (#481 <https://github.com/ros2/rcutils/issues/481>)
  (cherry picked from commit ea3675f63b0ce95dc81dc4a4aa3e263a75615c22)
  Co-authored-by: Yadu <mailto:yadunund@intrinsic.ai>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
