### PR TITLE
leo_simulator: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3951,7 +3951,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_simulator-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `1.1.1-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator-ros2.git
- release repository: https://github.com/ros2-gbp/leo_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## leo_gz_bringup

- No changes

## leo_gz_plugins

```
* Add dummy .sh files for .dsv hooks (#8 <https://github.com/LeoRover/leo_simulator-ros2/issues/8>) (#9 <https://github.com/LeoRover/leo_simulator-ros2/issues/9>)
* Contributors: Jan Hernas
```

## leo_gz_worlds

```
* Add dummy .sh files for .dsv hooks (#8 <https://github.com/LeoRover/leo_simulator-ros2/issues/8>) (#9 <https://github.com/LeoRover/leo_simulator-ros2/issues/9>)
* Contributors: Jan Hernas
```

## leo_simulator

- No changes
