### PR TITLE
ros_inorbit_samples: 0.3.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9756,7 +9756,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/inorbit-ai/ros_inorbit_samples.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_inorbit_samples` to `0.3.2-1`:

- upstream repository: https://github.com/inorbit-ai/ros_inorbit_samples.git
- release repository: https://github.com/inorbit-ai/ros_inorbit_samples-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## inorbit_republisher

```
* Fix LatchPublisher publish to handle ROS String messages (#26 <https://github.com/inorbit-ai/ros_inorbit_samples/issues/26>)
* Contributors: Leandro
```
