### PR TITLE
ament_cmake: 1.3.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -234,7 +234,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 1.3.10-1
+      version: 1.3.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `1.3.11-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.10-1`

## ament_cmake

- No changes

## ament_cmake_auto

- No changes

## ament_cmake_core

- No changes

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_nose

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

```
* Add explicit git dependency from ament_cmake_vendor_package (#557 <https://github.com/ament/ament_cmake/issues/557>)
* Fix patch file dependencies in ament_cmake_vendor_package (#520 <https://github.com/ament/ament_cmake/issues/520>) (#548 <https://github.com/ament/ament_cmake/issues/548>)
* Contributors: mergify[bot], roscan-tech
```

## ament_cmake_version

- No changes
