### PR TITLE
microstrain_inertial: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3456,7 +3456,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.5.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.4.0-1`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* ROS submodule update 11 07 2024 (#363 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/363>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* ROS submodule update 11 07 2024 (#363 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/363>)
* Contributors: Rob
```

## microstrain_inertial_rqt

- No changes
