### PR TITLE
novatel_gps_driver: 4.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5454,7 +5454,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.3-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.2.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.3-1`

## novatel_gps_driver

```
* Add dual antenna diagnostics (#124 <https://github.com/swri-robotics/novatel_gps_driver/issues/124>)
* Contributors: bgfxc4
```

## novatel_gps_msgs

```
* Add dual antenna diagnostics (#124 <https://github.com/swri-robotics/novatel_gps_driver/issues/124>)
* Contributors: bgfxc4
```
