### PR TITLE
dual_laser_merger: 0.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1394,6 +1394,11 @@ repositories:
       type: git
       url: https://github.com/pradyum/dual_laser_merger.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/dual_laser_merger-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/pradyum/dual_laser_merger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_laser_merger` to `0.0.1-1`:

- upstream repository: https://github.com/pradyum/dual_laser_merger.git
- release repository: https://github.com/ros2-gbp/dual_laser_merger-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## dual_laser_merger

```
* added missing dependency
* added shadow and average filters
* added calibration functions
* made node as ros component
* added demo files
* created ros package and added node cpp, launch file
* Initial commit
* Contributors: Pradyum Aadith, pradyum
```
