### PR TITLE
rt_usb_9axisimu_driver: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7645,6 +7645,22 @@ repositories:
       url: https://github.com/rt-net/rt_manipulators_cpp.git
       version: ros2
     status: maintained
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: jazzy
+    status: maintained
   rtabmap:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rt_usb_9axisimu_driver` to `3.0.0-1`:

- upstream repository: https://github.com/rt-net/rt_usb_9axisimu_driver.git
- release repository: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rt_usb_9axisimu_driver

```
* Update CI for ROS 2 Rolling (https://github.com/rt-net/rt_usb_9axisimu_driver/pull/62)
* Support for ROS 2 Jazzy (https://github.com/rt-net/rt_usb_9axisimu_driver/pull/61)
* Fix undefined behavior by storing std::string objects instead of const char* pointers
* Contributors: Kazushi Kurasawa, YusukeKato
```
