### PR TITLE
python_mrpt_ros: 2.14.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6834,7 +6834,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
-      version: 2.14.6-1
+      version: 2.14.7-1
     source:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_mrpt_ros` to `2.14.7-1`:

- upstream repository: https://github.com/MRPT/python_mrpt_ros.git
- release repository: https://github.com/ros2-gbp/python_mrpt_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.14.6-1`
