### PR TITLE
Add python3-bloom to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5029,6 +5029,12 @@ python3-bitstring:
     '*': [python3-bitstring]
     '7': [python36-bitstring]
   ubuntu: [python3-bitstring]
+python3-bloom:
+  debian: [python3-bloom]
+  rhel:
+    '*': null
+    '8': [python3-bloom]
+  ubuntu: [python3-bloom]
 python3-bluerobotics-ping-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-bloom

## Package Upstream Source:

https://github.com/ros-infrastructure/bloom

## Purpose of using this:

Bloom is a release automation tool, designed to make generating platform specific release artifacts from source projects easier.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-bloom
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-bloom
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/epel-x86_64/python3-bloom-0.11.2-2.el8.noarch.rpm.html
