### PR TITLE
geometry2: 0.39.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1999,7 +1999,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.39.2-1
+      version: 0.39.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.39.3-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.39.2-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Add a python3-dev dependency to tf2_py. (#733 <https://github.com/ros2/geometry2/issues/733>)
* Contributors: Chris Lalancette
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Add a python3-dev dependency to tf2_py. (#733 <https://github.com/ros2/geometry2/issues/733>)
* Contributors: Chris Lalancette
```

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Add a python3-dev dependency to tf2_py. (#733 <https://github.com/ros2/geometry2/issues/733>)
* Contributors: Chris Lalancette
```

## tf2_tools

- No changes
