### PR TITLE
omni_base_navigation: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5652,7 +5652,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_navigation-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_navigation` to `2.4.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_navigation.git
- release repository: https://github.com/pal-gbp/omni_base_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## omni_base_2dnav

```
* Apply 1 suggestion(s) to 1 file(s)
* Apply 1 suggestion(s) to 1 file(s)
* linters
* added unless condition to rviz
* Contributors: antoniobrandi, martinaannicelli
```

## omni_base_laser_sensors

- No changes

## omni_base_navigation

- No changes

## omni_base_rgbd_sensors

- No changes
