### PR TITLE
mrpt_path_planning: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4067,7 +4067,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.1.5-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.2.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.5-1`

## mrpt_path_planning

```
* Add support for new PTGs with internalState in MRPT >=2.14.2
* viz animations: draw vehicle frame for visual reference
* interpolate(): fix accumulated error along trajectories
* cli and viz: interpolate trajectory
* cli: add flags to control obstacles bbox and clipping
* ObstacleSource virtual API: implement clipping of obstacle sources
* A* grid reimplemented as unordered_map for maximum efficiency
* smoother obstacle cost function
* Add more profiler and debug traces
* remove -Wabi warnings
* viz: start with camera pointing to the path origin
* Contributors: Jose Luis Blanco-Claraco
```
