### PR TITLE
autoware_msgs: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -618,7 +618,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-1`

## autoware_common_msgs

- No changes

## autoware_control_msgs

- No changes

## autoware_localization_msgs

- No changes

## autoware_map_msgs

```
* feat(autoware_map_msgs): add MapProjectorInfo message (#102 <https://github.com/autowarefoundation/autoware_msgs/issues/102>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_perception_msgs

- No changes

## autoware_planning_msgs

- No changes

## autoware_sensing_msgs

- No changes

## autoware_system_msgs

- No changes

## autoware_v2x_msgs

- No changes

## autoware_vehicle_msgs

- No changes
