### PR TITLE
ess_imu_driver2: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2055,7 +2055,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ess_imu_driver2-release.git
-      version: 1.0.1-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/cubicleguy/ess_imu_driver2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_driver2` to `2.0.1-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_driver2.git
- release repository: https://github.com/ros2-gbp/ess_imu_driver2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## ess_imu_driver2

```
* Update CMakeLists.txt - set macro PLATFORM to NONE
```
