### PR TITLE
mp2p_icp: 1.6.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6299,7 +6299,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mp2p_icp-release.git
-      version: 1.6.2-2
+      version: 1.6.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.6.3-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/mrpt-ros-pkg-release/mp2p_icp-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.2-2`

## mp2p_icp

```
* icp-log-viewer: also reduce GUI refresh rate
* mm-viewer: avoid useless GUI refresh (CPU usage reduction)
* txt2mm: Add input filter xyzrgb
* mm-viewer: add a 'fit view to map' button
* New cli app rawlog-filter
* FilterCurvature: better handling scans with <=3 points in some rings
* new subcommand 'sm-cli tf'
* Contributors: Jose Luis Blanco-Claraco
```
