### PR TITLE
game_controller_spl: 2.2.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2735,7 +2735,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
-      version: 2.1.0-1
+      version: 2.2.0-2
     source:
       type: git
       url: https://github.com/ros-sports/game_controller_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `game_controller_spl` to `2.2.0-2`:

- upstream repository: https://github.com/ros-sports/game_controller_spl.git
- release repository: https://github.com/ros2-gbp/game_controller_spl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## game_controller_spl

```
* Updates for RCGCD16 (#92 <https://github.com/ros-sports/gc_spl/issues/92>)
* Clean up tests that were re-defining constants that were defined in the interfaces (#93 <https://github.com/ros-sports/gc_spl/issues/93>)
* Contributors: Kenji Brameld, ijnek
```

## game_controller_spl_interfaces

```
* Updates for RCGCD16 (#92 <https://github.com/ros-sports/gc_spl/issues/92>)
* Fix typo (#89 <https://github.com/ros-sports/gc_spl/issues/89>)
* Contributors: Kenji Brameld, ijnek
```

## gc_spl

- No changes

## gc_spl_2022

- No changes

## gc_spl_interfaces

```
* Fix typo (#89 <https://github.com/ros-sports/gc_spl/issues/89>)
* Contributors: Kenji Brameld, ijnek
```

## rcgcd_spl_14

```
* Fix typo (#89 <https://github.com/ros-sports/gc_spl/issues/89>)
* Contributors: Kenji Brameld, ijnek
```

## rcgcd_spl_14_conversion

- No changes

## rcgcrd_spl_4

- No changes

## rcgcrd_spl_4_conversion

- No changes
