### PR TITLE
joystick_drivers: Change branch name due to reorg

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4590,7 +4590,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: main
+      version: ros1
     release:
       packages:
       - joy
@@ -4603,7 +4603,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/joystick_drivers.git
-      version: main
+      version: ros1
     status: maintained
   jsk_3rdparty:
     doc:


### PR DESCRIPTION
Simple update to the branch names for the `joystick_drivers` repo due to branch reorg (only affects `noetic`).