### PR TITLE
robot_calibration: 0.8.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7692,7 +7692,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.8.2-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.1-1`

## robot_calibration

```
* include tf2_geometry_msgs earlier to avoid missing symbols (backport #182 <https://github.com/mikeferguson/robot_calibration/issues/182>) (#183 <https://github.com/mikeferguson/robot_calibration/issues/183>)
* do not run calibration if no feature finders (#167 <https://github.com/mikeferguson/robot_calibration/issues/167>)
  due to misconfiguration (for instance, camera_info topic
  is wrong) the finders may not initialize but the robot
  will move through all the poses, say it captured
  all of them, and then have no observations in the
  output bagfile
* remove redundant keep_last() (#166 <https://github.com/mikeferguson/robot_calibration/issues/166>)
* update checkerboard comment (#160 <https://github.com/mikeferguson/robot_calibration/issues/160>)
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
