### PR TITLE
mvsim: 0.11.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6551,7 +6551,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.11.1-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.0-1`

## mvsim

```
* Great performance improvement for worlds with many (>100) block objects.
  Terrain elevation query function has been refactored to use a 2D hash-map instead of naively visiting all objects.
* ROS node: use correct QoS for gridmap publication, and ensure it is published only once.
* ROS 2: turtlebot demo: Fix RViz wrong camera topic name
* ROS 2 1robot demo: update rviz config
* ROS 2: Use correct QoS for (possibly namespaced) /tf & /tf_static
* FIX: demo_1robot ROS2 launch error (wrong order in listing ros launch arguments)
* version.h
* Contributors: Jose Luis Blanco-Claraco
```
