### PR TITLE
hri_privacy_msgs: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3261,6 +3261,21 @@ repositories:
       url: https://github.com/ros4hri/hri_msgs.git
       version: humble-devel
     status: developed
+  hri_privacy_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_privacy_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros4hri/hri_privacy_msgs-release.git
+      version: 1.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_privacy_msgs.git
+      version: humble-devel
+    status: developed
   hri_rviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_privacy_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/ros4hri/privacy_msgs.git
- release repository: https://github.com/ros4hri/hri_privacy_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## hri_privacy_msgs

```
* rename to hri_privacy_msgs
  To comply with ROS's REP-144 on naming criteria, as suggested in https://github.com/ros/rosdistro/pull/42868
* Contributors: Séverin Lemaignan
```
