### PR TITLE
rviz: 14.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7158,7 +7158,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.2.6-1
+      version: 14.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.3.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.2.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* replace deprecated encodings 'yuv422' and 'yuv422_yuy2' (#1276 <https://github.com/ros2/rviz/issues/1276>)
* Contributors: Christian Rauch
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Avoid redefinition of default color materials (#1281 <https://github.com/ros2/rviz/issues/1281>)
* Contributors: Masayoshi Dohi
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
