### PR TITLE
jsk_control: 0.1.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4730,7 +4730,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_control-release.git
-      version: 0.1.17-2
+      version: 0.1.18-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_control` to `0.1.18-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_control.git
- release repository: https://github.com/tork-a/jsk_control-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.17-2`

## cmd_vel_smoother

- No changes

## contact_states_observer

- No changes

## eus_nlopt

- No changes

## eus_qp

- No changes

## eus_qpoases

- No changes

## eus_teleop

- No changes

## joy_mouse

- No changes

## jsk_calibration

- No changes

## jsk_control

- No changes

## jsk_footstep_controller

- No changes

## jsk_footstep_planner

- No changes

## jsk_ik_server

- No changes

## jsk_teleop_joy

```
* [jsk_teleop_joy] support midi launchpad X (#789 <https://github.com/jsk-ros-pkg/jsk_control/issues/789>)
* [jsk_teleop_joy] python3-pygame is required on noetic (#787 <https://github.com/jsk-ros-pkg/jsk_control/issues/787>)
* Contributors: Shun Hasegawa, Yoshiki Obinata
```
