### PR TITLE
inuitive-camera-ros2: 2.07.81-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3471,6 +3471,14 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: humble
     status: maintained
+  inuitive-camera-ros2:
+    release:
+      packages:
+      - inuros2
+      tags:
+        release: release/humble/{package}/{version}
+      url: git@bitbucket.org:inuitive/inuros2/branch/InuSW-inuitive-camera-humble.git
+      version: 2.07.81-1
   irobot_create_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `inuitive-camera-ros2` to `2.07.81-1`:

- upstream repository: git@bitbucket.org:inuitive/inuros2.git
- release repository: git@bitbucket.org:inuitive/inuros2/branch/InuSW-inuitive-camera-humble.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
