### PR TITLE
srdfdom: 2.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7517,7 +7517,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.6-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros2-gbp/srdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.5-1`

## srdfdom

```
* Fix linking against tinyxml2
* Install headers into include/srdfdom/srdfdom to make overlays work
* Contributors: Robert Haschke
```
