### PR TITLE
apriltag_mit: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -526,7 +526,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_mit-release.git
-      version: 1.1.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_mit` to `2.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_mit.git
- release repository: https://github.com/ros2-gbp/apriltag_mit-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.2-1`
