### PR TITLE
sdformat_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7220,7 +7220,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.1.3-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.3-1`

## sdformat_vendor

```
* Bump version to 15.0.0 (#5 <https://github.com/gazebo-release/sdformat_vendor/issues/5>)
* Apply prerelease suffix (#3 <https://github.com/gazebo-release/sdformat_vendor/issues/3>)
* Upgrade to Ionic
* Contributors: Addisu Z. Taddese
```
