### PR TITLE
image_pipeline: 5.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2846,7 +2846,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.4-1
+      version: 5.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.5-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.4-1`

## camera_calibration

- No changes

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

```
* Use TF2 package for quaternion conversion (backport #1031 <https://github.com/ros-perception/image_pipeline/issues/1031>) (#1041 <https://github.com/ros-perception/image_pipeline/issues/1041>)
  The OpenCV quaternion class was not added until OpenCV 4.5.1, so it's
  less widely available than the TF2 conversion. This change allows a
  source build of the ROS 2 "perception" variant on Ubuntu 20.04 without a
  custom source build of OpenCV.
  Addresses issue
  https://github.com/ros-perception/image_pipeline/issues/1030<hr>This is
  an automatic backport of pull request #1031 <https://github.com/ros-perception/image_pipeline/issues/1031> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Ted Steiner <mailto:tsteiner2@gmail.com>
* Contributors: mergify[bot]
```

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
