### PR TITLE
ros2_controllers: 4.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5989,6 +5989,7 @@ repositories:
       - joint_trajectory_controller
       - parallel_gripper_controller
       - pid_controller
+      - pose_broadcaster
       - position_controllers
       - range_sensor_broadcaster
       - ros2_controllers
@@ -6001,7 +6002,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.15.0-1
+      version: 4.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.15.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Adding use of robot description parameter in the Admittance Controller (#1247 <https://github.com/ros-controls/ros2_controllers/issues/1247>)
* Contributors: Dr. Denis, Kevin DeMarco, Nikola Banovic, Bence Magyar, Christoph Fröhlich
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* [ForceTorqueSensorBroadcaster] added force and torque offsets to the parameters + export state interfaces (#1215 <https://github.com/ros-controls/ros2_controllers/issues/1215>)
* Contributors: Sai Kishor Kothakota
```

## forward_command_controller

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* [JSB] Fix the behaviour of publishing unavailable state interfaces when they are previously available (#1331 <https://github.com/ros-controls/ros2_controllers/issues/1331>)
* Contributors: Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* [JTC] Fix the JTC length_error exceptions in the tests (#1360 <https://github.com/ros-controls/ros2_controllers/issues/1360>)
* [jtc] Improve trajectory sampling efficiency (#1297 <https://github.com/ros-controls/ros2_controllers/issues/1297>)
* fixes for windows compilation (#1330 <https://github.com/ros-controls/ros2_controllers/issues/1330>)
* [JTC] Add Parameter to Toggle State Setting on Activation (#1231 <https://github.com/ros-controls/ros2_controllers/issues/1231>)
* Contributors: Gilmar Correia, Kenta Kato, RobertWilbrandt, Sai Kishor Kothakota
```

## parallel_gripper_controller

- No changes

## pid_controller

```
* fixes for windows compilation (#1330 <https://github.com/ros-controls/ros2_controllers/issues/1330>)
* Contributors: Gilmar Correia
```

## pose_broadcaster

```
* Add hardware_interface_testing dependency (#1335 <https://github.com/ros-controls/ros2_controllers/issues/1335>)
* Implement new PoseBroadcaster controller (#1311 <https://github.com/ros-controls/ros2_controllers/issues/1311>)
* Contributors: Christoph Fröhlich, RobertWilbrandt
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
