### PR TITLE
pick_ik: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6307,7 +6307,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.1.1-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/ros2-gbp/pick_ik-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## pick_ik

```
* Initialize with the best seed instead of initial seed at population wipeout (#77 <https://github.com/PickNikRobotics/pick_ik/issues/77>)
* Fix timeout calculation if solution callback fails (#73 <https://github.com/PickNikRobotics/pick_ik/issues/73>)
* Remove incorrect override of tip_frames (#68 <https://github.com/PickNikRobotics/pick_ik/issues/68>)
* Contributors: Amal Nanavati, Sebastian Castro, Timon Engelke
```
