### PR TITLE
geometry2: 0.39.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1984,7 +1984,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.39.1-1
+      version: 0.39.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.39.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.39.1-1`

## examples_tf2_py

```
* Add in test_xmllint for geometry2 python packages. (#725 <https://github.com/ros2/geometry2/issues/725>)
* Contributors: Chris Lalancette
```

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Fix tf2_geometry_msgs_INCLUDE_DIRS. (#729 <https://github.com/ros2/geometry2/issues/729>)
* Contributors: rkeating-planted
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* specified quaternion order to be xyzw (#718 <https://github.com/ros2/geometry2/issues/718>)
* Contributors: Abhishek Kashyap
```

## tf2_ros_py

```
* Adding StaticTransformListener in Python (#719 <https://github.com/ros2/geometry2/issues/719>)
* Add in test_xmllint for geometry2 python packages. (#725 <https://github.com/ros2/geometry2/issues/725>)
* Contributors: Chris Lalancette, Lucas Wendland
```

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Add in test_xmllint for geometry2 python packages. (#725 <https://github.com/ros2/geometry2/issues/725>)
* Contributors: Chris Lalancette
```
