### PR TITLE
ur_description: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8377,7 +8377,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.4.5-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.5-1`

## ur_description

```
* Remove Iron workflows and from README (#230 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/230>)
* Assure the description is loaded as string (#229 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/229>)
* Contributors: Felix Exner
```
