### PR TITLE
image_pipeline: 6.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2563,7 +2563,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.3-1
+      version: 6.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.4-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.3-1`

## camera_calibration

```
* check_set_camera_info() code clean-up (#1034 <https://github.com/ros-perception/image_pipeline/issues/1034>)
  Removed the unnecessary if response.status_message is not None checks
  Co-authored-by: ugol-1 <mailto:ugol-1@potatomatic.com>
* Fix #1032 <https://github.com/ros-perception/image_pipeline/issues/1032> (#1033 <https://github.com/ros-perception/image_pipeline/issues/1033>)
  Use status_message from SetCameraInfo response instead of some
  non-existing result().
  Fixes #1032 <https://github.com/ros-perception/image_pipeline/issues/1032>
  Co-authored-by: ugol-1 <mailto:ugol-1@potatomatic.com>
* Contributors: ugol-1
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
