### PR TITLE
imu_tools: 2.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2490,7 +2490,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.1.4-1
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.2.0-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.4-1`

## imu_complementary_filter

```
* Add QoS overriding options (#207 <https://github.com/CCNYRoboticsLab/imu_tools/issues/207>)
* Contributors: Aleksander Szymański
```

## imu_filter_madgwick

- No changes

## imu_tools

- No changes

## rviz_imu_plugin

- No changes
