### PR TITLE
rc_reason_clients: 0.4.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8902,7 +8902,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_reason_clients_ros-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.4.0-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros.git
- release repository: https://github.com/roboception-gbp/rc_reason_clients_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## rc_reason_clients

```
* support 3-sided LoadCarriers
* make pipeline configurable
```

## rc_reason_msgs

```
* Grasp msg: add priority, gripper_id and collision_checked
* LoadCarrier msg: add height_open_side for 3-sided LC
* CadMatchDetectObject srv: add pose_prior_ids and data_acquisition_mode
* SilhouetteMatchDetectObject srv: add object_plane_detection
```
