### PR TITLE
spot-cpp-sdk: 4.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9902,6 +9902,23 @@ repositories:
       url: https://github.com/ros2/spdlog_vendor.git
       version: humble
     status: maintained
+  spot-cpp-sdk:
+    doc:
+      type: git
+      url: https://github.com/bdaiinstitute/spot-cpp-sdk.git
+      version: ros2
+    release:
+      packages:
+      - bosdyn
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/bdaiinstitute/spot-cpp-sdk-release.git
+      version: 4.1.0-1
+    source:
+      type: git
+      url: https://github.com/bdaiinstitute/spot-cpp-sdk.git
+      version: ros2
+    status: maintained
   srdfdom:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spot-cpp-sdk` to `4.1.0-1`:

- upstream repository: https://github.com/bdaiinstitute/spot-cpp-sdk.git
- release repository: https://github.com/bdaiinstitute/spot-cpp-sdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## bosdyn

```
* Prepare for ROS 2 release (#10 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/10>)
* Patch for ROS 2 release (#9 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/9>)
* Add Protobuf dev libraries to Spot C++ SDK debian deps (#8 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/8>)
* No CONFIG modules in Spot C++ SDK CMake config (#7 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/7>)
* Add gRPC dev libraries to Spot C++ SDK debian deps (#6 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/6>)
* Add dependencies to Spot C++ SDK debians (#5 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/5>)
* Update devcontainers for building debians (#4 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/4>)
* Release v4.1.0 of Boston Dynamics Spot SDK
* Contributors: Andrew Messing, Boston Dynamics SDK Publisher, Michel Hidalgo
```
