### PR TITLE
talos_robot: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9758,6 +9758,24 @@ repositories:
       url: https://github.com/ros2/system_tests.git
       version: humble
     status: developed
+  talos_robot:
+    release:
+      packages:
+      - talos_bringup
+      - talos_controller_configuration
+      - talos_description
+      - talos_description_calibration
+      - talos_description_inertial
+      - talos_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/talos_robot-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/talos_robot.git
+      version: humble-devel
+    status: developed
   tango_icons_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `2.0.1-1`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## talos_bringup

- No changes

## talos_controller_configuration

```
* Merge branch 'migration_bugfix' into 'humble-devel'
  Migration Bugfixing
  See merge request robots/talos_robot!134
* fix typo
* Contributors: Sai Kishor Kothakota, sergiacosta
```

## talos_description

- No changes

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes

## talos_robot

- No changes
