### PR TITLE
rc_reason_clients: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7014,7 +7014,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.4.0-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros2.git
- release repository: https://github.com/ros2-gbp/rc_reason_clients-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## rc_reason_clients

```
* support 3-sided LoadCarriers
* make pipeline configurable
```

## rc_reason_msgs

```
* Grasp msg: add priority, gripper_id and collision_checked
* LoadCarrier msg: add height_open_side for 3-sided LC
* CadMatchDetectObject srv: add pose_prior_ids and data_acquisition_mode
* SilhouetteMatchDetectObject srv: add object_plane_detection
```
