### PR TITLE
ros_babel_fish: 0.9.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6181,6 +6181,10 @@ repositories:
       version: main
     status: maintained
   ros_babel_fish:
+    doc:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: rolling
     release:
       packages:
       - ros_babel_fish
@@ -6188,7 +6192,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.9.3-1
+      version: 0.9.5-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.9.5-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.3-1`

## ros_babel_fish

```
* Fixes to compile on Rolling. (#8 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/8>)
  * Fixes to compile on Rolling.
  ROS 2 Rolling has made two changes that cause this package
  to not build in its current form:
  1. The TRACEPOINT macro has been renamed to TRACETOOLS_TRACEPOINT.
  2. The action_tutorials_interface package has been removed,
  since it was duplicating an action that was already available
  in example_interfaces.
  This commit fixes both of these issues.
  ---------
  Co-authored-by: Stefan Fabian <mailto:fabian@sim.tu-darmstadt.de>
* Contributors: Chris Lalancette
```

## ros_babel_fish_test_msgs

- No changes
