### PR TITLE
realtime_tools: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6046,7 +6046,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.8.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.0.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.1-1`

## realtime_tools

```
* remove unused state_ field (#215 <https://github.com/ros-controls/realtime_tools/issues/215>)
* Bump version of pre-commit hooks (#213 <https://github.com/ros-controls/realtime_tools/issues/213>)
* Add job for clang build (#207 <https://github.com/ros-controls/realtime_tools/issues/207>)
* Add support to parse multiple cores for setting CPU affinity (#208 <https://github.com/ros-controls/realtime_tools/issues/208>)
* Adapt API style of lock_memory to match the one of the other functions (#209 <https://github.com/ros-controls/realtime_tools/issues/209>)
* Move the header files to .hpp extension (#206 <https://github.com/ros-controls/realtime_tools/issues/206>)
* Use windows CI build (#204 <https://github.com/ros-controls/realtime_tools/issues/204>)
* Add downstream build CI job (#201 <https://github.com/ros-controls/realtime_tools/issues/201>)
* Fix RealtimeBox broken API + realtime_box_best_effort.h proper deprecation (#202 <https://github.com/ros-controls/realtime_tools/issues/202>)
* Replace existing RealtimeBox implementation with RealtimeBoxBestEffort implementation (#146 <https://github.com/ros-controls/realtime_tools/issues/146>)
* Overloading the set_thread_affinity method for Windows compatibility (#193 <https://github.com/ros-controls/realtime_tools/issues/193>)
* Remove iron workflows and update readme (#184 <https://github.com/ros-controls/realtime_tools/issues/184>)
* Add method to get the current callback time and period (#192 <https://github.com/ros-controls/realtime_tools/issues/192>)
* Use pthread_setaffinity_np for setting affinity rather than sched_setaffinity (#190 <https://github.com/ros-controls/realtime_tools/issues/190>)
* Add the same compile flags as with ros2_controllers and fix errors (#185 <https://github.com/ros-controls/realtime_tools/issues/185>)
* Contributors: Christoph Fröhlich, Gilmar Correia, Lennart Nachtigall, Sai Kishor Kothakota, github-actions[bot]
```
