### PR TITLE
gz_ros2_control: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2324,7 +2324,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.2-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## gz_ros2_control

```
* use gz-physics`#283 <https://github.com/ros-controls/gz_ros2_control/issues/283>`_ to implement joint_states/effort feedback (#186 <https://github.com/ros-controls/gz_ros2_control/issues/186>) (#430 <https://github.com/ros-controls/gz_ros2_control/issues/430>)
  (cherry picked from commit cc66e7342c6954bd5c3950e12a45567e2ca1652c)
  Co-authored-by: Andreas Bihlmaier <mailto:andreas.bihlmaier@gmx.de>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes
