### PR TITLE
teleop_tools: 1.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9818,7 +9818,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
-      version: 1.5.1-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.6.0-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros2-gbp/teleop_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.1-1`

## joy_teleop

```
* Extend mapping to index of an array (#76 <https://github.com/ros-teleop/teleop_tools/issues/76>)
* Contributors: El Jawad Alaa
```

## key_teleop

- No changes

## mouse_teleop

```
* Do periodic publishing on tkinter loop instead of ROS timer. (#72 <https://github.com/ros-teleop/teleop_tools/issues/72>)
* Contributors: Anthony Deschamps
```

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
