### PR TITLE
pal_statistics: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4861,7 +4861,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.2.4-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.5.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.4-1`

## pal_statistics

```
* add the documentation to the getUniqueRegistryKey method
* Add more changes to the renaming getOrCreateRegistry method
* Apply review suggestions
* Add new test on disabling the registered elements by default
* add enable option to the REGISTER_ENTITY.. macro
* Fix the cpp linter errors
* Unify getRegistry method for all types of instances of Node and LifeCycleNode
* deprecate getRegistry method
* Add support for REGISTRY_KEY on other macros
* Add getUniqueRegistryKey method for node and topic
* make getOrcreateRegistry more generic for nodes and classes
* Add scoped Bookkeeping test
* Add first test on the new macros and methods
* get resolve_topic_name method to get the proper namespaced/remapped key
* Add REGISTER_ENTITY and UNREGISTER_ENTITY macros
* Add INITIALIZE_REGISTRY macro
* Accept only if it is castable to double
* Rename the methods to getOrcreateRegistry
* add initializeRegistry method and some macros
* add createRegistry and getRegistry method for reutilizing the RegistryMap
* remove the node namespace argument
* add a way to handle the topic remappings
* Contributors: Jordan Palacios, Sai Kishor Kothakota
```

## pal_statistics_msgs

- No changes
