### PR TITLE
ros2_control: 3.30.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5994,7 +5994,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 3.29.0-1
+      version: 3.30.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `3.30.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.29.0-1`

## controller_interface

```
* [CM] Fix controller missing update cycles in a real setup (#1774 <https://github.com/ros-controls/ros2_control/issues/1774>) (#1858 <https://github.com/ros-controls/ros2_control/issues/1858>)
* Contributors: mergify[bot]
```

## controller_manager

```
* [ros2_control_node] Handle simulation environment clocks (backport #1810 <https://github.com/ros-controls/ros2_control/issues/1810>) (#1863 <https://github.com/ros-controls/ros2_control/issues/1863>)
* Fix CMP0115 (#1830 <https://github.com/ros-controls/ros2_control/issues/1830>) (#1849 <https://github.com/ros-controls/ros2_control/issues/1849>)
* Fix Hardware spawner and add tests for it (backport #1759 <https://github.com/ros-controls/ros2_control/issues/1759>) (#1828 <https://github.com/ros-controls/ros2_control/issues/1828>)
* Change from thread_priority.hpp to realtime_helpers.hpp (backport #1829 <https://github.com/ros-controls/ros2_control/issues/1829>) (#1867 <https://github.com/ros-controls/ros2_control/issues/1867>)
* [CM] Fix controller missing update cycles in a real setup (#1774 <https://github.com/ros-controls/ros2_control/issues/1774>) (#1858 <https://github.com/ros-controls/ros2_control/issues/1858>)
* [ros2_control_node] Add option to set the CPU affinity  (#1852 <https://github.com/ros-controls/ros2_control/issues/1852>) (#1857 <https://github.com/ros-controls/ros2_control/issues/1857>)
* [ros2_control_node] Add the realtime_tools lock_memory method to prevent page faults (backport #1822 <https://github.com/ros-controls/ros2_control/issues/1822>) (#1851 <https://github.com/ros-controls/ros2_control/issues/1851>)
* fix: typo use thread_priority (backport #1844 <https://github.com/ros-controls/ros2_control/issues/1844>) (#1846 <https://github.com/ros-controls/ros2_control/issues/1846>)
* [Spawner] Add support for wildcard entries in the controller param files  (#1724 <https://github.com/ros-controls/ros2_control/issues/1724>) (#1836 <https://github.com/ros-controls/ros2_control/issues/1836>)
* Add test coverage for params_file parameter in spawner/unspawner tests (backport #1754 <https://github.com/ros-controls/ros2_control/issues/1754>) (#1839 <https://github.com/ros-controls/ros2_control/issues/1839>)
* Fix unload of controllers when spawned with --unload-on-kill (#1717 <https://github.com/ros-controls/ros2_control/issues/1717>) (#1843 <https://github.com/ros-controls/ros2_control/issues/1843>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
