### PR TITLE
image_pipeline: 6.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2563,7 +2563,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.4-1
+      version: 6.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.5-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.4-1`

## camera_calibration

- No changes

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

```
* Use TF2 package for quaternion conversion (#1031 <https://github.com/ros-perception/image_pipeline/issues/1031>)
  The OpenCV quaternion class was not added until OpenCV 4.5.1, so it's
  less widely available than the TF2 conversion. This change allows a
  source build of the ROS 2 "perception" variant on Ubuntu 20.04 without a
  custom source build of OpenCV.
  Addresses issue
  https://github.com/ros-perception/image_pipeline/issues/1030
* Contributors: Ted Steiner
```

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
