### PR TITLE
axis_camera: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -912,6 +912,25 @@ repositories:
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git
       version: main
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: humble-devel
+    release:
+      packages:
+      - axis_camera
+      - axis_description
+      - axis_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: humble-devel
+    status: maintained
   backward_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `2.0.3-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## axis_camera

```
* Add/cmd vel topic (#90 <https://github.com/ros-drivers/axis_camera/issues/90>)
  * added cmd/velocity topic for continuous velocity control
* Contributors: Jose Mastrangelo
```

## axis_description

- No changes

## axis_msgs

- No changes
