### PR TITLE
ros_babel_fish: 0.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6193,7 +6193,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.9.5-1
+      version: 0.10.1-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.10.1-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.5-1`

## ros_babel_fish

```
* Add ActionServer (#9 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/9>)
  * More verbose error message when trying to assign a value to a CompoundMessage.
  * Moved BabelFishAction definition to separate header in preparation for BabelFishActionServer.
  * Added BabelFishActionServer with tests.
  * Suppress false positive in cppcheck.
  * Enable inline suppression in cppcheck.
* Updated test message and added goal rejected and cancel rejected tests for client.
* Refactored action client and added new tests.
* Added more method documentation.
* Added convenience methods to create empty action goals with BabelFish.
* Improved exceptions in type support loading.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Updated test message and added goal rejected and cancel rejected tests for client.
* Contributors: Stefan Fabian
```
