### PR TITLE
rosbridge_suite: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8307,7 +8307,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.3.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8294,7 +8294,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
-      version: ros2
+      version: humble
     release:
       packages:
       - rosapi
@@ -8311,7 +8311,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
-      version: ros2
+      version: humble
     status: developed
   rosidl:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.2-1`

## rosapi

```
* rosapi: Don't start parameter services that aren't spun (#944 <https://github.com/RobotWebTools/rosbridge_suite/issues/944>)
* Handle ROS 2 types properly (#883 <https://github.com/RobotWebTools/rosbridge_suite/issues/883>)
* Port unit tests to ROS 2 + Fix CBOR conversion and PNG compression (#882 <https://github.com/RobotWebTools/rosbridge_suite/issues/882>)
* Contributors: Brad Martin, Scott Bell, Sebastian Castro
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* Fix action cancellation by passing status from JSON (#953 <https://github.com/RobotWebTools/rosbridge_suite/issues/953>)
* Update pre-commit and fix issues (#954 <https://github.com/RobotWebTools/rosbridge_suite/issues/954>)
* Fix length-limited list types (#840 <https://github.com/RobotWebTools/rosbridge_suite/issues/840>)
* fix: update new subs with dds from publisher (#940 <https://github.com/RobotWebTools/rosbridge_suite/issues/940>)
* Avoid stale subscription when unsubscribing during resubscription (#948 <https://github.com/RobotWebTools/rosbridge_suite/issues/948>)
* Changed type hints in ros_loader.py to use imports from Typing (#938 <https://github.com/RobotWebTools/rosbridge_suite/issues/938>)
* Avoid stack traces when aborting an advertised action goal (#906 <https://github.com/RobotWebTools/rosbridge_suite/issues/906>)
* Timeout if service server not available within server_timeout_time (#905 <https://github.com/RobotWebTools/rosbridge_suite/issues/905>)
* Use ROS 2 Node Clock in Message Conversion (#900 <https://github.com/RobotWebTools/rosbridge_suite/issues/900>)
* Fix issues when canceling and unadvertising actions (#896 <https://github.com/RobotWebTools/rosbridge_suite/issues/896>)
* Support actions in rosbridge protocol (#886 <https://github.com/RobotWebTools/rosbridge_suite/issues/886>)
* Port unit tests to ROS 2 + Fix CBOR conversion and PNG compression (#882 <https://github.com/RobotWebTools/rosbridge_suite/issues/882>)
* Contributors: Brad Martin, Dimitri Nikitopoulos, EricGallimore, Ezra Brooks, Paul Gesel, Sebastian Castro, michael-cmt
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Fix action cancellation by passing status from JSON (#953 <https://github.com/RobotWebTools/rosbridge_suite/issues/953>)
* Update pre-commit and fix issues (#954 <https://github.com/RobotWebTools/rosbridge_suite/issues/954>)
* rosbridge_websocket: Stop websocket server if ROS shuts down (#946 <https://github.com/RobotWebTools/rosbridge_suite/issues/946>)
* Support actions in rosbridge protocol (#886 <https://github.com/RobotWebTools/rosbridge_suite/issues/886>)
* Port unit tests to ROS 2 + Fix CBOR conversion and PNG compression (#882 <https://github.com/RobotWebTools/rosbridge_suite/issues/882>)
* Contributors: Brad Martin, Sebastian Castro
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

```
* Fix action cancellation by passing status from JSON (#953 <https://github.com/RobotWebTools/rosbridge_suite/issues/953>)
* Fix length-limited list types (#840 <https://github.com/RobotWebTools/rosbridge_suite/issues/840>)
* Support actions in rosbridge protocol (#886 <https://github.com/RobotWebTools/rosbridge_suite/issues/886>)
* Contributors: Ezra Brooks, Sebastian Castro
```
