### PR TITLE
ros2_tracing: 8.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6176,7 +6176,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.4.0-1
+      version: 8.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.4.1-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.4.0-1`

## lttngpy

```
* Add python3-dev build_depend to lttngpy. (#146 <https://github.com/ros2/ros2_tracing/issues/146>)
* Don't try to build on BSD (#142 <https://github.com/ros2/ros2_tracing/issues/142>)
* Contributors: Chris Lalancette, Scott K Logan
```

## ros2trace

- No changes

## tracetools

```
* Don't try to build on BSD (#142 <https://github.com/ros2/ros2_tracing/issues/142>)
* Contributors: Scott K Logan
```

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
