### PR TITLE
leo_robot: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3049,7 +3049,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 1.4.0-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.0.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-2`

## leo_bringup

```
* Add web_video_server to dependencies (#13 <https://github.com/LeoRover/leo_robot-ros2/issues/13>) (#15 <https://github.com/LeoRover/leo_robot-ros2/issues/15>)
* Contributors: mergify[bot]
```

## leo_fw

```
* Update firmware binaries (#11 <https://github.com/LeoRover/leo_robot-ros2/issues/11>) (#12 <https://github.com/LeoRover/leo_robot-ros2/issues/12>)
* Fix mypy and pylint errors (#14 <https://github.com/LeoRover/leo_robot-ros2/issues/14>)
* Contributors: Błażej Sowa, mergify[bot]
```

## leo_robot

- No changes
