### PR TITLE
launch: 3.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2961,7 +2961,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.6.1-1
+      version: 3.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.7.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.1-1`

## launch

```
* Add test_xmllint to all of the ament_python packages. (#804 <https://github.com/ros2/launch/issues/804>)
* Contributors: Chris Lalancette
```

## launch_pytest

```
* Add test_xmllint to all of the ament_python packages. (#804 <https://github.com/ros2/launch/issues/804>)
* Contributors: Chris Lalancette
```

## launch_testing

```
* Add test_xmllint to all of the ament_python packages. (#804 <https://github.com/ros2/launch/issues/804>)
* Contributors: Chris Lalancette
```

## launch_testing_ament_cmake

```
* Stop using python_cmake_module. (#760 <https://github.com/ros2/launch/issues/760>)
* Contributors: Chris Lalancette
```

## launch_xml

```
* Add test_xmllint to all of the ament_python packages. (#804 <https://github.com/ros2/launch/issues/804>)
* Contributors: Chris Lalancette
```

## launch_yaml

```
* Add test_xmllint to all of the ament_python packages. (#804 <https://github.com/ros2/launch/issues/804>)
* Contributors: Chris Lalancette
```
