### PR TITLE
ros2cli: 0.36.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6197,7 +6197,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.35.0-1
+      version: 0.36.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.36.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.35.0-1`

## ros2action

- No changes

## ros2cli

```
* Fix instability in the ros2 daemon. (#947 <https://github.com/ros2/ros2cli/issues/947>)
* Drop dependency on python3-pkg-resources (#946 <https://github.com/ros2/ros2cli/issues/946>)
* NodeStrategy supports node name argument. (#941 <https://github.com/ros2/ros2cli/issues/941>)
* Contributors: Chris Lalancette, Scott K Logan, Tomoya Fujita
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* New flag and code update for its use (#942 <https://github.com/ros2/ros2cli/issues/942>)
* Contributors: Angel LoGa
```

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* cosmetic fixes for ros2param dump command. (#933 <https://github.com/ros2/ros2cli/issues/933>)
* Contributors: Tomoya Fujita
```

## ros2pkg

```
* Drop dependency on python3-pkg-resources (#946 <https://github.com/ros2/ros2cli/issues/946>)
* Contributors: Scott K Logan
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* NodeStrategy supports node name argument. (#941 <https://github.com/ros2/ros2cli/issues/941>)
* feat(echo --clear): add --clear option to echo (#819 <https://github.com/ros2/ros2cli/issues/819>)
* Contributors: Guillaume Beuzeboc, Tomoya Fujita
```
