### PR TITLE
zed-ros2-interfaces: 4.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11483,6 +11483,17 @@ repositories:
       version: humble
     status: maintained
   zed-ros2-interfaces:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: master
+    release:
+      packages:
+      - zed_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
+      version: 4.2.2-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-interfaces` to `4.2.2-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-interfaces.git
- release repository: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## zed_msgs

```
* Changed the name of the package zed_interfaces to zed_msgs to match the ROS2 naming convention
* Add ZED X One mesh
* Update packages version
* Update cmake_minimum_required
* Fix to support Iron
* Fix Foxy building
* Fix dependencies
* Add ZED X One STL
* Fix PosTrackStatusMsg
* Update PosTrackStatus.msg
* Add new GNSS status message and update PosTrackStatus
* Add mag heading status
* Update PosTrackStatus.msg
* Fix typo in enum for SEARCHING_FLOOR_PLANE
* Improve install info
* Update SetPose srv description
* Add new PosTrackStatus message type
* Add support for new BODY formats
* Add zedx and zedxm meshes
* Remove annoying build log messages
* Fix LINT test
* Add CONTRIBUTING rules
* Add setRoi service
* Add ROS2 distro check
* Add PlaneStamped message
* Add DepthInfoStamped.msg
* Add support for BODY_FORMAT::POSE_34
* Update Object topic
* Add msg, srv, and meshes files
* Initial commit
```
