### PR TITLE
Add python3 textual and its extensions

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10020,6 +10020,18 @@ python3-texttable:
   openembedded: [python3-texttable@meta-python]
   rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
+python3-textual-pip:
+  '*':
+    pip:
+      packages: [textual]
+python3-textual-plotext-pip:
+  '*':
+    pip:
+      packages: [textual-plotext]
+python3-textual-web-pip:
+  '*':
+    pip:
+      packages: [textual-web]
 python3-thop-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10025,7 +10025,9 @@ python3-textual:
   debian: [python3-textual]
   fedora: [python3-textual]
   nixos: [python311Packages.textual]
-  ubuntu: [python3-textual]
+  ubuntu:
+    '*': [python3-textual]
+    focal: null
 python3-textual-pip:
   '*':
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10020,6 +10020,12 @@ python3-texttable:
   openembedded: [python3-texttable@meta-python]
   rhel: ['python%{python3_pkgversion}-texttable']
   ubuntu: [python3-texttable]
+python3-textual:
+  arch: [python-textual]
+  debian: [python3-textual]
+  fedora: [python3-textual]
+  nixos: [python311Packages.textual]
+  ubuntu: [python3-textual]
 python3-textual-pip:
   '*':
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-textual-pip (textual)
python3-textual-plotext-pip (textual-plotext)
python3-textual-web-pip (textual-web)

## Package Upstream Source:

[textual](https://github.com/Textualize/textual)
[textual-textual-plotext](https://github.com/Textualize/textual-plotext)
[textual-web](https://github.com/Textualize/textual-web)

## Purpose of using this:

Popular TUI library and its official extensions for python, can be used where GUI is not available.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

Note: Since plugins are not available as distribution packages, PYPI source is preferred here.

- PYPI
  - https://pypi.org/project/textual/
  - https://pypi.org/project/textual-plotext/
  - https://pypi.org/project/textual_web/

- Debian: https://packages.debian.org/
  - https://packages.debian.org/stable/python3-textual
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/python3-textual
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-textual/python3-textual/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-textual/
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.05&show=python311Packages.textual&size=50&sort=relevance&type=packages&query=textual
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
