### PR TITLE
python3-piexif: added python3 dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7795,6 +7795,7 @@ python3-piexif:
   arch: [python-piexif]
   debian: [python3-piexif]
   fedora: [python3-piexif]
+  opensuse: [python3-piexif]
   ubuntu: [python3-piexif]
 python3-pika:
   debian: [python3-pika]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7791,6 +7791,11 @@ python3-pickleDB-pip:
   ubuntu:
     pip:
       packages: [pickleDB]
+python3-piefix:
+  arch: [python-piexif]
+  debian: [python3-piefix]
+  fedora: [python3-piexif]
+  ubuntu: [python3-piefix]
 python3-pika:
   debian: [python3-pika]
   fedora: [python3-pika]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7791,11 +7791,11 @@ python3-pickleDB-pip:
   ubuntu:
     pip:
       packages: [pickleDB]
-python3-piefix:
+python3-piexif:
   arch: [python-piexif]
-  debian: [python3-piefix]
+  debian: [python3-piexif]
   fedora: [python3-piexif]
-  ubuntu: [python3-piefix]
+  ubuntu: [python3-piexif]
 python3-pika:
   debian: [python3-pika]
   fedora: [python3-pika]


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:

- `python3-piexif`

## Package Upstream Source:

[https://github.com/hMatoba/Piexif](https://github.com/hMatoba/Piexif)

## Purpose of using this:

Exchangeable image file format(Exif) manipulation with pure python script.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [https://packages.debian.org/sid/python3-piexif](https://packages.debian.org/sid/python3-piexif)
  - [https://packages.debian.org/trixie/python3-piexif](https://packages.debian.org/trixie/python3-piexif)
  - [https://packages.debian.org/bookworm/python3-piexif](https://packages.debian.org/bookworm/python3-piexif)
  - [https://packages.debian.org/bullseye/python3-piexif](https://packages.debian.org/bullseye/python3-piexif)
- Ubuntu: https://packages.ubuntu.com/
  - [https://packages.ubuntu.com/focal/python3-piexif](https://packages.ubuntu.com/focal/python3-piexif)
  - [https://packages.ubuntu.com/jammy/python3-piexif](https://packages.ubuntu.com/jammy/python3-piexif)
  - [https://packages.ubuntu.com/noble/python3-piexif](https://packages.ubuntu.com/noble/python3-piexif)
- Fedora: https://packages.fedoraproject.org/
  - [https://packages.fedoraproject.org/pkgs/python-piexif/python3-piexif/](https://packages.fedoraproject.org/pkgs/python-piexif/python3-piexif/)
- Arch: https://www.archlinux.org/packages/
  - [https://archlinux.org/packages/extra/any/python-piexif/](https://archlinux.org/packages/extra/any/python-piexif/)

