### PR TITLE
geometric_shapes: 2.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2275,7 +2275,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.3.1-1`:

- upstream repository: https://github.com/moveit/geometric_shapes.git
- release repository: https://github.com/ros2-gbp/geometric_shapes-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## geometric_shapes

```
* Fix dependency handling (#256 <https://github.com/ros-planning/geometric_shapes/issues/256>)
  Declare fcl, qhull, and assimp as non-transitive, build-only dependencies. They are not exposed in headers.
* Contributors: Martin Pecka
```
