### PR TITLE
mavros: 1.20.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5648,7 +5648,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mavlink/mavros-release.git
-      version: 1.19.0-1
+      version: 1.20.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `1.20.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/mavlink/mavros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.19.0-1`

## libmavconn

- No changes

## mavros

```
* add param to odom plugin
* add frame_id parameter
* Contributors: EnderMandS
```

## mavros_extras

```
* Add missing std_srvs dependency
* add param to odom plugin
* add frame_id parameter
* Fix compile error when compiling with gcc 13
  The error is:
  src/plugins/mag_calibration_status.cpp:64:22: error: ‘bitset’ is not a member of ‘std’
* Contributors: EnderMandS, Michal Sojka, Roland Arsenault
```

## mavros_msgs

- No changes

## test_mavros

- No changes
