### PR TITLE
Add `psmisc` to rosdep database 

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7804,6 +7804,7 @@ ps-engine:
   fedora: [openni-primesense]
   ubuntu: [ps-engine]
 psmisc:
+  alpine: [psmisc]
   arch: [psmisc]
   debian: [psmisc]
   fedora: [psmisc]
@@ -7812,6 +7813,7 @@ psmisc:
   nixos: [psmisc]
   openembedded: [psmisc@openembedded-core]
   opensuse: [psmisc]
+  rhel: [psmisc]
   ubuntu: [psmisc]
 pstoedit:
   arch: [pstoedit]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7803,6 +7803,17 @@ ps-engine:
   debian: [ps-engine]
   fedora: [openni-primesense]
   ubuntu: [ps-engine]
+psmisc:
+  arch: [psmisc]
+  debian: [psmisc]
+  fedora: [psmisc]
+  freebsd: [psmisc]
+  gentoo: [sys-process/psmisc]
+  nixos: [psmisc]
+  openembedded: [psmisc@openembedded-core]
+  opensuse: [psmisc]
+  rhel: [psmisc]
+  ubuntu: [psmisc]
 pstoedit:
   arch: [pstoedit]
   debian: [pstoedit]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7812,7 +7812,6 @@ psmisc:
   nixos: [psmisc]
   openembedded: [psmisc@openembedded-core]
   opensuse: [psmisc]
-  rhel: [psmisc]
   ubuntu: [psmisc]
 pstoedit:
   arch: [pstoedit]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

psmisc

## Package Upstream Source:

https://gitlab.com/psmisc/psmisc

## Purpose of using this:

A fast solution to monitor file/share object open by which processes

Distro packaging links:

## Links to Distribution Packages

- Alpine: https://pkgs.alpinelinux.org
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/psmisc
- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/psmisc
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/oracular/psmisc
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/psmisc/psmisc/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/core/x86_64/psmisc/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-process/psmisc
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.05&show=psmisc&from=0&size=50&sort=relevance&type=packages&query=psmisc
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/psmisc