### PR TITLE
rclpy: 7.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5284,7 +5284,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.5.0-1
+      version: 7.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.6.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.5.0-1`

## rclpy

```
* TestClient.test_service_timestamps failing consistently. (#1364 <https://github.com/ros2/rclpy/issues/1364>)
* Revert "Add types to Action Server and Action Client (#1349 <https://github.com/ros2/rclpy/issues/1349>)" (#1359 <https://github.com/ros2/rclpy/issues/1359>)
* Revert "Executors types (#1345 <https://github.com/ros2/rclpy/issues/1345>)" (#1360 <https://github.com/ros2/rclpy/issues/1360>)
* remove mock_compat (#1357 <https://github.com/ros2/rclpy/issues/1357>)
* Executors types (#1345 <https://github.com/ros2/rclpy/issues/1345>)
* Add types to Action Server and Action Client (#1349 <https://github.com/ros2/rclpy/issues/1349>)
* Remove TODO for OpenSplice DDS issue. (#1354 <https://github.com/ros2/rclpy/issues/1354>)
* Add types to parameter_client.py (#1348 <https://github.com/ros2/rclpy/issues/1348>)
* Add types to Node.py (#1346 <https://github.com/ros2/rclpy/issues/1346>)
* Add types to signals.py (#1344 <https://github.com/ros2/rclpy/issues/1344>)
* Fixes spin_until_future_complete inside callback (#1316 <https://github.com/ros2/rclpy/issues/1316>)
* add types (#1339 <https://github.com/ros2/rclpy/issues/1339>)
* Add types to wait_for_message.py and moves Handles into type stubs (#1325 <https://github.com/ros2/rclpy/issues/1325>)
* Add types to waitable.py (#1328 <https://github.com/ros2/rclpy/issues/1328>)
* Replace rclpyHandle with type stubs (#1326 <https://github.com/ros2/rclpy/issues/1326>)
* Fix time subtraction (#1312 <https://github.com/ros2/rclpy/issues/1312>)
* Adds types to TypeDescriptionService. (#1329 <https://github.com/ros2/rclpy/issues/1329>)
* Import DurationHandle not DurationType (#1332 <https://github.com/ros2/rclpy/issues/1332>)
* Creates PublisherHandle and updates publisher.py (#1310 <https://github.com/ros2/rclpy/issues/1310>)
* Subscription types (#1281 <https://github.com/ros2/rclpy/issues/1281>)
* Add types to qos.py (#1255 <https://github.com/ros2/rclpy/issues/1255>)
* minor improvements (#1330 <https://github.com/ros2/rclpy/issues/1330>)
* Initialize signal handlers after context (#1331 <https://github.com/ros2/rclpy/issues/1331>)
* shutdown ThreadPoolExecutor in MultiThreadedExecutor. (#1309 <https://github.com/ros2/rclpy/issues/1309>)
* Generics Services and Clients (#1275 <https://github.com/ros2/rclpy/issues/1275>)
* Add types to ParameterService (#1262 <https://github.com/ros2/rclpy/issues/1262>)
* Add types to timer.py (#1260 <https://github.com/ros2/rclpy/issues/1260>)
* Add types to rcutils_logger.py (#1249 <https://github.com/ros2/rclpy/issues/1249>)
* Add types to topic_endpoint_info.oy (#1253 <https://github.com/ros2/rclpy/issues/1253>)
* Add types to parameter.py. (#1246 <https://github.com/ros2/rclpy/issues/1246>)
* Guard condition types. (#1252 <https://github.com/ros2/rclpy/issues/1252>)
* Add types to callback_groups.py (#1251 <https://github.com/ros2/rclpy/issues/1251>)
* Utilities.py types. (#1250 <https://github.com/ros2/rclpy/issues/1250>)
* reduce result_timeout to 10 secs from 15 mins. (#1171 <https://github.com/ros2/rclpy/issues/1171>)
* Add TimerInfo to timer callback. (#1292 <https://github.com/ros2/rclpy/issues/1292>)
* Contributors: Jonathan, Michael Carlstrom, Shane Loretz, Tomoya Fujita
```
