### PR TITLE
ur_description: 2.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8148,7 +8148,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.4.4-1
+      version: 2.4.5-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.4.5-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.4-1`

## ur_description

```
* Revert "Add passthrough command interfaces for joints (#204 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/204>)" (#214 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/214>)
* Auto-update pre-commit hooks (#211 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/211>)
* Contributors: Felix Exner (fexner), github-actions[bot]
```
