### PR TITLE
cob_common: 2.8.12-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       - cob_srvs
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/4am-robotics/cob_common-release.git
+      url: https://github.com/ros2-gbp/cob_common-release.git
       version: 2.8.12-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -967,6 +967,25 @@ repositories:
       url: https://github.com/coal-library/coal.git
       version: master
     status: developed
+  cob_common:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: foxy
+    release:
+      packages:
+      - cob_actions
+      - cob_msgs
+      - cob_srvs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/4am-robotics/cob_common-release.git
+      version: 2.8.12-1
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: foxy
+    status: maintained
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cob_common` to `2.8.12-1`:

- upstream repository: https://github.com/4am-robotics/cob_common.git
- release repository: https://github.com/4am-robotics/cob_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## cob_actions

- No changes

## cob_msgs

- No changes

## cob_srvs

- No changes
