### PR TITLE
ur_description: 2.1.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10636,7 +10636,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.7-1
+      version: 2.1.8-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.8-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.7-1`

## ur_description

```
* Add analog_output_domain_cmd command interface (baclport of #219 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/219>)
* Add a sensor for the TCP pose (backport of #197 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/197>)
* Add missing state interfaces for get_version service (backport of #216 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/216>)
* Ur3 infinite wrist (backport of #196 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/196>)
* Update dynamic properties (backport of #195 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/195>)
* Contributors: mergify[bot], Felix Exner, Rune Søe-Knudsen
```
