### PR TITLE
novatel_gps_driver: 4.1.2-6 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4431,7 +4431,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.2-5
+      version: 4.1.2-6
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.2-6`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.2-5`

## novatel_gps_driver

```
* Merge pull request #117 <https://github.com/danthony06/novatel_gps_driver/issues/117> from JWhitleyWork/add-time-reference
  Add the ability to publish TimeReference messages.
* Fix month.
* Try to fix nanoseconds in time reference.
* Add the ability to publish TimeReference messages.
* Contributors: David Anthony, Joshua Whitley
```

## novatel_gps_msgs

- No changes
