### PR TITLE
clearpath_desktop: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1310,7 +1310,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 0.3.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `1.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## clearpath_config_live

```
* Added minimum version.
* Contributors: Tony Baltovski
```

## clearpath_desktop

```
* Added minimum version.
* Contributors: Tony Baltovski
```

## clearpath_viz

```
* Added minimum version.
* Contributors: Tony Baltovski
```
