### PR TITLE
Adding docs for adi_3dtof_image_stitching

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -78,6 +78,10 @@ repositories:
       version: rolling
     status: developed
   adi_3dtof_image_stitching:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
+      version: humble-devel
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -76,6 +76,10 @@ repositories:
       version: noetic-devel
     status: maintained
   adi_3dtof_image_stitching:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Update This Package to add docs in the rosdistro.

adi_3dtof_image_stitching

# The source is here:

[analogdevicesinc/adi_3dtof_image_stitching](https://github.com/analogdevicesinc/adi_3dtof_image_stitching/tree/noetic-devel)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
