### PR TITLE
rosidl: 4.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6503,7 +6503,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.9.0-1
+      version: 4.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.9.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.9.0-1`

## rosidl_adapter

```
* Types for rosidl_adapter (#828 <https://github.com/ros2/rosidl/issues/828>)
* Contributors: Michael Carlstrom
```

## rosidl_cli

```
* Rosidl cli types with specs_set fix (#831 <https://github.com/ros2/rosidl/issues/831>)
* Contributors: Chris Lalancette, Michael Carlstrom
```

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

```
* Add types to definition.py in rosidl_parser (#791 <https://github.com/ros2/rosidl/issues/791>)
* Contributors: Michael Carlstrom
```

## rosidl_pycommon

```
* Add test_xmllint to rosidl_pycommon. (#833 <https://github.com/ros2/rosidl/issues/833>)
* Contributors: Chris Lalancette
```

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
