### PR TITLE
mvsim: 0.12.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6589,7 +6589,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
-      version: 0.11.2-1
+      version: 0.12.1-1
     source:
       type: git
       url: https://github.com/ual-arm-ros-pkg/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.12.1-1`:

- upstream repository: https://github.com/ual-arm-ros-pkg/mvsim.git
- release repository: https://github.com/ual-arm-ros-pkg-release/mvsim-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.11.2-1`

## mvsim

```
* Merge pull request #58 <https://github.com/MRPT/mvsim/issues/58> from MichaelGrupp/fix-navsatfix-ros1
  Fix ROS1 build
* Merge pull request #59 <https://github.com/MRPT/mvsim/issues/59> from MichaelGrupp/fix-segfault
  Fix segfault caused by uninitialized publisher
* Fix segfault caused by uninitialized publisher
  Crash occurs for example when running the demo_warehouse.launch with
  ROS 1. Debug build + gdb revealed that the issue was this publisher.
* Contributors: Jose Luis Blanco-Claraco, Michael Grupp
```
