### PR TITLE
inuitive-camera-ros2: 2.07.81-2 in 'galactic/distribution.yaml' [bloom]

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1710,6 +1710,14 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: galactic
     status: maintained
+  inuitive-camera-ros2:
+    release:
+      packages:
+      - inuros2
+      tags:
+        release: release/galactic/{package}/{version}
+      url: git@bitbucket.org:inuitive/inuros2/branch/InuSW-inuitive-camera-galactic.git
+      version: 2.07.81-2
   irobot_create_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `inuitive-camera-ros2` to `2.07.81-2`:

- upstream repository: git@bitbucket.org:inuitive/inuros2.git
- release repository: git@bitbucket.org:inuitive/inuros2/branch/InuSW-inuitive-camera-galactic.git
- distro file: `galactic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
