### PR TITLE
robot_calibration: 0.9.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6299,7 +6299,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.9.1-1
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.9.2-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.1-1`

## robot_calibration

```
* include tf2_geometry_msgs earlier to avoid missing symbols (#182 <https://github.com/mikeferguson/robot_calibration/issues/182>)
* port capture_poses script to ROS 2, document (#181 <https://github.com/mikeferguson/robot_calibration/issues/181>)
* improve parsing of xyz and rpy fields (#177 <https://github.com/mikeferguson/robot_calibration/issues/177>)
  * don't segfault if xyz or rpy missing
  * remove extra spaces in xyz/rpy fields
* urdf/model.h -> urdf/model.hpp (#175 <https://github.com/mikeferguson/robot_calibration/issues/175>)
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
