### PR TITLE
create3_sim: 3.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1106,6 +1106,10 @@ repositories:
       version: jazzy
     status: developed
   create3_sim:
+    doc:
+      type: git
+      url: https://github.com/iRobotEducation/create3_sim.git
+      version: jazzy
     release:
       packages:
       - irobot_create_common_bringup
@@ -1120,7 +1124,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/iRobotEducation/create3_sim.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1128,7 +1128,7 @@ repositories:
     source:
       type: git
       url: https://github.com/iRobotEducation/create3_sim.git
-      version: main
+      version: jazzy
     status: developed
   cudnn_cmake_module:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `create3_sim` to `3.0.4-1`:

- upstream repository: https://github.com/iRobotEducation/create3_sim.git
- release repository: https://github.com/ros2-gbp/create3_sim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.3-1`

## irobot_create_common_bringup

- No changes

## irobot_create_control

- No changes

## irobot_create_description

- No changes

## irobot_create_gz_bringup

- No changes

## irobot_create_gz_plugins

- No changes

## irobot_create_gz_sim

- No changes

## irobot_create_gz_toolbox

- No changes

## irobot_create_nodes

- No changes

## irobot_create_toolbox

```
* change gz_math_vendor from buildtool dependency to regular dependency
* Contributors: Alberto Soragna
```
