### PR TITLE
rosdep: Added fcl library (non-development version)

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1049,6 +1049,19 @@ fcgi:
   fedora: [fcgi, mod_fcgid, spawn-fcgi]
   gentoo: [dev-ruby/fcgi]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
+fcl:
+  debian:
+    '*': [libfcl0.7]
+    bullseye: [libfcl0.6]
+    buster: [libfcl0.5]
+  fedora: [fcl]
+  gentoo: [sci-libs/fcl]
+  nixos: [fcl]
+  openembedded: [fcl@meta-ros-common]
+  rhel: [fcl]
+  ubuntu:
+    '*': [libfcl0.7]
+    focal: [libfcl0.5]
 festival:
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1049,19 +1049,6 @@ fcgi:
   fedora: [fcgi, mod_fcgid, spawn-fcgi]
   gentoo: [dev-ruby/fcgi]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
-fcl:
-  debian:
-    '*': [libfcl0.7]
-    bullseye: [libfcl0.6]
-    buster: [libfcl0.5]
-  fedora: [fcl]
-  gentoo: [sci-libs/fcl]
-  nixos: [fcl]
-  openembedded: [fcl@meta-ros-common]
-  rhel: [fcl]
-  ubuntu:
-    '*': [libfcl0.7]
-    focal: [libfcl0.5]
 festival:
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]
@@ -3585,6 +3572,19 @@ libext2fs-dev:
   opensuse: [libext2fs-devel]
   rhel: [e2fsprogs-devel]
   ubuntu: [libext2fs-dev]
+libfcl:
+  debian:
+    '*': [libfcl0.7]
+    bullseye: [libfcl0.6]
+    buster: [libfcl0.5]
+  fedora: [fcl]
+  gentoo: [sci-libs/fcl]
+  nixos: [fcl]
+  openembedded: [fcl@meta-ros-common]
+  rhel: [fcl]
+  ubuntu:
+    '*': [libfcl0.7]
+    focal: [libfcl0.5]
 libfcl-dev:
   debian: [libfcl-dev]
   fedora: [fcl-devel]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -99,6 +99,10 @@ eigen:
     homebrew:
       depends: [gfortran]
       packages: [eigen]
+fcl:
+  osx:
+    homebrew:
+      packages: [dartsim/dart/fcl]
 ffmpeg:
   osx:
     homebrew:

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -99,10 +99,6 @@ eigen:
     homebrew:
       depends: [gfortran]
       packages: [eigen]
-fcl:
-  osx:
-    homebrew:
-      packages: [dartsim/dart/fcl]
 ffmpeg:
   osx:
     homebrew:
@@ -215,6 +211,10 @@ libedit-dev:
   osx:
     homebrew:
       packages: [libedit]
+libfcl:
+  osx:
+    homebrew:
+      packages: [dartsim/dart/fcl]
 libfcl-dev:
   osx:
     homebrew:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libfcl

## Package Upstream Source:

https://github.com/flexible-collision-library/fcl

## Purpose of using this:

There is already libfcl-dev. Key fcl should be for use in exec_depend.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/source/bookworm/fcl
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/source/focal/fcl
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/fcl/fcl/
  - IF AVAILABLE
- Arch: N/A (https://archlinux.org/packages/?sort=&q=fcl&maintainer=&flagged=)
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/sci-libs/fcl
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/fcl#default
  - IF AVAILABLE
- Alpine: N/A (https://pkgs.alpinelinux.org/packages?name=fcl&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=)
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.05&show=fcl&from=0&size=50&sort=relevance&type=packages&query=fcl
  - OPTIONAL
- openSUSE: N/A (https://software.opensuse.org/search?baseproject=ALL&q=fcl)
  - IF AVAILABLE
- rhel: https://pkgs.org/search/?q=fcl
  - IF AVAILABLE
- openembedded: https://layers.openembedded.org/layerindex/recipe/341107/