### PR TITLE
nicla_vision_ros: 1.0.2-1 in noetic/distribution.yaml

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6855,7 +6855,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ADVRHumanoids/nicla_vision_ros-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ADVRHumanoids/nicla_vision_ros.git


### PR DESCRIPTION
Updated nicla_vision_ros package


# Please Add This Package to be indexed in the rosdistro.

noetic

# The source is here:

https://github.com/ADVRHumanoids/nicla_vision_ros.git

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
