### PR TITLE
ros2_planning_system: 2.0.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6451,6 +6451,37 @@ repositories:
       url: https://github.com/ros-drivers/ros2_ouster_drivers.git
       version: ros2
     status: maintained
+  ros2_planning_system:
+    doc:
+      type: git
+      url: https://github.com/PlanSys2/ros2_planning_system.git
+      version: jazzy-devel
+    release:
+      packages:
+      - plansys2_bringup
+      - plansys2_bt_actions
+      - plansys2_core
+      - plansys2_domain_expert
+      - plansys2_executor
+      - plansys2_lifecycle_manager
+      - plansys2_msgs
+      - plansys2_pddl_parser
+      - plansys2_planner
+      - plansys2_popf_plan_solver
+      - plansys2_problem_expert
+      - plansys2_support_py
+      - plansys2_terminal
+      - plansys2_tests
+      - plansys2_tools
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_planning_system-release.git
+      version: 2.0.12-1
+    source:
+      type: git
+      url: https://github.com/PlanSys2/ros2_planning_system.git
+      version: jazzy-devel
+    status: developed
   ros2_robotiq_gripper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `2.0.12-1`:

- upstream repository: https://github.com/PlanSys2/ros2_planning_system.git
- release repository: https://github.com/ros2-gbp/ros2_planning_system-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## plansys2_bringup

```
* Add parameter for timeout of plan solver
* Added support for configuring the planner timeout
* Remove cmake warning
* Restore tests and enable warnings
* Use separate problem pddl for problem expert.
* Simplifying bound checkin logic.
* Change double quotes for simple ones (linter)
* Make explicit which BTCreator is being used
* bt-builder-plugins: Setting default BT builder plugin to SimpleBTBuilder.
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* revert if statement
* Contributors: Francisco Martín Rico, Josh Zapf, Marco Roveri, Splinter1984
```

## plansys2_bt_actions

```
* Remove cmake warning
* Removed some small references still related to the old version of BehaviorTree
* Bump Behaviortree.CPP v3 to v4
* fix code style issues with uncrustify
* Update BTAction.cpp
* fix groot enabling
* Linting
* Fix logger destruction at BTActions
* Update Changelog
* Insert in blackboard the action ROS 2 Node
* Insert in blackboard the action ROS 2 Node
* Correct tick function call in bt_actions test
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Explicitly ignore feedback in default on_feedback
* Add try/catch to bt creation, reset loggers
* Contributors: Andrianov Roman, Francisco Martín Rico, Jake Keller, Marco Roveri, Splinter1984
```

## plansys2_core

```
* Integrated feedback, and fixes to have tests to pass
* Added support for configuring the planner timeout
* Remove cmake warning
* Add option to use planner node to validate domain in domain expert
* Remove reference to SharedPtr
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Robodrome, Sebastian Castro, Splinter1984
```

## plansys2_domain_expert

```
* include "object" in getType
* fix code style
* add params to getDerivedPredicate
* add tests for getDerivedPredicate(s)
* add getDerivedPredicate
* add getDerivedPredicates
* add DomainReader::get_derived_predicates
* Small optimization
* Fixed expected output
* Remove cmake warning
* Fixed dump of functions/constants/types to handle the case where no funcions/constants/types declared to avoid printing the entry, thus generating a valid PDDL file
* Remove commented-out line in domain expert node
* Switch to MultiThreadedExecutor
* Spin up temporary node for domain validation
* Add option to use planner node to validate domain in domain expert
* Reduce copypasta in domain expert
* Configure POPF solver in domain expert
* Merge remote-tracking branch 'upstream/master' into return-stn
* Merge remote-tracking branch 'origin/humble-devel'
* Reverting changes to checking for valid domain.
* Supporting time-triggered execution.
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Robodrome, Sebastian Castro, Splinter1984
```

## plansys2_executor

