### PR TITLE
ros_inorbit_samples: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9746,13 +9746,17 @@ repositories:
       version: master
     status: developed
   ros_inorbit_samples:
+    doc:
+      type: git
+      url: https://github.com/inorbit-ai/ros_inorbit_samples.git
+      version: noetic-devel
     release:
       packages:
       - inorbit_republisher
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/inorbit-ai/ros_inorbit_samples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.3.1-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## inorbit_republisher

```
* Fix LatchPublisher peer_subscribe to publish all key-values (#25 <https://github.com/inorbit-ai/ros_inorbit_samples/issues/25>)
* Contributors: Leandro
```
