### PR TITLE
rosbag2_to_video: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6474,6 +6474,11 @@ repositories:
       type: git
       url: https://github.com/fictionlab/rosbag2_to_video.git
       version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_to_video-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/fictionlab/rosbag2_to_video.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6473,7 +6473,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/fictionlab/rosbag2_to_video.git
-      version: rolling
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -6482,7 +6482,7 @@ repositories:
     source:
       type: git
       url: https://github.com/fictionlab/rosbag2_to_video.git
-      version: rolling
+      version: ros2
     status: maintained
   rosbridge_suite:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_to_video` to `1.0.1-1`:

- upstream repository: https://github.com/fictionlab/rosbag2_to_video.git
- release repository: https://github.com/ros2-gbp/rosbag2_to_video-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rosbag2_to_video

```
* Update maintainer
* Add CONTRIBUTING.md
* Add mypy test
* Fix flake8 and pep257 errors
* Don't skip copyright check
* Contributors: Błażej Sowa
```
