### PR TITLE
control_msgs: 5.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1009,7 +1009,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.2.0-1
+      version: 5.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.3.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.2.0-1`

## control_msgs

```
* Add Dynamic Interface Group Values message (#155 <https://github.com/ros-controls/control_msgs/issues/155>)
* Add speed_scaling_factor msg and field in JointTrajectoryControllerState (#143 <https://github.com/ros-controls/control_msgs/issues/143>)
* Contributors: Felix Exner (fexner), Wiktor Bajor
```
