### PR TITLE
control_toolbox: 3.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1152,7 +1152,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.4.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.0-1`

## control_toolbox

```
* Add job for clang build (#239 <https://github.com/ros-controls/control_toolbox/issues/239>)
* Fix bug in rate_limiter filter and add more tests (#237 <https://github.com/ros-controls/control_toolbox/issues/237>)
* Fix jerk limiter in rate_limiter (#240 <https://github.com/ros-controls/control_toolbox/issues/240>)
* Add downstream build job (#243 <https://github.com/ros-controls/control_toolbox/issues/243>)
* Bump version of pre-commit hooks (#242 <https://github.com/ros-controls/control_toolbox/issues/242>)
* Fix mergify rules (#241 <https://github.com/ros-controls/control_toolbox/issues/241>)
* Remove iron workflows and update readme (#217 <https://github.com/ros-controls/control_toolbox/issues/217>)
* Minor include cleanup (#230 <https://github.com/ros-controls/control_toolbox/issues/230>)
* Minor CI updates (#236 <https://github.com/ros-controls/control_toolbox/issues/236>)
* Move speed limiter from ros2_control repo (#212 <https://github.com/ros-controls/control_toolbox/issues/212>)
* Add semi-binary build (#228 <https://github.com/ros-controls/control_toolbox/issues/228>)
* Add the same compile flags as with ros2_controllers and fix errors (#219 <https://github.com/ros-controls/control_toolbox/issues/219>)
* LPF: Throw if calling udpate unconfigured (#229 <https://github.com/ros-controls/control_toolbox/issues/229>)
* Add standalone version of LPF (#222 <https://github.com/ros-controls/control_toolbox/issues/222>)
* Pid class does not depend on rclcpp (#221 <https://github.com/ros-controls/control_toolbox/issues/221>)
* Change license to Apache-2 (#220 <https://github.com/ros-controls/control_toolbox/issues/220>)
* Update README.md (#215 <https://github.com/ros-controls/control_toolbox/issues/215>)
* Update README.md (#214 <https://github.com/ros-controls/control_toolbox/issues/214>)
* Bump version of pre-commit hooks (#213 <https://github.com/ros-controls/control_toolbox/issues/213>)
* Contributors: Christoph Fröhlich, Thibault Poignonec, github-actions[bot]
```
