### PR TITLE
autoware_msgs: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -598,11 +598,12 @@ repositories:
       - autoware_planning_msgs
       - autoware_sensing_msgs
       - autoware_system_msgs
+      - autoware_v2x_msgs
       - autoware_vehicle_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## autoware_common_msgs

- No changes

## autoware_control_msgs

- No changes

## autoware_localization_msgs

- No changes

## autoware_map_msgs

```
* feat(autoware_map_msgs): add msg and srv files releated with dynamic lanelet loading (#81 <https://github.com/autowarefoundation/autoware_msgs/issues/81>)
* Contributors: Barış Zeren, Ryohsuke Mitsudome, Yamato Ando
```

## autoware_perception_msgs

- No changes

## autoware_planning_msgs

```
* docs(TrajectoryPoint):  add comment for acceleration_mps2 to clarify its usage (#92 <https://github.com/autowarefoundation/autoware_msgs/issues/92>)
* Contributors: Ahmed Ebrahim
```

## autoware_sensing_msgs

- No changes

## autoware_system_msgs

- No changes

## autoware_v2x_msgs

```
* feat(autoware_v2x_msgs): add virtual gate messages (#77 <https://github.com/autowarefoundation/autoware_msgs/issues/77>)
* Contributors: Takagi, Isamu
```

## autoware_vehicle_msgs

- No changes
