### PR TITLE
ur_robot_driver: 2.2.16-5 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10674,7 +10674,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.15-1
+      version: 2.2.16-5
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.16-5`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.15-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Allow setting the analog output domain when setting an analog output (backport of #1123 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1123>)
* Service to get software version of robot (backport of #964 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/964>)
* Contributors: mergify[bot], Felix Enxer, Jacob Larsen
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Properly handle use_sim_time (#1146 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1146>) (#1159 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1159>)
* Disable execution_duration_monitoring by default (#1133 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1133>)
* Added option to publish SRDF file.
* Contributors: Felix Exner, mergify[bot], v-marsh
```

## ur_robot_driver

```
* Allow setting the analog output domain when setting an analog output (backport of #1123 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1123>)
* Fix component lifecycle (backport of #1098 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1098>)
* [moveit] Disable execution_duration_monitoring by default (#1133 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1133>)
* Service to get software version of robot (backport of #964 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/964>)
* Assure the description is loaded as string (backport of #1107 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1107>)
* Contributors: Felix Exner (fexner), mergify[bot], Jacob Larsen
```
