### PR TITLE
image_pipeline: 5.0.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2951,7 +2951,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.5-1
+      version: 5.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.6-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.5-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Support QoS override parameters in depth_image_proc/register (backport #1043 <https://github.com/ros-perception/image_pipeline/issues/1043>) (#1044 <https://github.com/ros-perception/image_pipeline/issues/1044>)
  This PR adds support to the depth_image_proc - register node for
  setting External QoS Configuration on topic _subscriptions_.
  Co-authored-by: Stuart Alldritt <mailto:s.k.alldritt@gmail.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

```
* add image_flip node (backport #942 <https://github.com/ros-perception/image_pipeline/issues/942>) (#1059 <https://github.com/ros-perception/image_pipeline/issues/1059>)
  This is a continuation of
  https://github.com/ros-perception/image_pipeline/pull/756:
  * [x] Squashed 16 commits in original PR for ease of rebase/review
  * [x] Moved node into image_rotate package
  * [x] Added lazy subscriber
  * [x] Removes QoS parameters - will add proper QoS overrides in a
  different PR (when we do the same for image_rotate)
  * [x] Adds documentation<hr>This is an automatic backport of pull
  request #942 <https://github.com/ros-perception/image_pipeline/issues/942> done by [Mergify](https://mergify.com).
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Contributors: mergify[bot]
```

## image_view

```
* image_view_node: support bayer images (backport #1046 <https://github.com/ros-perception/image_pipeline/issues/1046>) (#1058 <https://github.com/ros-perception/image_pipeline/issues/1058>)
  so far bayer images always failed with an error:
  ```
  [ERROR] [..] [image_view_node]: Unable to convert 'bayer_rggb8' image for display: 'cv_bridge.cvtColorForDisplay() does not have an output encoding                that is color or mono, and has is bit in depth'
  ```
  the stereo_view_node on the other hand already supports bayer images,
  however it always forcibly converts them to monochrome, even if they are
  colour images.
  for now, this adds the same logic for the single-image viewer and thus
  only partially resolves #1045 <https://github.com/ros-perception/image_pipeline/issues/1045>.<hr>This is an automatic backport of pull
  request #1046 <https://github.com/ros-perception/image_pipeline/issues/1046> done by [Mergify](https://mergify.com).
  Co-authored-by: Ralph Ursprung <mailto:39383228+rursprung@users.noreply.github.com>
* Contributors: mergify[bot]
```

## stereo_image_proc

```
* Fix spelling error in topic name (backport #1049 <https://github.com/ros-perception/image_pipeline/issues/1049>) (#1050 <https://github.com/ros-perception/image_pipeline/issues/1050>)
  <hr>This is an automatic backport of pull request #1049 <https://github.com/ros-perception/image_pipeline/issues/1049> done by
  [Mergify](https://mergify.com).
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Contributors: mergify[bot]
```

## tracetools_image_pipeline

- No changes
