### PR TITLE
ros2_control: 4.18.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6357,7 +6357,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.17.0-1
+      version: 4.18.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.18.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.17.0-1`

## controller_interface

```
* Adapt controller Reference/StateInterfaces to New Way of Exporting (variant support) (#1689 <https://github.com/ros-controls/ros2_control/issues/1689>)
* [ControllerInterface] Fix to properly propagate the controller NodeOptions (#1762 <https://github.com/ros-controls/ros2_control/issues/1762>)
* [Controller Interface] Make assign and release interfaces virtual (#1743 <https://github.com/ros-controls/ros2_control/issues/1743>)
* Contributors: Manuel Muth, Sai Kishor Kothakota
```

## controller_manager

```
* Adapt controller Reference/StateInterfaces to New Way of Exporting (variant support) (#1689 <https://github.com/ros-controls/ros2_control/issues/1689>)
* Add test coverage for params_file parameter in spawner/unspawner tests (#1754 <https://github.com/ros-controls/ros2_control/issues/1754>)
* [ros2controlcli] add params file parsing to load_controller verb and add namespacing support  (#1703 <https://github.com/ros-controls/ros2_control/issues/1703>)
* Contributors: Manuel Muth, Sai Kishor Kothakota, Santosh Govindaraj
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Adapt controller Reference/StateInterfaces to New Way of Exporting (variant support) (#1689 <https://github.com/ros-controls/ros2_control/issues/1689>)
* Automatic Creation of Handles in HW, Adding Getters/Setters (variant support) (#1688 <https://github.com/ros-controls/ros2_control/issues/1688>)
* [RM] Execute error callback of component on returning ERROR or with exception (#1730 <https://github.com/ros-controls/ros2_control/issues/1730>)
* Contributors: Manuel Muth, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Adapt controller Reference/StateInterfaces to New Way of Exporting (variant support) (#1689 <https://github.com/ros-controls/ros2_control/issues/1689>)
* Contributors: Manuel Muth
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Automatic Creation of Handles in HW, Adding Getters/Setters (variant support) (#1688 <https://github.com/ros-controls/ros2_control/issues/1688>)
* Contributors: Manuel Muth
```

## ros2controlcli

```
* [ros2controlcli] add params file parsing to load_controller verb and add namespacing support  (#1703 <https://github.com/ros-controls/ros2_control/issues/1703>)
* Contributors: Sai Kishor Kothakota
```

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
