### PR TITLE
turtlebot4_simulator: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8675,7 +8675,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_simulator` to `2.0.2-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_simulator.git
- release repository: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## turtlebot4_gz_bringup

```
* Add -r flag to Gazebo arguments (see https://github.com/turtlebot/turtlebot4_simulator/issues/81)
* Add missing dependency on create3_gz_plugins
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_gz_gui_plugins

- No changes

## turtlebot4_gz_toolbox

- No changes

## turtlebot4_simulator

- No changes
