### PR TITLE
launch_pal: 0.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3832,7 +3832,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.4.0-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.7.0-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## launch_pal

```
* update README iwith get_pal_configuration automatic arguments
* [pal_get_params] ensure we get the default values for nested parameters
* [get_pal_parm] automatically creates cmdline arguments for node params
  This is controlled by the 'cmdline_args' param of :
  - cmdline_args=True (default): create cmd line arguments for all params
  - cmdline_args=[...]: create cmdline arguments for the listed params
  - cmdline_args=False: do not create cmdline arguments
* [get_pal_param] show config files from high to lower precedence
  This is a more natural order in practise
* Contributors: Séverin Lemaignan
```
