### PR TITLE
raspimouse2: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5518,6 +5518,25 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: ros2
     status: maintained
+  raspimouse2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: jazzy
+    release:
+      packages:
+      - raspimouse
+      - raspimouse_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse2-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: jazzy
+    status: maintained
   raspimouse_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse2` to `2.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse2.git
- release repository: https://github.com/ros2-gbp/raspimouse2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## raspimouse

```
* Update CI for ROS 2 Rolling(https://github.com/rt-net/raspimouse2/pull/55)
* Fix documentation (https://github.com/rt-net/raspimouse2/pull/54)
* Support for ROS 2 Jazzy (https://github.com/rt-net/raspimouse2/pull/53)
* Replace Twist with TwistStamped in /cmd_vel
* Contributors: Kazushi Kurasawa, Yusuke Kato
```

## raspimouse_msgs

- No changes
