### PR TITLE
raspimouse_slam_navigation_ros2: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5674,6 +5674,26 @@ repositories:
       url: https://github.com/rt-net/raspimouse_sim.git
       version: jazzy
     status: maintained
+  raspimouse_slam_navigation_ros2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+      version: jazzy
+    release:
+      packages:
+      - raspimouse_navigation
+      - raspimouse_slam
+      - raspimouse_slam_navigation
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
+      version: jazzy
+    status: maintained
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `raspimouse_slam_navigation_ros2` to `3.0.0-1`:

- upstream repository: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
- release repository: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## raspimouse_navigation

```
* Support ROS 2 Jazzy (#13 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/13>)
* Added the setting enable_stamped_cmd_vel: True to standardize the velocity to TwistStamped from Twist
* Modified the use_sim_time setting in collision_monitor to be True during simulations and False during real-world operations
* Changed to provide use_sim_time from the launch command
* Removed the descriptions for default_nav_to_pose_bt_xml and default_nav_through_poses_bt_xml, changing to automatically load the default settings
* Contributors: Kazushi Kurasawa, YusukeKato
```

## raspimouse_slam

```
* Support ROS 2 Jazzy (#13 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/13>)
* Update slam_node to utilize LifecycleNode in accordance with changes made in slam_toolbox
* Contributors: Kazushi Kurasawa, YusukeKato
```

## raspimouse_slam_navigation

```
* Support ROS 2 Jazzy (#13 <https://github.com/rt-net/raspimouse_slam_navigation_ros2/issues/13>)
* Contributors: Kazushi Kurasawa, YusukeKato
```
