### PR TITLE
Run rosdistro-reviewer in target repository context

### DIFF
--- a/.github/workflows/reviewer.yaml
+++ b/.github/workflows/reviewer.yaml
@@ -1,7 +1,7 @@
 ---
 name: Automated review
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
     - opened
     - ready_for_review
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - run: git fetch origin ${{ github.event.pull_request.head.sha }}
     - uses: ros-infrastructure/rosdistro-reviewer@main
       with:
         token: ${{ github.token }}


### PR DESCRIPTION
When using the `pull_request` event, we can't use `write` permissions on the target repository, probably because the submitter could change the action as part of their PR.

The `pull_request_target` event runs the action with the target repository's state instead of the PR's merged state. This will make testing changes to the automation a little more difficult, but also means that the automation no longer requires approval to run for first-time submitters.

Because the checkout operation now fetches the PR target's HEAD, we need to explicitly fetch the PR's HEAD (but not check it out) so that the automation can inspect the git tree to find the changes.

Follow-up to #42309