### PR TITLE
octomap_rviz_plugins: 2.1.1-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4288,7 +4288,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `2.1.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## octomap_rviz_plugins

```
* Fix linkage to octomap (#49 <https://github.com/OctoMap/octomap_rviz_plugins/issues/49>)
* Contributors: Mike Wake
```
