### PR TITLE
Add rosdep key for minijinja

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7080,6 +7080,16 @@ python3-meson-pip:
   ubuntu:
     pip:
       packages: [meson]
+python3-minijinja-pip:
+  debian:
+    pip:
+      packages: [minijinja]
+  osx:
+    pip:
+      packages: [minijinja]
+  ubuntu:
+    pip:
+      packages: [minijinja]
 python3-minimalmodbus-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7103,6 +7103,9 @@ python3-minijinja:
     focal:
       pip:
         packages: [minijinja]
+    noble:
+      pip:
+        packages: [minijinja]
 python3-minimalmodbus-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7080,16 +7080,29 @@ python3-meson-pip:
   ubuntu:
     pip:
       packages: [meson]
-python3-minijinja-pip:
+python3-minijinja:
   debian:
-    pip:
-      packages: [minijinja]
+    '*': [librust-minijinja-dev]
+    bookworm:
+      pip:
+        packages: [minijinja]
+    bullseye:
+      pip:
+        packages: [minijinja]
+    buster:
+      pip:
+        packages: [minijinja]
   osx:
     pip:
       packages: [minijinja]
   ubuntu:
-    pip:
-      packages: [minijinja]
+    '*': [librust-minijinja-dev]
+    jammy:
+      pip:
+        packages: [minijinja]
+    focal:
+      pip:
+        packages: [minijinja]
 python3-minimalmodbus-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7097,10 +7097,10 @@ python3-minijinja:
       packages: [minijinja]
   ubuntu:
     '*': [librust-minijinja-dev]
-    jammy:
+    focal:
       pip:
         packages: [minijinja]
-    focal:
+    jammy:
       pip:
         packages: [minijinja]
     noble:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

minijinja

## Package Upstream Source:

https://github.com/mitsuhiko/minijinja/tree/main/minijinja-py

## Purpose of using this:

A powerful template engine for Python

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/minijinja/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/minijinja/
- macOS: https://formulae.brew.sh/
  - https://pypi.org/project/minijinja/