### PR TITLE
mrpt_ros: 2.14.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6444,7 +6444,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_ros-release.git
-      version: 2.14.4-1
+      version: 2.14.5-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.14.5-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.4-1`

## mrpt_apps

```
* GridmapNavSimul: Loading a different gridmap won't update the map visualization.
```

## mrpt_libapps

- No changes

## mrpt_libbase

```
* ExprTk updated to latest version (https://www.partow.net/programming/exprtk/exprtk_release_notes_v0.0.3.txt).
```

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

```
* mrpt::maps::CPointsMapXYZIRT::getPointRGB() now handles the case of no intensity without throwing, fixing the visualization of such clouds through mrpt::opengl::CPointCloudColoured::loadFromPointsMap().
```

## mrpt_libmath

```
* Upgraded nanoflann to v1.6.2 (fixes a potential bug).
```

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libros_bridge

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
