### PR TITLE
Add JSONWebToken rosdep rule for Python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6798,6 +6798,17 @@ python3-jupyros-pip:
   ubuntu:
     pip:
       packages: [jupyros]
+python3-jwt:
+  alpine: [py3-jwt]
+  arch: [python-pyjwt]
+  debian: [python3-jwt]
+  fedora: [python3-jwt]
+  gentoo: [dev-python/pyjwt]
+  nixos: [python3Packages.pyjwt]
+  opensuse: [python3-PyJWT]
+  rhel:
+    '9': [python3-jwt]
+  ubuntu: [python3-jwt]
 python3-kitchen:
   arch: [python-kitchen]
   debian: [python3-kitchen]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name

`python3-jwt`

## Package Upstream Source

https://github.com/jpadilla/pyjwt

## Purpose of using this

[JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) is a typical authentication mechanism for (but not limited to) HTTP APIs.

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3-jwt
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-jwt&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/pkgs/python-jwt/python3-jwt/
- Arch: https://archlinux.org/packages/extra/any/python-pyjwt
- Gentoo: https://packages.gentoo.org/packages/dev-python/pyjwt
- Alpine: https://pkgs.alpinelinux.org/packages?name=py3-jwt&branch=edge&repo=&arch=&origin=&flagged=&maintainer=
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=pyjwt
- openSUSE: https://software.opensuse.org/package/python-PyJWT
- rhel: https://pkgs.org/search/?q=python3-jwt
