### PR TITLE
kinematics_interface: 1.2.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2658,7 +2658,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.2.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## kinematics_interface

```
* API changes to support robot description (#83 <https://github.com/ros-controls/kinematics_interface/issues/83>)
* Contributors: Dr. Denis
```

## kinematics_interface_kdl

```
* API changes to support robot description (#83 <https://github.com/ros-controls/kinematics_interface/issues/83>)
* Contributors: Dr. Denis
```
