### PR TITLE
ros2_tracing: 8.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6091,7 +6091,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.3.0-1
+      version: 8.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.4.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.3.0-1`

## lttngpy

```
* Allow enabling syscalls through ``ros2 trace`` or the Trace action (#137 <https://github.com/ros2/ros2_tracing/issues/137>)
* Remove python_cmake_module use. (#91 <https://github.com/ros2/ros2_tracing/issues/91>)
* Add missing dependency on pkg-config to lttngpy (#130 <https://github.com/ros2/ros2_tracing/issues/130>)
* Contributors: Chris Lalancette, Christophe Bedard, Nathan Wiebe Neufeldt
```

## ros2trace

- No changes

## tracetools

```
* Change expected rmw GID array size to 16 bytes (#138 <https://github.com/ros2/ros2_tracing/issues/138>)
* Fix up two different C problems. (#129 <https://github.com/ros2/ros2_tracing/issues/129>)
* Ignore zero-variadic-macro-arguments warnings from lttng-ust macros (#126 <https://github.com/ros2/ros2_tracing/issues/126>)
* Remove deprecated TRACEPOINT macros (#123 <https://github.com/ros2/ros2_tracing/issues/123>)
* Fix type for buffer index argument in tracepoint event declaration. (#117 <https://github.com/ros2/ros2_tracing/issues/117>)
* Contributors: Chris Lalancette, Christophe Bedard, Mattis Kieffer
```

## tracetools_launch

```
* Allow enabling syscalls through ``ros2 trace`` or the Trace action (#137 <https://github.com/ros2/ros2_tracing/issues/137>)
* Contributors: Christophe Bedard
```

## tracetools_read

- No changes

## tracetools_test

```
* Run relevant test_tracetools tests with all instrumented rmw impls (#116 <https://github.com/ros2/ros2_tracing/issues/116>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Allow enabling syscalls through ``ros2 trace`` or the Trace action (#137 <https://github.com/ros2/ros2_tracing/issues/137>)
* Contributors: Christophe Bedard
```
