### PR TITLE
flir_camera_driver: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2494,7 +2494,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
-      version: 2.1.17-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `3.0.0-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.17-1`

## flir_camera_description

```
* removed changelogs
* Contributors: Bernd Pfrommer
```

## flir_camera_msgs

```
* removed changelogs
* Contributors: Bernd Pfrommer
```

## spinnaker_camera_driver

```
* Remove "NOT TESTED" from tested Chameleon params
  - Tested with CM3-U3-50S5C camera model, trigger_source: "Line0"
  and trigger_selector: "FrameStart"
* Re-order Chameleon config params to match Blackfly
  - Match Chameleon param order with Blackfly config params
* Add Reverse and VideoMode Chameleon config params
  - ReverseX/Y params flip the image as expected. This changes the pixel
  format accordingly (e.g. BayerRG8 -> BayerBG8 for an X and Y flip)
  - Video Mode options can affect effective resolution, frame rate and
  brightness depending on camera model, please check the documentation.
* support brightness computation for all bayer image types
* better documentation for setting GENTL variable
* only access camera with correct serial
* better diagnostics on incomplete images
* work around compile error on Iron
* fix multiple network interface refreshCameraList
* add support for transport layer and stream params
* added option to launch blackfly type
* mention SPINNAKER_GENTL64_CTI
* updated docs for jazzy, adjust download script
* remove unnecessary debs from package
* point to new spinnaker sdk for noble
* renamed stereo_synced file and added doc
* added user set control examples for blackfly/blackfly_s
* fix broken composable node by installing in correct location
* Add FLIR-AX5 Camera (#176 <https://github.com/ros-drivers/flir_camera_driver/issues/176>)
  * added config file for flir_ax5
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* add option to disable external control (default!)
* updated docs for sync driver, switch to RST
* widened the ExposureController interface
* fix build errors on rolling/noble
* added blacklevel and whitebalance support for blackfly
* use proper name for camerainfo when using sync driver
* fixes to compile on focal/galactic
* Oryx parameter file
* lint
* allow for unreadable command nodes
* Initial support for command nodes
* remove more spinnaker imports
* make Spinnaker private
* added blackfly GigE configuration file
* track incomplete frames
* fixed licensing documentation
* provision camera driver for exposure control
* fixed bugs discovered when running on GigE cams
* avoid searching ROS path for library
* added connect_while_subscribed feature
* Added binning parameter
* install spinnaker library in same place as driver library
* remove junk directories from search path
* added first implementation of synchronized driver
* prepare single-camera driver for use with sync'ed driver
* fixed stereo launch file serial nb bug
* removed changelogs
* Contributors: Alejandro Bordallo, Bernd Pfrommer, Luis Camero, Sir-Photch, anonymousarmadillo100, buckleytoby, iagogomes
```

## spinnaker_synchronized_camera_driver

```
* added primary_secondary launch file
* updated docs for sync driver, switch to RST
* added follower exposure controller renamed individual -> master
* fixes to compile on focal/galactic
* remove more spinnaker imports
* track incomplete frames
* fixed licensing documentation
* implement individual exposure controller
* fixed bugs discovered when running on GigE cams
* fix dependency on ament_cmake_black
* look in single driver lib if spinnaker not installed
* do not look for include files since not needed
* added first implementation of synchronized driver
* Contributors: Bernd Pfrommer
```
