### PR TITLE
ur_msgs: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8153,7 +8153,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
-      version: foxy
+      version: humble
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -8162,7 +8162,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
-      version: foxy
+      version: humble-devel
     status: developed
   ur_robot_driver:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8158,7 +8158,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.0.0-3
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-3`

## ur_msgs

```
* [ROS 2] Update README and ci (#31 <https://github.com/ros-industrial/ur_msgs/issues/31>)
* Add a service to set an analog output (#30 <https://github.com/ros-industrial/ur_msgs/issues/30>)
* Added service for getting the software version of the robot. (#25 <https://github.com/ros-industrial/ur_msgs/issues/25>)
* ci: bump checkout and cache (#23 <https://github.com/ros-industrial/ur_msgs/issues/23>)
* Contributors: Felix Exner, G.A. vd. Hoorn, URJala
```
