### PR TITLE
rmw_connextdds: 0.24.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5744,7 +5744,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.24.1-1
+      version: 0.24.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.24.2-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.24.1-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* fix: "Failed to parse type hash" message was overly spammy (ros2-50) (#149 <https://github.com/ros2/rmw_connextdds/issues/149>)
* Contributors: Taxo Rubio RTI
```

## rti_connext_dds_cmake_module

```
* Quiet a warning when CONNEXTDDS_DIR or NDDSHOME is not found. (#158 <https://github.com/ros2/rmw_connextdds/issues/158>)
* Contributors: Chris Lalancette
```
