### PR TITLE
launch_ros: 0.28.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2996,7 +2996,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.27.3-1
+      version: 0.28.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.28.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.27.3-1`

## launch_ros

```
* Add ament_xmllint to the ament_python packages. (#423 <https://github.com/ros2/launch_ros/issues/423>)
* Contributors: Chris Lalancette
```

## launch_testing_ros

```
* Add ament_xmllint to the ament_python packages. (#423 <https://github.com/ros2/launch_ros/issues/423>)
* Contributors: Chris Lalancette
```

## ros2launch

```
* Add ament_xmllint to the ament_python packages. (#423 <https://github.com/ros2/launch_ros/issues/423>)
* Contributors: Chris Lalancette
```
