### PR TITLE
sbg_driver: 3.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11122,7 +11122,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 3.1.1-7
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.2.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.1-7`

## sbg_driver

```
* Update README according to the latest changes
* Backported changes from ROS2 driver
* fix #70 <https://github.com/SBG-Systems/sbg_ros_driver/issues/70> build on Windows
* remove unused var
* update doc to build from sources
* Perform proper name resolution to make name remapping more convenient
  Fixes #75 <https://github.com/SBG-Systems/sbg_ros_driver/issues/75>.
* Contributors: Michael Zemb, Richard Braun, Samuel Toledano, cledant
```
