### PR TITLE
Updated python3-filterpy-pip using wildcard notation

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5921,16 +5921,7 @@ python3-filfinder-pip:
     pip:
       packages: [fil_finder]
 python3-filterpy-pip:
-  debian:
-    pip:
-      packages: [filterpy]
-  fedora:
-    pip:
-      packages: [filterpy]
-  osx:
-    pip:
-      packages: [filterpy]
-  ubuntu:
+  '*':
     pip:
       packages: [filterpy]
 python3-fiona:


### PR DESCRIPTION
Please modify the following dependency in the rosdep database to use pip on all distributions.

## Package name:

TODO

## Package Upstream Source:

https://pypi.org/project/filterpy/
https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python/

## Purpose of using this:

I use this library in my project for sensor filtering. I would like to also use it on Arch linux. This fix does not change compatibility at all, it just lets other linux distros use the pip key.

Distro packaging links:

## Links to Distribution Packages

None - only pip.