### PR TITLE
off_highway_sensor_drivers: 0.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5818,7 +5818,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 0.6.3-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `0.7.0-1`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.3-1`

## off_highway_can

```
* Update docs for CAN FD
* Check matching lengths in decoding
* Allow start bits in CAN FD range
* Make CRC and message counter optional
* Enable processing of CAN FD frames
* Remove unused definitions
* Do not force warnings as errors to fix rolling (#11)
* Contributors: Robin Petereit, Tim Clephas
```

## off_highway_general_purpose_radar

```
* Register GPR component
* Contributors: Robin Petereit
```

## off_highway_general_purpose_radar_msgs

- No changes

## off_highway_premium_radar_sample

```
* Do not force warnings as errors to fix rolling (#11)
* Contributors: Tim Clephas
```

## off_highway_premium_radar_sample_msgs

```
* Do not force warnings as errors to fix rolling (#11)
* Contributors: Tim Clephas
```

## off_highway_radar

```
* Do not force warnings as errors to fix rolling (#11)
* Contributors: Tim Clephas
```

## off_highway_radar_msgs

```
* Do not force warnings as errors to fix rolling (#11)
* Contributors: Tim Clephas
```

## off_highway_sensor_drivers

- No changes

## off_highway_sensor_drivers_examples

- No changes

## off_highway_uss

```
* Add object type SNA and filter such objects
* Do not force warnings as errors to fix rolling (#11)
* Contributors: Robin Petereit, Tim Clephas
```

## off_highway_uss_msgs

```
* Add object type SNA and filter such objects
* Contributors: Robin Petereit
```
