### PR TITLE
ur_robot_driver: 2.4.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8848,7 +8848,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.10-1
+      version: 2.4.12-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.12-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.10-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers


```
* Allow setting the analog output domain when setting an analog IO (#1123 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1123>)
* Service to get software version of robot (#964 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/964>)
* Improve usage documentation (#1110 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1110>)
* Contributors: Felix Exner (fexner), URJala, Rune Søe-Knudsen
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add note about TEM (#1136 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1136>)
* [moveit] Add config for trajectory execution and disable execution monitoring by default (#1132 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1132>)
* Contributors: Felix Exner (fexner), G.A. vd. Hoorn
```

## ur_robot_driver

```
* Add note about TEM (#1136 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1136>)
* Allow setting the analog output domain when setting an analog IO (#1123 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1123>)
* Service to get software version of robot (#964 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/964>)
* Fix for Controller Switching Issue and Refactor Controller Spawning (#1093 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1093>)
* Improve usage documentation (#1110 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1110>)
* Assure the description is loaded as string (#1106 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1106>)
* Contributors: Chen Chen, Felix Exner (fexner), URJala
```
