### PR TITLE
variants: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8385,7 +8385,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.11.0-1
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `variants` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/variants.git
- release repository: https://github.com/ros2-gbp/variants-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.11.0-1`

## desktop

```
* Removed action tutorials interfaces dependency (#44 <https://github.com/ros2/variants/issues/44>)
* Contributors: Alejandro Hernández Cordero
```

## desktop_full

- No changes

## perception

- No changes

## ros_base

- No changes

## ros_core

- No changes

## simulation

- No changes
