### PR TITLE
gazebo_noisy_depth_camera: 1.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3313,6 +3313,21 @@ repositories:
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
     status: maintained
+  gazebo_noisy_depth_camera:
+    doc:
+      type: git
+      url: https://github.com/peci1/gazebo_noisy_depth_camera.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/gazebo_noisy_depth_camera-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/peci1/gazebo_noisy_depth_camera.git
+      version: master
+    status: maintained
   gazebo_ros_control_select_joints:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_noisy_depth_camera` to `1.0.1-1`:

- upstream repository: https://github.com/peci1/gazebo_noisy_depth_camera.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/gazebo_noisy_depth_camera-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## gazebo_noisy_depth_camera

```
* Fixed the order of registrations of depth frame callbacks so that this plugin actually changes the image for all other plugins.
  Fixes #3 <https://github.com/peci1/gazebo_noisy_depth_camera/issues/3> .
* Noetic compatibility.
* Added a comment that clarifies mean meaning in the multiplicative model
* Added link to opengl branch.
* Initial commit.
* Contributors: Martin Pecka
```
