### PR TITLE
mrpt_ros: 2.14.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6436,7 +6436,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_ros-release.git
-      version: 2.14.3-1
+      version: 2.14.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.14.4-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.3-1`

## mrpt_apps

```
* package.xml and cmake: Fix generation of rosbag2rawlog for ROS 1 version of package mrpt_apps
* rosbag2rawlog: Fix detection of mrpt-ros1bridge when built within mrpt_ros ROS packaging.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

- No changes

## mrpt_libnav

```
* mrpt::nav::CAbstractPTGBasedReactive: Missing heading information in recently-added TP-Space targets as TPose2D.
```

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libros_bridge

```
* package.xml and cmake: Fix generation of rosbag2rawlog for ROS 1 version of package mrpt_apps
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
