### PR TITLE
rcl_logging: 3.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5215,7 +5215,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.2.1-1
+      version: 3.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.2.2-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.1-1`

## rcl_logging_interface

- No changes

## rcl_logging_noop

```
* rcl_logging_interface is only valid path with build environment. (#122 <https://github.com/ros2/rcl_logging/issues/122>)
* README update and some cleanups. (#120 <https://github.com/ros2/rcl_logging/issues/120>)
* Contributors: Tomoya Fujita
```

## rcl_logging_spdlog

```
* rcl_logging_interface is only valid path with build environment. (#122 <https://github.com/ros2/rcl_logging/issues/122>)
* README update and some cleanups. (#120 <https://github.com/ros2/rcl_logging/issues/120>)
* Contributors: Tomoya Fujita
```
