### PR TITLE
pal_statistics: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4962,7 +4962,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.6.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.5.0-1`

## pal_statistics
```
* Merge branch 'fix/crash/on_destruction' into 'humble-devel'
  Fix pal_statistics crash upon destruction
  See merge request qa/pal_statistics!48
* Add missing setEnabledmpl in registerInternal method
* Add DELETE_REGISTRY and CLEAR_ALL_REGISTRIES macros
* Check if the registry exists before calling `publishAsync`
* Add clearAllRegistries method
* Add deleteRegistry method in the macros.hpp
* Catch exceptions thrown in the publisher thread
* Merge branch 'make/topics/latched' into 'humble-devel'
  Make all topics latched by default
  See merge request qa/pal_statistics!47
* Make all topics latched by default
* Contributors: Jordan Palacios, Sai Kishor Kothakota
```
## pal_statistics_msgs

- No changes
