### PR TITLE
geometry2: 0.39.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1968,7 +1968,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.39.0-1
+      version: 0.39.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.39.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.39.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Error String Filled (#715 <https://github.com/ros2/geometry2//issues/715>)
* Contributors: Lucas Wendland
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Remove use of python_cmake_module (#651 <https://github.com/ros2/geometry2//issues/651>)
* Contributors: Chris Lalancette
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Remove use of python_cmake_module (#651 <https://github.com/ros2/geometry2//issues/651>)
* Contributors: Chris Lalancette
```

## tf2_ros

```
* Add configurable TF topics (#709 <https://github.com/ros2/geometry2//issues/709>)
* Contributors: Ryan
```

## tf2_ros_py

```
* Add configurable TF topics (#709 <https://github.com/ros2/geometry2//issues/709>)
* Fix the time_jump_callback signature. (#711 <https://github.com/ros2/geometry2//issues/711>)
* Contributors: Chris Lalancette, Ryan
```

## tf2_sensor_msgs

```
* Remove use of python_cmake_module (#651 <https://github.com/ros2/geometry2//issues/651>)
* Contributors: Chris Lalancette
```

## tf2_tools

```
* Add configurable TF topics (#709 <https://github.com/ros2/geometry2//issues/709>)
* Contributors: Ryan
```
