### PR TITLE
add mini_tof package

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3509,6 +3509,18 @@ repositories:
       url: https://github.com/ros2/mimick_vendor.git
       version: rolling
     status: maintained
+  mini_tof:
+    source:
+      type: git
+      url: https://github.com/uwgraphics/mini_tof.git
+      version: main
+    status: maintained
+  mini_tof_interfaces:
+    source:
+      type: git
+      url: https://github.com/uwgraphics/mini_tof_interfaces.git
+      version: main
+    status: maintained
   mir_robot:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

mini_tof, mini_tof_interfaces

These packages are for easy interfacing with miniature time-of-flight sensors (e.g. AMS TMF8820, ST VL53L8CH). They provide nodes for publishing the raw time-of-flight data from these sensors, and visualizing the data live. mini_tof_interfaces provides custom message definitions for the data coming off of the sensors, and is used by the mini_tof package.

# The source is here:

https://github.com/uwgraphics/mini_tof
https://github.com/uwgraphics/mini_tof_interfaces

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
