### PR TITLE
pmb2_robot: 5.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6288,7 +6288,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.3.0-1
+      version: 5.3.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.3.1-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.0-1`

## pmb2_bringup

```
* Merge branch 'fix/aca/joy-turbo' into 'humble-devel'
  using same configuration of joy_teleop of TIAGo
  See merge request robots/pmb2_robot!148
* using same configuration of joy_teleop of TIAGo
* Contributors: andreacapodacqua
```

## pmb2_controller_configuration

- No changes

## pmb2_description

- No changes

## pmb2_robot

- No changes
