### PR TITLE
ess_imu_driver: 2.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2637,7 +2637,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/cubicleguy/ess_imu_driver-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/cubicleguy/ess_imu_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_driver` to `2.0.2-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_driver.git
- release repository: https://github.com/cubicleguy/ess_imu_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## ess_imu_driver

```
* bugfix with TimeCorrection class for PPS input
```
