### PR TITLE
kinematics_interface: 1.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3063,7 +3063,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.2.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## kinematics_interface

```
* API changes to support robot description (#83 <https://github.com/ros-controls/kinematics_interface/issues/83>)
* Contributors: Dr. Denis
```

## kinematics_interface_kdl

```
* API changes to support robot description (#83 <https://github.com/ros-controls/kinematics_interface/issues/83>)
* Contributors: Dr. Denis
```
