### PR TITLE
locator_ros_bridge: 1.0.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5397,7 +5397,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/locator_ros_bridge-release.git
-      version: 1.0.11-2
+      version: 1.0.13-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `1.0.13-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.11-2`

## bosch_locator_bridge

```
* update tag compatible with Locator 1.9
* Update to Locator 1.10 #67 <https://github.com/boschglobal/locator_ros_bridge/issues/67> from boschglobal/noetic-v1.10""
* Contributors: Sheung Ying Yuen-Wille
```
