### PR TITLE
rtabmap_ros: 0.21.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7870,7 +7870,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.21.5-3
+      version: 0.21.9-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.21.9-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.21.5-3`
