### PR TITLE
openeb_vendor: 2.0.1-2 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4349,7 +4349,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: iron
+      version: release
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -4358,7 +4358,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: iron
+      version: release
     status: developed
   openni2_camera:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4354,7 +4354,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/openeb_vendor-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openeb_vendor` to `2.0.1-2`:

- upstream repository: https://github.com/ros-event-camera/openeb_vendor.git
- release repository: https://github.com/ros2-gbp/openeb_vendor-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## openeb_vendor

```
* added silkyev_cam plugin
* Contributors: Bernd Pfrommer
```
