### PR TITLE
libfranka: 0.14.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4036,11 +4036,15 @@ repositories:
       version: master
     status: maintained
   libfranka:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/libfranka-release.git
+      version: release/foxy/libfranka
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.13.6-1
+      version: 0.14.2-1
     source:
       type: git
       url: https://github.com/frankaemika/libfranka.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4039,11 +4039,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/frankaemika/libfranka-release.git
-      version: release/foxy/libfranka
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/frankaemika/libfranka-release.git
+      url: https://github.com/frankaemika/libfranka.git
       version: 0.14.2-1
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4039,7 +4039,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/frankaemika/libfranka.git
+      url: https://github.com/frankaemika/libfranka-release.git
       version: 0.14.2-1
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4036,10 +4036,6 @@ repositories:
       version: master
     status: maintained
   libfranka:
-    doc:
-      type: git
-      url: https://github.com/frankaemika/libfranka-release.git
-      version: main
     release:
       tags:
         release: release/humble/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.14.2-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.13.6-1`
