### PR TITLE
cob_common: 2.8.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1136,6 +1136,25 @@ repositories:
       url: https://github.com/coal-library/coal.git
       version: devel
     status: developed
+  cob_common:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: foxy
+    release:
+      packages:
+      - cob_actions
+      - cob_msgs
+      - cob_srvs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/4am-robotics/cob_common-release.git
+      version: 2.8.12-1
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: foxy
+    status: maintained
   color_names:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1148,7 +1148,7 @@ repositories:
       - cob_srvs
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/4am-robotics/cob_common-release.git
+      url: https://github.com/ros2-gbp/cob_common-release.git
       version: 2.8.12-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `2.8.12-1`:

- upstream repository: https://github.com/4am-robotics/cob_common.git
- release repository: https://github.com/4am-robotics/cob_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## cob_actions

- No changes

## cob_msgs

- No changes

## cob_srvs

- No changes
