### PR TITLE
ur_robot_driver: 2.4.12-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8185,7 +8185,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.11-1
+      version: 2.4.12-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.12-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.11-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Revert "Add passthrough interfaces for joints (#1121 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1121>)" (#1151 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1151>)
* Contributors: Felix Exner (fexner)
```
