### PR TITLE
moveit: 2.5.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4831,7 +4831,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.5.5-1
+      version: 2.5.6-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.6-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.5-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* fix move_group_capabilities usage (#3018 <https://github.com/ros-planning/moveit2/issues/3018>) (#3033 <https://github.com/ros-planning/moveit2/issues/3033>)
* Backport of #2172 <https://github.com/ros-planning/moveit2/issues/2172> and #2684 <https://github.com/ros-planning/moveit2/issues/2684> into Humble (#2779 <https://github.com/ros-planning/moveit2/issues/2779>)
* Use different packages for launch and config packages in generate_demo_launch (backport #2647 <https://github.com/ros-planning/moveit2/issues/2647>) (#2650 <https://github.com/ros-planning/moveit2/issues/2650>)
* Pass along move_group_capabilities parameters (#2587 <https://github.com/ros-planning/moveit2/issues/2587>) (#2696 <https://github.com/ros-planning/moveit2/issues/2696>)
* Use $DISPLAY rather than assuming :0 (#2049 <https://github.com/ros-planning/moveit2/issues/2049>) (#2365 <https://github.com/ros-planning/moveit2/issues/2365>)
* Contributors: Michael Ferguson, Anthony Baker, Alex Navarro, Forrest Rogers-Marcovitz, Stephanie Eng, mergify[bot]
```

## moveit_core

```
* Allow RobotState::setFromIK to work with subframes (backport #3077 <https://github.com/ros-planning/moveit2/issues/3077>) (#3085 <https://github.com/ros-planning/moveit2/issues/3085>)
* Fixes flaky RobotState test (backport #3105 <https://github.com/ros-planning/moveit2/issues/3105>) (#3107 <https://github.com/ros-planning/moveit2/issues/3107>)
* Fix flipped comments in joint_model.h (#3047 <https://github.com/ros-planning/moveit2/issues/3047>) (#3049 <https://github.com/ros-planning/moveit2/issues/3049>)
* Fix RobotState::getRigidlyConnectedParentLinkModel() (#2985 <https://github.com/ros-planning/moveit2/issues/2985>, #2993 <https://github.com/ros-planning/moveit2/issues/2993>)
* Backport to Humble: Pass more distance information out from FCL collision check #2572 <https://github.com/ros-planning/moveit2/issues/2572> (#2979 <https://github.com/ros-planning/moveit2/issues/2979>)
* Fix doc reference to non-existent function (#2765 <https://github.com/ros-planning/moveit2/issues/2765>) (#2766 <https://github.com/ros-planning/moveit2/issues/2766>)
* Update moveit::core::error_msg_to_string (#2689 <https://github.com/ros-planning/moveit2/issues/2689>)
* [TOTG] Exit loop when position can't change (backport #2307 <https://github.com/ros-planning/moveit2/issues/2307>) (#2646 <https://github.com/ros-planning/moveit2/issues/2646>)
* Fix angular distance calculation in floating joint model (backport #2538 <https://github.com/ros-planning/moveit2/issues/2538>) (#2543 <https://github.com/ros-planning/moveit2/issues/2543>)
* Change collision_detection_bullet install path back to include/moveit (#2403 <https://github.com/ros-planning/moveit2/issues/2403>)
* Use find_package for fcl (backport #2399 <https://github.com/ros-planning/moveit2/issues/2399>) (#2400 <https://github.com/ros-planning/moveit2/issues/2400>)
* Contributors: Chris Schindlbeck, Gabriel Pacheco, Nacho Mellado, Tom Noble, Sebastian Castro, reidchristopher, Robert Haschke, Henning Kayser, Tyler Weaver, mergify[bot]
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

```
* CI: Fix building of ikfast plugins (#2791 <https://github.com/ros-planning/moveit2/issues/2791>)
* Contributors: Robert Haschke, mergify[bot]
```

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Invoke OMPL debug print only when debug logging is enabled (backport #2608 <https://github.com/ros-planning/moveit2/issues/2608>) (#2762 <https://github.com/ros-planning/moveit2/issues/2762>)
* Map ompl's APPROXIMATE_SOLUTION -> TIMED_OUT / PLANNING_FAILED (#2455 <https://github.com/ros-planning/moveit2/issues/2455>) (#2459 <https://github.com/ros-planning/moveit2/issues/2459>)
* Contributors: Igor Medvedev, Robert Hashcke, mergify[bot]
```

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* PRBT IkFast patch from robostack (#2395 <https://github.com/ros-planning/moveit2/issues/2395>) (#2397 <https://github.com/ros-planning/moveit2/issues/2397>)
* Contributors: Tyler Weaver, mergify[bot]
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* Use the non-deprecated service fields for switching controllers (#2927 <https://github.com/ros-planning/moveit2/issues/2927>)
* Contributors: Sai Kishor Kothakota
```

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* PSM: keep references to scene_ valid upon receiving full scenes (#2850 <https://github.com/ros-planning/moveit2/issues/2850>)
* Protect against zero frequency in TrajectoryMonitorMiddlewareHandler (#2423 <https://github.com/ros-planning/moveit2/issues/2423>) (#2424 <https://github.com/ros-planning/moveit2/issues/2424>)
* Re-enable waiting for current state in MoveItCpp (#2419 <https://github.com/ros-planning/moveit2/issues/2419>) (#2426 <https://github.com/ros-planning/moveit2/issues/2426>)
* Contributors: Robert Haschke, Sebastian Castro, Henning Kayser, mergify[bot]
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Attached Collision Object Transparency (#3093 <https://github.com/ros-planning/moveit2/issues/3093>) (#3099 <https://github.com/ros-planning/moveit2/issues/3099>)
* fix for not having transparency in collision scenes on rviz, backporting the fix to humble (#2929 <https://github.com/ros-planning/moveit2/issues/2929>)
* Check valid interactive marker pointer before trying to update pose (#1581 <https://github.com/ros-planning/moveit2/issues/1581>) (#2366 <https://github.com/ros-planning/moveit2/issues/2366>)
* Contributors: Sami Alperen Akgün, Aiden Neale, Sebastian Castro, mergify[bot]
```

## moveit_ros_warehouse

```
* Use node logging in warehouse broadcast (#2432 <https://github.com/ros-planning/moveit2/issues/2432>) (#2443 <https://github.com/ros-planning/moveit2/issues/2443>)
* Contributors: Tyler Weaver, mergify[bot]
```

## moveit_runtime

- No changes

## moveit_servo

```
* Make moveit_servo listen to Octomap updates (backport #2601 <https://github.com/ros-planning/moveit2/issues/2601>) (#2606 <https://github.com/ros-planning/moveit2/issues/2606>)
* Use ACM in all MoveIt Servo collision checks (#2643 <https://github.com/ros-planning/moveit2/issues/2643>)
* Contributors: Amal Nanavati, Sebastian Castro, mergify[bot]
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

```
* Don't assume gripper controller for single joint control in MoveIt Setup Assistant (backport #2555 <https://github.com/ros-planning/moveit2/issues/2555>) (#2559 <https://github.com/ros-planning/moveit2/issues/2559>)
  * For single joint controllers which are not gripper controllers, still output joints list
  * Use OR
  * Only check for GripperActionController
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  ---------
  Co-authored-by: Sebastian Jahr <mailto:sebastian.jahr@picknik.ai>
  (cherry picked from commit 81094a63898ace7829687d2d6aa3ccb3cdd81b58)
  Co-authored-by: Forrest Rogers-Marcovitz <mailto:39061824+forrest-rm@users.noreply.github.com>
* Contributors: Forrest Rogers-Marcovitz, mergify[bot]
```

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

```
* Cast of "max_velocity" and "max_acceleration" values to double (#2803 <https://github.com/ros-planning/moveit2/issues/2803>) (#3038 <https://github.com/ros-planning/moveit2/issues/3038>)
* Fix #1971 <https://github.com/ros-planning/moveit2/issues/1971> (#2428 <https://github.com/ros-planning/moveit2/issues/2428>) (#2430 <https://github.com/ros-planning/moveit2/issues/2430>)
* Contributors: Michael Ferguson, Jorge Pérez Ramos, David V. Lu!!, mergify[bot]
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

```
* Become standard-compatible (#2895 <https://github.com/ros-planning/moveit2/issues/2895>)
* Contributors: Tobias Fischer
```

## pilz_industrial_motion_planner

```
* Allow RobotState::setFromIK to work with subframes (backport #3077 <https://github.com/ros-planning/moveit2/issues/3077>) (#3085 <https://github.com/ros-planning/moveit2/issues/3085>)
* Enhancement/ports moveit 3522 (backport #3070 <https://github.com/ros-planning/moveit2/issues/3070>) (#3074 <https://github.com/ros-planning/moveit2/issues/3074>)
* Ports moveit/moveit/pull/3519 to ros2 (backport #3055 <https://github.com/ros-planning/moveit2/issues/3055>) (#3061 <https://github.com/ros-planning/moveit2/issues/3061>)
* Fix Pilz blending times (backport #2961 <https://github.com/ros-planning/moveit2/issues/2961>) (#3000 <https://github.com/ros-planning/moveit2/issues/3000>)
* PILZ: Throw if IK solver doesn't exist (#2082 <https://github.com/ros-planning/moveit2/issues/2082>) (#2921 <https://github.com/ros-planning/moveit2/issues/2921>)
* Contributors: Tom Noble, Sebastian Castro, Sebastian Jahr, Robert Haschke, mergify[bot]
```

## pilz_industrial_motion_planner_testutils

- No changes
