### PR TITLE
image_transport_plugins: 4.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2928,7 +2928,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `4.0.3-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.2-1`

## compressed_depth_image_transport

- No changes

## compressed_image_transport

```
* inlcude alpha channel in PNG compression (#171 <https://github.com/ros-perception/image_transport_plugins/issues/171>) (#173 <https://github.com/ros-perception/image_transport_plugins/issues/173>)
  (cherry picked from commit 9695d1b2a88e3dcae8ab2f28e1078e68a7893af5)
  Co-authored-by: Aleksander Szymański <mailto:bitterisland6@gmail.com>
* Contributors: mergify[bot]
```

## image_transport_plugins

- No changes

## theora_image_transport

- No changes

## zstd_image_transport

- No changes
