### PR TITLE
launch_ros: 0.19.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3998,7 +3998,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.7-2
+      version: 0.19.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.8-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.19.7-2`

## launch_ros

```
* Fix url in setup.py (backport #413 <https://github.com/ros2/launch_ros/issues/413>) (#415 <https://github.com/ros2/launch_ros/issues/415>)
* [backport] cache lookup of importlib metadata in Node action (#365 <https://github.com/ros2/launch_ros/issues/365>) (#406 <https://github.com/ros2/launch_ros/issues/406>)
* Contributors: mergify[bot], xueying
```

## launch_testing_ros

```
* [Backport] Make launch_testing_ros examples more robust. (#394 <https://github.com/ros2/launch_ros/issues/394>) (backport #420 <https://github.com/ros2/launch_ros/issues/420>) (#421 <https://github.com/ros2/launch_ros/issues/421>)
* Contributors: mergify[bot]
```

## ros2launch

```
* Fix url in setup.py (backport #413 <https://github.com/ros2/launch_ros/issues/413>) (#415 <https://github.com/ros2/launch_ros/issues/415>)
* Contributors: mergify[bot]
```
