### PR TITLE
turtlebot4_setup: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8635,7 +8635,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_setup-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_setup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_setup` to `2.0.2-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_setup.git
- release repository: https://github.com/ros2-gbp/turtlebot4_setup-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## turtlebot4_setup

```
* Add e2fsck to SD-flasher script
* Bump default version numbers
* Fix default hostname to match released SD card images
* Append p2 for mmcblk devices, but just 2 for sd* devices when expanding the last partition
* Contributors: Chris Iverach-Brereton
```
