### PR TITLE
cras_ros_utils: 2.4.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1808,7 +1808,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.5-1
+      version: 2.4.6-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1808,7 +1808,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.6-1
+      version: 2.4.7-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.4.7-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.5-1`

## cras_cpp_common

```
* Fixed installation of nodelet_manager_sharing_tf_buffer.
* nodelet_utils: Allowed accessing the shared_ptr of the shared TF buffer.
* node_from_nodelet: Worked around the bug where remapping private topics was impossible for anonymous nodes.
* tf2_utils: Added TfMessageFilter compatible with log_utils.
* time_utils: Added converters between ros::Time and struct tm.
* Fixed a few printf format issues.
* string_utils: Handle possible error in vsnprintf. Added printf-format attributes to cras::format() to enable compile-time checks of format strings.
* string_utils: Added iconvConvert(), transliterateToAscii() and toValidRosName() functions.
* Contributors: Martin Pecka
```

## cras_docs_common

- No changes

## cras_py_common

```
* string_utils: Added iconvConvert(), transliterateToAscii() and toValidRosName() functions.
* Contributors: Martin Pecka
```

## cras_topic_tools

- No changes

## image_transport_codecs

- No changes
