### PR TITLE
sick_scan_xd: 3.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11413,7 +11413,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan_xd-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.6.0-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/SICKAG/sick_scan_xd-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.0-1`

## sick_scan_xd

```
* Release v3.6.0
  * add: Launchfiles and configuration for picoScan120
  * add: Optional AngleRangeFilter and IntervalFilter for picoScan
  * fix: Obsolete topic "/sick_multiscan/scan" removed
  * add: IMU automatically deactivated after receiving an error code for IMU activation from picoScan w/o addons
  * fix: Customization of hash values for authorization #366
  * fix: Replaced builtin_addressof expressions #370
  * add: Different UDP timeouts for state initial and running, improved UDP timeout handling
  * fix: Picoscan range_min value in laserScan message #382
  * add: Support for RMS2xxx LIDoutputstate telegrams
  * fix: sick_generic_caller debug assertion #385
  * add: Check of udp receiver ip at startup
  * add: cmake-option to overwrite optimization level
  * change: Documentation restructured
  * add: Improved field evaluation TiM7xx, Tim7xxS (publish LIDinputstate messages, configuration and services for options FieldSetSelectionMethod and ActiveFieldSet)
  * fix: PicoScan parameter add_transform_xyz_rpy #399
  * fix: LMS4000 encoder settings #403
  * fix: CMake-flag for target sick_scan_xd_api_dockertest #404
  * change: Merge PR #405 (typo) and PR #406 (sick_scan_xd_api_test)
```
