### PR TITLE
Add crypto++ entry for nixos

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -718,6 +718,7 @@ crypto++:
   debian: [libcrypto++-dev]
   fedora: [cryptopp-devel]
   gentoo: [dev-libs/crypto++]
+  nixos: [cryptopp]
   ubuntu: [libcrypto++-dev]
 curl:
   alpine: [curl-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please update the following entry in the rosdep database.

## Package name:

crypto++

Distro packaging links:

- [NixOS/nixpkgs](https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=cryptopp)
