### PR TITLE
fuse: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1855,7 +1855,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.2.1-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-1`

## fuse

- No changes

## fuse_constraints

```
* Fix stringop-overread compile issues (#381 <https://github.com/locusrobotics/fuse/issues/381>)
* Contributors: Stephen Williams
```

## fuse_core

```
* Fix CallbackWrapper class for the Rolling release
  * Update for changes to the ROS2 Waitable base class
  * implement pure virtual waitable functions as in https://github.com/ros2/system_tests/pull/548
  Author: Henry Moore <mailto:henry.moore@picknik.ai>
* Contributors: Stephen Williams
```

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

```
* Fix stringop-overread compile issues (#381 <https://github.com/locusrobotics/fuse/issues/381>)
* Contributors: Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

- No changes

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

- No changes
