### PR TITLE
Fedora 39 is EOL, long live Fedora 41

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -471,9 +471,7 @@ catch2:
   alpine: [catch2]
   arch: [catch2]
   debian: [catch2]
-  fedora:
-    '*': [catch2-devel]
-    '37': null
+  fedora: [catch2-devel]
   freebsd: [catch2]
   gentoo: [dev-cpp/catch]
   nixos: [catch2]
@@ -3417,9 +3415,7 @@ libdpkg-dev:
 libdraco-dev:
   arch: [draco]
   debian: [libdraco-dev]
-  fedora:
-    '*': [draco-devel, draco-static]
-    '39': [draco-devel]
+  fedora: [draco-devel, draco-static]
   nixos: [draco]
   rhel:
     '*': [draco-devel, draco-static]
@@ -7976,9 +7972,7 @@ pybind11-dev:
   ubuntu: [pybind11-dev]
 pybind11-json-dev:
   debian: [pybind11-json-dev]
-  fedora:
-    '*': [pybind11-json-devel]
-    '38': null
+  fedora: [pybind11-json-devel]
   rhel: [pybind11-json-devel]
   ubuntu:
     '*': [pybind11-json-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9463,12 +9463,7 @@ python3-segno:
   debian:
     '*': [python3-segno]
     buster: null
-  fedora: [python3-segno]
   nixos: [python3Packages.segno]
-  rhel:
-    '*': [python3-segno]
-    '7': null
-    '8': null
   ubuntu:
     '*': [python3-segno]
     bionic:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6139,9 +6139,7 @@ python3-flake8-quotes:
     bullseye:
       pip:
         packages: [flake8-quotes]
-  fedora:
-    '*': [python3-flake8-quotes]
-    '35': null
+  fedora: [python3-flake8-quotes]
   freebsd: [devel/py-flake8-quotes]
   nixos: []
   openembedded: [python3-flake8-quotes@meta-ros-common]
@@ -8683,9 +8681,7 @@ python3-pyside6:
     bullseye:
       pip:
         packages: [PySide6]
-  fedora:
-    '*': [python3-pyside6]
-    '39': null
+  fedora: [python3-pyside6]
   osx:
     pip:
       packages: [PySide6]
@@ -9467,10 +9463,7 @@ python3-segno:
   debian:
     '*': [python3-segno]
     buster: null
-  fedora:
-    '*': [python3-segno]
-    '36': null
-    '37': null
+  fedora: [python3-segno]
   nixos: [python3Packages.segno]
   rhel:
     '*': [python3-segno]

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -67,8 +67,8 @@ supported_versions:
   debian:
   - bookworm
   fedora:
-  - '39'
   - '40'
+  - '41'
   opensuse:
   - '15.2'
   openembedded:
@@ -101,9 +101,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '37':
+    '40':
       '%{__isa_name}': 'x86'
-    '38':
+    '41':
       '%{__isa_name}': 'x86'
   openembedded:
     master:


### PR DESCRIPTION
https://lists.fedoraproject.org/archives/list/announce@lists.fedoraproject.org/thread/E7OANKIDHH2B6RHRKQHVKFOWAS23EQIH/

The number of invalid rules remained the same from Fedora 40 at 57.

Requires #43722