### PR TITLE
twist_stamper: 0.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8142,7 +8142,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/twist_stamper-release.git
-      version: 0.0.3-3
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_stamper` to `0.0.5-1`:

- upstream repository: https://github.com/joshnewans/twist_stamper.git
- release repository: https://github.com/ros2-gbp/twist_stamper-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-3`

## twist_stamper

```
* Trying to fix flake8 errors
* Fix typo
* Contributors: Josh Newans
```
