### PR TITLE
swri_console: 2.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7551,7 +7551,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.6-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.5-1`

## swri_console

```
* Fix: "Human readable time" now shows milliseconds correctly. (#67 <https://github.com/swri-robotics/swri_console/issues/67>)
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Update industrial_ci.yml
  Adds CI for Jazzy and Rolling.
* Allow default support for mcap files (#65 <https://github.com/swri-robotics/swri_console/issues/65>)
* Add: Added support for log files of the format "Example: 1724314618.146484723 [INFO] [namespace.Node::Fuction]:  The actual log msg". (#66 <https://github.com/swri-robotics/swri_console/issues/66>)
  Refactor: Removed nested if's
* Update README.md
* Contributors: David Anthony, Rasmus Skovgaard Andersen, Tim Clephas
```
