### PR TITLE
gz_ros2_control: 1.2.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2706,7 +2706,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.8-1
+      version: 1.2.9-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.9-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.8-1`

## gz_ros2_control

```
* use gz-physics`#283 <https://github.com/ros-controls/gz_ros2_control/issues/283>`_ to implement joint_states/effort feedback (#186 <https://github.com/ros-controls/gz_ros2_control/issues/186>)
* Contributors: Andreas Bihlmaier
```

## gz_ros2_control_demos

```
* Add Mecanum vehicle example (#451 <https://github.com/ros-controls/gz_ros2_control/issues/451>) (#455 <https://github.com/ros-controls/gz_ros2_control/issues/455>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 18bdde12b46814d9b4607817a7f5df0cb0930364)
  Co-authored-by: Marq Rasmussen <mailto:marq.razz@gmail.com>
* Add missing bridge for simulation time (#443 <https://github.com/ros-controls/gz_ros2_control/issues/443>) (#445 <https://github.com/ros-controls/gz_ros2_control/issues/445>)
  (cherry picked from commit 301ca580d0772b9952579a783632500eeca7e53b)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```
