### PR TITLE
mapviz: 2.4.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4215,7 +4215,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.2-1
+      version: 2.4.3-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.3-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.2-1`

## mapviz

```
* update launch params (#830 <https://github.com/swri-robotics/mapviz/issues/830>)
* Contributors: DangitBen
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* update plugin subscribers to use all of qos (#827 <https://github.com/swri-robotics/mapviz/issues/827>)
  Co-authored-by: Ben <mailto:benjamin.andrew@swri.org>
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Added kludgy install for autogened TopicSelect header that is required if external plugin packages include topic_select.h (#825 <https://github.com/swri-robotics/mapviz/issues/825>)
* Contributors: DangitBen, Robert Brothers
```

## multires_image

- No changes

## tile_map

- No changes
