### PR TITLE
grasping_msgs: 0.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2248,6 +2248,21 @@ repositories:
       url: https://github.com/PickNikRobotics/graph_msgs.git
       version: ros2
     status: maintained
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/mikeferguson/grasping_msgs-ros2-gbp.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros2
+    status: maintained
   grbl_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grasping_msgs` to `0.5.0-1`:

- upstream repository: https://github.com/mikeferguson/grasping_msgs.git
- release repository: https://github.com/mikeferguson/grasping_msgs-ros2-gbp.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## grasping_msgs

```
* Missing dependency (on std_msgs) (#4 <https://github.com/mikeferguson/grasping_msgs/issues/4>)
  msg/Object.msg depends on std_msgs but it's missing in the dependency chain.
* add license and readme files
* Contributors: Isaac Saito, Michael Ferguson
```
