### PR TITLE
rmf_demos: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5607,7 +5607,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `2.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.0-1`

## rmf_demos

```
* Provide example for robot-specific finishing request (#255 <https://github.com/open-rmf/rmf_demos/issues/255>)
* Add proto-reservation node as core part of RMF (#212 <https://github.com/open-rmf/rmf_demos/issues/212>)
* Contributors: Arjo Chakravarty, Xiyu
```

## rmf_demos_assets

```
* Use environment hooks for plugins / assets (#262 <https://github.com/open-rmf/rmf_demos/issues/262>)
* Contributors: Luca Della Vedova
```

## rmf_demos_bridges

- No changes

## rmf_demos_fleet_adapter

```
* Add proto-reservation node as core part of RMF (#212 <https://github.com/open-rmf/rmf_demos/issues/212>)
* Remove nav graph for fleet manager and update Office world (#263 <https://github.com/open-rmf/rmf_demos/issues/263>)
* Fix existing style issues (#252 <https://github.com/open-rmf/rmf_demos/issues/252>)
* Fixes undefined variable in FleetManager (#251 <https://github.com/open-rmf/rmf_demos/issues/251>)
* Add attach cart action (#225 <https://github.com/open-rmf/rmf_demos/issues/225>)
* Contributors: Arjo Chakravarty, Luca Della Vedova, Xiyu
```

## rmf_demos_gz

```
* Add proto-reservation node as core part of RMF (#212 <https://github.com/open-rmf/rmf_demos/issues/212>)
* Adds the ability to set the update rate of the simulation (#264 <https://github.com/open-rmf/rmf_demos/issues/264>)
* Use environment hooks for plugins / assets (#262 <https://github.com/open-rmf/rmf_demos/issues/262>)
* Contributors: Arjo Chakravarty, Luca Della Vedova
```

## rmf_demos_maps

```
* Add proto-reservation node as core part of RMF (#212 <https://github.com/open-rmf/rmf_demos/issues/212>)
* Remove nav graph for fleet manager and update Office world (#263 <https://github.com/open-rmf/rmf_demos/issues/263>)
* Contributors: Arjo Chakravarty, Xiyu
```

## rmf_demos_tasks

```
* Add proto-reservation node as core part of RMF (#212 <https://github.com/open-rmf/rmf_demos/issues/212>)
* Fix existing style issues (#252 <https://github.com/open-rmf/rmf_demos/issues/252>)
* Add attach cart action (#225 <https://github.com/open-rmf/rmf_demos/issues/225>)
* Adding requester and request time for dispatch scripts (#240 <https://github.com/open-rmf/rmf_demos/issues/240>)
* Contributors: Aaron Chong, Arjo Chakravarty, Luca Della Vedova, Xiyu
```
