### PR TITLE
realtime_tools: 2.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7222,7 +7222,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.8.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.0-1`

## realtime_tools

```
* Add methods to set the thread affinity (#186 <https://github.com/ros-controls/realtime_tools/issues/186>)
* Fix pre-commit of #187 <https://github.com/ros-controls/realtime_tools/issues/187> (#188 <https://github.com/ros-controls/realtime_tools/issues/188>)
* Removing thread_priority.hpp warning for Windows Systems (#187 <https://github.com/ros-controls/realtime_tools/issues/187>)
* Fix build error with clang (#183 <https://github.com/ros-controls/realtime_tools/issues/183>)
* Bump version of pre-commit hooks (#182 <https://github.com/ros-controls/realtime_tools/issues/182>)
* [AsyncFunctionHandler] return execution time in nanoseconds (#181 <https://github.com/ros-controls/realtime_tools/issues/181>)
* Rename thread_priority to realtime_helpers header (#178 <https://github.com/ros-controls/realtime_tools/issues/178>)
* Include <functional> in realtime_box_best_effort (#173 <https://github.com/ros-controls/realtime_tools/issues/173>)
* Bump version of pre-commit hooks (#171 <https://github.com/ros-controls/realtime_tools/issues/171>)
* Add fixes to the code to work for the windows systems (#180 <https://github.com/ros-controls/realtime_tools/issues/180>)
* Update thread_priority.cpp (#170 <https://github.com/ros-controls/realtime_tools/issues/170>)
* Add a helper method to lock the pages of memory in the RAM (#175 <https://github.com/ros-controls/realtime_tools/issues/175>)
* Contributors: Christoph Fröhlich, Felix Exner (fexner), Gilmar Correia, Luca Della Vedova, Sai Kishor Kothakota, github-actions[bot]
```
