### PR TITLE
message_filters: 6.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3371,7 +3371,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 6.0.5-1
+      version: 6.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `6.0.6-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.5-1`

## message_filters

```
* Adds an input aligner filter (#148 <https://github.com/ros2/message_filters/issues/148>)
* Stop using python_cmake_module. (#114 <https://github.com/ros2/message_filters/issues/114>)
* Contributors: Chris Lalancette, Sascha Arnold, Alejandro Hernández Cordero
```
