### PR TITLE
raspimouse_description: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5518,6 +5518,22 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: ros2
     status: maintained
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_description-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: jazzy
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_description` to `2.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_description.git
- release repository: https://github.com/ros2-gbp/raspimouse_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## raspimouse_description

```
* Support ROS 2 Jazzy (#55 <https://github.com/rt-net/raspimouse_description/issues/55>)
  Co-authored-by: Kazushi Kurasawa <mailto:Kurasawa@rt-net.jp>
* Replace ign to gz
* Updated the remapping for subscription to reflect the removal of unstamped from ros2_controllers <https://github.com/ros-controls/ros2_controllers/blob/57c50e584e33b316dd64801916cf6d951e0cff5b/tricycle_controller/CHANGELOG.rst#4100-2024-07-01>
* Contributors: YusukeKato
```
