### PR TITLE
ros2_control: 2.44.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7852,7 +7852,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.43.1-1
+      version: 2.44.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.44.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.43.1-1`

## controller_interface

```
* Add few warning compiler options to error (backport #1181 <https://github.com/ros-controls/ros2_control/issues/1181>) (#1816 <https://github.com/ros-controls/ros2_control/issues/1816>)
* Add -Wconversion flag to protect future developments (#1053 <https://github.com/ros-controls/ros2_control/issues/1053>) (#1815 <https://github.com/ros-controls/ros2_control/issues/1815>)
* Add PoseSensor semantic component (#1775 <https://github.com/ros-controls/ros2_control/issues/1775>) (#1785 <https://github.com/ros-controls/ros2_control/issues/1785>)
* Contributors: mergify[bot]
```

## controller_manager

```
* [ros2_control_node] Handle simulation environment clocks (backport #1810 <https://github.com/ros-controls/ros2_control/issues/1810>) (#1862 <https://github.com/ros-controls/ros2_control/issues/1862>)
* Change from thread_priority.hpp to realtime_helpers.hpp (backport #1829 <https://github.com/ros-controls/ros2_control/issues/1829>) (#1866 <https://github.com/ros-controls/ros2_control/issues/1866>)
* [ros2_control_node] Add option to set the CPU affinity  (backport #1852 <https://github.com/ros-controls/ros2_control/issues/1852>) (#1856 <https://github.com/ros-controls/ros2_control/issues/1856>)
* [ros2_control_node] Add the realtime_tools lock_memory method to prevent page faults (backport #1822 <https://github.com/ros-controls/ros2_control/issues/1822>) (#1850 <https://github.com/ros-controls/ros2_control/issues/1850>)
* fix: typo use thread_priority (backport #1844 <https://github.com/ros-controls/ros2_control/issues/1844>) (#1847 <https://github.com/ros-controls/ros2_control/issues/1847>)
* [Spawner] Add support for wildcard entries in the controller param files  (#1724 <https://github.com/ros-controls/ros2_control/issues/1724>) (#1835 <https://github.com/ros-controls/ros2_control/issues/1835>)
* Add test coverage for params_file parameter in spawner/unspawner tests (#1754 <https://github.com/ros-controls/ros2_control/issues/1754>) (#1838 <https://github.com/ros-controls/ros2_control/issues/1838>)
* Fix unload of controllers when spawned with --unload-on-kill (#1717 <https://github.com/ros-controls/ros2_control/issues/1717>) (#1842 <https://github.com/ros-controls/ros2_control/issues/1842>)
* add thread_priority option to the ros2_control_node (#1820 <https://github.com/ros-controls/ros2_control/issues/1820>) (#1824 <https://github.com/ros-controls/ros2_control/issues/1824>)
* Add few warning compiler options to error (backport #1181 <https://github.com/ros-controls/ros2_control/issues/1181>) (#1816 <https://github.com/ros-controls/ros2_control/issues/1816>)
* Add -Wconversion flag to protect future developments (#1053 <https://github.com/ros-controls/ros2_control/issues/1053>) (#1815 <https://github.com/ros-controls/ros2_control/issues/1815>)
* Fix timeout value in std output (backport #1807 <https://github.com/ros-controls/ros2_control/issues/1807>) (#1812 <https://github.com/ros-controls/ros2_control/issues/1812>)
* Improve launch utils to support the multiple controller names (#1782 <https://github.com/ros-controls/ros2_control/issues/1782>) (#1783 <https://github.com/ros-controls/ros2_control/issues/1783>)
* allow extra spawner arguments to not declare every argument in launch utils (#1505 <https://github.com/ros-controls/ros2_control/issues/1505>) (#1792 <https://github.com/ros-controls/ros2_control/issues/1792>)
* Refactor spawner to be able to reuse code for ros2controlcli (backport #1661 <https://github.com/ros-controls/ros2_control/issues/1661>) (#1695 <https://github.com/ros-controls/ros2_control/issues/1695>)
* [rqt_controller_manager] Add hardware components (#1455 <https://github.com/ros-controls/ros2_control/issues/1455>) (#1586 <https://github.com/ros-controls/ros2_control/issues/1586>)
* [CM] Handle other exceptions while loading the controller plugin (#1731 <https://github.com/ros-controls/ros2_control/issues/1731>) (#1733 <https://github.com/ros-controls/ros2_control/issues/1733>)
* [CM] Throw an exception when the components initially fail to be in the required state (backport #1729 <https://github.com/ros-controls/ros2_control/issues/1729>) (#1777 <https://github.com/ros-controls/ros2_control/issues/1777>)
* Fix spawner tests timeout on source builds (backport #1692 <https://github.com/ros-controls/ros2_control/issues/1692>) (#1697 <https://github.com/ros-controls/ros2_control/issues/1697>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add few warning compiler options to error (backport #1181 <https://github.com/ros-controls/ros2_control/issues/1181>) (#1816 <https://github.com/ros-controls/ros2_control/issues/1816>)
* Add -Wconversion flag to protect future developments (#1053 <https://github.com/ros-controls/ros2_control/issues/1053>) (#1815 <https://github.com/ros-controls/ros2_control/issues/1815>)
* Add resources_lock_ lock_guards to avoid race condition when loading robot_description through topic (backport #1451 <https://github.com/ros-controls/ros2_control/issues/1451>) (#1599 <https://github.com/ros-controls/ros2_control/issues/1599>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Add few warning compiler options to error (backport #1181 <https://github.com/ros-controls/ros2_control/issues/1181>) (#1816 <https://github.com/ros-controls/ros2_control/issues/1816>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Add few warning compiler options to error (backport #1181 <https://github.com/ros-controls/ros2_control/issues/1181>) (#1816 <https://github.com/ros-controls/ros2_control/issues/1816>)
* Add -Wconversion flag to protect future developments (#1053 <https://github.com/ros-controls/ros2_control/issues/1053>) (#1815 <https://github.com/ros-controls/ros2_control/issues/1815>)
* Contributors: mergify[bot]
```

## ros2_control

```
* Add custom rosdoc2 config for ros2_control metapackage (#1484 <https://github.com/ros-controls/ros2_control/issues/1484>) (#1588 <https://github.com/ros-controls/ros2_control/issues/1588>)
* Contributors: mergify[bot]
```

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Refactor spawner to be able to reuse code for ros2controlcli (backport #1661 <https://github.com/ros-controls/ros2_control/issues/1661>) (#1695 <https://github.com/ros-controls/ros2_control/issues/1695>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* fix: call configure_controller  on 'unconfigured' state instead load_controller (#1794 <https://github.com/ros-controls/ros2_control/issues/1794>) (#1797 <https://github.com/ros-controls/ros2_control/issues/1797>)
* [rqt_controller_manager] Add hardware components (#1455 <https://github.com/ros-controls/ros2_control/issues/1455>) (#1586 <https://github.com/ros-controls/ros2_control/issues/1586>)
* Contributors: mergify[bot]
```

## transmission_interface

```
* Add few warning compiler options to error (backport #1181 <https://github.com/ros-controls/ros2_control/issues/1181>) (#1816 <https://github.com/ros-controls/ros2_control/issues/1816>)
* Add -Wconversion flag to protect future developments (#1053 <https://github.com/ros-controls/ros2_control/issues/1053>) (#1815 <https://github.com/ros-controls/ros2_control/issues/1815>)
* Contributors: mergify[bot]
```
