### PR TITLE
ur_description: 2.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8811,7 +8811,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.4.3-1
+      version: 2.4.5-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.4.5-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.3-1`

## ur_description

```
* Add a sensor for the TCP pose (#197 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/197>)
* Add passthrough command interfaces for joints (#204 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/204>)
* Ur3 infinite wrist (#196 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/196>)
* Update dynamic properties (#195 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/195>)
  Co-authored-by: Rune Søe-Knudsen <mailto:41109954+urrsk@users.noreply.github.com>
* Auto-update pre-commit hooks (#211 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/211>)
* Contributors: Felix Exner (fexner), github-actions[bot]
```
