### PR TITLE
realtime_support: 0.18.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5462,7 +5462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.18.1-1
+      version: 0.18.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `0.18.2-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.18.1-1`

## rttest

```
* Don't try to build on BSD (#126 <https://github.com/ros2/realtime_support/issues/126>)
* Contributors: Scott K Logan
```

## tlsf_cpp

- No changes
