### PR TITLE
ur_msgs: 1.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12475,7 +12475,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/ur_msgs-release.git
-      version: 1.3.4-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12470,7 +12470,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
-      version: melodic
+      version: noetic
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -12479,7 +12479,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   ur_robot_driver:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `1.4.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros-industrial-release/ur_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.4-1`

## ur_msgs

```
* Added service to get robot software version. (#24 <https://github.com/ros-industrial/ur_msgs/issues/24>)
* ci: bump checkout and cache (#22 <https://github.com/ros-industrial/ur_msgs/issues/22>)
* Document pin mapping in SetIO service (#16 <https://github.com/ros-industrial/ur_msgs/issues/16>)
* Contributors: Felix Exner, G.A. vd. Hoorn, URJala
```
