### PR TITLE
libfranka: 0.13.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4026,6 +4026,11 @@ repositories:
       version: master
     status: maintained
   libfranka:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: 0.13.6-1
     source:
       type: git
       url: https://github.com/frankaemika/libfranka.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.13.6-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
