### PR TITLE
rmf_ros2: 2.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5652,13 +5652,14 @@ repositories:
       - rmf_charging_schedule
       - rmf_fleet_adapter
       - rmf_fleet_adapter_python
+      - rmf_reservation_node
       - rmf_task_ros2
       - rmf_traffic_ros2
       - rmf_websocket
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.7.1-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.9.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.1-1`

## rmf_charging_schedule

```
* Fixes warning given by colcon_ros on Jazzy (#377 <https://github.com/open-rmf/rmf_ros2/issues/377>)
* Add icecream as a rosdep dependency (#358 <https://github.com/open-rmf/rmf_ros2/issues/358>)
* Contributors: Arjo Chakravarty
```

## rmf_fleet_adapter

```
* Add reached API to read-only fleet adapter (#387 <https://github.com/open-rmf/rmf_ros2/issues/387>)
* Fix lift disruption issue (#393 <https://github.com/open-rmf/rmf_ros2/issues/393>)
* Allow automatic action cancellation to be toggled (#392 <https://github.com/open-rmf/rmf_ros2/issues/392>)
* Adds a simple parking spot management system.  (#325 <https://github.com/open-rmf/rmf_ros2/issues/325>)
* Publish fleet and task updates over ROS 2 if websocket is not provided (#383 <https://github.com/open-rmf/rmf_ros2/issues/383>)
* Allow robot-specific finishing request and specify parking spots (#379 <https://github.com/open-rmf/rmf_ros2/issues/379>)
* Issue relocalization command if the robot is on the wrong map (#316 <https://github.com/open-rmf/rmf_ros2/issues/316>)
* set request_time in lift end session request. (#385 <https://github.com/open-rmf/rmf_ros2/issues/385>)
* Update _last_active_task_time if robot is executing task (#384 <https://github.com/open-rmf/rmf_ros2/issues/384>)
* Populate Booking.Priority, added schema to validate Priority (#381 <https://github.com/open-rmf/rmf_ros2/issues/381>)
* Emergency trigger to use transient local qos (#341 <https://github.com/open-rmf/rmf_ros2/issues/341>)
* Add a timeout before automatically releasing lift (#369 <https://github.com/open-rmf/rmf_ros2/issues/369>)
* Configure strict lanes (#367 <https://github.com/open-rmf/rmf_ros2/issues/367>)
* Only fail on_cancel deserializations when none of the activities are possible (#378 <https://github.com/open-rmf/rmf_ros2/issues/378>)
* Fix a minor typo in fleet adapter error log (#307 <https://github.com/open-rmf/rmf_ros2/issues/307>)
* Provide an API that says the robot's lift destination (#376 <https://github.com/open-rmf/rmf_ros2/issues/376>)
* Populate LiftProperties for Destination in localize callbacks (#373 <https://github.com/open-rmf/rmf_ros2/issues/373>)
* Revert "Event based lift / door logic (#320 <https://github.com/open-rmf/rmf_ros2/issues/320>)" (#372 <https://github.com/open-rmf/rmf_ros2/issues/372>)
* Update with new RobotMode field (#345 <https://github.com/open-rmf/rmf_ros2/issues/345>)
* Quiet cancel API (#357 <https://github.com/open-rmf/rmf_ros2/issues/357>)
* Contributors: Aaron Chong, Arjo Chakravarty, Grey, Luca Della Vedova, Xiyu, cwrx777
```

## rmf_fleet_adapter_python

```
* Allow automatic action cancellation to be toggled (#392 <https://github.com/open-rmf/rmf_ros2/issues/392>)
* Adds a simple parking spot management system.  (#325 <https://github.com/open-rmf/rmf_ros2/issues/325>)
* Allow robot-specific finishing request and specify parking spots (#379 <https://github.com/open-rmf/rmf_ros2/issues/379>)
* Provide an API that says the robot's lift destination (#376 <https://github.com/open-rmf/rmf_ros2/issues/376>)
* Quiet cancel API (#357 <https://github.com/open-rmf/rmf_ros2/issues/357>)
* Contributors: Arjo Chakravarty, Grey, Xiyu
```

## rmf_reservation_node

```
* Adds a simple parking spot management system.  (#325 <https://github.com/open-rmf/rmf_ros2/issues/325>)
* Contributors: Arjo Chakravarty
```

## rmf_task_ros2

```
* Publish fleet and task updates over ROS 2 if websocket is not provided (#383 <https://github.com/open-rmf/rmf_ros2/issues/383>)
* Fix incorrect std rounding function used when generating timestamp strings for task ID (#366 <https://github.com/open-rmf/rmf_ros2/issues/366>)
* Contributors: Aaron Chong
```

## rmf_traffic_ros2

```
* Adds a simple parking spot management system.  (#325 <https://github.com/open-rmf/rmf_ros2/issues/325>)
* Contributors: Arjo Chakravarty
```

## rmf_websocket

- No changes
