### PR TITLE
rqt_image_overlay: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7263,7 +7263,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.3.1-4
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7255,7 +7255,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: jazzy
     release:
       packages:
       - rqt_image_overlay
@@ -7267,7 +7267,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
-      version: rolling
+      version: jazzy
     status: developed
   rqt_image_view:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.4.0-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-4`

## rqt_image_overlay

- No changes

## rqt_image_overlay_layer

```
* Change rclcpp::get_typesupport_handle to rclcpp::get_message_typesupport_handle (#67 <https://github.com/ros-sports/rqt_image_overlay/issues/67>)
* Contributors: Kenji Brameld
```
