### PR TITLE
simple_grasping: 0.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7976,6 +7976,21 @@ repositories:
       url: https://github.com/DLu/simple_actions.git
       version: main
     status: developed
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/simple_grasping-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros2
+    status: developed
   simple_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.5.0-1`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros2-gbp/simple_grasping-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## simple_grasping

```
* remove unported script
* add documentation
* forward port continuous detection (#16 <https://github.com/mikeferguson/simple_grasping/issues/16>)
  forward port of #7 <https://github.com/mikeferguson/simple_grasping/issues/7>
* add support for QoS overrides (#15 <https://github.com/mikeferguson/simple_grasping/issues/15>)
* add continuous integration (#14 <https://github.com/mikeferguson/simple_grasping/issues/14>)
  targeting iron only right now - grasping_msgs just released into jazzy
* cleanup dependencies and build, works on jazzy
* replace c-style cast
* fix issues in package.xml
  trying to get the build farm to succeed on source job
* add LICENSE file
* updates for ROS2 humble (#9 <https://github.com/mikeferguson/simple_grasping/issues/9>)
* initial port to ros2 (#6 <https://github.com/mikeferguson/simple_grasping/issues/6>)
* Contributors: Michael Ferguson
```
