### PR TITLE
Add nanobind, an alternative to pybind11

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7228,9 +7228,6 @@ nanobind-dev:
     "*":
       pip:
         packages: [nanobind]
-  "*":
-    pip:
-      packages: [nanobind]
 nanoflann:
   debian:
     '*': [libnanoflann-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7218,7 +7218,11 @@ muparser:
   ubuntu: [libmuparser-dev]
 nanobind-dev:
   arch: [nanobind]
-  debian: [nanobind-dev]
+  debian:
+    '*': [nanobind-dev]
+    bookworm:
+      pip:
+        packages: [nanobind]
   freebsd: [nanobind]
   ubuntu:
     noble: [nanobind-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7225,9 +7225,11 @@ nanobind-dev:
         packages: [nanobind]
   freebsd: [nanobind]
   ubuntu:
-    noble: [nanobind-dev]
-    oracular: [nanobind-dev]
-    "*":
+    '*': [nanobind-dev]
+    focal:
+      pip:
+        packages: [nanobind]
+    jammy:
       pip:
         packages: [nanobind]
 nanoflann:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7217,9 +7217,7 @@ muparser:
   opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
 nanobind-dev:
-  arch:
-    pacman:
-      packages: [nanobind]
+  arch: [nanobind]
   debian: [nanobind-dev]
   freebsd: [nanobind]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7216,6 +7216,21 @@ muparser:
   nixos: [muparser]
   opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
+nanobind-dev:
+  arch:
+    pacman:
+      packages: [nanobind]
+  debian: [nanobind-dev]
+  freebsd: [nanobind]
+  ubuntu:
+    noble: [nanobind-dev]
+    oracular: [nanobind-dev]
+    "*":
+      pip:
+        packages: [nanobind]
+  "*":
+    pip:
+      packages: [nanobind]
 nanoflann:
   debian:
     '*': [libnanoflann-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7271,10 +7271,6 @@ python3-myst-parser-pip:
   ubuntu:
     pip:
       packages: [myst-parser]
-python3-nanobind-pip:
-  '*':
-    pip:
-      packages: [nanobind]
 python3-natsort:
   debian: [python3-natsort]
   fedora: [python3-natsort]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7271,6 +7271,10 @@ python3-myst-parser-pip:
   ubuntu:
     pip:
       packages: [myst-parser]
+python3-nanobind-pip:
+  '*':
+    pip:
+      packages: [nanobind]
 python3-natsort:
   debian: [python3-natsort]
   fedora: [python3-natsort]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

nanobind-dev

## Package Upstream Source:

[nanobind](https://github.com/wjakob/nanobind)

## Purpose of using this:

Nanobind is a lightweight alternative to pybind11. It can be useful to bind c++ code to python and vice-versa. 

## Links to Distribution Packages

- [Arch](https://archlinuxarm.org/packages/any/nanobind)
- [Debian Sid](https://packages.debian.org/sid/nanobind-dev)
- [Ubuntu Oracular](https://packages.ubuntu.com/oracular/nanobind-dev)
- [Ubuntu Noble](https://packages.ubuntu.com/noble/nanobind-dev)
- [FreeBSD 13-14-15](https://www.freshports.org/devel/nanobind)
- [PIPY](https://pypi.org/project/nanobind/)