### PR TITLE
camera_info_manager_py: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1075,6 +1075,21 @@ repositories:
       url: https://github.com/FraunhoferIOSB/camera_aravis2.git
       version: main
     status: maintained
+  camera_info_manager_py:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/camera_info_manager_py.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/camera_info_manager_py-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/camera_info_manager_py.git
+      version: ros2
+    status: maintained
   camera_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_info_manager_py` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/camera_info_manager_py.git
- release repository: https://github.com/clearpath-gbp/camera_info_manager_py-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## camera_info_manager_py

```
* Ros2 (#2 <https://github.com/clearpathrobotics/camera_info_manager_py/issues/2>)
  * Run magic converter
  * Ament_python package
  * Fix some imports
  * Remove references to cpp camera info manager.
  Disable tests
  * Linting
  * Fully Remove old tests
  * Add lint tests
  * Final tests
  * Remove pep257 from depends
* Contributors: Michael Hosmar
```
