### PR TITLE
adi_tmcl: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -95,7 +95,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/adi_tmcl-release.git
-      version: 2.0.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_tmcl` to `2.0.2-1`:

- upstream repository: https://github.com/analogdevicesinc/tmcl_ros2.git
- release repository: https://github.com/ros2-gbp/adi_tmcl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## adi_tmcl

```
* Added support for TMCM-1316
* Contributors: Jamila Macagba
```
