### PR TITLE
ros2_controllers: 4.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5999,7 +5999,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.14.0-1
+      version: 4.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.14.0-1`

## ackermann_steering_controller

```
* Adapt test to new way of exporting reference interfaces (Related to #1240 <https://github.com/ros-controls/ros2_controllers/issues/1240> in ros2_control) (#1103 <https://github.com/ros-controls/ros2_controllers/issues/1103>)
* Contributors: Manuel Muth
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Adapt test to new way of exporting reference interfaces (Related to #1240 <https://github.com/ros-controls/ros2_controllers/issues/1240> in ros2_control) (#1103 <https://github.com/ros-controls/ros2_controllers/issues/1103>)
* Contributors: Manuel Muth
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## parallel_gripper_controller

- No changes

## pid_controller

```
* Adapt test to new way of exporting reference interfaces (Related to #1240 <https://github.com/ros-controls/ros2_controllers/issues/1240> in ros2_control) (#1103 <https://github.com/ros-controls/ros2_controllers/issues/1103>)
* Contributors: Manuel Muth
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Adapt test to new way of exporting reference interfaces (Related to #1240 <https://github.com/ros-controls/ros2_controllers/issues/1240> in ros2_control) (#1103 <https://github.com/ros-controls/ros2_controllers/issues/1103>)
* fix(timeout): do not reset steer wheels to 0. on timeout (#1289 <https://github.com/ros-controls/ros2_controllers/issues/1289>)
* fix(steering-odometry): convert twist to steering angle (#1288 <https://github.com/ros-controls/ros2_controllers/issues/1288>)
* Contributors: Manuel Muth, Rein Appeldoorn
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Adapt test to new way of exporting reference interfaces (Related to #1240 <https://github.com/ros-controls/ros2_controllers/issues/1240> in ros2_control) (#1103 <https://github.com/ros-controls/ros2_controllers/issues/1103>)
* Contributors: Manuel Muth
```

## velocity_controllers

- No changes
