### PR TITLE
jacro: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3491,6 +3491,17 @@ repositories:
       type: git
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
       version: humble
+  jacro:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/JafarAbdi/jacro-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/jacro.git
+      version: main
+    status: developed
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jacro` to `0.2.0-1`:

- upstream repository: https://github.com/JafarAbdi/jacro.git
- release repository: https://github.com/JafarAbdi/jacro-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## jacro

```
* Replace minijinja with jinja2
* Contributors: JafarAbdi
```
