### PR TITLE
mrpt_navigation: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3771,7 +3771,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.2.1-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## mrpt_map_server

- No changes

## mrpt_msgs_bridge

- No changes

## mrpt_nav_interfaces

- No changes

## mrpt_navigation

- No changes

## mrpt_pf_localization

- No changes

## mrpt_pointcloud_pipeline

- No changes

## mrpt_rawlog

- No changes

## mrpt_reactivenav2d

```
* Update for MRPT 2.14.3 (new RNAV weight for target heading)
* Support speed_ratio property for Waypoints
* Improve astar navigation demo
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tps_astar_planner

```
* Update demo for astar
* Publish costmaps to ROS for visualization too apart of the custom MRPT GUI
* Improve astar navigation demo
* astar planner: add refine() step and parameter to optionally disable it
* astar node: add two more launch args: problem_world_bbox_margin and problem_world_bbox_ignore_obstacles
* astar params: add more comments and tune for speed
* PTGs .ini: Add docs on how to enable backward motions
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

```
* Update demo for astar
* Publish costmaps to ROS for visualization too apart of the custom MRPT GUI
* rviz layout: show rnav selected path
* Improve astar navigation demo
* astar planner: add refine() step and parameter to optionally disable it
* astar node: add two more launch args: problem_world_bbox_margin and problem_world_bbox_ignore_obstacles
* Contributors: Jose Luis Blanco-Claraco
```