```
* add ActionVariant
* execute regular actions
* Remove cmake warning
* Fix ccplinti and uncrustify
* fail execute_plan action if initial conditions changed
  We terminate the program is many senarios instead of just returning an
  explict value. We used to terminate if the initial conditions changed
  before the plan is started. Now just send a result that the action
  server failed to execute the plan
* Send Cancelation response to ActionClient
* ExecutorNode, remove unused ros node
* Removed some small references still related to the old version of BehaviorTree
* Bump Behaviortree.CPP v3 to v4 - fix executor test
* Fix Timeout BT Node
* Adding imports to stn builder
* Fixing line-length
* Adding duration to dotgraphs.
* Restore tests and enable warnings
* Revert STN changes in Executor BT
* Removing unused or commented out code.
* Updating ComputeBT.cpp.
* Fix Terminal and executor bugs
* Fixing bug in propagation step.
* Adding dependency on eigen3_cmake_module to plansys2_executor.
* Fixing min time bounds in STN to adhere to plan times.
* Adding some print statements to help with debugging.
* Saving progress.
* Removing unused code. Debuggin get_threat function.
* Simplifying bound checkin logic.
* Update and propagate time constraints after applying effects.
* Adding action graph to blackboard.
* Moving STNBTBuilder node and graph structures to parent class.
* Ensure that every start node has direct link to end node in BT.
* Change MultiThreaded for SingleThreaded in CI failing tests
* Change double quotes for simple ones (linter)
* Insert in blackboard the action ROS 2 Node
* Adding Eigen3 dependency to plansys2_executor.
* Removing redundant get_current_time function.
* Fixing RCLCPP_ERROR message bug.
* Fixing colcon build warning.
* Fixing colcon build warnings.
* Cleaning up code for merge request.
* Cleaning up changes.
* Match example is now working!
* Modified BT by hand to get plan to succeed.
* BT not finishing.
* Fixing bug with updating STN time bounds.
* Adding time propagation step.
* Don't check time limits on start-end connections.
* Supporting time-triggered execution.
* Checking for self-referencing edges in STNBTBuilder. Adding standalone compute_bt service.
* bt-builder-plugins: Setting default BT builder plugin to SimpleBTBuilder.
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* Check at end reqs in bt builder
* Change MultiThreaded for SingleThreaded in CI failing tests
* Insert in blackboard the action ROS 2 Node
* Checking for self-referencing edges in STNBTBuilder. Adding standalone compute_bt service.
* bt-builder-plugins: Setting default BT builder plugin to SimpleBTBuilder.
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* Contributors: Alexander Xydes, Andrianov Roman, Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Mostafa Gomaa, Samuele Sandrini, Splinter1984, robodrome
```

## plansys2_lifecycle_manager

```
* lifecycle_manager: activate planner first
* Remove cmake warning
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Splinter1984
```

## plansys2_msgs

```
* add uint8 EXISTS = 10 to Node.msg
* support for ParamExpression and ConstExpression
* add Derived.msg and GetDomainDerivedPredicateDetails.srv
* Add option to use planner node to validate domain in domain expert
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Robodrome, Sebastian Castro
```

## plansys2_pddl_parser

```
* fix Exists print
* add fromStringExists
* adjust toStringExists
* fix Exists parse
* add test for Exists::getTree
* adjust prints and utils
* adjust Ground getTree
* add exists getTree
* fix exists parse
* add :existential-preconditions requirement
* fix bug in ParamExpression getTree
* fix ParamExpression PDDLPrint
* support for ParamExpression and ConstExpression
* adjust toString for negated comp expression
* support negation of CompositeExpression
* include "object" in getType
* Fixed errors that prevented all the tests to pass
* Remove cmake warning
* Fixed the regexps in getNodeType function
* Added proper support for constants in the goal
* Slightly changed order of printing
* pddl_parser. Fix support for disjunctive-preconditions
* Add forall and imply to PDDL parsing test
* Remove commented out debug stuff
* Add Imply to PDDL domain parsing
* fix regex for 'and' and 'or'
* fix regex for NOT
* Removed debug code
* Fixed support for complex goals and other changes
* Fixed some errors and some tests to comply with the revised output
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Fixed support for the complex goal parsing both from the terminal and from file
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Mostafa Gomaa, Paul Gesel, Sebastian Castro, Splinter1984
```

