### PR TITLE
feetech_ros2_driver: 0.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1565,6 +1565,21 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.14.x
     status: maintained
+  feetech_ros2_driver:
+    doc:
+      type: git
+      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/JafarAbdi/feetech_ros2_driver-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      version: main
+    status: developed
   ffmpeg_encoder_decoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `feetech_ros2_driver` to `0.1.0-1`:

- upstream repository: https://github.com/JafarAbdi/feetech_ros2_driver.git
- release repository: https://github.com/JafarAbdi/feetech_ros2_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## feetech_ros2_driver

```
* Add feetech ros2 driver
* Contributors: Jafar Uruç
```
