### PR TITLE
rmf_traffic_editor: 1.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5733,7 +5733,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.10.0-1
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.11.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.10.0-1`

## rmf_building_map_tools

```
* Fix startup error when waypoint's name is pure numbers (#508 <https://github.com/open-rmf/rmf_traffic_editor/pull/508>)
* Contributors: Gary Bey
```

## rmf_traffic_editor

```
* Fix lift cabin graphics on rotated floor plans (#513 <https://github.com/open-rmf/rmf_traffic_editor/issues/513>)
* Fix crash when no features are available to calculate a layer transform (#460 <https://github.com/open-rmf/rmf_traffic_editor/issues/460>)
* Addition of delete button for lift table (#511 <https://github.com/open-rmf/rmf_traffic_editor/issues/511>)
* Fix reference file name being kept when loading new building (#501 <https://github.com/open-rmf/rmf_traffic_editor/issues/501>)
* Contributors: Luca Della Vedova, Tan Jun Kiat
```

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

- No changes
