### PR TITLE
turtlebot4_desktop: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8475,7 +8475,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_desktop` to `2.0.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_desktop.git
- release repository: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## turtlebot4_desktop

- No changes

## turtlebot4_viz

```
* Remove base_footprint from tf tree view
* Move the Slam Toolbox plugin to a tab so it occupies the same screen real-estate as Nav2's plugin
* Contributors: Chris Iverach-Brereton
```
