### PR TITLE
ur_description: 2.1.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10893,7 +10893,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.8-2
+      version: 2.1.9-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.9-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.8-2`

## ur_description

```
* Assure the description is loaded as string (backport #229 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/229>)
* Added ground plane to URDF for simulators (#226 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/226>)
* Contributors: Vincenzo Di Pentima, Felix Exner
```
