### PR TITLE
backward_ros: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -690,7 +690,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.6-1`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/ros2-gbp/backward_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.5-1`

## backward_ros

```
* Update backward_rosConfig.cmake.in
  adding both OS paths
* Update backward_rosConfig.cmake.in to windows location
* Set cxx standard to 14
  Foxy targets = C++14
  https://docs.ros.org/en/foxy/The-ROS2-Project/Contributing/Code-Style-Language-Versions.html
* Merge branch 'remove/linters' into 'foxy-devel'
  Remove linter tests for backward_ros
  See merge request qa/backward_ros!8
* Merge branch 'fix/ament_cmake_config' into 'remove/linters'
  Include BackwardConfigAment.cmake in backward_ros cmake config
  See merge request qa/backward_ros!10
* Include the full path to BackwardConfigAment.cmake
* include the contents of BackwardConfigAment.cmake
* Remove linter tests for backward_ros
* Merge branch 'fix/link_library_always' into 'foxy-devel'
  Set backward_ros library to be linked always
  See merge request qa/backward_ros!7
* Set backward_ros library to be linked always
* Contributors: Gilmar Correia, Noel Jimenez, Sai Kishor Kothakota, mosfet80
```
