### PR TITLE
adi_3dtof_image_stitching: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -82,10 +82,16 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
       version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_3dtof_image_stitching-release.git
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
       version: humble-devel
+    status: maintained
   adi_tmcl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `adi_3dtof_image_stitching` to `2.1.0-1`:

- upstream repository: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
- release repository: https://github.com/ros2-gbp/adi_3dtof_image_stitching-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
