### PR TITLE
log_view: 0.2.4-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4306,15 +4306,20 @@ repositories:
       version: humble
     status: maintained
   log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/hatchbed/log_view-release.git
-      version: 0.2.3-1
+      version: 0.2.4-2
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git
       version: ros2
+    status: developed
   lsc_ros2_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.2.4-2`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-1`

## log_view

```
* Fix build error caused by mvwprintw. (#19 <https://github.com/hatchbed/log_view/issues/19>)
* Contributors: Marc Alban
```
