### PR TITLE
mrpt_navigation: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3770,7 +3770,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.2.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## mrpt_map_server

```
* Merge pull request #149 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/149> from mrpt-ros-pkg/feature/utm-coordinates
  Support UTM global coordinates for geo-referenciated maps
* Update package.xml: minimum required version of mp2p_icp
* mrpt_map_server now publishes the map georeferenciation metadata, as topics and /tf (frames: utm, enu)
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* reformat clang-format with 100 column width
* Update README.md with geo-referenciation concepts
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* fix missing linters; tune tutorial params
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* reformat clang-format with 100 column width
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav_interfaces

```
* Merge pull request #149 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/149> from mrpt-ros-pkg/feature/utm-coordinates
  Support UTM global coordinates for geo-referenciated maps
* Add new msg GeoreferencingMetadata.msg
* Update URL entries in package.xml to each package proper documentation
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

```
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pf_localization

```
* less strict unit test failure limit (fixes potential spurious failure)
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* reformat clang-format with 100 column width
* mrpt_pf_localization is now robust against temporary failures of /tf resolutions for sensor poses
* New optional param 'metric_map_use_only_these_layers' to use only a subset of the .mm map layers
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

```
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* reformat clang-format with 100 column width
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_rawlog

```
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* reformat clang-format with 100 column width
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* reformat clang-format with 100 column width
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tps_astar_planner

```
* fix missing linters; tune tutorial params
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* Add roslog INFO traces to measure time spent initializing PTGs
* reformat clang-format with 100 column width
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

```
* Merge pull request #149 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/149> from mrpt-ros-pkg/feature/utm-coordinates
  Support UTM global coordinates for geo-referenciated maps
* demo launch file: add "mm_file" as a proper launch required argument instead of an optional env variable
* fix missing linters; tune tutorial params
* Update URL entries in package.xml to each package proper documentation
* ament linters: manually enable just cmake and xml linters
* Contributors: Jose Luis Blanco-Claraco
```
