### PR TITLE
ros2_controllers: 3.27.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6004,6 +6004,7 @@ repositories:
       - joint_state_broadcaster
       - joint_trajectory_controller
       - pid_controller
+      - pose_broadcaster
       - position_controllers
       - range_sensor_broadcaster
       - ros2_controllers
@@ -6016,7 +6017,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.26.3-1
+      version: 3.27.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `3.27.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.26.3-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* [JSB] Fix the behaviour of publishing unavailable state interfaces when they are previously available (#1331 <https://github.com/ros-controls/ros2_controllers/issues/1331>) (#1340 <https://github.com/ros-controls/ros2_controllers/issues/1340>)
  * Add test to reproduce the behaviour of https://github.com/ros-controls/ros2_control_demos/pull/417#discussion_r1823443110
  * Add fix to solve the issue of the publishing non-existing joint_states
  (cherry picked from commit 87f21b39c5e81327eb8adf8ed16e5fde1101bd97)
  Co-authored-by: Sai Kishor Kothakota <mailto:sai.kishor@pal-robotics.com>
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* fixes for windows compilation (#1330 <https://github.com/ros-controls/ros2_controllers/issues/1330>) (#1333 <https://github.com/ros-controls/ros2_controllers/issues/1333>)
  Co-authored-by: SENAI-GilmarCorreia <mailto:gilmar.correia@sp.senai.br>
  (cherry picked from commit fa42b5ec97b0af5420060844b7027b8e8912c05d)
  Co-authored-by: Gilmar Correia <mailto:gilmar.jeronimo@sp.senai.br>
* [JTC] Add Parameter to Toggle State Setting on Activation (#1231 <https://github.com/ros-controls/ros2_controllers/issues/1231>) (#1319 <https://github.com/ros-controls/ros2_controllers/issues/1319>)
  * [JTC] Add param to setting last command interface value as state on activation
  * [JTC] add a note about set_last_command_interface_value_as_state_on_activation to release_notes. Updated the parameters.yaml description to match the same wording.
  ---------
  Co-authored-by: Bence Magyar <mailto:bence.magyar.robotics@gmail.com>
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  (cherry picked from commit f96d2fc0fbf94537f769cffcf844858f7a085671)
  Co-authored-by: Kenta Kato <mailto:kenta.kato.4321@gmail.com>
* Contributors: mergify[bot]
```

## pid_controller

```
* fixes for windows compilation (#1330 <https://github.com/ros-controls/ros2_controllers/issues/1330>) (#1333 <https://github.com/ros-controls/ros2_controllers/issues/1333>)
  Co-authored-by: SENAI-GilmarCorreia <mailto:gilmar.correia@sp.senai.br>
  (cherry picked from commit fa42b5ec97b0af5420060844b7027b8e8912c05d)
  Co-authored-by: Gilmar Correia <mailto:gilmar.jeronimo@sp.senai.br>
* Contributors: mergify[bot]
```

## pose_broadcaster

```
* Implement new PoseBroadcaster controller (backport #1311 <https://github.com/ros-controls/ros2_controllers/issues/1311>) (#1327 <https://github.com/ros-controls/ros2_controllers/issues/1327>)
  * Implement new PoseBroadcaster controller (#1311 <https://github.com/ros-controls/ros2_controllers/issues/1311>)
  (cherry picked from commit 7c89c17a5cf6ac5d553c79ccc63182f2e1454388)
  * Fix API in tests
  * Add hardware_interface_testing dependency
  ---------
  Co-authored-by: RobertWilbrandt <mailto:wilbrandt@fzi.de>
  Co-authored-by: Christoph Froehlich <mailto:christoph.froehlich@ait.ac.at>
* Contributors: mergify[bot]
* Implement new PoseBroadcaster controller (backport #1311 <https://github.com/ros-controls/ros2_controllers/issues/1311>) (#1327 <https://github.com/ros-controls/ros2_controllers/issues/1327>)
  * Implement new PoseBroadcaster controller (#1311 <https://github.com/ros-controls/ros2_controllers/issues/1311>)
  (cherry picked from commit 7c89c17a5cf6ac5d553c79ccc63182f2e1454388)
  * Fix API in tests
  * Add hardware_interface_testing dependency
  ---------
  Co-authored-by: RobertWilbrandt <mailto:wilbrandt@fzi.de>
  Co-authored-by: Christoph Froehlich <mailto:christoph.froehlich@ait.ac.at>
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* fix(steering-odometry): convert twist to steering angle (#1288 <https://github.com/ros-controls/ros2_controllers/issues/1288>) (#1296 <https://github.com/ros-controls/ros2_controllers/issues/1296>)
  (cherry picked from commit 50036e109d6a03e41bb9b43a4f67411887b48640)
  Co-authored-by: Rein Appeldoorn <mailto:rein.appeldoorn@nobleo.nl>
* fix(steering-odometry): handle infinite turning radius properly (#1285 <https://github.com/ros-controls/ros2_controllers/issues/1285>) (#1287 <https://github.com/ros-controls/ros2_controllers/issues/1287>)
  (cherry picked from commit 1dc3d2aa47bb7746f5a414d016e9566c9eef4060)
  Co-authored-by: Rein Appeldoorn <mailto:reinzor@gmail.com>
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
