### PR TITLE
image_common: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2533,10 +2533,11 @@ repositories:
       - camera_info_manager
       - image_common
       - image_transport
+      - image_transport_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## image_common

- No changes

## image_transport

```
* feat: python bindings for image_transport and publish (#323 <https://github.com/ros-perception/image_common/issues/323>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Földi Tamás
```

## image_transport_py

```
* feat: python bindings for image_transport and publish (#323 <https://github.com/ros-perception/image_common/issues/323>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Földi Tamás
```
