### PR TITLE
steering_functions: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7542,6 +7542,21 @@ repositories:
       url: https://github.com/ros2/sros2.git
       version: rolling
     status: developed
+  steering_functions:
+    doc:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/steering_functions-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    status: maintained
   stomp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `steering_functions` to `0.3.0-1`:

- upstream repository: https://github.com/hbanzhaf/steering_functions.git
- release repository: https://github.com/ros2-gbp/steering_functions-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
