### PR TITLE
laser_segmentation: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2935,6 +2935,11 @@ repositories:
       type: git
       url: https://github.com/ajtudela/laser_segmentation.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_segmentation-release.git
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ajtudela/laser_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_segmentation` to `3.0.2-1`:

- upstream repository: https://github.com/ajtudela/laser_segmentation.git
- release repository: https://github.com/ros2-gbp/laser_segmentation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## laser_segmentation

```
* Update to use modern CMake idioms.
```
