### PR TITLE
srdfdom: 2.0.5-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7711,7 +7711,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.4-3
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.5-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros2-gbp/srdfdom-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-3`

## srdfdom

```
* Fix README instructions for ROS 2 (#130 <https://github.com/moveit/srdfdom/issues/130>)
* Support conditional urdf/model.hpp include (#127 <https://github.com/moveit/srdfdom/issues/127>)
* Remove rospy usage (#129 <https://github.com/moveit/srdfdom/issues/129>)
* Add Jazzy to CI (#128 <https://github.com/moveit/srdfdom/issues/128>)
* Update CMakeLists.txt (#123 <https://github.com/moveit/srdfdom/issues/123>)
  - minimum cmake version: 3.8
  - use default C++17
* CI: Use clang-format-14
* CI: update pre-commit tool versions (#125 <https://github.com/moveit/srdfdom/issues/125>)
* CI: drop Galactic, add Iron
* CI: Update action versions (#121 <https://github.com/moveit/srdfdom/issues/121>)
* CI: update actions/checkout to version 3 (#116 <https://github.com/moveit/srdfdom/issues/116>)
* Update .pre-commit-config.yaml (#113 <https://github.com/moveit/srdfdom/issues/113>)
* Parse decimals in a locale-independent way (#108 <https://github.com/moveit/srdfdom/issues/108>)
* Humble and formatting updates (#107 <https://github.com/moveit/srdfdom/issues/107>)
* Contributors: AndyZe, Robert Haschke, Sebastian Castro, Vatan Aksoy Tezer, mosfet80
```
