### PR TITLE
ros_gz: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6264,7 +6264,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.2-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-1`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Create ros_gz_spawn_model.launch (#604 <https://github.com/gazebosim/ros_gz/issues/604>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Add create_own_container argument to ros_gz_spawn_model.launch.py (#622 <https://github.com/gazebosim/ros_gz/issues/622>)
* Fix ros_gz_sim.launch.py when create_own_container is enabled. (#620 <https://github.com/gazebosim/ros_gz/issues/620>)
* Contributors: Aarav Gupta, Amronos, Carlos Agüero
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
