### PR TITLE
rosbag2: 0.15.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8445,7 +8445,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.12-1
+      version: 0.15.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.13-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.12-1`

## mcap_vendor

- No changes

## ros2bag

```
* Prevent using message compression mode with mcap storage (#1782 <https://github.com/ros2/rosbag2/issues/1782>)
* Contributors: Roman Shtylman
```

## rosbag2

- No changes

## rosbag2_compression

```
* [humble] Make snapshot writing into a new file each time it is triggered (backport #1842 <https://github.com/ros2/rosbag2/issues/1842>) (#1850 <https://github.com/ros2/rosbag2/issues/1850>)
* Prevent using message compression mode with mcap storage (#1782 <https://github.com/ros2/rosbag2/issues/1782>)
* Contributors: Roman Shtylman, mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* [humble] Make snapshot writing into a new file each time it is triggered (backport #1842 <https://github.com/ros2/rosbag2/issues/1842>) (#1850 <https://github.com/ros2/rosbag2/issues/1850>)
* [humble] Bugfix for rosbag2_cpp serialization converter (backport #1814 <https://github.com/ros2/rosbag2/issues/1814>) (backport #1823 <https://github.com/ros2/rosbag2/issues/1823>) (#1824 <https://github.com/ros2/rosbag2/issues/1824>)
* Contributors: mergify[bot]
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* Fixes clang compiler error introduced by #1404 <https://github.com/ros2/rosbag2/issues/1404>. (#1769 <https://github.com/ros2/rosbag2/issues/1769>)
* Contributors: Halvor Platou
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Suppress mcap warnings. (#1854 <https://github.com/ros2/rosbag2/issues/1854>)
* [humble] Allow unknown types in bag rewrite (backport #1812 <https://github.com/ros2/rosbag2/issues/1812>) (#1819 <https://github.com/ros2/rosbag2/issues/1819>)
* Contributors: Chris Lalancette, mergify[bot]
```

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [humble] Allow unknown types in bag rewrite (backport #1812 <https://github.com/ros2/rosbag2/issues/1812>) (#1819 <https://github.com/ros2/rosbag2/issues/1819>)
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
