### PR TITLE
rcl: 10.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5168,7 +5168,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.4.1-1
+      version: 10.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.0.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.4.1-1`

## rcl

```
* Cleanup test_graph.cpp. (#1193 <https://github.com/ros2/rcl/issues/1193>)
* Expect a minimum of two nodes to be alive in test_graph (#1192 <https://github.com/ros2/rcl/issues/1192>)
* escalate RCL_RET_ACTION_xxx to 40XX. (#1191 <https://github.com/ros2/rcl/issues/1191>)
* Fix NULL allocator and racy condition. (#1188 <https://github.com/ros2/rcl/issues/1188>)
* Properly initialize the char array used in type hash calculations. (#1182 <https://github.com/ros2/rcl/issues/1182>)
* Increased timeouts (#1181 <https://github.com/ros2/rcl/issues/1181>)
* Skip some event tests on rmw_zenoh (#1180 <https://github.com/ros2/rcl/issues/1180>)
* doc: rcl_logging_spdlog is the default impl. (#1177 <https://github.com/ros2/rcl/issues/1177>)
* Update wait.h documentation for rcl_wait (#1176 <https://github.com/ros2/rcl/issues/1176>)
* Change the starting time of the goal expiration timeout (#1121 <https://github.com/ros2/rcl/issues/1121>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chris Lalancette, Felix Penzlin, Tomoya Fujita, Yadu
```

## rcl_action

```
* Cleanup test_graph.cpp. (#1193 <https://github.com/ros2/rcl/issues/1193>)
* Expect a minimum of two nodes to be alive in test_graph (#1192 <https://github.com/ros2/rcl/issues/1192>)
* escalate RCL_RET_ACTION_xxx to 40XX. (#1191 <https://github.com/ros2/rcl/issues/1191>)
* Fix NULL allocator and racy condition. (#1188 <https://github.com/ros2/rcl/issues/1188>)
* Increased timeouts (#1181 <https://github.com/ros2/rcl/issues/1181>)
* Change the starting time of the goal expiration timeout (#1121 <https://github.com/ros2/rcl/issues/1121>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chris Lalancette, Tomoya Fujita, Yadu
```

## rcl_lifecycle

```
* Fix NULL allocator and racy condition. (#1188 <https://github.com/ros2/rcl/issues/1188>)
* Fix typo in rcl_lifecycle_com_interface_t doc (#1174 <https://github.com/ros2/rcl/issues/1174>)
* Contributors: Christophe Bedard, Tomoya Fujita
```

## rcl_yaml_param_parser

- No changes
