### PR TITLE
demos: 0.35.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1091,7 +1091,6 @@ repositories:
     release:
       packages:
       - action_tutorials_cpp
-      - action_tutorials_interfaces
       - action_tutorials_py
       - composition
       - demo_nodes_cpp
@@ -1114,7 +1113,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.34.2-1
+      version: 0.35.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.35.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.34.2-1`

## action_tutorials_cpp

```
* Remove action_tutorials_interfaces. (#701 <https://github.com/ros2/demos/issues/701>)
* Contributors: Chris Lalancette
```

## action_tutorials_py

```
* Remove action_tutorials_interfaces. (#701 <https://github.com/ros2/demos/issues/701>)
* Contributors: Chris Lalancette
```

## composition

```
* Fix typo in composition comment (#703 <https://github.com/ros2/demos/issues/703>)
* Contributors: Christophe Bedard
```

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
