### PR TITLE
rosidl_dynamic_typesupport: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6575,7 +6575,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport` to `0.3.0-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-1`

## rosidl_dynamic_typesupport

```
* Drop support for long double/float128. (#12 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/12>)
* Contributors: Chris Lalancette
```
