### PR TITLE
ros_gz: 1.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6759,7 +6759,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.7-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.6-1`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Bugfix: if "false" is always True (#617 <https://github.com/gazebosim/ros_gz/issues/617>) (#640 <https://github.com/gazebosim/ros_gz/issues/640>)
  There is an issue in this launch file when passing the string 'false' as
  an argument. In Python, non-empty strings are always evaluated as True,
  regardless of their content. This means that even if you pass 'false',
  the system will still evaluate it as True.
  This bug results in the launch system incorrectly calling the OnShutdown
  method twice. When any ROS launch action invokes a RosAdapter, it
  triggers the following exception: "Cannot shutdown a ROS adapter that is
  not running."
  To temporarily work around this issue, you can launch gz_sim_launch.py
  with the on_exit_shutdown argument set to an empty string. This prevents
  the erroneous shutdown sequence and avoids the associated exception.
  (cherry picked from commit 1e30af0105058d68c8f1c98f37904505f613cf97)
  Co-authored-by: Ignacio Vizzo <mailto:ignaciovizzo@gmail.com>
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
