### PR TITLE
raspimouse_sim: 3.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5667,7 +5667,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_sim-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_sim` to `3.0.1-1`:

- upstream repository: https://github.com/rt-net/raspimouse_sim.git
- release repository: https://github.com/ros2-gbp/raspimouse_sim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## raspimouse_fake

- No changes

## raspimouse_gazebo

- No changes

## raspimouse_sim

```
* Changed launch command options (#83 <https://github.com/rt-net/raspimouse_sim/issues/83>)
* Contributors: Kazushi Kurasawa, YusukeKato
```
