### PR TITLE
turtlebot4_simulator: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8495,7 +8495,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `2.0.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## turtlebot4_gz_bringup

- No changes

## turtlebot4_gz_gui_plugins

```
* Generalize gz vendor use and modernize CMake (#82 <https://github.com/turtlebot/turtlebot4_simulator/issues/82>)
* Contributors: Jose Luis Rivero
```

## turtlebot4_gz_toolbox

- No changes

## turtlebot4_simulator

- No changes
