### PR TITLE
ptz_action_server: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6472,6 +6472,23 @@ repositories:
       url: https://github.com/umdlife/psdk_ros2.git
       version: main
     status: maintained
+  ptz_action_server:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/ptz_action_server.git
+      version: ros2
+    release:
+      packages:
+      - ptz_action_server_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/ptz_action_server-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/ptz_action_server.git
+      version: ros2
+    status: maintained
   puma_motor_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ptz_action_server` to `2.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/ptz_action_server.git
- release repository: https://github.com/clearpath-gbp/ptz_action_server-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ptz_action_server_msgs

```
* Added new general Ptz message (#6 <https://github.com/clearpathrobotics/ptz_action_server/issues/6>)
* Contributors: Jose Mastrangelo
```
