### PR TITLE
mola: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3956,7 +3956,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Support publishing IMU readings MOLA -> ROS2
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Update ROS2 demos for Mulran replay
* mola_viz: Show IMU data in the GUI too
* Contributors: Jose Luis Blanco-Claraco
```

## mola_imu_preintegration

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

```
* Mulran: Publish IMU too
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* Fix typo in warning message
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* NavStateFilter interface: add API for merging GNSS observations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

```
* NDT maps: more render options (enable colormaps,etc.)
* mola_metric_maps: robin-maps upgraded to latest version
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_navstate_fg

```
* Start integrating GNSS observation. Added a new CLI program mola-navstate-cli for testing state fusion
* Contributors: Jose Luis Blanco-Claraco
```

## mola_navstate_fuse

```
* Start integrating GNSS observation. Added a new CLI program mola-navstate-cli for testing state fusion
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* mola_viz: Show IMU data in the GUI too
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
