### PR TITLE
Fix branch names for Gazebo vendor packages in Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2400,7 +2400,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2410,13 +2410,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_dartsim_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2426,13 +2426,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_dartsim_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_fuel_tools_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2442,13 +2442,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_gui_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2457,13 +2457,13 @@ repositories:
     source:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_launch_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2473,7 +2473,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_math_vendor:
     doc:
@@ -2495,7 +2495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2505,13 +2505,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_ogre_next_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2521,13 +2521,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_physics_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_physics_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2537,13 +2537,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_physics_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_plugin_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2553,13 +2553,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_rendering_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2569,7 +2569,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_ros2_control:
     doc:
@@ -2593,7 +2593,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2603,13 +2603,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_sim_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2619,13 +2619,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_tools_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2635,13 +2635,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_transport_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2651,7 +2651,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   gz_utils_vendor:
     doc:
@@ -7748,7 +7748,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -7758,7 +7758,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   septentrio_gnss_driver:
     doc:


### PR DESCRIPTION
The Gazebo vendor packages for Jazzy are all being released from `jazzy` branches, but the `doc` and `source` entries were incorrectly pointing to `rolling`.