### PR TITLE
ros2_controllers: 4.17.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6107,10 +6107,12 @@ repositories:
       - effort_controllers
       - force_torque_sensor_broadcaster
       - forward_command_controller
+      - gpio_controllers
       - gripper_controllers
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - mecanum_drive_controller
       - parallel_gripper_controller
       - pid_controller
       - pose_broadcaster
@@ -6126,7 +6128,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.16.0-1
+      version: 4.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.17.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.16.0-1`

## ackermann_steering_controller

```
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## admittance_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## bicycle_steering_controller

```
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## diff_drive_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Fix RealtimeBox API changes (#1385 <https://github.com/ros-controls/ros2_controllers/issues/1385>)
* Rename Twist->TwistStamped (#1393 <https://github.com/ros-controls/ros2_controllers/issues/1393>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## effort_controllers

```
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## force_torque_sensor_broadcaster

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## forward_command_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## gpio_controllers

```
* Add missing dependency to gpio_controllers (#1410 <https://github.com/ros-controls/ros2_controllers/issues/1410>)
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Gpio command controller (#1251 <https://github.com/ros-controls/ros2_controllers/issues/1251>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Wiktor Bajor
```

## gripper_controllers

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add explicit cast to period.count() (#1404 <https://github.com/ros-controls/ros2_controllers/issues/1404>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## imu_sensor_broadcaster

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## joint_state_broadcaster

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* JTC: sum periods (#1395 <https://github.com/ros-controls/ros2_controllers/issues/1395>)
* [JTC] Sample at t + dT instead of the beginning of the control cycle (#1306 <https://github.com/ros-controls/ros2_controllers/issues/1306>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Felix Exner (fexner), Sai Kishor Kothakota
```

## mecanum_drive_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add Mecanum Drive Controller (#512 <https://github.com/ros-controls/ros2_controllers/issues/512>)
* Contributors: Dr. Denis, Sai Kishor Kothakota
```

## parallel_gripper_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## pid_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## pose_broadcaster

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## position_controllers

```
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## range_sensor_broadcaster

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## ros2_controllers

```
* Add Mecanum Drive Controller (#512 <https://github.com/ros-controls/ros2_controllers/issues/512>)
* Gpio command controller (#1251 <https://github.com/ros-controls/ros2_controllers/issues/1251>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Dr. Denis, Wiktor Bajor
```

## ros2_controllers_test_nodes

```
* Don't call shutdown() after an exception (#1400 <https://github.com/ros-controls/ros2_controllers/issues/1400>)
* Add another dependency (#1382 <https://github.com/ros-controls/ros2_controllers/issues/1382>)
* Add missing deps for test_nodes (#1378 <https://github.com/ros-controls/ros2_controllers/issues/1378>)
* test_nodes: catch keyboard interrupt and add simple launch tests (#1369 <https://github.com/ros-controls/ros2_controllers/issues/1369>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich
```

## rqt_joint_trajectory_controller

```
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich
```

## steering_controllers_library

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Add Mecanum Drive Controller (#512 <https://github.com/ros-controls/ros2_controllers/issues/512>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Dr. Denis, Sai Kishor Kothakota
```

## tricycle_controller

```
* Use the .hpp headers from realtime_tools package (#1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>)
* Fix RealtimeBox API changes (#1385 <https://github.com/ros-controls/ros2_controllers/issues/1385>)
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* TractionLimiter: Fix wrong input checks (#1341 <https://github.com/ros-controls/ros2_controllers/issues/1341>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## tricycle_steering_controller

```
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## velocity_controllers

```
* Add few warning flags to error in all ros2_controllers packages and fix tests (#1370 <https://github.com/ros-controls/ros2_controllers/issues/1370>)
* Update maintainers and add url tags (#1363 <https://github.com/ros-controls/ros2_controllers/issues/1363>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
