### PR TITLE
Add python3-fabric to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5801,13 +5801,13 @@ python3-fabric:
     pip:
       packages: [fabric]
   nixos: [Fabric]
-  opensuse: [python-fabric]
+  opensuse: [python-Fabric]
   osx: [fabric]
   rhel:
     '*': [python3-fabric]
     '8':
       pip:
-        packages: [fabric]    
+        packages: [fabric]
   ubuntu: [python3-fabric]
 python3-falcon:
   arch: [python-falcon]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5792,6 +5792,23 @@ python3-ezdxf:
     focal:
       pip:
         packages: [ezdxf]
+python3-fabric:
+  alpine: [fabric]
+  arch: [fabric]
+  debian: [python3-fabric]
+  fedora: [python3-fabric]
+  gentoo:
+    pip:
+      packages: [fabric]
+  nixos: [Fabric]
+  opensuse: [python-fabric]
+  osx: [fabric]
+  rhel:
+    '*': [python3-fabric]
+    '8':
+      pip:
+        packages: [fabric]    
+  ubuntu: [python3-fabric]
 python3-falcon:
   arch: [python-falcon]
   debian: [python3-falcon]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-fabric

## Package Upstream Source:

https://github.com/fabric/fabric

## Purpose of using this:

Fabric is a Python3 utility library for remote execution of processes using SSH with first-class citizens for ssh-connection, processes, etc.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/python3-fabric
- Ubuntu: https://packages.ubuntu.com/noble/python3-fabric
- Fedora: https://packages.fedoraproject.org/pkgs/python-fabric/python3-fabric/
- Arch: https://archlinux.org/packages/extra/any/fabric/
- Gentoo: not available
- macOS: https://formulae.brew.sh/formula/fabric
- Alpine: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/fabric
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=Fabric
- openSUSE: https://software.opensuse.org/package/python-Fabric
- rhel: https://rhel.pkgs.org/9/epel-x86_64/python3-fabric-2.7.0-2.el9.noarch.rpm.html (9 only)

