### PR TITLE
ros_babel_fish: 0.10.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6862,7 +6862,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.10.0-1
+      version: 0.10.3-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.10.3-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.0-1`

## ros_babel_fish

```
* Fixes service server segfaulting (#10 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/10>) and adds a new test to cover this.
* Added convenience methods to get and set values of compound messages.
* Updated export of cmake variables.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes
