### PR TITLE
hri_face_body_matcher: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3221,6 +3221,21 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_actions_msgs.git
       version: humble-devel
+  hri_face_body_matcher:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_face_body_matcher.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_face_body_matcher-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_face_body_matcher.git
+      version: humble-devel
+    status: developed
   hri_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_face_body_matcher` to `2.1.0-1`:

- upstream repository: https://github.com/ros4hri/hri_face_body_matcher.git
- release repository: https://github.com/ros4hri/hri_face_body_matcher-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## hri_face_body_matcher

```
* re-license as Apache 2.0
* Contributors: Séverin Lemaignan
```
