### PR TITLE
ur_robot_driver: 2.4.13-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8201,7 +8201,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.12-1
+      version: 2.4.13-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.4.13-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.12-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* [SJTC] Make scaling interface optional (#1145 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1145>)
* Contributors: Felix Exner (fexner)
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Pass use_sim_time to MoveIt's RViz instance (#1144 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1144>)
* Contributors: Felix Exner (fexner)
```

## ur_robot_driver

```
* Fix component lifecycle (#1098 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1098>)
* Add missing state interfaces for get_robot_software_version (#1153 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1153>)
* Contributors: Felix Exner (fexner)
```
