### PR TITLE
raspimouse_ros2_examples: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5619,6 +5619,22 @@ repositories:
       url: https://github.com/rt-net/raspimouse_description.git
       version: jazzy
     status: maintained
+  raspimouse_ros2_examples:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_ros2_examples.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_ros2_examples.git
+      version: jazzy
+    status: maintained
   raspimouse_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_ros2_examples` to `3.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_ros2_examples.git
- release repository: https://github.com/ros2-gbp/raspimouse_ros2_examples-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## raspimouse_ros2_examples

```
* Support ROS 2 Jazzy (#62 <https://github.com/rt-net/raspimouse_ros2_examples/issues/62>)
* Replaced "Twist" with "TwistStamped"
* Contributors: Kazushi Kurasawa, YusukeKato
```
