### PR TITLE
clearpath_msgs: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1330,12 +1330,13 @@ repositories:
       version: main
     release:
       packages:
+      - clearpath_motor_msgs
       - clearpath_msgs
       - clearpath_platform_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_motor_msgs

```
* [clearpath_motor_msgs] Updated package version.
* Initial clearpath_motor_msgs
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_msgs

```
* Added clearpath_motor_msgs dependency in clearpath_msgs
* Contributors: Roni Kreinin
```

## clearpath_platform_msgs

- No changes
