### PR TITLE
ur_description: 2.3.3-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8372,7 +8372,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.3.2-1
+      version: 2.3.3-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.3.3-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.2-1`

## ur_description

```
* Add analog_output_domain_cmd command interface (#219 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/219>)
* Add a sensor for the TCP pose (backport of #197 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/197>)
* Add missing state interfaces for get_version service (#216 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/216>)
* Ur3 infinite wrist (backport of #196 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/196>)
* Update dynamic properties (backport of #195 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/195>)
* Contributors: Felix Exner (fexner), mergify[bot], Rune Søe-Knudsen
```
