### PR TITLE
marker_msgs: 0.0.8-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3334,6 +3334,21 @@ repositories:
       url: https://github.com/apl-ocean-engineering/marine_msgs.git
       version: ros2
     status: developed
+  marker_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/tuw-robotics/marker_msgs-release.git
+      version: 0.0.8-4
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: ros2
+    status: maintained
   marti_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.8-4`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/tuw-robotics/marker_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## marker_msgs

```
* updated for ros2
* Update MarkerDetection.msg
* Update README.md
* Create README.md
* Contributors: Markus Bader
```
