### PR TITLE
axis_camera: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -681,6 +681,25 @@ repositories:
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git
       version: main
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: jazzy-devel
+    release:
+      packages:
+      - axis_camera
+      - axis_description
+      - axis_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/axis_camera-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: jazzy-devel
+    status: maintained
   azure_iot_sdk_c:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `axis_camera` to `3.0.0-1`:

- upstream repository: https://github.com/ros-drivers/axis_camera.git
- release repository: https://github.com/clearpath-gbp/axis_camera-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## axis_camera

```
* Add/cmd vel topic (#90 <https://github.com/ros-drivers/axis_camera/issues/90>)
  * added cmd/velocity topic for continuous velocity control
* Contributors: jmastrangelo-cpr
```

## axis_description

- No changes

## axis_msgs

- No changes
