### PR TITLE
Add python3-streamz to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9886,6 +9886,18 @@ python3-streamlit-pip:
   '*':
     pip:
       packages: [streamlit]
+python3-streamz:
+  debian:
+    bookworm: [python3-streamz]
+    bullseye: [python3-streamz]
+  ubuntu:
+    '*': [python3-streamz]
+    bionic:
+      pip:
+        packages: [streamz]
+    focal:
+      pip:
+        packages: [streamz]
 python3-suas-interop-clients-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9892,9 +9892,6 @@ python3-streamz:
     bullseye: [python3-streamz]
   ubuntu:
     '*': [python3-streamz]
-    bionic:
-      pip:
-        packages: [streamz]
     focal:
       pip:
         packages: [streamz]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9890,6 +9890,7 @@ python3-streamz:
   debian:
     bookworm: [python3-streamz]
     bullseye: [python3-streamz]
+  opensuse: [python3-streamz]
   ubuntu:
     '*': [python3-streamz]
     focal:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-streamz`: Pipelines to manage continuous streams of data

## Package Upstream Source:

https://github.com/python-streamz/streamz/

## Purpose of using this:

We use `streamz` to apply a sliding window average on raw input data for logging and user interface.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=streamz&searchon=names&suite=stable&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/oracular/python3-streamz
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/nixos-24.05/pkgs/development/python-modules/streamz/default.nix#L83
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-streamz
- rhel: https://rhel.pkgs.org/
  - https://debian.pkgs.org/12/debian-main-amd64/python3-streamz_0.6.4-1_all.deb.html


