### PR TITLE
rcl: 9.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5486,7 +5486,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.2.3-1
+      version: 9.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.2.4-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `9.2.3-1`

## rcl

```
* Properly initialize the char array used in type hash calculations. (#1182 <https://github.com/ros2/rcl/issues/1182>) (#1183 <https://github.com/ros2/rcl/issues/1183>)
  Previously, we were zero initializing it and only setting
  up one of its fields.  But that doesn't totally properly
  initialize it; we really should call rcutils_char_array_init
  to make sure everything is initialized.  Do that in the
  live source, as well as in the test for it.
  (cherry picked from commit bfe00f71b7056bb64b27a8d5f5bacefe0564c43e)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
