### PR TITLE
add ROS Agents to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -155,6 +155,16 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/affordance_primitives.git
       version: main
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ai_prompt_msgs:
     doc:
       type: git
@@ -9810,16 +9820,6 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git
-      version: main
-    status: developed
-  sugar:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
       version: main
     status: developed
   swri_console:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -155,6 +155,16 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/affordance_primitives.git
       version: main
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ai_prompt_msgs:
     doc:
       type: git
@@ -3677,6 +3687,16 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
+  kompass:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   kuka_drivers:
     doc:
       type: git
@@ -9810,6 +9830,16 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/stubborn_buddies.git
+      version: main
+    status: developed
+  sugar:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
       version: main
     status: developed
   swri_console:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -155,16 +155,6 @@ repositories:
       type: git
       url: https://github.com/PickNikRobotics/affordance_primitives.git
       version: main
-  agents:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    status: developed
   ai_prompt_msgs:
     doc:
       type: git
@@ -3687,16 +3677,6 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
-  kompass:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    status: developed
   kuka_drivers:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -79,6 +79,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git
@@ -2712,6 +2722,16 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
+  kompass:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   lanelet2:
     doc:
       type: git
@@ -7816,6 +7836,16 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
+  sugar:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    status: developed
   swri_console:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -79,6 +79,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git
@@ -7822,16 +7832,6 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
-  sugar:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    status: developed
   swri_console:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -79,16 +79,6 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
-  agents:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    status: developed
   ament_acceleration:
     doc:
       type: git
@@ -2722,16 +2712,6 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
-  kompass:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    status: developed
   lanelet2:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -79,16 +79,6 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
-  agents:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    status: developed
   ament_acceleration:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ai_prompt_msgs:
     doc:
       type: git
@@ -8265,16 +8275,6 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
-  sugar:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    status: developed
   swri_console:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ai_prompt_msgs:
     doc:
       type: git
@@ -3133,6 +3143,16 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
+  kompass:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   lanelet2:
     doc:
       type: git
@@ -8265,6 +8285,16 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
+  sugar:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    status: developed
   swri_console:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -80,16 +80,6 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
-  agents:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    status: developed
   ai_prompt_msgs:
     doc:
       type: git
@@ -3143,16 +3133,6 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
-  kompass:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    status: developed
   lanelet2:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git
@@ -7666,16 +7676,6 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
-  sugar:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-sugar.git
-      version: main
-    status: developed
   swri_console:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -80,16 +80,6 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
-  agents:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/ros-agents.git
-      version: main
-    status: developed
   ament_acceleration:
     doc:
       type: git
@@ -2870,16 +2860,6 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
-  kompass:
-    doc:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/automatika-robotics/kompass.git
-      version: main
-    status: developed
   lanelet2:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   ament_acceleration:
     doc:
       type: git
@@ -2860,6 +2870,16 @@ repositories:
       url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
       version: release/0.15.x
     status: maintained
+  kompass:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   lanelet2:
     doc:
       type: git
@@ -7631,6 +7651,16 @@ repositories:
       url: https://github.com/ros-industrial/stomp.git
       version: main
     status: maintained
+  sugar:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    status: developed
   swri_console:
     doc:
       type: git


### PR DESCRIPTION
# Please add agents to be indexed in the rosdistro

## Package name:

`agents`

## Package Upstream Source:

https://github.com/automatika-robotics/ros-agents.git

## Purpose of using this:

`agents` is  a fully-loaded framework for creating interactive embodied agents that can understand, remember, and act upon contextual information from their environment


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro