### PR TITLE
clearpath_simulator: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1333,7 +1333,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 0.2.6-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `0.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.6-1`

## clearpath_generator_gz

```
* Removed prefix_launch_arg no longer used
* Add ridgeback
* Fixed change log order
* Added manipulators to generator and spawn
* Contributors: Luis Camero
```

## clearpath_gz

```
* Added manipulators to generator and spawn
* Contributors: Luis Camero
```

## clearpath_simulator

```
* Fixed changelogs
* Contributors: Luis Camero
```
