### PR TITLE
ament_cmake_ros: 0.13.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -176,7 +176,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.13.0-1
+      version: 0.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.13.1-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.13.0-1`

## ament_cmake_ros

- No changes

## domain_coordinator

```
* Add test_xmllint to domain_coordinator. (#17 <https://github.com/ros2/ament_cmake_ros/issues/17>)
* Contributors: Chris Lalancette
```
