### PR TITLE
rosidl_typesupport_fastrtps: 3.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6664,7 +6664,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.7.0-1
+      version: 3.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.7.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.0-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Remove deprecated functions benchmark tests (#122 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/122>)
* Contributors: Miguel Company
```

## rosidl_typesupport_fastrtps_cpp

```
* Remove deprecated functions benchmark tests (#122 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/122>)
* Contributors: Miguel Company
```
