### PR TITLE
add simple_grasping to rosdistro

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7338,6 +7338,11 @@ repositories:
       url: https://github.com/DLu/simple_actions.git
       version: main
     status: developed
+  simple_grasping:
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros2
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

simple_grasping

# The source is here:

https://github.com/mikeferguson/simple_grasping

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro