### PR TITLE
Update `osmium` entry to `libosmium2-dev` for debian and ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7527,10 +7527,10 @@ osm2pgsql:
   ubuntu: [osm2pgsql]
 osmium:
   arch: [libosmium]
-  debian: [libosmium-dev]
+  debian: [libosmium2-dev]
   fedora: [libosmium-devel]
   nixos: [libosmium]
-  ubuntu: [libosmium-dev]
+  ubuntu: [libosmium2-dev]
 pandoc:
   arch: [pandoc-cli]
   debian: [pandoc]


### PR DESCRIPTION
Please update the following entry to the rosdep database.

## Package name:

`osmium`

## Package Upstream Source:

[osmcode/libosmium](https://github.com/osmcode/libosmium/)

## Purpose of using this:

`libosmium-dev` have been renamed `libosmium2-dev` for a few years now in debian and ubuntu based systems.
This change have been tested both in ubuntu focal and noble.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [`libosmium2-dev`](https://packages.debian.org/sid/libosmium2-dev)
- Ubuntu: https://packages.ubuntu.com/
  - [`libosmium2-dev`](https://packages.ubuntu.com/noble/libosmium2-dev)
