### PR TITLE
image_common: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2537,7 +2537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.3.2-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.2-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

```
* Add optional namespace to /set_camera_info service in CameraInfoManager (#324 <https://github.com/ros-perception/image_common/issues/324>)
* Contributors: Jan Hernas
```

## image_common

- No changes

## image_transport

```
* Apply remappings to base topic before creating transport-specific topics (#326 <https://github.com/ros-perception/image_common/issues/326>)
* Add lazy subscription to republisher (#325 <https://github.com/ros-perception/image_common/issues/325>)
* Fix node name (#321 <https://github.com/ros-perception/image_common/issues/321>)
* Contributors: Błażej Sowa, Michal Sojka
```
