### PR TITLE
pick_ik: 1.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4629,7 +4629,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.1.0-3
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.1.1-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/ros2-gbp/pick_ik-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-3`

## pick_ik

```
* Initialize with the best seed instead of initial seed at population wipeout (#77 <https://github.com/PickNikRobotics/pick_ik/issues/77>)
* Fix timeout calculation if solution callback fails (#73 <https://github.com/PickNikRobotics/pick_ik/issues/73>)
* Remove incorrect override of tip_frames (#68 <https://github.com/PickNikRobotics/pick_ik/issues/68>)
* Contributors: Amal Nanavati, Sebastian Castro, Timon Engelke
```
