### PR TITLE
ament_index: 1.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -210,7 +210,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.10.0-1
+      version: 1.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.10.1-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.10.0-1`

## ament_index_cpp

- No changes

## ament_index_python

```
* Add test_xmllint to ament_index_python. (#96 <https://github.com/ament/ament_index/issues/96>)
* Contributors: Chris Lalancette
```
