### PR TITLE
jacro: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2972,6 +2972,17 @@ repositories:
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
       version: rolling
     status: developed
+  jacro:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/JafarAbdi/jacro-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/jacro.git
+      version: main
+    status: developed
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jacro` to `0.2.0-1`:

- upstream repository: https://github.com/JafarAbdi/jacro.git
- release repository: https://github.com/JafarAbdi/jacro-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## jacro

```
* Replace minijinja with jinja2
* Contributors: JafarAbdi
```
