### PR TITLE
slg_msgs: 3.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7400,6 +7400,11 @@ repositories:
       type: git
       url: https://github.com/ajtudela/slg_msgs.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/slg_msgs-release.git
+      version: 3.9.1-1
     source:
       type: git
       url: https://github.com/ajtudela/slg_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slg_msgs` to `3.9.1-1`:

- upstream repository: https://github.com/ajtudela/slg_msgs.git
- release repository: https://github.com/ros2-gbp/slg_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## slg_msgs

```
* Update to use modern CMake idioms.
```
