### PR TITLE
moveit_resources: 3.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4090,7 +4090,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 3.0.0-3
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `3.1.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-3`

## dual_arm_panda_moveit_config

```
* Remove mimic tags from ros2_control URDF in Panda descriptions (#200 <https://github.com/ros-planning/moveit_resources/issues/200>)
* Allow nonzero velocity at trajectory end for ros2_controllers (#198 <https://github.com/ros-planning/moveit_resources/issues/198>)
* Contributors: Sebastian Castro
```

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Fix name of execution_duration_monitoring parameter (#202 <https://github.com/ros-planning/moveit_resources/issues/202>)
* Add missing dependencies
* Allow nonzero velocity at trajectory end for ros2_controllers (#198 <https://github.com/ros-planning/moveit_resources/issues/198>)
* Contributors: Felix Exner (fexner), Robert Haschke, Sebastian Castro
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Fix name of execution_duration_monitoring parameter (#202 <https://github.com/ros-planning/moveit_resources/issues/202>)
* Add missing dependencies
* CI: Update actions
* Add reasonable joint jerk limits for the Panda (#201 <https://github.com/ros-planning/moveit_resources/issues/201>)
* Remove mimic tags from ros2_control URDF in Panda descriptions (#200 <https://github.com/ros-planning/moveit_resources/issues/200>)
* Allow nonzero velocity at trajectory end for ros2_controllers (#198 <https://github.com/ros-planning/moveit_resources/issues/198>)
* Contributors: AndyZe, Felix Exner (fexner), Robert Haschke, Sebastian Castro
```

## moveit_resources_pr2_description

- No changes
