### PR TITLE
ros_gz: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6263,7 +6263,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.1-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Extra parameter to start a container (#616 <https://github.com/gazebosim/ros_gz/issues/616>)
* adds deadline and liveliness QoSPolicyKinds to qos_overriding_options (#609 <https://github.com/gazebosim/ros_gz/issues/609>)
  Co-authored-by: nora <mailto:nko@bogaertsgl.com>
* Contributors: Carlos Agüero, norakon
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Extra parameter to start a container (#616 <https://github.com/gazebosim/ros_gz/issues/616>)
* Bugfix: if "false" is always True (#617 <https://github.com/gazebosim/ros_gz/issues/617>)
  There is an issue in this launch file when passing the string 'false' as
  an argument. In Python, non-empty strings are always evaluated as True,
  regardless of their content. This means that even if you pass 'false',
  the system will still evaluate it as True.
  This bug results in the launch system incorrectly calling the OnShutdown
  method twice. When any ROS launch action invokes a RosAdapter, it
  triggers the following exception: "Cannot shutdown a ROS adapter that is
  not running."
  To temporarily work around this issue, you can launch gz_sim_launch.py
  with the on_exit_shutdown argument set to an empty string. This prevents
  the erroneous shutdown sequence and avoids the associated exception.
* Name gazebo sim node (#611 <https://github.com/gazebosim/ros_gz/issues/611>)
* Contributors: Carlos Agüero, Ignacio Vizzo, Nabeel Sherazi
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
