### PR TITLE
velodyne: 2.5.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9129,7 +9129,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `2.5.1-1`:

- upstream repository: https://github.com/ros-drivers/velodyne.git
- release repository: https://github.com/ros2-gbp/velodyne-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## velodyne

- No changes

## velodyne_driver

- No changes

## velodyne_laserscan

- No changes

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Fix compiling on RHEL-8. (#549 <https://github.com/ros-drivers/velodyne/issues/549>)
* Contributors: Chris Lalancette
```
