### PR TITLE
game_controller_spl: 5.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1917,17 +1917,10 @@ repositories:
       packages:
       - game_controller_spl
       - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
-      version: 4.0.1-1
+      version: 5.0.0-2
     source:
       type: git
       url: https://github.com/ros-sports/game_controller_spl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `game_controller_spl` to `5.0.0-2`:

- upstream repository: https://github.com/ros-sports/game_controller_spl.git
- release repository: https://github.com/ros2-gbp/game_controller_spl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-1`

## game_controller_spl

```
* Updates for RCGCD16 (#92 <https://github.com/ros-sports/gc_spl/issues/92>)
* Clean up tests that were re-defining constants that were defined in the interfaces (#93 <https://github.com/ros-sports/gc_spl/issues/93>)
* Contributors: Kenji Brameld, ijnek
```

## game_controller_spl_interfaces

```
* Updates for RCGCD16 (#92 <https://github.com/ros-sports/gc_spl/issues/92>)
* Fix typo (#88 <https://github.com/ros-sports/gc_spl/issues/88>)
* Contributors: Kenji Brameld, ijnek
```
