### PR TITLE
neo_nav2_bringup: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4344,6 +4344,18 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jazzy
     status: maintained
+  neo_nav2_bringup:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: jazzy
+    status: maintained
   neo_simulation2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.3.0-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
