### PR TITLE
hri_rviz: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3195,7 +3195,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros4hri/hri_rviz-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros4hri/hri_rviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_rviz` to `2.1.0-1`:

- upstream repository: https://github.com/ros4hri/hri_rviz.git
- release repository: https://github.com/ros4hri/hri_rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## hri_rviz

```
* display expression when available
* Contributors: saracooper
```
