### PR TITLE
rosidl_python: 0.24.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6609,7 +6609,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.23.1-1
+      version: 0.24.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.24.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.23.1-1`

## rosidl_generator_py

```
* Revamp how we check for the correct class. (#218 <https://github.com/ros2/rosidl_python/issues/218>)
* Remove python_cmake_module and set hints (#204 <https://github.com/ros2/rosidl_python/issues/204>)
* Contributors: Chris Lalancette
```
