### PR TITLE
marti_common: 3.7.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3273,7 +3273,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.7.2-1
+      version: 3.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.7.3-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.2-1`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* Removing ros_environment usage in favor of directly checking package versions (#754 <https://github.com/swri-robotics/marti_common/issues/754>)
* Contributors: David Anthony
```

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Update origin params (#752 <https://github.com/swri-robotics/marti_common/issues/752>)
  * Update origin publisher params
  ---------
  Co-authored-by: Ben <mailto:benjamin.andrew@swri.org>
* Contributors: DangitBen
```
