### PR TITLE
Changed ros_babel_fish source entry version to rolling for rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6307,7 +6307,7 @@ repositories:
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
-      version: jazzy
+      version: rolling
     status: developed
   ros_battery_monitoring:
     doc:


### PR DESCRIPTION
This should fix the build server failure when changes are pushed to the source repo.
Unfortunately, I could not do this using bloom, so I updated it by hand.