### PR TITLE
performance_test: 2.3.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4539,7 +4539,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git
-      version: 1.2.1
+      version: master
     release:
       tags:
         release: release/iron/{package}/{version}

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4544,7 +4544,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 1.2.1-4
+      version: 2.3.0-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test` to `2.3.0-1`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-4`
