### PR TITLE
Add python3-validators to rosdistro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10257,7 +10257,7 @@ python3-validators:
   debian: [python3-validators]
   fedora: [python3-validators]
   opensuse: [python3-validators]
-  ubuntu: 
+  ubuntu:
     '*': [python3-validators]
     focal: null
 python3-vcstool:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10257,14 +10257,9 @@ python3-validators:
   debian: [python3-validators]
   fedora: [python3-validators]
   opensuse: [python3-validators]
-  ubuntu:
+  ubuntu: 
     '*': [python3-validators]
-    bionic:
-      pip:
-        packages: [validators]
-    focal:
-      pip:
-        packages: [validators]
+    focal: null
 python3-vcstool:
   alpine: [vcstool]
   debian: [python3-vcstool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10256,6 +10256,7 @@ python3-uvloop:
 python3-validators:
   debian: [python3-validators]
   fedora: [python3-validators]
+  opensuse: [python3-validators]
   ubuntu:
     '*': [python3-validators]
     bionic:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10253,19 +10253,10 @@ python3-uvloop:
   nixos: [python3Packages.uvloop]
   openembedded: [python3-uvloop@meta-ros2]
   ubuntu: [python3-uvloop]
-python3-validators-pip:
-  debian:
-    pip:
-      packages: [validotors]
-  fedora:
-    pip:
-      packages: [validotors]
-  rhel:
-    pip:
-      packages: [validotors]
-  ubuntu:
-    pip:
-      packages: [validotors]
+python3-validators:
+  debian: [python3-validators]
+  fedora: [python3-validators]
+  ubuntu: [python3-validators]
 python3-vcstool:
   alpine: [vcstool]
   debian: [python3-vcstool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10253,6 +10253,19 @@ python3-uvloop:
   nixos: [python3Packages.uvloop]
   openembedded: [python3-uvloop@meta-ros2]
   ubuntu: [python3-uvloop]
+python3-validators-pip:
+  debian:
+    pip:
+      packages: [validotors]
+  fedora:
+    pip:
+      packages: [validotors]
+  rhel:
+    pip:
+      packages: [validotors]
+  ubuntu:
+    pip:
+      packages: [validotors]
 python3-vcstool:
   alpine: [vcstool]
   debian: [python3-vcstool]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10256,7 +10256,14 @@ python3-uvloop:
 python3-validators:
   debian: [python3-validators]
   fedora: [python3-validators]
-  ubuntu: [python3-validators]
+  ubuntu:
+    '*': [python3-validators]
+    bionic:
+      pip:
+        packages: [validators]
+    focal:
+      pip:
+        packages: [validators]
 python3-vcstool:
   alpine: [vcstool]
   debian: [python3-vcstool]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-validators-pip

## Package Upstream Source:

https://github.com/python-validators/validators/

## Purpose of using this:

For robot AI processing, while using AI python packages like openai or ollama, they will rely on this python package.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
    - pip
        - https://pypi.org/project/validators/
- Ubuntu: https://packages.ubuntu.com/
   - pip
        - https://pypi.org/project/validators/
- Fedora: https://packages.fedoraproject.org/
    - pip
        - https://pypi.org/project/validators/
- rhel: https://rhel.pkgs.org/
    - pip
        - https://pypi.org/project/validators/