### PR TITLE
interactive_marker_twist_server: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3475,7 +3475,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
-      version: 2.1.0-2
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_marker_twist_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_marker_twist_server` to `2.1.1-1`:

- upstream repository: https://github.com/ros-visualization/interactive_marker_twist_server.git
- release repository: https://github.com/ros-gbp/interactive_marker_twist_server-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-2`

## interactive_marker_twist_server

```
* Fixed linting.
* Updated CI for Humble and Jazzy.
* Add the use_stamped_msgs param to allow support for publishing TwistStamped messages instead of Twist
* Contributors: Chris Iverach-Brereton, Tony Baltovski
```
