### PR TITLE
hatchbed_common: 0.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3857,6 +3857,21 @@ repositories:
       url: https://github.com/crigroup/handeye.git
       version: master
     status: maintained
+  hatchbed_common:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: ros1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/hatchbed_common-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: ros1
+    status: developed
   hebi_cpp_api_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hatchbed_common` to `0.0.2-1`:

- upstream repository: https://github.com/hatchbed/hatchbed_common.git
- release repository: https://github.com/ros2-gbp/hatchbed_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## hatchbed_common

```
* Contributors: Marc Alban
```
