### PR TITLE
Add pytest-order

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8775,7 +8775,11 @@ python3-pytest-order:
   nixos: [python3Packages.pytest-order]
   openembedded: [python3-pytest-order@meta-ros-common]
   opensuse: [python3-pytest-order]
-  ubuntu: [python3-pytest-order]
+  ubuntu:
+    '*': [python3-pytest-order]
+    focal:
+      pip:
+        packages: [pytest-order]
 python3-pytest-pylint:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8773,7 +8773,6 @@ python3-pytest-order:
   debian: [python3-pytest-order]
   gentoo: [dev-python/pytest-order]
   nixos: [python3Packages.pytest-order]
-  openembedded: [python3-pytest-order@meta-ros-common]
   opensuse: [python3-pytest-order]
   ubuntu:
     '*': [python3-pytest-order]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8769,18 +8769,12 @@ python3-pytest-mock:
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-order:
-  alpine: [py3-pytest-order]
   arch: [python-pytest-order]
   debian: [python3-pytest-order]
-  fedora: [python3-pytest-order]
   gentoo: [dev-python/pytest-order]
   nixos: [python3Packages.pytest-order]
   openembedded: [python3-pytest-order@meta-ros-common]
   opensuse: [python3-pytest-order]
-  osx:
-    pip:
-      packages: [pytest-order]
-  rhel: ['python%{python3_pkgversion}-pytest-order']
   ubuntu: [python3-pytest-order]
 python3-pytest-pylint:
   arch:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8773,12 +8773,9 @@ python3-pytest-order:
   debian: [python3-pytest-order]
   gentoo: [dev-python/pytest-order]
   nixos: [python3Packages.pytest-order]
-  opensuse: [python3-pytest-order]
   ubuntu:
     '*': [python3-pytest-order]
-    focal:
-      pip:
-        packages: [pytest-order]
+    focal: null
 python3-pytest-pylint:
   arch:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8768,6 +8768,20 @@ python3-pytest-mock:
       packages: [pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
+python3-pytest-order:
+  alpine: [py3-pytest-order]
+  arch: [python-pytest-order]
+  debian: [python3-pytest-order]
+  fedora: [python3-pytest-order]
+  gentoo: [dev-python/pytest-order]
+  nixos: [python3Packages.pytest-order]
+  openembedded: [python3-pytest-order@meta-ros-common]
+  opensuse: [python3-pytest-order]
+  osx:
+    pip:
+      packages: [pytest-order]
+  rhel: ['python%{python3_pkgversion}-pytest-order']
+  ubuntu: [python3-pytest-order]
 python3-pytest-pylint:
   arch:
     pip:


### PR DESCRIPTION
- https://pypi.org/project/pytest-order/

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pytest-order

## Package Upstream Source:

- https://github.com/pytest-dev/pytest-order
- https://pypi.org/project/pytest-order/

## Purpose of using this:

This is pytest plugin to run your tests in a specific order, such combining with launch-pytest to run smoke tests before longer or more thorough tests, to enable more efficient fail fast testing strategies, saving time on starting test the you know would fail, without having to consolidating all your test files and test cases into a monolithic fixture.

> Note: pytest-order is the successor to `pytest-ordering`

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-pytest-order
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-pytest-order
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-pytest-order/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/pytest-order
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=pytest-order
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pytest-order
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here:

https://github.com/pytest-dev/pytest-order

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
