### PR TITLE
update branch name for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7650,7 +7650,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git
-      version: ros2
+      version: humble
     release:
       packages:
       - robot_calibration
@@ -7662,7 +7662,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git
-      version: ros2
+      version: humble
     status: developed
   robot_controllers:
     doc:


### PR DESCRIPTION
We've made some changes that break humble in the "ros2" branch - created a new branch that properly supports humble