### PR TITLE
Revert "mrpt_navigation: 2.2.1-1 in 'humble/distribution.yaml' [bloom…

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4920,7 +4920,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.2.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
This should fix a [recent regression the buildfarm](https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__mrpt_tps_astar_planner__ubuntu_jammy_amd64__binary/18/).

The main error seems to be:
```
/tmp/binarydeb/ros-humble-mrpt-tps-astar-planner-2.2.1/src/mrpt_tps_astar_planner_node.cpp:808:33: error: ‘using element_type = class mpp::CostEvaluator’ {aka ‘class mpp::CostEvaluator’} has no member named ‘get_visualization_as_grid’; did you mean ‘get_visualization’?
  808 |                 auto grid = cm->get_visualization_as_grid();
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                 get_visualization
make[4]: *** [CMakeFiles/mrpt_tps_astar_planner_node.dir/build.make:79: CMakeFiles/mrpt_tps_astar_planner_node.dir/src/mrpt_tps_astar_planner_node.cpp.o] Error 1
```

FYI @jlblancoc.