### PR TITLE
ros2_canopen: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6068,7 +6068,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.12-2
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.0-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.12-2`

## canopen

```
* Update CiA402 bus config docs
* Remove set heartbeat service from master documentation (#294 <https://github.com/ros-industrial/ros2_canopen/issues/294>)
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
* Add cyclic torque mode to cia402 driver and robot system controller (#293 <https://github.com/ros-industrial/ros2_canopen/issues/293>)
  * Add base functions for switching to cyclic torque mode
  * Add cyclic torque mode as effort interface to robot_system controller
  * Add documentation about cyclic torque mode.
  ---------
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
```

## canopen_402_driver

```
* Reformat using pre-commit
* Implement position offsets
* pre-commit fix
* impl operation mode
* Add cyclic torque mode to cia402 driver and robot system controller (#293 <https://github.com/ros-industrial/ros2_canopen/issues/293>)
  * Add base functions for switching to cyclic torque mode
  * Add cyclic torque mode as effort interface to robot_system controller
  * Add documentation about cyclic torque mode.
  ---------
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
```

## canopen_base_driver

- No changes

## canopen_core

- No changes

## canopen_fake_slaves

```
* fix loop timer for run_velocity_mode
* Fix clang format
* Add comments for the fake slave function
* Fix the thread issue.
* Apply suggestions from code review
  Co-authored-by: Dr. Denis <mailto:denis@stoglrobotics.de>
* Working version.
* Periodic messages sent, but not received properly.
* Working logic. Still have to work on the edf file.
* Put the periodic messages in OnWrite
* Extend fake_slaves to publish messages via rpdo
```

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

- No changes

## canopen_ros2_control

```
* pre-commit fix
* impl operation mode
* Add cyclic torque mode to cia402 driver and robot system controller (#293 <https://github.com/ros-industrial/ros2_canopen/issues/293>)
  * Add base functions for switching to cyclic torque mode
  * Add cyclic torque mode as effort interface to robot_system controller
  * Add documentation about cyclic torque mode.
  ---------
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
* Fix clang format
* Update canopen_system.hpp
* Add pdo mapping support
* Fix clang format
* Fix pre-commit
* Periodic messages sent, but not received properly.
* Fix the bug that the rpdo queue keeps poping although it is empty.
* Use proper function to get rpdo data
* Fix bug in state interface indexing..
* WIP: Extend the rpdo to have a queue (FIFO) to save the values.
  The read function take the latest value out of the queue and assign to the system interface.
  Need tests.
```

## canopen_ros2_controllers

- No changes

## canopen_tests

```
* Add new line to get checking pipeline okay
* Working version.
* Periodic messages sent, but not received properly.
```

## canopen_utils

- No changes

## lely_core_libraries

```
* Add yaml dependency to package.xml of lely_core_libraries (#290 <https://github.com/ros-industrial/ros2_canopen/issues/290>)
```
