### PR TITLE
Add clangd to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -589,11 +589,8 @@ clangd:
   gentoo: [sys-devel/clang]
   nixos: [clang]
   opensuse: [clang]
-  rhel:
-    '*': [clang-tools-extra]
-    '7': null
-  ubuntu:
-    '*': [clangd]
+  rhel: [clang-tools-extra]
+  ubuntu: [clangd]
 cmake:
   alpine: [cmake]
   arch: [cmake]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -560,6 +560,7 @@ clang-format:
   fedora: [clang-tools-extra, git-clang-format]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  opensuse: [clang]
   osx:
     homebrew:
       packages: [clang-format]
@@ -574,11 +575,25 @@ clang-tidy:
   fedora: [clang-tools-extra]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  opensuse: [clang]
   rhel:
     '*': [clang-tools-extra]
     '7': null
   ubuntu:
     '*': [clang-tidy]
+clangd:
+  alpine: [clang-extra-tools]
+  arch: [clang]
+  debian: [clangd]
+  fedora: [clang-tools-extra]
+  gentoo: [sys-devel/clang]
+  nixos: [clang]
+  opensuse: [clang]
+  rhel:
+    '*': [clang-tools-extra]
+    '7': null
+  ubuntu:
+    '*': [clangd]
 cmake:
   alpine: [cmake]
   arch: [cmake]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

clangd

## Package Upstream Source:

https://github.com/llvm/llvm-project/

## Purpose of using this:

We are using clangd for linting in-IDE and for significantly faster (but less insightful) static analysis than clang-tidy through `colcon test`.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/clangd
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/clangd
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/clang/clang-tools-extra/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/clang/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-devel/clang
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/v3.16/main/x86_64/clang-extra-tools
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?query=libclang
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/clang
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/raven-modular-x86_64/clang-tools-extra-19.1.1-1.el8.x86_64.rpm.html