### PR TITLE
openeb_vendor: 2.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4321,7 +4321,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/openeb_vendor-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4316,7 +4316,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4325,7 +4325,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: rolling
+      version: release
     status: developed
   openni2_camera:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openeb_vendor` to `2.0.1-2`:

- upstream repository: https://github.com/ros-event-camera/openeb_vendor.git
- release repository: https://github.com/ros2-gbp/openeb_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## openeb_vendor

```
* added silkyev_cam plugin
* Contributors: Bernd Pfrommer
```
