### PR TITLE
generate_parameter_library: 0.3.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2789,7 +2789,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.8-3
+      version: 0.3.9-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.3.9-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.8-3`

## cmake_generate_parameter_module_example

```
* Drop yaml brackets for consistency and readability (#203 <https://github.com/PickNikRobotics/generate_parameter_library/issues/203>)
* Contributors: Tim Clephas
```

## generate_parameter_library

```
* Disable cache for program (#218 <https://github.com/PickNikRobotics/generate_parameter_library/issues/218>)
* Contributors: Paul Gesel
```

## generate_parameter_library_example

```
* Add "additional_constraints" support (#221 <https://github.com/PickNikRobotics/generate_parameter_library/issues/221>)
* Use int64_t instead of int for parameter integer range, fixes #199 <https://github.com/PickNikRobotics/generate_parameter_library/issues/199> (#214 <https://github.com/PickNikRobotics/generate_parameter_library/issues/214>)
* Add Non-Blocking try_get_params Function for Real-Time Control Systems (#205 <https://github.com/PickNikRobotics/generate_parameter_library/issues/205>)
* Drop yaml brackets for consistency and readability (#203 <https://github.com/PickNikRobotics/generate_parameter_library/issues/203>)
* Contributors: Auguste Bourgois, David Revay, KentaKato, Tim Clephas
```

## generate_parameter_library_py

```
* fix error with not being able to find unpack_parameter_dict when using set_params_from_dict (#220 <https://github.com/PickNikRobotics/generate_parameter_library/issues/220>)
* Add "additional_constraints" support (#221 <https://github.com/PickNikRobotics/generate_parameter_library/issues/221>)
* Use int64_t instead of int for parameter integer range, fixes #199 <https://github.com/PickNikRobotics/generate_parameter_library/issues/199> (#214 <https://github.com/PickNikRobotics/generate_parameter_library/issues/214>)
* Fix floating point range for upper/lt/lt_eq validations (#216 <https://github.com/PickNikRobotics/generate_parameter_library/issues/216>)
* Fix nested parameter in Python template (#210 <https://github.com/PickNikRobotics/generate_parameter_library/issues/210>)
* Fix test on rolling CI (#187 <https://github.com/PickNikRobotics/generate_parameter_library/issues/187>)
* Add ability for param_listener to load values from yaml dictionary (#211 <https://github.com/PickNikRobotics/generate_parameter_library/issues/211>)
* Use exist_ok=True in makedirs instead of checking for existence first, in case of multiple concurrent processes (#212 <https://github.com/PickNikRobotics/generate_parameter_library/issues/212>)
* Add Non-Blocking try_get_params Function for Real-Time Control Systems (#205 <https://github.com/PickNikRobotics/generate_parameter_library/issues/205>)
* Drop yaml brackets for consistency and readability (#203 <https://github.com/PickNikRobotics/generate_parameter_library/issues/203>)
* Contributors: Karan Khanna, Auguste Bourgois, David Revay, Emerson Knapp, Jacob Seibert, KentaKato, Marq Rasmussen, Paul Gesel, Tim Clephas
```

## generate_parameter_module_example

```
* Add "additional_constraints" support (#221 <https://github.com/PickNikRobotics/generate_parameter_library/issues/221>)
* Drop yaml brackets for consistency and readability (#203 <https://github.com/PickNikRobotics/generate_parameter_library/issues/203>)
* Contributors: David Revay, Tim Clephas
```

## parameter_traits

- No changes
