### PR TITLE
openni2_camera: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4278,7 +4278,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.2.2-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`

## openni2_camera

```
* add dynamic parameters (#141 <https://github.com/ros-drivers/openni2_camera/issues/141>)
  In ROS 1, a number of things were dynamic - this PR re-adds them using
  the new ROS 2 paradigm for parameter updating. I've tested this with a
  Primesense device and am able to disable auto_exposure and
  auto_white_balance.
* Contributors: Michael Ferguson
```
