### PR TITLE
sick_safetyscanners2: 1.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7668,6 +7668,21 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
     status: maintained
+  sick_safetyscanners2:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2.git
+      version: master
+    status: developed
   sick_safetyscanners2_interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2` to `1.0.4-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2.git
- release repository: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sick_safetyscanners2

```
* possible fix for out of range
* Add material for correct representation in Gazebo Sim.
* Enable workin in Gazebo under humble.
* enabled gazebo integration in urdf
* generated description folder using RTW
* diagnostics for lifecycle node aswell
* refactor: combine Node and LifeCycle node implementations
* Contributors: Dr. Denis Štogl, Lennart Puck, Nibanovic, Rein Appeldoorn
```
