### PR TITLE
pal_maps: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5922,7 +5922,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_maps-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_maps` to `0.0.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_maps.git
- release repository: https://github.com/pal-gbp/pal_maps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-1`

## pal_maps

```
* Merge branch 'man/feat/w' into 'humble-devel'
  added willow garage
  See merge request navigation/pal_maps!5
* added willow garage
* Contributors: andreacapodacqua, martinaannicelli
```
