### PR TITLE
dbw_ros: 2.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1183,7 +1183,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.2.0-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.2.3-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2024/10/01 release package
* Add eye tracker message (Mach-E only)
* Add disengage reason power-cycle
* Add prints for braking due to external brake button and comms loss
* Check for timeouts on received messages for system enable/disable/override logic
* Increase range of throttle sweep script
* Add gear manual and gear sport enumerations
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```

## ds_dbw_joystick_demo

- No changes

## ds_dbw_msgs

```
* Add eye tracker message (Mach-E only)
* Add gear manual and gear sport enumerations
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```
