### PR TITLE
gz_sensors_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2339,7 +2339,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.1.2-3
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.2-3`

## gz_sensors_vendor

```
* Bump version to 9.0.0 (#3 <https://github.com/gazebo-release/gz_sensors_vendor/issues/3>)
* Apply prerelease suffix (#2 <https://github.com/gazebo-release/gz_sensors_vendor/issues/2>)
  * Apply prerelease suffix
  * Drop BUILD_DOCS
  ---------
* Upgrade to Ionic
* Contributors: Addisu Z. Taddese, Ian Chen
```
