### PR TITLE
orocos_kdl_vendor: 0.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4348,7 +4348,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.6.1-1
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.1-1`

## orocos_kdl_vendor

```
* fix: add cxx_standard to avoid c++ check error (#30 <https://github.com/ros2/orocos_kdl_vendor/issues/30>)
* Contributors: Homalozoa X
```

## python_orocos_kdl_vendor

```
* fix: use fetchcontent_makeavailable to fix CMP0169 (#32 <https://github.com/ros2/orocos_kdl_vendor/issues/32>)
* Remove the use of python_cmake_module (#26 <https://github.com/ros2/orocos_kdl_vendor/issues/26>)
* Contributors: Chris Lalancette, Homalozoa X
```
