### PR TITLE
turtlebot4_robot: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8556,6 +8556,27 @@ repositories:
       url: https://github.com/turtlebot/turtlebot4_desktop.git
       version: jazzy
     status: developed
+  turtlebot4_robot:
+    doc:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_robot.git
+      version: jazzy
+    release:
+      packages:
+      - turtlebot4_base
+      - turtlebot4_bringup
+      - turtlebot4_diagnostics
+      - turtlebot4_robot
+      - turtlebot4_tests
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/turtlebot/turtlebot4_robot.git
+      version: jazzy
+    status: developed
   turtlebot4_simulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_robot` to `2.0.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_robot.git
- release repository: https://github.com/ros2-gbp/turtlebot4_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot4_base

- No changes

## turtlebot4_bringup

```
* Enable power-saver by default
* Add a delay to the oakd startup to work around a bug where the camera doesn't reliably publish data after restarting the systemd job
* Fix the resolution for the OakD config files
* Enable respawn for the republisher node
* Clean up config file formatting
* Remove unused variables
* Remove unused imports
* Disable XML linter; it's timing out and isn't needed for this package
* Update the reamappings for the stamped/unstamped topics
* Always use the Create3 republisher node
* Remove deprecations in robot.launch.py
* Enable TwistStamped publications for the teleop node
* Add joy_device launch argument in case js0 isn't the correct joystick
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_diagnostics

```
* Reduce the expected IMU rate to the actual rate published by the Create3
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_robot

- No changes

## turtlebot4_tests

```
* Small formatting fixes
* Contributors: Chris Iverach-Brereton
```
