### PR TITLE
Revert "rc_reason_clients: 0.4.0-1 in 'rolling/distribution.yaml' [bl…

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5208,7 +5208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
-      version: 0.4.0-1
+      version: 0.3.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
…oom] (#43580)"

This reverts commit 577e099f8425fe6783998eab9cc797323d96ece1.

This is failing to build on the buildfarm: https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rc_reason_msgs__ubuntu_noble_amd64__binary/23/ .  

@flixr FYI