### PR TITLE
ur_simulation_gz: 2.1.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9265,6 +9265,11 @@ repositories:
       version: main
     status: developed
   ur_simulation_gz:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `2.1.0-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ur_simulation_gz

```
* Update README.md with correct example script (#67 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/67>)
* Use sjtc and generate /clock topic (#58 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/58>)
* Add a ground plane to the gz URDF (#61 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/61>)
* Contributors: Felix Exner
```
