### PR TITLE
marker_msgs: 0.0.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4461,8 +4461,8 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/tuw-robotics/marker_msgs-release.git
-      version: 0.0.8-3
+      url: https://github.com/ros2-gbp/marker_msgs-release.git
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/tuw-robotics/marker_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `marker_msgs` to `0.0.8-1`:

- upstream repository: https://github.com/tuw-robotics/marker_msgs.git
- release repository: https://github.com/ros2-gbp/marker_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.8-3`

## marker_msgs

```
* updated for ros2
* Update MarkerDetection.msg
* Update README.md
* Create README.md
* Contributors: Markus Bader
```
