### PR TITLE
gz_utils_vendor: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2464,7 +2464,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_utils_vendor` to `0.2.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_utils_vendor.git
- release repository: https://github.com/ros2-gbp/gz_utils_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-1`

## gz_utils_vendor

```
* Bump version to 3.1.0 (#8 <https://github.com/gazebo-release/gz_utils_vendor/issues/8>)
* Contributors: Michael Carroll
```
