### PR TITLE
novatel_gps_driver: 4.1.3-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4161,7 +4161,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.2-1
+      version: 4.1.3-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.1.3-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.2-1`

## novatel_gps_driver

```
* Updated cmake to generate both composable node plugin library and standalone executable for NovatelGpsNode. (#122 <https://github.com/swri-robotics/novatel_gps_driver/issues/122>)
* Contributors: Robert Brothers
```

## novatel_gps_msgs

- No changes
