### PR TITLE
tuw_geometry: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10656,7 +10656,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_geometry-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_geometry` to `0.1.2-1`:

- upstream repository: https://github.com/tuw-robotics/tuw_geometry.git
- release repository: https://github.com/ros2-gbp/tuw_geometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## tuw_geometry

```
* unittest fixed
* reformatted
* init map updated
* origin struct removed
* update on geo_handler
* point update
* direction vector on lines added
* WorldFile class enhanced
* GeographicLib from export_dependencies removed
* Update ament_export_dependencies
* spaces removed
* formating fixed
* uncrustify
* minor
* cv support enhanced
* minor
* geo handler added
* map_handler added
* map to utm added
* WorldFile added
* uncrustified
* tests updated
* Makefile added
* doku added
* codeformatierung fixed
* geomap added
* figure inti with matrix
* export dependencies for sensor_msgs std_msgs OpenCV added
* export dependencies for sensor_msgs std_msgs OpenCV added
* coding fixed
* reformated
* warning in test removed
* uncrustify
* plan3d added
* plan3d added
* plan3d added
* <test_depend>ament_cmake_cppcheck</test_depend> added
* Contributors: Alexander Lampalzer, Markus Bader, markus
```
