### PR TITLE
Added python3 PrusaLinkPy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7960,6 +7960,10 @@ python3-protobuf:
     '*': [python3-protobuf]
     '7': null
   ubuntu: [python3-protobuf]
+python3-prusalinkpy-pip:
+  '*':
+    pip:
+      packages: [PrusaLinkPy]
 python3-psutil:
   alpine: [py3-psutil]
   arch: [python-psutil]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

PrusaLinkPy

## Package Upstream Source:

https://github.com/guillaume-rico/PrusaLinkPy
## Purpose of using this:

Python library that allows to control Prusa 3D printers remotely. 

Distro packaging links:

## Links to Distribution Packages
https://pypi.org/project/PrusaLinkPy/
