### PR TITLE
pose_cov_ops: 0.3.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8000,7 +8000,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
-      version: 0.3.12-1
+      version: 0.3.13-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pose_cov_ops` to `0.3.13-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
- release repository: https://github.com/mrpt-ros-pkg-release/pose_cov_ops-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.3.12-1`

## pose_cov_ops

```
* Update README.md to add links to example ROS1/ROS2 packages.
* FIX: Missing CMake export symbol for ROS1
* Contributors: Jose Luis Blanco-Claraco
```
