### PR TITLE
Added libtmux

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6988,6 +6988,7 @@ python3-libtmux:
   fedora: [python-libtmux]
   gentoo: [dev-python/libtmux]
   opensuse: [python-libtmux]
+  rhel: [python3-libtmux]
   ubuntu: [python3-libtmux]
 python3-lingua-franca-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6987,8 +6987,12 @@ python3-libtmux:
   debian: [python3-libtmux]
   fedora: [python-libtmux]
   gentoo: [dev-python/libtmux]
-  opensuse: [python-libtmux]
-  rhel: [python3-libtmux]
+  opensuse:
+    '*': [python-libtmux]
+    '15.2': null
+  rhel:
+    '*': [python3-libtmux]
+    '8': null
   ubuntu: [python3-libtmux]
 python3-lingua-franca-pip:
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6979,6 +6979,16 @@ python3-libgpiod:
   ubuntu:
     '*': [python3-libgpiod]
     bionic: null
+python3-libtmux:
+  alpine:
+    pip:
+      packages: [libtmux]
+  arch: [python-libtmux]
+  debian: [python3-libtmux]
+  fedora: [python-libtmux]
+  gentoo: [dev-python/libtmux]
+  opensuse: [python-libtmux]
+  ubuntu: [python3-libtmux]
 python3-lingua-franca-pip:
   debian:
     pip:


### PR DESCRIPTION
## Package name:

libtmux

## Package Upstream Source:

[https://github.com/tmux-python/libtmux](https://github.com/tmux-python/libtmux)

## Purpose of using this:

This is a useful and commonly used python library to interact with tmux which is a great tool to use when interacting with robots on the console.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/python3-libtmux
- Ubuntu: https://packages.ubuntu.com/
  - [python3-libtmux](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=libtmux)
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-libtmux/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/python-libtmux/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/libtmux
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Only available via pip
- NixOS/nixpkgs: https://search.nixos.org/packages
  - I found [two](https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=libtmux), but I not sure which one I would have to add, so I didn't add any not to break anything.
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python-libtmux
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/python3-libtmux-0.37.0-3.el9.noarch.rpm.html