### PR TITLE
mp2p_icp: 1.6.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4868,7 +4868,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.6.2-1
+      version: 1.6.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.6.3-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.2-1`

## mp2p_icp

```
* icp-log-viewer: also reduce GUI refresh rate
* mm-viewer: avoid useless GUI refresh (CPU usage reduction)
* txt2mm: Add input filter xyzrgb
* mm-viewer: add a 'fit view to map' button
* New cli app rawlog-filter
* FilterCurvature: better handling scans with <=3 points in some rings
* new subcommand 'sm-cli tf'
* Contributors: Jose Luis Blanco-Claraco
```
