### PR TITLE
rclcpp: 29.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5323,7 +5323,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.0.0-1
+      version: 29.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.1.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `29.0.0-1`

## rclcpp

```
* a couple of typo fixes in doc section for LoanedMessage. (#2676 <https://github.com/ros2/rclcpp/issues/2676>)
* Make sure callback_end tracepoint is triggered in AnyServiceCallback (#2670 <https://github.com/ros2/rclcpp/issues/2670>)
* Correct the incorrect comments in generic_client.hpp (#2662 <https://github.com/ros2/rclcpp/issues/2662>)
* Fix NodeOptions assignment operator (#2656 <https://github.com/ros2/rclcpp/issues/2656>)
* set QoS History KEEP_ALL explicitly for statistics publisher. (#2650 <https://github.com/ros2/rclcpp/issues/2650>)
* Fix test_intra_process_manager.cpp with rmw_zenoh_cpp (#2653 <https://github.com/ros2/rclcpp/issues/2653>)
* Fixed test_events_executors in zenoh (#2643 <https://github.com/ros2/rclcpp/issues/2643>)
* rmw_fastrtps supports service event gid uniqueness test. (#2638 <https://github.com/ros2/rclcpp/issues/2638>)
* print warning if event callback is not supported instead of passing exception. (#2648 <https://github.com/ros2/rclcpp/issues/2648>)
* Implement callback support of async_send_request for service generic client (#2614 <https://github.com/ros2/rclcpp/issues/2614>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chris Lalancette, Christophe Bedard, Romain DESILLE, Tomoya Fujita
```

## rclcpp_action

```
* Fix documentation typo in server_goal_handle.hpp (#2669 <https://github.com/ros2/rclcpp/issues/2669>)
* Contributors: YR
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Fix error message in rclcpp_lifecycle::State::reset() (#2647 <https://github.com/ros2/rclcpp/issues/2647>)
* Contributors: Christophe Bedard
```
