### PR TITLE
[rosdep] no more distutils as of Python 3.12

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5583,13 +5583,19 @@ python3-distro:
   ubuntu: [python3-distro]
 python3-distutils:
   debian:
-    '*': [python3-distutils]
+    '*': null
+    bookworm: [python3-distutils]
+    bullseye: [python3-distutils]
+    buster: [python3-distutils]
     stretch: null
   fedora: [python3]
   gentoo: [dev-lang/python]
   nixos: [python3]
   ubuntu:
-    '*': [python3-distutils]
+    '*': null
+    bionic: [python3-distutils]
+    focal: [python3-distutils]
+    jammy: [python3-distutils]
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]


### PR DESCRIPTION
As per PEP 632 https://peps.python.org/pep-0632/ distutils has been deprecated from Python 3.10 and is not distributed as of Python 3.12.

The package cannot be installed on newer platforms.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

This PR mark explicitly past distros as providing the package and defaults to null for all other distros.

- Debian: https://packages.debian.org/search?keywords=python3-distutils&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-distutils&searchon=names&suite=all&section=all

Not sure how to deal with other distros that juste reference python standard library