### PR TITLE
raspimouse_sim: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5619,6 +5619,26 @@ repositories:
       url: https://github.com/rt-net/raspimouse_description.git
       version: jazzy
     status: maintained
+  raspimouse_sim:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: jazzy
+    release:
+      packages:
+      - raspimouse_fake
+      - raspimouse_gazebo
+      - raspimouse_sim
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_sim-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_sim.git
+      version: jazzy
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_sim` to `3.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_sim.git
- release repository: https://github.com/ros2-gbp/raspimouse_sim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## raspimouse_fake

```
* Support ROS 2 Jazzy (#80 <https://github.com/rt-net/raspimouse_sim/issues/80>)
* Changed the header file extension from ".h" to ".hpp"
* Contributors: Kazushi Kurasawa, YusukeKato
```

## raspimouse_gazebo

```
* Support ROS 2 Jazzy (#80 <https://github.com/rt-net/raspimouse_sim/issues/80>)
* Changed Gazebo from "Ignition Gazebo" to "Gazebo Sim"
* Contributors: Kazushi Kurasawa, YusukeKato
```

## raspimouse_sim

```
* Support ROS 2 Jazzy (#80 <https://github.com/rt-net/raspimouse_sim/issues/80>)
```
