### PR TITLE
adi_tmc_coe: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -99,7 +99,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/adi_tmcl_coe-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_tmc_coe.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_tmc_coe` to `1.0.2-1`:

- upstream repository: https://github.com/analogdevicesinc/adi_tmc_coe.git
- release repository: https://github.com/ros2-gbp/adi_tmcl_coe-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## adi_tmc_coe

```
* Added RPATH in CMakeList
  - Added RPATH in CMakeList.txt to run package even with binary installation.
  - Rename maintainer name in package.xml
* Contributors: Cacar, jmacagba
```
