### PR TITLE
gz_common_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2145,7 +2145,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## gz_common_vendor

```
* Bump version to 6.0.0 (#4 <https://github.com/gazebo-release/gz_common_vendor/issues/4>)
* Apply prerelease suffix (#3 <https://github.com/gazebo-release/gz_common_vendor/issues/3>)
  * Apply prerelease suffix
  * Use spdlog_vendor instead of spdlog, drop BUILD_DOCS
  ---------
* Upgrade to Ionic
* Contributors: Addisu Z. Taddese
```
