### PR TITLE
rmf_internal_msgs: 3.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5555,6 +5555,7 @@ repositories:
       - rmf_ingestor_msgs
       - rmf_lift_msgs
       - rmf_obstacle_msgs
+      - rmf_reservation_msgs
       - rmf_scheduler_msgs
       - rmf_site_map_msgs
       - rmf_task_msgs
@@ -5563,7 +5564,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.4.0-1
+      version: 3.4.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_internal_msgs` to `3.4.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_internal_msgs.git
- release repository: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-1`

## rmf_charger_msgs

- No changes

## rmf_dispenser_msgs

- No changes

## rmf_door_msgs

- No changes

## rmf_fleet_msgs

```
* Add attach cart actions (#70 <https://github.com/open-rmf/rmf_internal_msgs/issues/70>)
* Contributors: Luca Della Vedova, Xiyu
```

## rmf_ingestor_msgs

- No changes

## rmf_lift_msgs

- No changes

## rmf_obstacle_msgs

- No changes

## rmf_reservation_msgs

```
* Messages for proto-reservation system  (#64 <https://github.com/open-rmf/rmf_internal_msgs/issues/64>)
* Contributors: Arjo Chakravarty
```

## rmf_scheduler_msgs

- No changes

## rmf_site_map_msgs

- No changes

## rmf_task_msgs

```
* New alert messages (#71 <https://github.com/open-rmf/rmf_internal_msgs/issues/71>)
* Contributors: Aaron Chong
```

## rmf_traffic_msgs

- No changes

## rmf_workcell_msgs

- No changes
