### PR TITLE
robot_calibration: 0.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5858,7 +5858,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.9.0-1
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.9.1-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.0-1`

## robot_calibration

```
* add qos overrides for finders (#174 <https://github.com/mikeferguson/robot_calibration/issues/174>)
  this is primarily a workaround for the issues seen
  in jazzy where large topics do not come through
  over best effort subscribers.
* do not run calibration if no feature finders (#167 <https://github.com/mikeferguson/robot_calibration/issues/167>)
  due to misconfiguration (for instance, camera_info topic
  is wrong) the finders may not initialize but the robot
  will move through all the poses, say it captured
  all of them, and then have no observations in the
  output bagfile
* remove redundant keep_last() (#166 <https://github.com/mikeferguson/robot_calibration/issues/166>)
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
