### PR TITLE
proto2ros: 1.0.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6618,6 +6618,21 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  proto2ros:
+    doc:
+      type: git
+      url: https://github.com/bdaiinstitute/proto2ros.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/bdaiinstitute/proto2ros-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/bdaiinstitute/proto2ros.git
+      version: main
+    status: developed
   proxsuite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `proto2ros` to `1.0.0-3`:

- upstream repository: https://github.com/bdaiinstitute/proto2ros.git
- release repository: https://github.com/bdaiinstitute/proto2ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## proto2ros

```
* Add proto2ros documentation (#5 <https://github.com/bdaiinstitute/proto2ros/issues/5>)
* Add GHA CI workflow (#3 <https://github.com/bdaiinstitute/proto2ros/issues/3>)
* Please pre-commit linters (#2 <https://github.com/bdaiinstitute/proto2ros/issues/2>)
* Bring sources from bdaiinstitute/ros_utilities (#1 <https://github.com/bdaiinstitute/proto2ros/issues/1>)
* Contributors: mhidalgo-bdai
```
