### PR TITLE
python3-expiringdict (rosdep)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5769,6 +5769,9 @@ python3-events-pip:
   ubuntu:
     pip:
       packages: [Events]
+python3-expiringdict:
+  debian: [python3-expiringdict]
+  ubuntu: [python3-expiringdict]
 python3-ezdxf:
   debian:
     '*': [python3-ezdxf]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-expiringdict

## Package Upstream Source:

https://github.com/mailgun/expiringdict/tree/master

## Purpose of using this:

Used by https://github.com/uleroboticsgroup/yasmin

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-expiringdict
- Ubuntu: https://packages.ubuntu.com/
  - https://launchpad.net/ubuntu/focal/ppc64el/python3-expiringdict