### PR TITLE
realtime_tools: 2.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7418,7 +7418,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.8.1-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.9.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.1-1`

## realtime_tools

```
* Overloading the set_thread_affinity method for Windows compatibility (#193 <https://github.com/ros-controls/realtime_tools/issues/193>)
* Remove iron workflows and update readme (#184 <https://github.com/ros-controls/realtime_tools/issues/184>)
* Add method to get the current callback time and period (#192 <https://github.com/ros-controls/realtime_tools/issues/192>)
* Use pthread_setaffinity_np for setting affinity rather than sched_setaffinity (#190 <https://github.com/ros-controls/realtime_tools/issues/190>)
* Add the same compile flags as with ros2_controllers and fix errors (#185 <https://github.com/ros-controls/realtime_tools/issues/185>)
* Contributors: Christoph Fröhlich, Gilmar Correia, Sai Kishor Kothakota
```
