### PR TITLE
Added python3-pillow packages under python3-pillow-imagetk package.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7948,9 +7948,22 @@ python3-pil:
       packages: [python3-pillow]
   ubuntu: [python3-pil]
 python3-pil-imagetk:
+  alpine: [py3-pillow]
+  arch: [python-pillow]
   debian: [python3-pil.imagetk]
   fedora: [python3-pillow-tk]
+  freebsd: [graphics/py-pillow]
+  gentoo: [dev-python/pillow]
+  nixos: [python3Packages.pillow]
+  openembedded: [python3-pillow@meta-python]
+  opensuse: [python3-Pillow]
+  osx:
+    pip:
+      packages: [Pillow]
   rhel: [python3-pillow-tk]
+  slackware:
+    slackpkg:
+      packages: [python3-pillow]
   ubuntu: [python3-pil.imagetk]
 python3-pip:
   alpine: [py3-pip]


### PR DESCRIPTION
Please add the following entries under the existing python3-pillow-imagetk rosdep key.

## Package name:

python3-pillow

## Package Upstream Source:

https://github.com/python-pillow/Pillow

## Purpose of using this:

This key is used in my current ros2 project for a GUI. It improves compatibility on ubuntu. However, on Arch, I think this key should point to python-pillow as that package contains python3-pillow-imagetk.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->


 - Debian: https://packages.debian.org/sid/python3-pil.imagetk
 - Ubuntu: https://packages.ubuntu.com/focal/riscv64/python3-pil.imagetk
 - Fedora: https://packages.fedoraproject.org/pkgs/python-pillow/python3-pillow-tk/
- Arch: https://archlinux.org/packages/extra/x86_64/python-pillow/
- Gentoo: https://packages.gentoo.org/packages/dev-python/pillow
- macOS: not available, just use pip
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86/py3-pillow
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.11&show=python312Packages.pillow&from=0&size=50&sort=relevance&type=packages&query=pillow
- openSUSE: https://software.opensuse.org/package/python3-Pillow
- rhel: https://rhel.pkgs.org/9/epel-x86_64/python3-pillow-10.0.1-1.el9.x86_64.rpm.html

(BTW, for these keys I basically just took them from the package above, python3-pillow. Hopefully that is the right call here.)