### PR TITLE
talos_simulation: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9781,6 +9781,19 @@ repositories:
       url: https://github.com/pal-robotics/talos_robot.git
       version: humble-devel
     status: developed
+  talos_simulation:
+    release:
+      packages:
+      - talos_gazebo
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/talos_simulation-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/talos_simulation.git
+      version: humble-devel
+    status: developed
   tango_icons_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_simulation` to `2.0.0-1`:

- upstream repository: https://github.com/pal-robotics/talos_simulation.git
- release repository: https://github.com/pal-gbp/talos_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## talos_gazebo

```
* Merge branch 'ros2-migration' into 'humble-devel'
  Ros2 migration
  See merge request robots/talos_simulation!18
* added default controllers to talos_gazebo launch
* reuse the launch args from launch_pal CommonArgs for talos_gazebo
* reuse the launch args from launch_pal CommonArgs
* Add robot model type as argument
* Remove metapkg. Create single package talos_gazebo
* Add the initial pose as arguments of the launch file.
* launch automatically the simulation
* add launch folder
* simulation with positions controllers
* fix version and delete depend from metapkg
* delete talos_cc_gazebo - talos_cc of the main pkg will be used
* migration talos_hardware_gazebo
* migration to ROS2 CMakeLists and package.xml - hardware_gazebo
* migration to ROS2 CMakeLists and package.xml - gazebo
* migration to ROS2 CMakeLists and package.xml - controller_conf
* migration to ROS2 CMakeLists and package.xml - metapkg
* Contributors: Adrià Roig, Maximilien Naveau, Sai Kishor Kothakota, ileniaperrella
```
