### PR TITLE
image_common: 5.1.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2890,12 +2890,13 @@ repositories:
       packages:
       - camera_calibration_parsers
       - camera_info_manager
+      - camera_info_manager_py
       - image_common
       - image_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.4-1
+      version: 5.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.5-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.4-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

```
* Add camera_info_manager_py (#335 <https://github.com/ros-perception/image_common/issues/335>) (#336 <https://github.com/ros-perception/image_common/issues/336>)
  (cherry picked from commit d09c82cfb5558d253de99317a4d7d5fb61867b03)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## image_common

- No changes

## image_transport

```
* Add lazy subscription to republisher (backport #325 <https://github.com/ros-perception/image_common/issues/325>) (#327 <https://github.com/ros-perception/image_common/issues/327>)
  Co-authored-by: Błażej Sowa <mailto:bsowa123@gmail.com>
* Fix node name (#321 <https://github.com/ros-perception/image_common/issues/321>) (#322 <https://github.com/ros-perception/image_common/issues/322>)
  Node name appears in logs and confuses readers.
  (cherry picked from commit ea6a9e47c259cc875b7a4545e07359b63bd27f60)
  Co-authored-by: Michal Sojka <mailto:michal.sojka@cvut.cz>
* Contributors: mergify[bot]
```
