### PR TITLE
adi_tmcl: 4.0.2-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -114,7 +114,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/adi_tmcl-release.git
-      version: 4.0.1-3
+      version: 4.0.2-2
     source:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_tmcl` to `4.0.2-2`:

- upstream repository: https://github.com/analogdevicesinc/tmcl_ros.git
- release repository: https://github.com/ros2-gbp/adi_tmcl-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-3`

## adi_tmcl

```
* Added support for TMCM-1316.
  Rename Maintainer name in package.xml
* Contributors: CAcarADI, jmacagba
```
