### PR TITLE
Add `cli11` rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -591,6 +591,16 @@ clangd:
   opensuse: [clang]
   rhel: [clang-tools-extra]
   ubuntu: [clangd]
+cli11:
+  arch: [cli11]
+  debian: [libcli11-dev]
+  fedora: [cli11-devel]
+  gentoo: [dev-cpp/cli11]
+  nixos: [cli11]
+  rhel: [cli11-devel]
+  ubuntu:
+    '*': [libcli11-dev]
+    'focal': null
 cmake:
   alpine: [cmake]
   arch: [cmake]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name

`cli11`

## Package Upstream Source

https://github.com/CLIUtils/CLI11

## Purpose of using this:

`cli11` is a fairly popular C++11 command line parsing library. It helps CLI development in C++.

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=cli11-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/search?keywords=libcli11-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/pkgs/cli11/cli11-devel/
- Arch: https://archlinux.org/packages/extra/any/cli11/
- Gentoo: https://packages.gentoo.org/packages/dev-cpp/cli11
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=cli11&from=0&size=50&sort=relevance&type=packages&query=cli11
- openSUSE: https://software.opensuse.org/package/cli11
- rhel: https://pkgs.org/download/cli11-devel