### PR TITLE
eiquadprog: 1.2.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1686,6 +1686,21 @@ repositories:
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel
     status: maintained
+  eiquadprog:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+      version: 1.2.9-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    status: maintained
   ess_imu_driver2:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1694,7 +1694,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
+      url: https://github.com/ros2-gbp/eiquadprog-release.git
       version: 1.2.9-1
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eiquadprog` to `1.2.9-1`:

- upstream repository: git@github.com:stack-of-tasks/eiquadprog.git
- release repository: https://github.com/stack-of-tasks/eiquadprog-ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
