### PR TITLE
rqt_image_overlay: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6822,7 +6822,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.3.1-3
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_overlay` to `0.5.0-1`:

- upstream repository: https://github.com/ros-sports/rqt_image_overlay.git
- release repository: https://github.com/ros2-gbp/rqt_image_overlay-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-3`

## rqt_image_overlay

```
* Fix deprecated headers and methods (#68 <https://github.com/ros-sports/rqt_image_overlay/issues/68>)
* Contributors: Kenji Brameld
```

## rqt_image_overlay_layer

```
* Fix deprecated headers and methods (#68 <https://github.com/ros-sports/rqt_image_overlay/issues/68>)
* Change rclcpp::get_typesupport_handle to rclcpp::get_message_typesupport_handle (#67 <https://github.com/ros-sports/rqt_image_overlay/issues/67>)
* Contributors: Kenji Brameld
```
