### PR TITLE
rclpy: 7.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5339,7 +5339,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.6.0-1
+      version: 7.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.7.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.6.0-1`

## rclpy

```
* Fix the race condition while calling rcl_shutdown (#1353 <https://github.com/ros2/rclpy/issues/1353>)
* Use @deprecated to mark deprecated APIs for type checkers. (#1350 <https://github.com/ros2/rclpy/issues/1350>)
* init (#1358 <https://github.com/ros2/rclpy/issues/1358>)
* Avoid redundant done callbacks of the future while repeatedly calling spin_until_future_complete (#1374 <https://github.com/ros2/rclpy/issues/1374>)
* Clean qos zenoh tests (#1369 <https://github.com/ros2/rclpy/issues/1369>)
* adjust warn message that requested goal is already expired. (#1363 <https://github.com/ros2/rclpy/issues/1363>)
* Adds types to Lifecycle Objects (#1338 <https://github.com/ros2/rclpy/issues/1338>)
* Remove python_cmake_module use (#1220 <https://github.com/ros2/rclpy/issues/1220>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chris Lalancette, Michael Carlstrom, Tomoya Fujita
```
