### PR TITLE
popf: 0.0.17-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5154,6 +5154,21 @@ repositories:
       url: https://github.com/MetroRobots/polygon_ros.git
       version: main
     status: developed
+  popf:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: jazzy-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/popf-release.git
+      version: 0.0.17-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: jazzy-devel
+    status: maintained
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `0.0.17-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/ros2-gbp/popf-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## popf

- No changes
