### PR TITLE
robot_calibration: 0.8.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7886,7 +7886,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.8.2-1
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.8.3-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.2-1`

## robot_calibration

```
* temporarily depend on libfcl-dev (#187 <https://github.com/mikeferguson/robot_calibration/issues/187>)
  The new release of geometric_shapes only exec_depends on libfcl, which appears to cause linking issues in building the Debians.
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
