### PR TITLE
leo_common: 2.0.4-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2853,7 +2853,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `2.0.4-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## leo

- No changes

## leo_description

```
* Add dummy .sh file for .dsv hook (backport #14 <https://github.com/LeoRover/leo_common-ros2/issues/14>) (#15 <https://github.com/LeoRover/leo_common-ros2/issues/15>)
* Contributors: Jan Hernas
```

## leo_msgs

- No changes

## leo_teleop

- No changes
