### PR TITLE
neo_nav2_bringup: 1.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3997,6 +3997,11 @@ repositories:
       type: git
       url: https://github.com/neobotix/neo_nav2_bringup.git
       version: iron
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/neobotix/neo_nav2_bringup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.1.1-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## neo_nav2_bringup

```
* updating package.xml
* Create LICENSE
* Update package.xml
* updating the depend tags
* updating package.xml
* updating launch (#23 <https://github.com/neobotix/neo_nav2_bringup/issues/23>)
* now can set relative path for the behavior trees
* update
* rviz config update
* updating the package description
* fixes to the default config
* map_server is used standalone for multi_robot navigation
* Humble update (#13 <https://github.com/neobotix/neo_nav2_bringup/issues/13>)
  * minor fixes
  * update readme
  * variable rename for better understanding
  * update recoveries to behaviors
* variable rename for better understanding
* update readme
* minor fixes
* namespace handling for single robot vs multi robot case
* removing the namespace tag
* adding rviz files
* Feature/multi robot (#4 <https://github.com/neobotix/neo_nav2_bringup/issues/4>)
  * adding a multi robot tag
  * update
* launch updated
* adding launch files
* adding configs and maps
* adding CMakelists and package
* Update README.md
* Initial commit
* Contributors: PRP, Pradheep, Pradheep Krishna, Pradheep-office
```
