### PR TITLE
rosdep: Add libexif and libexif-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3503,6 +3503,32 @@ libevent-dev:
   opensuse: [libevent-devel]
   rhel: [libevent-devel]
   ubuntu: [libevent-dev]
+libexif:
+  alpine: [libexif]
+  arch: [libexif]
+  debian: [libexif12]
+  fedora: [libexif]
+  gentoo: [media-libs/libexif]
+  nixos: [libexif]
+  opensuse: [libexif]
+  osx:
+    homebrew:
+      packages: [libexif]
+  rhel: [libexif]
+  ubuntu: [libexif12]
+libexif-dev:
+  alpine: [libexif-dev]
+  arch: [libexif]
+  debian: [libexif-dev]
+  fedora: [libexif-devel]
+  gentoo: [media-libs/libexif]
+  nixos: [libexif]
+  opensuse: [libexif]
+  osx:
+    homebrew:
+      packages: [libexif]
+  rhel: [libexif-devel]
+  ubuntu: [libexif-dev]
 libexpat1-dev:
   arch: [expat]
   debian: [libexpat1-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libexif

## Package Upstream Source:

https://libexif.github.io/

## Purpose of using this:

C++ API for parsing EXIF metadata.

Distro packaging links:

## Links to Distribution Packages

### libexif

- Debian: https://packages.debian.org/buster/libexif12
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/libexif12
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/libexif/libexif/
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/extra/x86_64/libexif/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/media-libs/libexif
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/libexif
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/libexif
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=libexif&from=0&size=50&sort=relevance&type=packages&query=libexif
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/libexif
  - IF AVAILABLE
- rhel: https://centos.pkgs.org/9-stream/centos-appstream-x86_64/libexif-0.6.22-6.el9.x86_64.rpm.html
  - IF AVAILABLE

### libexif-dev

- Debian: https://packages.debian.org/buster/libexif-dev
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/libexif-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/libexif/libexif-devel/
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/extra/x86_64/libexif/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/media-libs/libexif
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/libexif
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/libexif-dev
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=libexif&from=0&size=50&sort=relevance&type=packages&query=libexif
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/libexif
  - IF AVAILABLE
- rhel: https://centos.pkgs.org/9-stream/centos-crb-x86_64/libexif-devel-0.6.22-6.el9.x86_64.rpm.html
  - IF AVAILABLE
