### PR TITLE
geometric_shapes: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2915,7 +2915,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.1.3-2
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.3.0-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros2-gbp/geometric_shapes-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.3-2`

## geometric_shapes

```
* Install headers into subdirectory (#253 <https://github.com/moveit/geometric_shapes/issues/253>)
* Added bodies::Body::computeBoundingBox (oriented box version) (#239 <https://github.com/moveit/geometric_shapes/issues/239>)
* Improve padding of meshes using weighted vertex normals (#240 <https://github.com/moveit/geometric_shapes/issues/240>)
* Contributors: Kenji Brameld (TRACLabs), Robert Haschke, Sebastian Castro, Sebastian Pelletier, Tyler Mayoff
```
