### PR TITLE
Add dh_python to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -812,6 +812,9 @@ dfu-util:
   gentoo: [app-mobilephone/dfu-util]
   nixos: [dfu-util]
   ubuntu: [dfu-util]
+dh-python:
+  debian: [dh-python]
+  ubuntu: [dh-python]
 disper:
   debian: [disper]
   nixos: [disper]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

dh_python

## Package Upstream Source:

https://salsa.debian.org/python-team/tools/dh-python

## Purpose of using this:

dh-python is used when a Debian package is created from a ROS package using the scripts generated by [bloom](https://github.com/ros/rosdistro/pull/43171).

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/dh-python
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/dh-python

This package is only applicable to distributions which are Debian-based.

