### PR TITLE
demos: 0.35.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1119,7 +1119,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.35.0-1
+      version: 0.35.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.35.1-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.35.0-1`

## action_tutorials_cpp

- No changes

## action_tutorials_py

```
* Add test_xmllint.py to all of the ament_python packages. (#704 <https://github.com/ros2/demos/issues/704>)
* Contributors: Chris Lalancette
```

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* Add test_xmllint.py to all of the ament_python packages. (#704 <https://github.com/ros2/demos/issues/704>)
* Contributors: Chris Lalancette
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

```
* Add test_xmllint.py to all of the ament_python packages. (#704 <https://github.com/ros2/demos/issues/704>)
* Contributors: Chris Lalancette
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

```
* Add test_xmllint.py to all of the ament_python packages. (#704 <https://github.com/ros2/demos/issues/704>)
* Contributors: Chris Lalancette
```

## topic_monitor

```
* Add test_xmllint.py to all of the ament_python packages. (#704 <https://github.com/ros2/demos/issues/704>)
* Contributors: Chris Lalancette
```

## topic_statistics_demo

- No changes
