### PR TITLE
web_video_server: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11152,6 +11152,22 @@ repositories:
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git
       version: ros2
     status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/web_video_server-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: ros2
+    status: maintained
   webots_ros2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `2.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/ros2-gbp/web_video_server-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## web_video_server

```
* Replace boost with std (#164)
* Add ament_cpplint test, resolve TODOs (#162)
* Add license headers to all C++ source files, update copyrights (#161)
* Add support for alpha pngs by adding per stream type decode functions (backport #106) (#163)
* Add link to /stream in stream list (backport #118) (#160)
* Add support for jpg compression format (backport #142) (#159)
* Reformat the code with uncrustify (#158)
* Use hpp extension for headers (#157)
* Fix request logging, remove global parameters (#156)
* Replace nh with node (#155)
* Fix declaring and retrieving node parameters (#154)
* Fix usage of deprecated libavcodec functions (#150)
* Use cv_bridge hpp headers when available (#149)
* Use target_link_libraries instead of ament_target_dependencies where applicable
* Don't install headers
* Add CI workflow and ament_lint tests (#148)
* Update package maintainer
* allow topic searches to continue past invalid multi-type topics. (#146)
* Add QoS profile query parameters (#133)
* Fix build for ROS2 Humble (#129)
* Fix build for ROS2 Foxy (#111)
* Contributors: Błażej Sowa, Domenic Rodriguez, Robert Brothers, Sebastian Castro, Tina Tian, TobinHall, Matthew Bries
```
