### PR TITLE
rosdep: import python3-babel

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4967,6 +4967,14 @@ python3-awsiotsdk-pip:
   ubuntu:
     pip:
       packages: [awsiotsdk]
+python3-babel:
+  debian: [python3-babel]
+  fedora: [python3-babel]
+  opensuse: [python3-Babel]
+  rhel:
+    '*': [python3-babel]
+    '7': null
+  ubuntu: [python3-babel]
 python3-babeltrace:
   alpine: [py3-babeltrace]
   debian: [python3-babeltrace]


### PR DESCRIPTION
python-babel was already present; add the py3 version.

