### PR TITLE
ur_simulation_gz: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10938,6 +10938,11 @@ repositories:
       version: humble
     status: developed
   ur_simulation_gz:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `0.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ur_simulation_gz

```
* Start gz bridge for clock topic (#60 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/60>)
* Contributors: Felix Exner (fexner)
```
