### PR TITLE
realtime_tools: 2.7.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5454,7 +5454,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.7.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.0-1`

## realtime_tools

```
* [AsyncFunctionHandler] Add exception handling (#172 <https://github.com/ros-controls/realtime_tools/issues/172>)
* Bump version of pre-commit hooks (#169 <https://github.com/ros-controls/realtime_tools/issues/169>)
* Contributors: Sai Kishor Kothakota, github-actions[bot]
```
