### PR TITLE
gz_utils_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2403,7 +2403,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_utils_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_utils_vendor.git
- release repository: https://github.com/ros2-gbp/gz_utils_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## gz_utils_vendor

```
* Bump version to 3.0.0 (#7 <https://github.com/gazebo-release/gz_utils_vendor/issues/7>)
* Add in a dependency on spdlog_vendor. (#6 <https://github.com/gazebo-release/gz_utils_vendor/issues/6>)
  * Add in a dependency on spdlog_vendor.
  That way when building on e.g. Windows, the paths to
  spdlog will be setup properly before trying to build this
  vendor package.
  * Also remove the spdlog dependency.
  That's because we will just depend on the vendor package to
  provide that dependency for us as necessary.
  ---------
* Remove the BUILD_DOCS cmake argument. (#5 <https://github.com/gazebo-release/gz_utils_vendor/issues/5>)
  It is apparently deprecated in newer Gazebo.
* Apply prerelease suffix (#4 <https://github.com/gazebo-release/gz_utils_vendor/issues/4>)
* Upgrade to Ionic
* Contributors: Addisu Z. Taddese, Chris Lalancette
```
