### PR TITLE
topic_tools: 1.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8389,7 +8389,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.3.2-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.1-1`

## topic_tools

```
* fix: install python executables again (#115 <https://github.com/ros-tooling/topic_tools/issues/115>) (#121 <https://github.com/ros-tooling/topic_tools/issues/121>)
* fix: cpp install paths (#116 <https://github.com/ros-tooling/topic_tools/issues/116>) (#120 <https://github.com/ros-tooling/topic_tools/issues/120>)
* Fix unsubscribing when switching to none topic (#111 <https://github.com/ros-tooling/topic_tools/issues/111>) (#118 <https://github.com/ros-tooling/topic_tools/issues/118>)
* Contributors: Adam Morrissett, Philipp Schnattinger
```

## topic_tools_interfaces

- No changes
