### PR TITLE
rosdistro: fix a typo in `empy`

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5767,7 +5767,7 @@ python3-empy:
   opensuse: [python3-empy]
   osx:
     pip:
-      packakges: [empy]
+      packages: [empy]
   rhel: ['python%{python3_pkgversion}-empy']
   ubuntu: [python3-empy]
 python3-environs-pip:


### PR DESCRIPTION
Just a typo.

## Package name:

empy

