### PR TITLE
add clips_vendor to index of current distros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1355,6 +1355,12 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_simulator.git
       version: main
     status: developed
+  clips_vendor:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_vendor.git
+      version: main
+    status: maintained
   cob_common:
     doc:
       type: git
@@ -1373,12 +1379,6 @@ repositories:
       type: git
       url: https://github.com/4am-robotics/cob_common.git
       version: foxy
-    status: maintained
-  clips_vendor:
-    source:
-      type: git
-      url: https://github.com/carologistics/clips_vendor.git
-      version: main
     status: maintained
   color_names:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1374,6 +1374,12 @@ repositories:
       url: https://github.com/4am-robotics/cob_common.git
       version: foxy
     status: maintained
+  clips_vendor:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_vendor.git
+      version: main
+    status: maintained
   color_names:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -951,6 +951,12 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clips_vendor:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_vendor.git
+      version: main
+    status: maintained
   color_names:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -901,6 +901,12 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clips_vendor:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_vendor.git
+      version: main
+    status: maintained
   color_names:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble jazzy and rolling

# The source is here:

https://github.com/carologistics/clips_vendor

# Checks
 - [] All packages have a declared license in the package.xml
 - [] This repository has a LICENSE file
 - [] This package is expected to build on the submitted rosdistro

# Explanation
I would like to vendor CLIPS (https://clipsrules.net/) as a preparation for releasing a high-level knowledge-based reasoning framework [the CLIPS-Executive](https://github.com/fawkesrobotics/ros2-clips-executive/tree/tviehmann/major-cleanup) for ROS 2 using it. We have been using CLIPS for many years now, but never went through with actually making it available to the ROS ecosystem, which I now want to correct.

A very old version of CLIPS is available in Ubuntu already (https://packages.ubuntu.com/noble/clips) (Version 6.30-4.1build1) as well as on fedora (https://packages.fedoraproject.org/pkgs/clips/clips/) with version 6.31-10.
However, Version 6.4x has been around for years now, offering a more modern API  and version 7 is currently being developed as well.

Packaging CLIPS is a bit of a hassle as it is plain C code and makefiles (and the build system in general is minimalistic, not compiling shared libraries).
The packaged versions for Ubuntu and Fedora use plain makefiles and provide pkg-config files for projects.

To make it broadly available in the ROS ecosystem I instead  wrote a new CMake based buildsys that is used by the proposed clips_vendor package, which allows for a way easier integration with other ROS projects and offers some additional QoL things such as optionally building the java-based examples and IDE.

The vendor package exposes 3 ways of leveraging CLIPS, as plain C library, as C++ library or as C++ library with added namespaces (by automatically wrapping every code block with a namespace). The latter variant is what I would recommend for usage to minimize the amount of unintentional interference with other libraries (which is sadly still unavoidable to some extend due to the large number of preprocessor macros used throughout CLIPS). 

The package is building fine on Ubuntu and Fedora (tested on humble and jazzy and saw no breaking changes in rolling), I have no Windows setup to test it on at the moment, but CLIPS itself is compatible with Windows and therefore I only expect some tweaking to be necessary (if at all) to make it available on Windows.

There will be two warnings when building (and I already oppressed many more):
```bash
/home/tviehmann/ros2/clips_ws/build/clips_vendor/clips_vendor-prefix/src/clips_vendor/core/textpro.c:714:25: warning: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
  714 |     theString = genalloc(theEnv,length+1);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~
      |                         |
      |                         void*
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-invalid-cast’ may have been intended to silence earlier diagnostics
/home/tviehmann/ros2/clips_ws/build/clips_vendor/clips_vendor-prefix/src/clips_vendor-build/ns_core/textpro.c: In function ‘clips::TextProError clips::ParseLine(Environment*, const char*, int*, char*, char**)’:
/home/tviehmann/ros2/clips_ws/build/clips_vendor/clips_vendor-prefix/src/clips_vendor-build/ns_core/textpro.c:723:25: warning: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
  723 |     theString = genalloc(theEnv,length+1);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~
      |                         |
      |                         void*
```
I could patch them out in principle, but for maintainability I so far tried to stay away from patching individual things in CLIPS (I am not the maintainer of CLIPS, just an enthusiastic user).

Once the package is indexed I intend to start the release procedure, following the documentation of releasing a package.
So feedback is very welcome :) 