### PR TITLE
Fix xtensor key for Debian and Ubuntu.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9238,7 +9238,9 @@ xtensor:
   rhel:
     '*': [xtensor-devel]
     '8': null
-  ubuntu: [libxtensor-dev]
+  ubuntu:
+    '*': [libxtensor-dev]
+    focal: null
 xterm:
   arch: [xterm]
   debian: [xterm]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9232,15 +9232,13 @@ xsltproc:
   nixos: [libxslt]
   ubuntu: [xsltproc]
 xtensor:
+  debian: [libxtensor-dev]
   fedora: [xtensor-devel]
   nixos: [xtensor]
   rhel:
     '*': [xtensor-devel]
     '8': null
-  ubuntu:
-    bionic: [xtensor-dev]
-    jammy: [libxtensor-dev]
-    noble: [libxtensor-dev]
+  ubuntu: [libxtensor-dev]
 xterm:
   arch: [xterm]
   debian: [xterm]


### PR DESCRIPTION
Please update the following dependency to the rosdep database.

## Package name:

xtensor

## Package Upstream Source:

https://github.com/xtensor-stack/xtensor

## Purpose of using this:

Needed by newer versions of Navigation2

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libxtensor-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libxtensor-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://pkgs.org/search/?q=xtensor-devel
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=xtensor-devel