### PR TITLE
sick_safetyscanners2: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9183,8 +9183,8 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/SICKAG/sick_safetyscanners2-release.git
-      version: 1.0.3-1
+      url: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.4-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## sick_safetyscanners2

```
* possible fix for out of range
* Add material for correct representation in Gazebo Sim.
* Enable workin in Gazebo under humble.
* enabled gazebo integration in urdf
* generated description folder using RTW
* diagnostics for lifecycle node aswell
* refactor: combine Node and LifeCycle node implementations
* Contributors: Dr. Denis Štogl, Lennart Puck, Nibanovic, Rein Appeldoorn
```
