### PR TITLE
apriltag_mit: 1.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -387,6 +387,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
       version: rolling
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_mit-release.git
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_mit` to `1.0.3-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_mit.git
- release repository: https://github.com/ros2-gbp/apriltag_mit-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## apriltag_mit

```
* Merge branch 'master' into rolling
* disabled clang-tidy
* Contributors: Bernd Pfrommer
```
