### PR TITLE
microstrain_inertial: 4.4.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3342,7 +3342,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.3.0-1
+      version: 4.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.4.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.3.0-1`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* ROS submodule update 10/07/2024 (#356 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/356>)
* ROS submodule update 08/23/2024 (#349 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/349>)
* Contributors: Rob
```

## microstrain_inertial_examples

```
* ROS Adds example of providing NMEA over CV7-INS aux port (#351 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/351>)
  * Adds ROS CV7-INS NMEA aux port example
  * Adds example files to README
* Contributors: Rob
```

## microstrain_inertial_msgs

```
* ROS submodule update 08/23/2024 (#349 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/349>)
* Contributors: Rob
```

## microstrain_inertial_rqt

- No changes
