### PR TITLE
Add rhel key for libcap

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3132,6 +3132,7 @@ libcap-dev:
   nixos: [libcap]
   openembedded: [libcap@openembedded-core]
   opensuse: [libcap-devel]
+  rhel: [libcap-devel]
   ubuntu: [libcap-dev]
 libcap-ng-dev:
   arch: [libcap-ng]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libcap

## Package Upstream Source:

n/a

## Purpose of using this:

https://github.com/ros-controls/realtime_tools/pull/175

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=libcap-devel
