### PR TITLE
ur_robot_driver: 2.3.12-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -8440,7 +8440,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.3.11-2
+      version: 2.3.12-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.12-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.11-2`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* [SJTC] Make scaling interface optional (#1145 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1145>) (#1171 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1171>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Use pose_broadcaster to publish the TCP pose (#1108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1108>) (#1182 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1182>)
  Adds a broadcaster for the robot's TCP pose.
* Contributors: Felix Exner
```
