### PR TITLE
ros2_control: 3.29.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5979,7 +5979,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.28.1-1
+      version: 3.29.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.29.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.28.1-1`

## controller_interface

```
* PoseSensor semantic component (backport #1775 <https://github.com/ros-controls/ros2_control/issues/1775>) (#1786 <https://github.com/ros-controls/ros2_control/issues/1786>)
* Contributors: mergify[bot]
```

## controller_manager

```
* add thread_priority option to the ros2_control_node (#1820 <https://github.com/ros-controls/ros2_control/issues/1820>) (#1825 <https://github.com/ros-controls/ros2_control/issues/1825>)
* Fix timeout value in std output (backport #1807 <https://github.com/ros-controls/ros2_control/issues/1807>) (#1813 <https://github.com/ros-controls/ros2_control/issues/1813>)
* Improve launch utils to support the multiple controller names (#1782 <https://github.com/ros-controls/ros2_control/issues/1782>) (#1784 <https://github.com/ros-controls/ros2_control/issues/1784>)
* allow extra spawner arguments to not declare every argument in launch utils (#1505 <https://github.com/ros-controls/ros2_control/issues/1505>) (#1793 <https://github.com/ros-controls/ros2_control/issues/1793>)
* Refactor spawner to be able to reuse code for ros2controlcli (backport #1661 <https://github.com/ros-controls/ros2_control/issues/1661>) (#1696 <https://github.com/ros-controls/ros2_control/issues/1696>)
* [CM] Handle other exceptions while loading the controller plugin (#1731 <https://github.com/ros-controls/ros2_control/issues/1731>) (#1734 <https://github.com/ros-controls/ros2_control/issues/1734>)
* [CM] Throw an exception when the components initially fail to be in the required state (backport #1729 <https://github.com/ros-controls/ros2_control/issues/1729>) (#1778 <https://github.com/ros-controls/ros2_control/issues/1778>)
* Fix spawner tests timeout on source builds (backport #1692 <https://github.com/ros-controls/ros2_control/issues/1692>) (#1698 <https://github.com/ros-controls/ros2_control/issues/1698>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add resources_lock_ lock_guards to avoid race condition when loading robot_description through topic (backport #1451 <https://github.com/ros-controls/ros2_control/issues/1451>) (#1600 <https://github.com/ros-controls/ros2_control/issues/1600>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Refactor spawner to be able to reuse code for ros2controlcli (backport #1661 <https://github.com/ros-controls/ros2_control/issues/1661>) (#1696 <https://github.com/ros-controls/ros2_control/issues/1696>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* fix: call configure_controller  on 'unconfigured' state instead load_controller (#1794 <https://github.com/ros-controls/ros2_control/issues/1794>) (#1798 <https://github.com/ros-controls/ros2_control/issues/1798>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
