### PR TITLE
soar_ros: Add documentation

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9604,6 +9604,11 @@ repositories:
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
       version: ros2
     status: maintained
+  soar_ros:
+    doc:
+      type: git
+      url: https://github.com/THA-Embedded-Systems-Lab/soar_ros.git
+      version: main
   soccer_interfaces:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

- HUMBLE

# The source is here:

https://github.com/THA-Embedded-Systems-Lab/soar_ros

# Checks

 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
