### PR TITLE
ros2_control: 2.45.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8031,7 +8031,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.44.0-1
+      version: 2.45.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.45.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.44.0-1`

## controller_interface

- No changes

## controller_manager

```
* Add CM switch_controller service timeout as parameter to spawner.py (backport #1790 <https://github.com/ros-controls/ros2_control/issues/1790>) (#1879 <https://github.com/ros-controls/ros2_control/issues/1879>)
* Fix Hardware spawner and add tests for it (backport #1759 <https://github.com/ros-controls/ros2_control/issues/1759>) (#1827 <https://github.com/ros-controls/ros2_control/issues/1827>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
