### PR TITLE
leo_common: 1.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3894,7 +3894,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.2.4-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.3-1`

## leo

- No changes

## leo_description

```
* Add dummy .sh file for .dsv hook (backport #14 <https://github.com/LeoRover/leo_common-ros2/issues/14>) (#16 <https://github.com/LeoRover/leo_common-ros2/issues/16>)
* Contributors: Jan Hernas
```

## leo_msgs

- No changes

## leo_teleop

- No changes
