### PR TITLE
moveit_visual_tools: 4.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5022,7 +5022,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
-      version: 4.1.0-1
+      version: 4.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `4.1.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/ros2-gbp/moveit_visual_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-1`

## moveit_visual_tools

```
* CI: Fix broken pre-commit action
* CI: Return to custom cache action
* Update status badges in README
* Fix typo in warning message (#141 <https://github.com/ros-planning/moveit_visual_tools/issues/141>)
* CI: Fix ament_flake8 issues
* CI: Update actions
* Default state publisher topic to DISPLAY_ROBOT_STATE_TOPIC (#135 <https://github.com/ros-planning/moveit_visual_tools/issues/135>)
* Update GHA (#128 <https://github.com/ros-planning/moveit_visual_tools/issues/128>)
* publishTrajectoryLine(): issue error when no end-effector tips are found (#127 <https://github.com/ros-planning/moveit_visual_tools/issues/127>)
* Switch to clang-format-14 (#126 <https://github.com/ros-planning/moveit_visual_tools/issues/126>)
* Typo fix (#124 <https://github.com/ros-planning/moveit_visual_tools/issues/124>)
* Update README.md (#122 <https://github.com/ros-planning/moveit_visual_tools/issues/122>)
* Humble CI and clang-format updates (#120 <https://github.com/ros-planning/moveit_visual_tools/issues/120>)
* Contributors: Henning Kayser, Mario Prats, Paul Draghicescu, Robert Haschke, Stephanie Eng, Vatan Aksoy Tezer, mosfet80
```
