### PR TITLE
rosbag2_to_video: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6927,6 +6927,21 @@ repositories:
       version: master
     status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
+  rosbag2_to_video:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/rosbag2_to_video.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_to_video-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/fictionlab/rosbag2_to_video.git
+      version: ros2
+    status: maintained
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_to_video` to `1.0.1-1`:

- upstream repository: https://github.com/fictionlab/rosbag2_to_video.git
- release repository: https://github.com/ros2-gbp/rosbag2_to_video-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rosbag2_to_video

```
* Update maintainer
* Add CONTRIBUTING.md
* Add mypy test
* Fix flake8 and pep257 errors
* Don't skip copyright check
* Contributors: Błażej Sowa
```
