### PR TITLE
Add python3-ollama-pip to rosdistro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7485,6 +7485,19 @@ python3-odrive-pip:
   ubuntu:
     pip:
       packages: [odrive]
+python3-ollama-pip:
+  debian:
+    pip:
+      packages: [ollama]
+  fedora:
+    pip:
+      packages: [ollama]
+  rhel:
+    pip:
+      packages: [ollama]
+  ubuntu:
+    pip:
+      packages: [ollama]
 python3-onnxruntime-gpu-pip:
   arch:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-ollama-pip

## Package Upstream Source:

https://github.com/ollama/ollama-python

## Purpose of using this:

This dependency allows access to ollama's servers for robot AI processing

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
    - pip
        - https://pypi.org/project/ollama/
- Ubuntu: https://packages.ubuntu.com/
   - pip
        - https://pypi.org/project/ollama/
- Fedora: https://packages.fedoraproject.org/
    - pip
        - https://pypi.org/project/ollama/
- rhel: https://rhel.pkgs.org/
    - pip
        - https://pypi.org/project/ollama/