### PR TITLE
gz_cmake_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2129,7 +2129,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## gz_cmake_vendor

```
* Bump version to 4.0.0 (#10 <https://github.com/gazebo-release/gz_cmake_vendor/issues/10>)
* Fixes the cmake-config used during find_package (#8 <https://github.com/gazebo-release/gz_cmake_vendor/issues/8>)
  The provided cmake-config was not actually working if one did
  ```
  find_package(gz_cmake_vendor)
  find_package(gz-cmake)
  ```
  This because the config file tried to create aliases to targets
  that don't exist. For example, gz-cmake4::gz-cmake4 is not exported
  by gz-cmake.
* Remove the BUILD_DOCS cmake argument. (#9 <https://github.com/gazebo-release/gz_cmake_vendor/issues/9>)
  It is apparently deprecated in newer Gazebo.
* Apply prerelease suffix and remove patch (#7 <https://github.com/gazebo-release/gz_cmake_vendor/issues/7>)
* Upgrade to Ionic
* Contributors: Addisu Z. Taddese, Chris Lalancette
```
