### PR TITLE
ros_gz: 1.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6668,7 +6668,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.5-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.4-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Merge pull request #607 <https://github.com/gazebosim/ros_gz/issues/607> from Amronos/ros2-jazzy-backport
* Fix changelogs and versions
* adds deadline and liveliness QoSPolicyKinds to qos_overriding_options (#609 <https://github.com/gazebosim/ros_gz/issues/609>) (#613 <https://github.com/gazebosim/ros_gz/issues/613>)
* Remove default_value for required arguments (#602 <https://github.com/gazebosim/ros_gz/issues/602>)
* Fix errors with name of bridge not being given (#600 <https://github.com/gazebosim/ros_gz/issues/600>)
* Use optional parameters in actions (#601 <https://github.com/gazebosim/ros_gz/issues/601>)
* Making use_composition true by default (#578 <https://github.com/gazebosim/ros_gz/issues/578>)
* Use ignoreLocalMessages in the bridge (#559 <https://github.com/gazebosim/ros_gz/issues/559>)
* Update launch files with name parameter (#556 <https://github.com/gazebosim/ros_gz/issues/556>)
* Ensure the same container is used for the bridge and gz_server (#553 <https://github.com/gazebosim/ros_gz/issues/553>)
* Launch ros_gz_bridge from xml (#550 <https://github.com/gazebosim/ros_gz/issues/550>)
* Launch gzserver and the bridge as composable nodes (#528 <https://github.com/gazebosim/ros_gz/issues/528>)
* adds deadline and liveliness QoSPolicyKinds to qos_overriding_options (#609 <https://github.com/gazebosim/ros_gz/issues/609>) (#613 <https://github.com/gazebosim/ros_gz/issues/613>)
* Contributors: Aarav Gupta, Addisu Z. Taddese, Alejandro Hernández Cordero, Amronos, Carlos Agüero, mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Merge pull request #607 <https://github.com/gazebosim/ros_gz/issues/607> from Amronos/ros2-jazzy-backport
* Fix changelogs and versions
* Name gazebo sim node (#611 <https://github.com/gazebosim/ros_gz/issues/611>) (#612 <https://github.com/gazebosim/ros_gz/issues/612>)
* Change world_string to model_string in gz_spawn_model files (#606 <https://github.com/gazebosim/ros_gz/issues/606>)
* Use model string in ros_gz_spawn_model.launch.py (#605 <https://github.com/gazebosim/ros_gz/issues/605>)
* Remove default_value for required arguments (#602 <https://github.com/gazebosim/ros_gz/issues/602>)
* Fix errors with name of bridge not being given (#600 <https://github.com/gazebosim/ros_gz/issues/600>)
* Restore launch file (#603 <https://github.com/gazebosim/ros_gz/issues/603>)
* Use optional parameters in actions (#601 <https://github.com/gazebosim/ros_gz/issues/601>)
* Wait for create service to be available. (#588 <https://github.com/gazebosim/ros_gz/issues/588>)
* Update launch files with name parameter (#556 <https://github.com/gazebosim/ros_gz/issues/556>)
* Launch gz_spawn_model from xml (#551 <https://github.com/gazebosim/ros_gz/issues/551>)
* Launch ros_gz_bridge from xml (#550 <https://github.com/gazebosim/ros_gz/issues/550>)
* Launch gzserver and the bridge as composable nodes (#528 <https://github.com/gazebosim/ros_gz/issues/528>)
* Name gazebo sim node (#611 <https://github.com/gazebosim/ros_gz/issues/611>) (#612 <https://github.com/gazebosim/ros_gz/issues/612>)
* Contributors: Aarav Gupta, Addisu Z. Taddese, Alejandro Hernández Cordero, Amronos, Carlos Agüero, Sebastian Kasperski, mergify[bot]
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
