### PR TITLE
adi_3dtof_image_stitching: 1.1.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -76,6 +76,11 @@ repositories:
       version: noetic-devel
     status: maintained
   adi_3dtof_image_stitching:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/raebelchristo-adi/adi_3dtof_image_stitching-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_3dtof_image_stitching` to `1.1.0-1`:

- upstream repository: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
- release repository: https://github.com/raebelchristo-adi/adi_3dtof_image_stitching-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
