### PR TITLE
leo_robot: 1.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3963,7 +3963,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.5.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-1`

## leo_bringup

```
* Add web_video_server to dependencies (#13 <https://github.com/LeoRover/leo_robot-ros2/issues/13>)
* Contributors: Błażej Sowa
```

## leo_fw

```
* Update firmware binaries (#11 <https://github.com/LeoRover/leo_robot-ros2/issues/11>)
* Add merged odometry to firmware message converter (#9 <https://github.com/LeoRover/leo_robot-ros2/issues/9>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_robot

- No changes
