### PR TITLE
yaets: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9573,6 +9573,21 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: ros2
     status: maintained
+  yaets:
+    doc:
+      type: git
+      url: https://github.com/fmrico/yaets.git
+      version: jazzy-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/fmrico/yaets-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/fmrico/yaets.git
+      version: jazzy-devel
+    status: developed
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `yaets` to `0.0.2-1`:

- upstream repository: https://github.com/fmrico/yaets.git
- release repository: https://github.com/fmrico/yaets-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## yaets

```
* Add e2e traces
* One extra exmaple in README
* Add end to end traces
* Adjust width
* Initial commit
* Contributors: Francisco Martín Rico
```
