### PR TITLE
rosdep: add some NixOS keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3808,6 +3808,7 @@ libglm-dev:
   debian: [libglm-dev]
   fedora: [glm-devel]
   gentoo: [media-libs/glm]
+  nixos: [glm]
   rhel: [glm-devel]
   ubuntu: [libglm-dev]
 libglui-dev:
@@ -8265,6 +8266,7 @@ sdl2-image:
   arch: [sdl2_image]
   debian: [libsdl2-image-dev]
   fedora: [SDL2_image-devel]
+  nixos: [SDL2_image]
   rhel:
     '7': [SDL2_image-devel]
   ubuntu: [libsdl2-image-dev]


### PR DESCRIPTION
Please update the following dependencies to have NixOS keys.

## Package name:

* `libglm-dev`
* `sdl2-image`

## Purpose of using this:

These packages already have an entry in rosdep, they are just missing NixOS keys.

## Links to Distribution Packages

- NixOS/nixpkgs: https://search.nixos.org/packages
  * [glm](https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=glm)
  * [sdl2-image](https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=SDL2_image)