### PR TITLE
performance_test: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4490,7 +4490,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 2.0.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4485,7 +4485,7 @@ repositories:
     doc:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git
-      version: 1.2.1
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test` to `2.3.0-1`:

- upstream repository: https://gitlab.com/ApexAI/performance_test.git
- release repository: https://github.com/ros2-gbp/performance_test-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`
