### PR TITLE
ess_imu_driver2: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1578,6 +1578,21 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel
     status: maintained
+  ess_imu_driver2:
+    doc:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_driver2.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ess_imu_driver2-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/cubicleguy/ess_imu_driver2.git
+      version: jazzy
+    status: maintained
   etsi_its_messages:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_driver2` to `2.0.2-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_driver2.git
- release repository: https://github.com/ros2-gbp/ess_imu_driver2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ess_imu_driver2

```
* Add changes stating support for Jazzy
```
