### PR TITLE
launch_ros: 0.24.2-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2832,7 +2832,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.24.1-1
+      version: 0.24.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.24.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.24.1-1`

## launch_ros

```
* cache lookup of importlib metadata in Node action (#411 <https://github.com/ros2/launch_ros/issues/411>)
* Fix url in setup.py (#416 <https://github.com/ros2/launch_ros/issues/416>)
* Contributors: roscan-tech, Wei HU
```

## launch_testing_ros

```
* Make launch_testing_ros examples more robust. (#420 <https://github.com/ros2/launch_ros/issues/420>)
* Contributors: Tomoya Fujita
```

## ros2launch

```
* Fix url in setup.py (#416 <https://github.com/ros2/launch_ros/issues/416>)
* Contributors: Wei HU
```
