### PR TITLE
octomap_msgs: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4160,7 +4160,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_msgs-release.git
-      version: 2.0.0-4
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/octomap/octomap_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_msgs.git
- release repository: https://github.com/ros2-gbp/octomap_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-4`

## octomap_msgs

```
* Fix CMake install of headers (#20 <https://github.com/OctoMap/octomap_msgs/issues/20>)
* Contributors: Tyler Weaver, Wolfgang Merkt
```
