### PR TITLE
dual_laser_merger: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1899,7 +1899,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dual_laser_merger-release.git
-      version: 0.0.1-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/pradyum/dual_laser_merger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dual_laser_merger` to `0.1.1-1`:

- upstream repository: https://github.com/pradyum/dual_laser_merger.git
- release repository: https://github.com/ros2-gbp/dual_laser_merger-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-1`

## dual_laser_merger

```
* minor version bump denoting ros2 distro - humble
```
