### PR TITLE
gz_dartsim_vendor: 0.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2525,7 +2525,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_dartsim_vendor` to `0.0.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_dartsim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## gz_dartsim_vendor

```
* Add check for system installed dartsim (#6 <https://github.com/gazebo-release/gazebo_dartsim_vendor/issues/6>)
  * Check for system installed dart first.
  * Update dart version and add extra debug message
  * Add relaxed version matching when requested
  ---------
  Co-authored-by: Rhys Mainwaring <mailto:rhys.mainwaring@me.com>
* Contributors: Øystein Sture
```
