### PR TITLE
novatel_gps_driver: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4085,7 +4085,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.1.3-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.2.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.3-1`

## novatel_gps_driver

```
* Add dual antenna diagnostics (#124 <https://github.com/swri-robotics/novatel_gps_driver/issues/124>)
* Contributors: bgfxc4
```

## novatel_gps_msgs

```
* Add dual antenna diagnostics (#124 <https://github.com/swri-robotics/novatel_gps_driver/issues/124>)
* Contributors: bgfxc4
```
