### PR TITLE
omni_base_simulation: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5690,7 +5690,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_simulation-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_simulation` to `2.2.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_simulation.git
- release repository: https://github.com/pal-gbp/omni_base_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## omni_base_gazebo

```
* Merge branch 'man/feat/advanced-nav' into 'humble-devel'
  added advanced nav launch arg to navigation
  See merge request robots/omni_base_simulation!25
* added advanced nav launch arg to navigation
* Contributors: antoniobrandi, martinaannicelli
```

## omni_base_simulation

- No changes
