### PR TITLE
clearpath_config: 0.3.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1257,7 +1257,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `0.3.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.2-1`

## clearpath_config

```
* Allow all parameters to be modified
* Contributors: Luis Camero
```
