### PR TITLE
ur_description: 2.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8144,7 +8144,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.4.3-1
+      version: 2.4.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.4.4-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.3-1`

## ur_description

```
* Add a sensor for the TCP pose (#197 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/197>)
* Add passthrough command interfaces for joints (#204 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/204>)
* Ur3 infinite wrist (#196 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/196>)
* Update dynamic properties (#195 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/195>)
  Co-authored-by: Rune Søe-Knudsen <mailto:41109954+urrsk@users.noreply.github.com>
* Contributors: Chalongrath Pholsiri, Felix Exner (fexner), URJala, Rune Søe-Knudsen
```
