### PR TITLE
rosbridge_suite: 2.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6434,7 +6434,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 1.3.2-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.1.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.2-1`

## rosapi

```
* Fix invalid import of get_parameter_value in rosapi for ROS2 Jazzy. (#932 <https://github.com/RobotWebTools/rosbridge_suite/issues/932>)
* Contributors: David Oberacker
```

## rosapi_msgs

- No changes

## rosbridge_library

- No changes

## rosbridge_msgs

- No changes

## rosbridge_server

- No changes

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
