### PR TITLE
leo_simulator: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3316,7 +3316,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_simulator-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `2.0.1-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator-ros2.git
- release repository: https://github.com/ros2-gbp/leo_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## leo_gz_bringup

```
* Fix mypy errors (#11 <https://github.com/LeoRover/leo_simulator-ros2/issues/11>) (#12 <https://github.com/LeoRover/leo_simulator-ros2/issues/12>)
* Add launch_ros to dependencies
* Contributors: Błażej Sowa
```

## leo_gz_plugins

```
* Add dummy .sh files for .dsv hooks (#8 <https://github.com/LeoRover/leo_simulator-ros2/issues/8>)
* Contributors: Jan Hernas
```

## leo_gz_worlds

```
* Add dummy .sh files for .dsv hooks (#8 <https://github.com/LeoRover/leo_simulator-ros2/issues/8>)
* Contributors: Jan Hernas
```

## leo_simulator

- No changes
