### PR TITLE
Adding vizanti to documentation index for jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9239,6 +9239,16 @@ repositories:
       url: https://github.com/ros-acceleration/vitis_common.git
       version: rolling
     status: developed
+  vizanti:
+    doc:
+      type: git
+      url: https://github.com/MoffKalast/vizanti.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/MoffKalast/vizanti.git
+      version: ros2
+    status: maintained
   vrpn:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Jazzy

# The source is here:

https://github.com/MoffKalast/vizanti/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
