### PR TITLE
twist_mux: 4.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8560,7 +8560,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux-release.git
-      version: 4.3.0-3
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `4.4.0-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros2-gbp/twist_mux-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-3`

## twist_mux

```
* TwistStamped Support (#50 <https://github.com/ros-teleop/twist_mux/issues/50>)
* Contributors: luis-camero
```
