### PR TITLE
twist_stamper: 0.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8835,7 +8835,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/twist_stamper-release.git
-      version: 0.0.3-4
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_stamper` to `0.0.4-1`:

- upstream repository: https://github.com/joshnewans/twist_stamper.git
- release repository: https://github.com/ros2-gbp/twist_stamper-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-4`

## twist_stamper

```
* Further improvements to shutdown handling
* fix(shutdown): clean shutdown on keyboard interrupt (#6 <https://github.com/joshnewans/twist_stamper/issues/6>)
* Fix deprecation warning (#3 <https://github.com/joshnewans/twist_stamper/issues/3>)
* Contributors: Josh Newans, Rein Appeldoorn, Rick-v-E
```
