### PR TITLE
moveit: 2.12.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4034,6 +4034,7 @@ repositories:
       - moveit_ros_planning_interface
       - moveit_ros_robot_interaction
       - moveit_ros_tests
+      - moveit_ros_trajectory_cache
       - moveit_ros_visualization
       - moveit_ros_warehouse
       - moveit_runtime
@@ -4050,7 +4051,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.10.0-1
+      version: 2.12.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.12.0-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.0-1`

## chomp_motion_planner

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_common

- No changes

## moveit_configs_utils

```
* Added joint limits to rviz launch file. (#3091 <https://github.com/ros-planning/moveit2/issues/3091>)
* Switch to get for Dict lookup to prevent KeyError (#3043 <https://github.com/ros-planning/moveit2/issues/3043>)
* fix move_group_capabilities usage (#3018 <https://github.com/ros-planning/moveit2/issues/3018>)
* Contributors: Brendan Burns, Matthew Elwin, Michael Ferguson
```

## moveit_core

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Removes unused deprecation.h file (#3128 <https://github.com/ros-planning/moveit2/issues/3128>)
* Add use_padding flag + deprecate checkCollisionUnpadded() functions (#3088 <https://github.com/ros-planning/moveit2/issues/3088>)
* Fixes flaky RobotState test (#3105 <https://github.com/ros-planning/moveit2/issues/3105>)
* Allow RobotState::setFromIK to work with subframes (#3077 <https://github.com/ros-planning/moveit2/issues/3077>)
* Fix jacobian calculation (#3069 <https://github.com/ros-planning/moveit2/issues/3069>)
* Port fixes for handling orientation constraints (#3052 <https://github.com/ros-planning/moveit2/issues/3052>)
* Fix createTrajectoryMessage (#3064 <https://github.com/ros-planning/moveit2/issues/3064>)
* Fix flipped comments in joint_model.h (#3047 <https://github.com/ros-planning/moveit2/issues/3047>)
* add helper function to load robot from package name + urdf + srdf (#3039 <https://github.com/ros-planning/moveit2/issues/3039>)
* Fix Cartesian interpolation (#3020 <https://github.com/ros-planning/moveit2/issues/3020>)
* Update urdf/model.h -> urdf/model.hpp (#3003 <https://github.com/ros-planning/moveit2/issues/3003>)
* Contributors: Mario Prats, Paul Gesel, Robert Haschke, Sebastian Castro, Sebastian Jahr, Tom Noble
```

## moveit_hybrid_planning

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_kinematics

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_planners

```
* have moveit_planners depend on chomp (#3015 <https://github.com/ros-planning/moveit2/issues/3015>)
* Contributors: Michael Ferguson
```

## moveit_planners_chomp

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_planners_ompl

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Port fixes for handling orientation constraints (#3052 <https://github.com/ros-planning/moveit2/issues/3052>)
* Contributors: Robert Haschke, Tom Noble
```

## moveit_planners_stomp

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_plugins

- No changes

## moveit_py

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Add use_padding flag + deprecate checkCollisionUnpadded() functions (#3088 <https://github.com/ros-planning/moveit2/issues/3088>)
* Fixed Typo get_trajectory_execution_manager in planning.pyi file (#3029 <https://github.com/ros-planning/moveit2/issues/3029>)
* Contributors: Jens Vanhooydonck, Sebastian Jahr, Tom Noble
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Add use_padding flag + deprecate checkCollisionUnpadded() functions (#3088 <https://github.com/ros-planning/moveit2/issues/3088>)
* Contributors: Sebastian Jahr, Tom Noble
```

## moveit_ros_control_interface

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_move_group

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_occupancy_map_monitor

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_perception

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_planning

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Re-enable flaky PSM test (#3124 <https://github.com/ros-planning/moveit2/issues/3124>)
* Add use_padding flag + deprecate checkCollisionUnpadded() functions (#3088 <https://github.com/ros-planning/moveit2/issues/3088>)
* Remove plugins from export set (#3024 <https://github.com/ros-planning/moveit2/issues/3024>)
* Update urdf/model.h -> urdf/model.hpp (#3003 <https://github.com/ros-planning/moveit2/issues/3003>)
* Contributors: Paul Gesel, Robert Haschke, Sebastian Castro, Sebastian Jahr, Tom Noble
```

## moveit_ros_planning_interface

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Enhancement/moveit ros1 ports (#3041 <https://github.com/ros-planning/moveit2/issues/3041>)
* remove dead pick and place code (#3025 <https://github.com/ros-planning/moveit2/issues/3025>)
* Contributors: Michael Ferguson, Tom Noble
```

## moveit_ros_robot_interaction

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_tests

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_trajectory_cache

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_ros_visualization

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Attached Collision Object Transparency (#3093 <https://github.com/ros-planning/moveit2/issues/3093>)
* Contributors: Aiden, Tom Noble
```

## moveit_ros_warehouse

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_runtime

- No changes

## moveit_servo

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* [moveit_servo] avoid race condition when calling ~/pause_servo (#3059 <https://github.com/ros-planning/moveit2/issues/3059>)
* Cleanup #3056 <https://github.com/ros-planning/moveit2/issues/3056> (#3058 <https://github.com/ros-planning/moveit2/issues/3058>)
* Wait for nonzero joint states in PSM in Servo CPP integration test (#3056 <https://github.com/ros-planning/moveit2/issues/3056>)
* [moveit_servo] fix: ensure ee_pose on planning_frame (#3046 <https://github.com/ros-planning/moveit2/issues/3046>)
* set filter state when no commands (#3027 <https://github.com/ros-planning/moveit2/issues/3027>)
* Obtain time from node. (#3032 <https://github.com/ros-planning/moveit2/issues/3032>)
* [Servo] Use velocity scaling properly in Cartesian and pose tracking commands (#3007 <https://github.com/ros-planning/moveit2/issues/3007>)
* Contributors: Dongya Jiang, Jelmer de Wolde, Paul Gesel, Robert Haschke, Sebastian Castro, Tom Noble
```

## moveit_setup_app_plugins

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_setup_assistant

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_setup_controllers

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_setup_core_plugins

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_setup_framework

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Update urdf/model.h -> urdf/model.hpp (#3003 <https://github.com/ros-planning/moveit2/issues/3003>)
* Contributors: Robert Haschke, Tom Noble
```

## moveit_setup_srdf_plugins

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```

## moveit_simple_controller_manager

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* fix parameter namespacing for gripper controller (#3023 <https://github.com/ros-planning/moveit2/issues/3023>)
* Contributors: Michael Ferguson, Tom Noble
```

## pilz_industrial_motion_planner

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Fix: Resolve race condition in MoveGroupSequenceAction (#3125 <https://github.com/ros-planning/moveit2/issues/3125>)
* Fixes pilz tests (#3095 <https://github.com/ros-planning/moveit2/issues/3095>)
* Allow RobotState::setFromIK to work with subframes (#3077 <https://github.com/ros-planning/moveit2/issues/3077>)
* Enhancement/ports moveit 3522 (#3070 <https://github.com/ros-planning/moveit2/issues/3070>)
* Ports moveit/moveit/pull/3519 to ros2 (#3055 <https://github.com/ros-planning/moveit2/issues/3055>)
* Enhancement/moveit ros1 ports (#3041 <https://github.com/ros-planning/moveit2/issues/3041>)
* Contributors: Maxwell.L, Tom Noble
```

## pilz_industrial_motion_planner_testutils

```
* Enhancement/use hpp for headers (#3113 <https://github.com/ros-planning/moveit2/issues/3113>)
* Contributors: Tom Noble
```
