### PR TITLE
Fix jupyter-notebook for nixos

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -271,7 +271,7 @@ jupyter-notebook:
   debian:
     '*': [jupyter-notebook]
   fedora: [python3-notebook]
-  nixos: [jupyter]
+  nixos: [python3Packages.notebook]
   ubuntu:
     '*': [jupyter-notebook]
 libgv-python:


### PR DESCRIPTION
The nixpkgs `jupyter` package is a kind of meta-package designed for interactive use. It causes problems with used as a dependency alongside other Python packages. Instead, depend on the `notebook` package, which matches what is done for the other distros.

Before this change, `tracetools_analysis` failed to build:
```
Found duplicated packages in closure for dependency 'python_dateutil': 
  python_dateutil 2.9.0.post0 (/nix/store/vhxyf7q8cc3600sa34zlj7p2yim6grw7-python3-3.12.5-env)
    dependency chain:
      this derivation: /nix/store/pvvb1jfw6c4n0m4pl1hziq3g783cmby7-python3.12-ros-rolling-tracetools-analysis-3.1.0-r1
      ...depending on: /nix/store/vhxyf7q8cc3600sa34zlj7p2yim6grw7-python3-3.12.5-env
  python_dateutil 2.9.0.post0 (/nix/store/22d4sr968zx6l3sl7xrzcq4z18frqb7m-python3.12-python-dateutil-2.9.0.post0)
    dependency chain:
      this derivation: /nix/store/pvvb1jfw6c4n0m4pl1hziq3g783cmby7-python3.12-ros-rolling-tracetools-analysis-3.1.0-r1
      ...depending on: /nix/store/v6qwrli608p7v2qaxn3vhphzq4dw3s8l-python3.12-pandas-2.2.2
      ...depending on: /nix/store/22d4sr968zx6l3sl7xrzcq4z18frqb7m-python3.12-python-dateutil-2.9.0.post0
Found duplicated packages in closure for dependency 'six': 
  six 1.16.0 (/nix/store/vhxyf7q8cc3600sa34zlj7p2yim6grw7-python3-3.12.5-env)
    dependency chain:
      this derivation: /nix/store/pvvb1jfw6c4n0m4pl1hziq3g783cmby7-python3.12-ros-rolling-tracetools-analysis-3.1.0-r1
      ...depending on: /nix/store/vhxyf7q8cc3600sa34zlj7p2yim6grw7-python3-3.12.5-env
  six 1.16.0 (/nix/store/rgfl07w7jjb0mmxgifzyca6g6fh6cq36-python3.12-six-1.16.0)
    dependency chain:
      this derivation: /nix/store/pvvb1jfw6c4n0m4pl1hziq3g783cmby7-python3.12-ros-rolling-tracetools-analysis-3.1.0-r1
      ...depending on: /nix/store/v6qwrli608p7v2qaxn3vhphzq4dw3s8l-python3.12-pandas-2.2.2
      ...depending on: /nix/store/22d4sr968zx6l3sl7xrzcq4z18frqb7m-python3.12-python-dateutil-2.9.0.post0
      ...depending on: /nix/store/rgfl07w7jjb0mmxgifzyca6g6fh6cq36-python3.12-six-1.16.0

Package duplicates found in closure, see above. Usually this happens if two packages depend on different version of the same dependency.
```

cc @kjeremy 