### PR TITLE
rosbag2: 0.22.8-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6411,7 +6411,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.22.7-1
+      version: 0.22.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.22.8-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.22.7-1`

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Bugfix for rosbag2_cpp serialization converter (#1823 <https://github.com/ros2/rosbag2/issues/1823>)
* Allow unknown types in bag rewrite (#1818 <https://github.com/ros2/rosbag2/issues/1818>)
* Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1766 <https://github.com/ros2/rosbag2/issues/1766>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Bugfix for wrong timestamps in ros2 bag info (#1753 <https://github.com/ros2/rosbag2/issues/1753>)
* Contributors: Michael Orlov
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

```
* Add topics with zero message counts to the SQLiteStorage::get_metadata(). (#1766 <https://github.com/ros2/rosbag2/issues/1766>)
* Fix for failing throws_on_invalid_pragma_in_config_file on Windows (#1747 <https://github.com/ros2/rosbag2/issues/1747>)
* Contributors: Michael Orlov
```

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Bugfix for wrong timestamps in ros2 bag info (#1753 <https://github.com/ros2/rosbag2/issues/1753>)
* Contributors: Michael Orlov
```

## rosbag2_transport

```
* Allow unknown types in bag rewrite (#1818 <https://github.com/ros2/rosbag2/issues/1818>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
