### PR TITLE
topic_tools: 1.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7820,7 +7820,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.4.1-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-1`

## topic_tools

```
* fix: install python executables again (#115 <https://github.com/ros-tooling/topic_tools/issues/115>)
* fix: cpp install paths (#116 <https://github.com/ros-tooling/topic_tools/issues/116>)
* Contributors: Philipp Schnattinger
```

## topic_tools_interfaces

- No changes
