### PR TITLE
rviz: 12.4.9-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7233,7 +7233,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 12.4.8-1
+      version: 12.4.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `12.4.9-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `12.4.8-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Handle Tool::Finished returned by processKeyEvent (#1264 <https://github.com/ros2/rviz/issues/1264>)
* Correclty load icons of panels with whitespaces in their name (#1244 <https://github.com/ros2/rviz/issues/1244>)
* Contributors: Patrick Roncagliolo
```

## rviz_default_plugins

```
* Enabling manual space width for TextViewFacingMarker (#1269 <https://github.com/ros2/rviz/issues/1269>)
* Contributors: Tom Moore
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
