### PR TITLE
opencv-contrib-python added to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2602,6 +2602,16 @@ python-opencv:
     '7': [opencv-python]
   slackware: [opencv]
   ubuntu: [python-opencv]
+python-opencv-contrib-pip:
+  debian:
+    pip:
+      packages: [opencv-contrib-python]
+  fedora:
+    pip:
+      packages: [opencv-contrib-python]
+  ubuntu:
+    pip:
+      packages: [opencv-contrib-python]
 python-opengl:
   arch: [python2-opengl]
   debian: [python-opengl]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

opencv-contrib-python

## Package Upstream Source:
[opencv-contrib-python](https://pypi.org/project/opencv-contrib-python/)

## Purpose of using this:

Some libraries for marker detection in OpenCV are only available in said package.
This package is automatically installed when using `pip install opencv-python` but not when using `apt-get install python-opencv` or  `apt-get install python3-opencv`.
Since the request to make OpenCV installable through pip was discarded [here](https://github.com/ros/rosdistro/pull/41870), I would like to, at least, have the opencv-contrib-python package available.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- PyPi: https://pypi.org/project/opencv-contrib-python/