### PR TITLE
log_view: 0.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3249,6 +3249,11 @@ repositories:
       type: git
       url: https://github.com/hatchbed/log_view.git
       version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/log_view-release.git
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.2.4-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/ros2-gbp/log_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## log_view

```
* Fix build error caused by mvwprintw. (#19 <https://github.com/hatchbed/log_view/issues/19>)
* Contributors: Marc Alban
```
