### PR TITLE
clearpath_desktop: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1274,7 +1274,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 0.1.2-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.2-1`

## clearpath_config_live

```
* Watch file directly instead of directory
* Contributors: Luis Camero
```

## clearpath_desktop

- No changes

## clearpath_viz

```
* Undo changes to view_robot
* Added kinematics to RViz parameters
* Added MoveIt visualization launch file
* MoveIt rviz config
* Remappings for moveit
* Contributors: Luis Camero
```
