### PR TITLE
foxglove_compressed_video_transport: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2605,7 +2605,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_compressed_video_transport` to `1.0.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
- release repository: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## foxglove_compressed_video_transport

```
* Fill empty message fields (#1 <https://github.com/ros-misc-utilities/foxglove_compressed_video_transport/issues/1>)
  * Fix missing timestamp and frame_id in subscriber and publisher
* Contributors: Bernd Pfrommer, eLEcTRiCZiTy
```
