### PR TITLE
Add rosdep key 'python3-osrf-pycommon'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7753,6 +7753,11 @@ python3-orjson:
   ubuntu:
     pip:
       packages: [orjson]
+python3-osrf-pycommon:
+  debian: [python3-osrf-pycommon]
+  fedora: [python3-osrf-pycommon]
+  rhel: [python3-osrf-pycommon]
+  ubuntu: [python3-osrf-pycommon]
 python3-overrides:
   arch: [python-overrides]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`python3-osrf-pycommon`

## Package Upstream Source:

https://github.com/osrf/osrf_pycommon

## Purpose of using this:

This package is used by rosdep2, catkin_tools, ros2cli, etc.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-osrf-pycommon
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-osrf-pycommon
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-osrf-pycommon
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - NOT AVAILABLE
- openSUSE: https://software.opensuse.org/package/
  - NOT AVAILABLE
- rhel: https://rhel.pkgs.org/
  - https://packages.fedoraproject.org/

This package is also part of the `ros_bootstrap` repository: http://repos.ros.org/repos/ros_bootstrap/pool/main/p/python-osrf-pycommon/

Part of osrf/osrf_pycommon#80