### PR TITLE
ros2_controllers: 2.38.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7877,6 +7877,7 @@ repositories:
       - joint_state_broadcaster
       - joint_trajectory_controller
       - pid_controller
+      - pose_broadcaster
       - position_controllers
       - range_sensor_broadcaster
       - ros2_controllers
@@ -7889,7 +7890,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.37.3-1
+      version: 2.38.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.38.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.37.3-1`

## ackermann_steering_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## admittance_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## effort_controllers

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## force_torque_sensor_broadcaster

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## gripper_controllers

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* [JSB] Fix the behaviour of publishing unavailable state interfaces when they are previously available (#1331 <https://github.com/ros-controls/ros2_controllers/issues/1331>) (#1339 <https://github.com/ros-controls/ros2_controllers/issues/1339>)
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* [JTC] Fix the JTC length_error exceptions in the tests (backport #1360 <https://github.com/ros-controls/ros2_controllers/issues/1360>) (#1361 <https://github.com/ros-controls/ros2_controllers/issues/1361>)
* [jtc] Improve trajectory sampling efficiency (#1297 <https://github.com/ros-controls/ros2_controllers/issues/1297>) (#1357 <https://github.com/ros-controls/ros2_controllers/issues/1357>)
* fixes for windows compilation (#1330 <https://github.com/ros-controls/ros2_controllers/issues/1330>) (#1332 <https://github.com/ros-controls/ros2_controllers/issues/1332>)
* [JTC] Add Parameter to Toggle State Setting on Activation (backport #1231 <https://github.com/ros-controls/ros2_controllers/issues/1231>) (#1320 <https://github.com/ros-controls/ros2_controllers/issues/1320>)
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## pid_controller

```
* fixes for windows compilation (#1330 <https://github.com/ros-controls/ros2_controllers/issues/1330>) (#1332 <https://github.com/ros-controls/ros2_controllers/issues/1332>)
* Contributors: mergify[bot]
```

## pose_broadcaster

```
* Implement new PoseBroadcaster controller (backport #1311 <https://github.com/ros-controls/ros2_controllers/issues/1311>) (#1326 <https://github.com/ros-controls/ros2_controllers/issues/1326>)
* Contributors: mergify[bot]
```

## position_controllers

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* fix(steering-odometry): convert twist to steering angle (#1288 <https://github.com/ros-controls/ros2_controllers/issues/1288>) (#1295 <https://github.com/ros-controls/ros2_controllers/issues/1295>)
* fix(steering-odometry): handle infinite turning radius properly (#1285 <https://github.com/ros-controls/ros2_controllers/issues/1285>) (#1286 <https://github.com/ros-controls/ros2_controllers/issues/1286>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```

## velocity_controllers

```
* Added -Wconversion flag and fix warnings (#667 <https://github.com/ros-controls/ros2_controllers/issues/667>) (#1321 <https://github.com/ros-controls/ros2_controllers/issues/1321>)
* Contributors: mergify[bot]
```
