### PR TITLE
rmf_simulation: 2.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5604,7 +5604,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.4.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.0-1`

## rmf_building_sim_gz_plugins

```
* Add environment hooks for plugins path (#136 <https://github.com/open-rmf/rmf_simulation/issues/136>)
* Miscellaneous fixes for Ionic (#134 <https://github.com/open-rmf/rmf_simulation/issues/134>)
* Remove undefined behavior from the startup conditions (#132 <https://github.com/open-rmf/rmf_simulation/issues/132>)
* Contributors: Addisu Z. Taddese, Grey, Luca Della Vedova
```

## rmf_robot_sim_common

```
* Enable cart attachment in slotcar (#120 <https://github.com/open-rmf/rmf_simulation/issues/120>)
* Contributors: Luca Della Vedova, Xiyu
```

## rmf_robot_sim_gz_plugins

```
* Add environment hooks for plugins path (#136 <https://github.com/open-rmf/rmf_simulation/issues/136>)
* Miscellaneous fixes for Ionic (#134 <https://github.com/open-rmf/rmf_simulation/issues/134>)
* Enable cart attachment in slotcar (#120 <https://github.com/open-rmf/rmf_simulation/issues/120>)
* Contributors: Addisu Z. Taddese, Luca Della Vedova, Xiyu
```
