### PR TITLE
image_pipeline: 6.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2638,7 +2638,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.5-1
+      version: 6.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.6-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.5-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Support QoS override parameters in depth_image_proc/register (#1043 <https://github.com/ros-perception/image_pipeline/issues/1043>)
  This PR adds support to the depth_image_proc - register node for
  setting External QoS Configuration on topic _subscriptions_.
* Contributors: Stuart Alldritt
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

```
* add image_flip node (#942 <https://github.com/ros-perception/image_pipeline/issues/942>)
  This is a continuation of
  https://github.com/ros-perception/image_pipeline/pull/756:
  * [x] Squashed 16 commits in original PR for ease of rebase/review
  * [x] Moved node into image_rotate package
  * [x] Added lazy subscriber
  * [x] Removes QoS parameters - will add proper QoS overrides in a
  different PR (when we do the same for image_rotate)
  * [x] Adds documentation
  ---------
  Co-authored-by: David Conner <mailto:robotics@cnu.edu>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Michael Ferguson
```

## image_view

```
* image_view_node: support bayer images (#1046 <https://github.com/ros-perception/image_pipeline/issues/1046>)
  so far bayer images always failed with an error:
  ```
  [ERROR] [..] [image_view_node]: Unable to convert 'bayer_rggb8' image for display: 'cv_bridge.cvtColorForDisplay() does not have an output encoding                that is color or mono, and has is bit in depth'
  ```
  the stereo_view_node on the other hand already supports bayer images,
  however it always forcibly converts them to monochrome, even if they are
  colour images.
  for now, this adds the same logic for the single-image viewer and thus
  only partially resolves #1045 <https://github.com/ros-perception/image_pipeline/issues/1045>.
* Contributors: Ralph Ursprung
```

## stereo_image_proc

```
* stereo_image_proc: disparity_node: Add parameter to control camera_info (#1051 <https://github.com/ros-perception/image_pipeline/issues/1051>)
  Add a parameter, use_image_transport_camera_info (default:
  true), to control whether DisparityNode uses
  image_transport::getCameraInfoTopic for deriving camera_info topics.
  Default Behavior (backward compatible):
  When use_image_transport_camera_info is true, the node continues using
  image_transport::getCameraInfoTopic for camera_info resolution,
  maintaining existing functionality.
  Custom Behavior:
  When use_image_transport_camera_info is false, the node directly uses
  the camera_info topics specified via remapping (e.g., left/camera_info
  and right/camera_info), bypassing image_transport's derivation logic.
  This solution allows users to explicitly remap the camera_info topics
  for both cameras, providing flexibility for scenarios where topic names
  are not unique or need customization.
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Fix spelling error in topic name (#1049 <https://github.com/ros-perception/image_pipeline/issues/1049>)
* Contributors: Michael Ferguson, quic-zhaoyuan
```

## tracetools_image_pipeline

- No changes
