### PR TITLE
rqt_dotgraph: 0.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6763,6 +6763,11 @@ repositories:
       type: git
       url: https://github.com/niwcpac/rqt_dotgraph.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_dotgraph-release.git
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/niwcpac/rqt_dotgraph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dotgraph` to `0.0.4-1`:

- upstream repository: https://github.com/niwcpac/rqt_dotgraph.git
- release repository: https://github.com/ros2-gbp/rqt_dotgraph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rqt_dotgraph

```
* Contributors: Alexander Xydes, Thomas Denewiler
```
