### PR TITLE
create3_examples: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1082,6 +1082,20 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  create3_examples:
+    release:
+      packages:
+      - create3_coverage
+      - create3_examples_msgs
+      - create3_examples_py
+      - create3_lidar_slam
+      - create3_republisher
+      - create3_teleop
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/create3_examples-release.git
+      version: 1.0.0-1
+    status: developed
   create3_sim:
     release:
       packages:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1083,6 +1083,10 @@ repositories:
       version: main
     status: maintained
   create3_examples:
+    doc:
+      type: git
+      url: https://github.com/iRobotEducation/create3_examples.git
+      version: jazzy
     release:
       packages:
       - create3_coverage
@@ -1095,6 +1099,10 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/create3_examples-release.git
       version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/create3_examples.git
+      version: jazzy
     status: developed
   create3_sim:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_examples` to `1.0.0-1`:

- upstream repository: https://github.com/iRobotEducation/create3_examples.git
- release repository: https://github.com/ros2-gbp/create3_examples-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## create3_coverage

- No changes

## create3_examples_msgs

- No changes

## create3_examples_py

- No changes

## create3_lidar_slam

- No changes

## create3_republisher

```
* Merge pull request #58 <https://github.com/iRobotEducation/create3_examples/issues/58> from civerachb-cpr/patch-1
  Adds the new /cmd_vel_stamped topic to the robot subscriptions.
* Merge pull request #56 <https://github.com/iRobotEducation/create3_examples/issues/56> from hilary-luo/hluo/rel-namespace-fix
  Relative Namespace Fix
* Remove manual handling of namespace not being fully qualified
* Contributors: Alberto Soragna, Chris Iverach-Brereton, Hilary Luo
```

## create3_teleop

- No changes
