### PR TITLE
talos_moveit_config: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9763,6 +9763,17 @@ repositories:
       url: https://github.com/ros2/system_tests.git
       version: humble
     status: developed
+  talos_moveit_config:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/talos_moveit_config-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/talos_moveit_config.git
+      version: humble-devel
+    status: developed
   talos_robot:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_moveit_config` to `2.0.0-1`:

- upstream repository: https://github.com/pal-robotics/talos_moveit_config.git
- release repository: https://github.com/pal-gbp/talos_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## talos_moveit_config

```
* Merge branch 'ros2-migration' into 'humble-devel'
  ROS 2 Migration
  See merge request control/talos_moveit_config!8
* Remove moveit_fake_controller_manager dependency
* add moveit-ros-perception depend
* re-structure of the move_group launch files
* fix ros_controllers yaml file
* fix config files
* clean libraries moveit_rviz
* launch files
* licence and contributing
* config files
* migration of CMakeLists.txt and package.xml to ros2
* Contributors: Adrià Roig, Sai Kishor Kothakota, ileniaperrella
```
