### PR TITLE
apriltag_mit: 1.0.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -385,7 +385,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_mit-release.git
-      version: 1.2.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_mit` to `1.0.3-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_mit.git
- release repository: https://github.com/ros2-gbp/apriltag_mit-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.2-1`

## apriltag_mit

```
* Merge branch 'master' into rolling
* disabled clang-tidy
* Contributors: Bernd Pfrommer
```
