### PR TITLE
Added adi_3dtof_image_stitching package

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -77,6 +77,11 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  adi_3dtof_image_stitching:
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
+      version: humble-devel
   adi_tmcl:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -79,7 +79,8 @@ repositories:
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
-      version: v1.1.0
+      version: noetic-devel
+    status: maintained
   adi_tmc_coe:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -75,6 +75,11 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  adi_3dtof_image_stitching:
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
+      version: v1.1.0
   adi_tmc_coe:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

adi_3dtof_image_stitching

## Package Upstream Source:

https://github.com/analogdevicesinc/adi_3dtof_image_stitching/tree/v1.1.0

## Purpose of using this:

`adi_3dtof_image_stitching` dependency allows a user to stitch together multiple depth and IR images published by the ADI's ADTF3175D ToF sensor. This has a significance in wide angle applications to increase the field of view.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
