### PR TITLE
velodyne: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8428,7 +8428,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
-      version: 2.3.0-3
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.5.0-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros2-gbp/velodyne-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-3`

## velodyne

```
* feat: support vls128 for ros2 (#493 <https://github.com/ros-drivers/velodyne/issues/493>)
* Contributors: Daisuke Nishimatsu
```

## velodyne_driver

```
* feat(config): make parameter 'enabled' dynamic (#548 <https://github.com/ros-drivers/velodyne/issues/548>)
* Clalancette/cmake cleanups (#546 <https://github.com/ros-drivers/velodyne/issues/546>)
* feat: support vls128 for ros2 (#493 <https://github.com/ros-drivers/velodyne/issues/493>)
* Update rolling ci (#512 <https://github.com/ros-drivers/velodyne/issues/512>) (#513 <https://github.com/ros-drivers/velodyne/issues/513>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Joshua Whitley
```

## velodyne_laserscan

```
* Clalancette/cmake cleanups (#546 <https://github.com/ros-drivers/velodyne/issues/546>)
* Update rolling ci (#512 <https://github.com/ros-drivers/velodyne/issues/512>) (#513 <https://github.com/ros-drivers/velodyne/issues/513>)
* Contributors: Chris Lalancette, Joshua Whitley
```

## velodyne_msgs

```
* Clalancette/cmake cleanups (#546 <https://github.com/ros-drivers/velodyne/issues/546>)
* Contributors: Chris Lalancette
```

## velodyne_pointcloud

```
* Clalancette/cmake cleanups (#546 <https://github.com/ros-drivers/velodyne/issues/546>)
* Fix exports (#535 <https://github.com/ros-drivers/velodyne/issues/535>)
* Add in the Eigen dependency to velodyne_pointcloud (#545 <https://github.com/ros-drivers/velodyne/issues/545>)
* Add package to compile in Jazzy (#539 <https://github.com/ros-drivers/velodyne/issues/539>)
* Feature script add two pt ros2 (#498 <https://github.com/ros-drivers/velodyne/issues/498>)
* delete unused valiable (#529 <https://github.com/ros-drivers/velodyne/issues/529>)
* Add vert offset corrections to VLP16 calib file (#518 <https://github.com/ros-drivers/velodyne/issues/518>)
* Fix double-include.
* feat: support vls128 for ros2 (#493 <https://github.com/ros-drivers/velodyne/issues/493>)
* Update rolling ci (#512 <https://github.com/ros-drivers/velodyne/issues/512>) (#513 <https://github.com/ros-drivers/velodyne/issues/513>)
* Contributors: Chris Lalancette, Daisuke Nishimatsu, Joshua Whitley, Mateusz Szczygielski, Pierrick Koch, Taiga Takano, Thomas Emter, g-kurz
```
