### PR TITLE
rclpy: 3.3.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7242,7 +7242,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.14-1
+      version: 3.3.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.15-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.14-1`

## rclpy

```
* TestClient.test_service_timestamps failing consistently. (#1364 <https://github.com/ros2/rclpy/issues/1364>) (#1365 <https://github.com/ros2/rclpy/issues/1365>)
* Fixes spin_until_future_complete inside callback (#1316 <https://github.com/ros2/rclpy/issues/1316>) (#1343 <https://github.com/ros2/rclpy/issues/1343>)
* Install signal handlers after context is initialized. (#1333 <https://github.com/ros2/rclpy/issues/1333>) (#1335 <https://github.com/ros2/rclpy/issues/1335>)
* Avoid causing infinite loop when message is empty (#935 <https://github.com/ros2/rclpy/issues/935>) (#1334 <https://github.com/ros2/rclpy/issues/1334>)
* Contributors: mergify[bot]
```
