### PR TITLE
ur_robot_driver: 2.3.11-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8409,7 +8409,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.10-1
+      version: 2.3.11-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.11-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.10-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Allow setting the analog output domain when setting an analog output (backport of #1123 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1123>)
* Service to get software version of robot (#964 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/964>) (#1128 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1128>)
* Contributors: mergify[bot], Jacob Larsen, Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Properly handle use_sim_time (#1146 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1146>)
* Disable execution_duration_monitoring by default (#1134 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1134>)
* Contributors: Felix Exner (fexner)
```

## ur_robot_driver

```
* Allow setting the analog output domain when setting an analog output (backport of #1123 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1123>)
* Fix component lifecycle (backport of #1098 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1098>)
* Service to get software version of robot (#964 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/964>) (#1128 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1128>)
* Assure the description is loaded as string (#1107 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1107>)
* Fix for forward_velocity_controller test (backport of #1076 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1076>)
* Contributors: Felix Exner (fexner), mergify[bot], Vincenzo Di Pentima, Jacob Larsen
```
