### PR TITLE
Add rosdep key for rich

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9073,6 +9073,12 @@ python3-retrying:
       packages: [retrying]
   ubuntu: [python3-retrying]
 python3-rich:
+  debian: [python3-rich]
+  fedora: [python3-rich]
+  gentoo: [rich]
+  osx:
+    pip:
+      packages: [rich]
   ubuntu: [python3-rich]
 python3-river-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9079,6 +9079,9 @@ python3-rich:
   osx:
     pip:
       packages: [rich]
+  rhel:
+    '*': [python3-rich]
+    '8': null
   ubuntu:
     '*': [python3-rich]
     focal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9079,7 +9079,11 @@ python3-rich:
   osx:
     pip:
       packages: [rich]
-  ubuntu: [python3-rich]
+  ubuntu:
+    '*': [python3-rich]
+    focal:
+      pip:
+        packages: [rich]
 python3-river-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9072,6 +9072,8 @@ python3-retrying:
     pip:
       packages: [retrying]
   ubuntu: [python3-retrying]
+python3-rich:
+  ubuntu: [python3-rich]
 python3-river-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rich

## Package Upstream Source:

https://github.com/Textualize/rich

## Purpose of using this:

render rich text, tables, progress bars, syntax highlighting, markdown

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-rich
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-rich
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-rich/python3-rich/
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/rich
- macOS: https://formulae.brew.sh/
  - https://pypi.org/project/rich/
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE