### PR TITLE
dep: `libwebp-tools`

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6535,6 +6535,16 @@ libwebp-dev:
   nixos: [libwebp]
   openembedded: [libwebp@openembedded-core]
   ubuntu: [libwebp-dev]
+libwebp-tools:
+  alpine: [libwebp-tools]
+  debian: [webp]
+  fedora: [libwebp-tools]
+  opensuse: [libwebp-tools]
+  osx:
+    homebrew:
+      packages: [webp]
+  rhel: [libwebp-tools]
+  ubuntu: [webp]
 libwebsocketpp-dev:
   arch: [websocketpp]
   debian: [libwebsocketpp-dev]
@@ -9037,12 +9047,6 @@ wayland-dev:
   openembedded: [wayland@openembedded-core]
   rhel: [wayland-devel, wayland-protocols-devel]
   ubuntu: [libwayland-dev, wayland-protocols]
-webp:
-  debian: [webp]
-  osx:
-    homebrew:
-      packages: [webp]
-  ubuntu: [webp]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6543,7 +6543,9 @@ libwebp-tools:
   osx:
     homebrew:
       packages: [webp]
-  rhel: [libwebp-tools]
+  rhel:
+    '*': [libwebp-tools]
+    '8': null
   ubuntu: [webp]
 libwebsocketpp-dev:
   arch: [websocketpp]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9037,6 +9037,12 @@ wayland-dev:
   openembedded: [wayland@openembedded-core]
   rhel: [wayland-devel, wayland-protocols-devel]
   ubuntu: [libwayland-dev, wayland-protocols]
+webp:
+  debian: [webp]
+  osx:
+    homebrew:
+      packages: [webp]
+  ubuntu: [webp]
 wget:
   arch: [wget]
   debian: [wget]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

## Package name:

`webp`

## Package Upstream Source:

Likely [official page (developers.google.com)](https://developers.google.com/speed/webp)

Note this is different from libwebp, of which dep key has already been added https://github.com/ros/rosdistro/pull/12531.

## Purpose of using this:

Newer alternative for image file format.

Mentioned also in https://github.com/ros/rosdistro/pull/14163#issuecomment-286455819 by former perception pipeline maintainer who also seems to be one of webp developers https://github.com/ros/rosdistro/pull/12531.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?keywords=webp
- Ubuntu: https://packages.ubuntu.com/search?keywords=webp
- Fedora: https://packages.fedoraproject.org/pkgs/libwebp/libwebp-tools/
- :x: Arch: https://archlinux.org/packages/extra/x86_64/libwebp-tools/ -> 404
   - The description of `libwebp` pkg reads as follows, i.e. includes "tools". But looking at the list of files https://archlinux.org/packages/extra/x86_64/libwebp/files/, I do not see e.g. `vwebp`, the very tool I like to use. So I'd say no.
      > WebP library and conversion tools
- macOS: https://formulae.brew.sh/formula/webp
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/libwebp-tools
- openSUSE: https://software.opensuse.org/package/libwebp-tools
