### PR TITLE
python_mrpt_ros: 2.14.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8525,7 +8525,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/python_mrpt_ros-release.git
-      version: 2.14.6-1
+      version: 2.14.7-1
     source:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_mrpt_ros` to `2.14.7-1`:

- upstream repository: https://github.com/MRPT/python_mrpt_ros.git
- release repository: https://github.com/mrpt-ros-pkg-release/python_mrpt_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.14.6-1`