## plansys2_planner

```
* Integrated feedback, and fixes to have tests to pass
* Added support for configuring the planner timeout
* Spin up temporary node for domain validation
* Add option to use planner node to validate domain in domain expert
* Minor changes to the tests to comply with some change in the generated output
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Robodrome, Sebastian Castro, Splinter1984
```

## plansys2_popf_plan_solver

```
* adjust prints and utils
* Integrated feedback, and fixes to have tests to pass
* Added support for configuring the planner timeout
* Add unit tests
* Do not segfault with filesystem errors in POPF, and allow ~ for home directory
* Add option to use planner node to validate domain in domain expert
* Configure POPF solver in domain expert
* Add ability to specify output folder in POPF planner
* Remove reference to SharedPtr
* Fix is_valid_domain by parsing out file
* bt-builder-plugins: Creating BT builder plugin interface. Moving current BT builder to plugin named SimpleBTBuilder. Adding new and improved STN-based BT builder plugin named STNBTBuilder.
* Fix problem in is_valid_domain function
* add status check into popf_plan_solver
* add system status check
* Remove reference to SharedPtr
* Contributors: Andrianov Roman, Francisco Martín Rico, Gustavo, Jake Keller, Josh Zapf, Marco Roveri, Robodrome, Sebastian Castro, Splinter1984
```

## plansys2_problem_expert

```
* evaluate exists use_state==false
* evaluate exsits w/ problem_client
* add replace_children_param
* return derived predicates in getPredicates
* add cart_produdct and replace_children_param
* fix bug in ParamExpression getTree
* support for ParamExpression and ConstExpression
* add test for negated comp expression
* negate evaluation of comp expression
* add test problem_expert.exist_precidate
* in existPredicate check if derived predicate is satisfied
* Fixed support for constants in predicates/functions/goals
* Make problemExpert case-insensitive to Instance types
* Use separate problem pddl for problem expert.
* Minor changes to the tests to comply with some change in the generated output
* Fixed some errors and some tests to comply with the revised output
* Fixed support for the complex goal parsing both from the terminal and from file
* Minor changes to the tests to comply with some change in the generated output
* Check instance types and associated tests
* Fixed support for the complex goal parsing both from the terminal and from file
* Contributors: Ashton Larkin, Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Mostafa Gomaa, Splinter1984, adfea625
```

## plansys2_support_py

```
* Support action performers in Python
* Contributors: Francisco Martín Rico, Marco Roveri
```

## plansys2_terminal

```
* add get model derived predicates to terminal
* Added some information in the README to allow for using a configuration file to change the planner timeout
* Read multiple lines in terminal input
* Fix Terminal and executor bugs
* Change MultiThreaded for SingleThreaded in CI failing tests
* Fix terminal tests
* Contributors: Andrianov Roman, Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, Splinter1984
* Merge remote-tracking branch 'origin/humble-devel'
* Merge pull request #251 <https://github.com/PlanSys2/ros2_planning_system/issues/251> from PlanSys2/fix_bt_node
  Fix bt node
* Change MultiThreaded for SingleThreaded in CI failing tests
* Merge pull request #238 <https://github.com/PlanSys2/ros2_planning_system/issues/238> from roveri-marco/fix_goal_structure_issue_205
  Fix goal structure issue 205
* Fix terminal tests
* Minor fix
* Merge remote-tracking branch 'origin/master' into fix_goal_structure_issue_205
* Merge remote-tracking branch 'upstream/master'
* Merge branch 'IntelligentRoboticsLabs:master' into master
* Contributors: Andrianov Roman, Francisco Martín Rico, Marco Roveri, Splinter1984
```

## plansys2_tests

```
* Bump Behaviortree.CPP v3 to v4
* Contributors: Francisco Martín Rico, Gustavo, Josh Zapf, Marco Roveri, robodrome
```

## plansys2_tools

- No changes
