### PR TITLE
camera_aravis2: 1.1.0-1 in 'iron/distribution.yaml' [bloom]

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -718,7 +718,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/camera_aravis2-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis2` to `1.1.0-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis2.git
- release repository: https://github.com/ros2-gbp/camera_aravis2-release.git
- distro file: `iron/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## camera_aravis2

```
* Update maintainer -> Raphael Hagmanns
* Enhance: Improved assertions and error messages
* Fix: added failure exit code to nodes
* Enhance: changed message of acquisition start/stop to info-level
* Fix: calculation of ROS topic subscriber count -> fix start/stop acquisition
* Fix: added epsilon in the comparison between double values
* Fix: handling of missing 'file://' in camera_info_url
* Fix: Adjusted step of integer and fp range
* Feat: Added support to access GigEVision cameras via IP address.
* Feat: Support for USB3 Cameras.
* Feat: Added functionally do specify parameters that are to be made dynamically changeable.
* Added service to manually trigger computation of white balance.
* Minor changes and bug fixes
* Contributors: Boitumelo Ruf, Louis-Romain JOLY, Ralph Ursprung
```

## camera_aravis2_msgs

```
* Update maintainer -> Raphael Hagmanns
* Added dynamic paramters.
* Added service to manually trigger computation of white balance.
* Contributors: Boitumelo Ruf
```
