### PR TITLE
sbg_driver: 3.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9120,6 +9120,22 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: ros2
     status: maintained
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      version: 3.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
+    status: developed
   scenario_execution:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.2.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros2.git
- release repository: https://github.com/SBG-Systems/sbg_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sbg_driver

```
* Update README with ROS2 commands to launch magnetic calibration
* Fix segfault when running magnetic calibration
* Removed unused flags from SbgEkfStatus message
* Added new flags to SbgShipMotionStatus message
* Improved SbgStatusAiding message with new flags
* Improved SbgPosStatus message with new flags
* Improved SbgEkfStatus message with new flags
* Improved SbgStatusGeneral message with datalogger and cpu flags
* Updated documentation for sbgGpsPos message
* Updated documentation for sbgGpsHdt message
* Improved SbgUtcTime message with internal clock quality indicators
* Improved SbgStatusCom message with ethernet tx and rx status
* Improved SbgGpsHdt message with number of SV tracked and used
* Improved SbgGpsPos message with numSvTracked
* Improved SbgGpsPosStatus message with spoofing, jamming and OSNMA status
* Updated config files with new messages
* Removed obsolete documentation
* Updated published topic list
* Added missing topic names
* Updated dependencies requirement
* Added settings log_ekf_rot_accel_body / log_ekf_rot_accel_ned / log_ekf_vel_body
* Fixed functions description
* Added SbgEkfRotAccel body and NED messages
* Added SbgEkfVelBody message
* Fixing compiling issues
* Updated sbgECom lib with version 4.0-1987-stable
* Fixed typos about lever arm
* Fixed config applier for IMU Alignment / Aiding / Odometer lever arms
* Remove boost dependency
  (cherry picked from commit ab54c33f1e442c3737dd8e1c09a8b6f36c2c1afa)
* Cleanup
* Moved LLAtoECEF into a helper
* Variable naming
* WIP code cleanup
* Class documentation
* Code indentation
* Utm as class
* Indentation fix
* Updated sbg_utm documentation and function prototype
* Added documentation on Utm structure
* Added documentation on Position class
* Added Position class
* Factory for UTM data
* Fixed space / tabluations issues
* Code indentation
* SbgUtm documentation
* Using fma for computation
* Added constexpr to some variables
* Using pow instead of multiply
* Reworked createRosPointStampedMessage computations
* Removed sendTransform in fillTransform method
* Moved functions into helper namespace
* Moved UTM initialization into its own class
* Removed catkin reference in CMakeLists.txt
* Updated naming convention
* Improved ENU/NED documentation
* Disabling ROS standard message when in NED frame convention
* Reverted NED to ENU quaternion conversion
* Quaternion: cleaner version for NED to ENU conversion
* Reworked odometry message
* Quaternion: NED to ENU conversion rework
* Updated readme about ENU frame convention
* Reworked angle wrapping functions
* Added range for Euler angle measurement.
* More explicit naming for quaternions
* Reverted NED to ENU array conversion
* Documentation update
* odom->base_link is now correct in NED mode
* Renamed function.
* Fixed variable inversion.
* odom->base_link is now correct in NED mode
* Refactored NED to ENU array conversion
* Updated ROS messages documentation
* Fixed Euler / Quaternion orientation in ENU mode
* Fixed nmea output condition
* Compilation fixes
* NTRIP: GGA generation Work In Progress with the following fixex:
  - GPS to UTC time correctly apply leap second offset
  - GGA only sent if a valid position is available
  - GGA is sent at 1 Hz only
  - Minor improvements
  Code is not yet tested nor build
* Compilation fix
* Improved GGA generation and code cleanup
* Improved RTCM and NMEA parameters naming
* Code cleanup - removed (void) as it is not recommended in C++
* Reworked and improved main project README and small fixed in yaml examples
* Added documentation about RTCM messages and device configuration.
* Removed MessageSubscriber class
* Switched dependency from mavros_msgs to rtcm_msgs
* Updated documentation
* Removed SbgInterface as class member
* Removed threaded subscription.
* Namespace related coding style fix
* Fixes in GGA serialization
* Realigned members.
* Code documentation
* Improved NMEA GGA message
* Added rtcm / nmea parameters in config files
* Fixed deprecated header warning
* Added publisher for nmea msg
* Added subscription to RTCM msg
* remove build status
* fix build on Windows
* time_reference parameter fix
* Fix deprecated use of rosidl_target_interfaces
  The use of rosidl_target_interfaces is deprecated (see [Humble release notes](http://docs.ros.org.ros.informatik.uni-freiburg.de/en/humble/Releases/Release-Humble-Hawksbill.html#deprecation-of-rosidl-target-interfaces). Here that actually causes an issue with CMake not setting the right include directory paths, breaking colcon build on humble.
  This applies the documented update, making the driver build under Humble
* Contributors: Michael Zemb, Raphael Siryani, Samuel Toledano, SanderVanDijk-StreetDrone, Timon Mentink, VladimirL, cledant, rsiryani
```
