### PR TITLE
moveit: 2.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3619,6 +3619,7 @@ repositories:
       - moveit_ros_planning_interface
       - moveit_ros_robot_interaction
       - moveit_ros_tests
+      - moveit_ros_trajectory_cache
       - moveit_ros_visualization
       - moveit_ros_warehouse
       - moveit_runtime
@@ -3635,7 +3636,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.11.0-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.0-1`

## chomp_motion_planner

```
* CHOMP: Fix handling of mimic joints (#3625 <https://github.com/moveit/moveit2/issues/3625>)
* Fix CHOMP segfault (#3621 <https://github.com/moveit/moveit2/issues/3621>)
* Contributors: Robert Haschke
```

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* Fix RobotState::getRigidlyConnectedParentLinkModel() (#2985 <https://github.com/moveit/moveit2/issues/2985>)
* Implement realtime Ruckig jerk-limited smoothing (#2956 <https://github.com/moveit/moveit2/issues/2956>)
* New implementation for computeCartesianPath() (#2916 <https://github.com/moveit/moveit2/issues/2916>)
* Don't set reset observer callback & set CB after world_ is initialized (#2950 <https://github.com/moveit/moveit2/issues/2950>)
* Deduplicate joint trajectory points in Pilz Move Group Sequence capability (#2943 <https://github.com/moveit/moveit2/issues/2943>)
* Optimize MOVE_SHAPE operations for FCL (#3601 <https://github.com/moveit/moveit2/issues/3601>)
* Allow moving of all shapes of an object in one go (#3599 <https://github.com/moveit/moveit2/issues/3599>)
* Silent "empty quaternion" warning from poseMsgToEigen() (#3435 <https://github.com/moveit/moveit2/issues/3435>)
* Propagate "clear octomap" actions to monitoring planning scenes (#3134 <https://github.com/moveit/moveit2/issues/3134>)
* Copy planning scene predicates in the copy constructor (#2858 <https://github.com/moveit/moveit2/issues/2858>)
* PSM: Correctly handle full planning scene message (#3610 <https://github.com/moveit/moveit2/issues/3610>) (#2876 <https://github.com/moveit/moveit2/issues/2876>), fixes #3538 <https://github.com/moveit/moveit2/issues/3538>/#3609 <https://github.com/moveit/moveit2/issues/3609>
* Switch to system version of octomap (#2881 <https://github.com/moveit/moveit2/issues/2881>)
* Contributors: AndyZe, Captain Yoshi, Chris Lalancette, Chris Schindlbeck, FSund, Gaël Écorchard, Robert Haschke, Sebastian Castro, Sebastian Jahr
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

```
* Export the IKFast library correctly (#2999 <https://github.com/moveit/moveit2/issues/2999>)
* Use Python3 with IKFast generation script (#2997 <https://github.com/moveit/moveit2/issues/2997>)
* Contributors: AndyZe
```

## moveit_planners

- No changes

## moveit_planners_chomp

```
* Fix CHOMP segfault (#3621 <https://github.com/moveit/moveit2/issues/3621>)
* Contributors: Robert Haschke
```

## moveit_planners_ompl

```
* Fix constrained-based planning / PoseModelStateSpace (#2910 <https://github.com/moveit/moveit2/issues/2910>)
* Contributors: Robert Haschke
```

## moveit_planners_stomp

- No changes

## moveit_plugins

- No changes

## moveit_py

```
* Add python bindings for saving and loading geometry from a .scene file (#2971 <https://github.com/moveit/moveit2/issues/2971>)
* Add namespace to MoveitPy (#2884 <https://github.com/moveit/moveit2/issues/2884>)
* New planning scene message (#2885 <https://github.com/moveit/moveit2/issues/2885>)
* Contributors: Abhiroop Bhavsar, Bilal Gill, Jens Vanhooydonck
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

```
* Add SaveGeometryToFile and LoadGeometryFromFile services (#2973 <https://github.com/moveit/moveit2/issues/2973>)
* New implementation for computeCartesianPath() (#2916 <https://github.com/moveit/moveit2/issues/2916>)
* Consider attached collision objects in the ComputeFK service (#2953 <https://github.com/moveit/moveit2/issues/2953>)
* Contributors: Bilal Gill, Daniel García López, Robert Haschke
```

## moveit_ros_occupancy_map_monitor

```
* Switch to system version of octomap (#2881 <https://github.com/moveit/moveit2/issues/2881>)
* Contributors: Chris Lalancette
```

## moveit_ros_perception

```
* Replace obsolete header (#2978 <https://github.com/moveit/moveit2/issues/2978>)
* Fixed segmentation fault in depth_image_octomap_updater (#2963 <https://github.com/moveit/moveit2/issues/2963>)
* Fix deprecation warning (#2922 <https://github.com/moveit/moveit2/issues/2922>)
* Contributors: CihatAltiparmak, Robert Haschke, Sebastian Jahr
```

## moveit_ros_planning

- No changes

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

- No changes

## moveit_ros_visualization

```
* New implementation for computeCartesianPath() (#2916 <https://github.com/moveit/moveit2/issues/2916>)
* Contributors: Robert Haschke
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Support single-element joint limit margins vector and fix joint halting logic for multi-DOF Joints (#2970 <https://github.com/moveit/moveit2/issues/2970>)
* Implement realtime Ruckig jerk-limited smoothing (#2956 <https://github.com/moveit/moveit2/issues/2956>)
* Ensure the robot state is up-to-date before Servoing (#2954 <https://github.com/moveit/moveit2/issues/2954>)
* Correctly load smoothing plugins in Servo integration tests (#2965 <https://github.com/moveit/moveit2/issues/2965>)
* Small fixes to flaky MoveIt Servo integration tests (#2962 <https://github.com/moveit/moveit2/issues/2962>)
* Tune Servo params so it does not get stuck so easily (#2939 <https://github.com/moveit/moveit2/issues/2939>)
* Contributors: AndyZe, Sebastian Castro
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

```
* Fix key duplication in moveit_setup_assistant for FollowJointTrajectory (#2959 <https://github.com/moveit/moveit2/issues/2959>)
* Replace deprecated load_yaml with xacro.load_yaml in ros2_control.xacro template (#2934 <https://github.com/moveit/moveit2/issues/2934>)
* Remove additional word 'hardware' in Moveit Controllers section of MoveIt Setup Assistant (#2936 <https://github.com/moveit/moveit2/issues/2936>)
* Contributors: Chris Schindlbeck
```

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

```
* Cast of "max_velocity" and "max_acceleration" values to double (#2803 <https://github.com/moveit/moveit2/issues/2803>)
  Co-authored-by: Henning Kayser <mailto:henningkayser@picknik.ai>
* Contributors: Jorge Pérez Ramos
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Fix Pilz blending times... the right way (#2961 <https://github.com/moveit/moveit2/issues/2961>)
* Deduplicate joint trajectory points in Pilz Move Group Sequence capability (#2943 <https://github.com/moveit/moveit2/issues/2943>)
* Contributors: Chris Schindlbeck, Sebastian Castro
```

## pilz_industrial_motion_planner_testutils

- No changes
