### PR TITLE
rclcpp: 16.0.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7226,7 +7226,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.10-1
+      version: 16.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.11-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `16.0.10-1`

## rclcpp

```
* Fix subscription.is_serialized() for callbacks with message info (#1950 <https://github.com/ros2/rclcpp/issues/1950>) (#2622 <https://github.com/ros2/rclcpp/issues/2622>)
* Use the same context for the specified node in rclcpp::spin functions… (#2618 <https://github.com/ros2/rclcpp/issues/2618>) (#2620 <https://github.com/ros2/rclcpp/issues/2620>)
* Contributors: mergify[bot], roscan-tech
```

## rclcpp_action

```
* fix: Fixed race condition in action server between is_ready and take. Backport from iron #2531 <https://github.com/ros2/rclcpp/issues/2531> (#2635 <https://github.com/ros2/rclcpp/issues/2635>)
* Contributors: Camilo Camacho
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
