### PR TITLE
cras_ros_utils: 2.4.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1808,7 +1808,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.4-1
+      version: 2.4.5-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.4.5-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.4-1`

## cras_cpp_common

```
* string_utils: Added date/time parsing methods.
* string_utils: Added methods for parsing integers with known radix.
* diag_utils: Added tests for offline diag updater.
* diag_utils: Added offline diag updater.
* node_from_nodelet: Added support for stopping the node when requestStop() has been called in the nodelet code.
* Contributors: Martin Pecka
```

## cras_docs_common

- No changes

## cras_py_common

- No changes

## cras_topic_tools

- No changes

## image_transport_codecs

- No changes
