### PR TITLE
compass: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1576,12 +1576,15 @@ repositories:
       version: master
     release:
       packages:
+      - compass_conversions
       - compass_msgs
+      - magnetic_model
       - magnetometer_compass
+      - magnetometer_pipeline
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
-      version: 1.0.3-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `2.0.1-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## compass_conversions (new package)

```
* Fixed license issues preventing bloom-release.
* Fixed documentation generation.
* Restructured the repo, created compass_conversions, magnetic_model and magnetometer_pipeline packages.
* Contributors: Martin Pecka
```

## compass_msgs

```
* Fixed license issues preventing bloom-release.
* Improved readme.
* Restructured the repo, created compass_conversions, magnetic_model and magnetometer_pipeline packages.
  The behavior of the compass nodelet should not change.
  The visualize_azimuth Python script was substituted by a C++ node with the same name and compatible behavior.
  The data directory with WMM was moved from magnetometer_compass to magnetic_model.
* Contributors: Martin Pecka
```

## magnetic_model (new package)

```
* Fixed license issues preventing bloom-release.
* Fixed documentation generation.
* Restructured the repo, created compass_conversions, magnetic_model and magnetometer_pipeline packages.
* Contributors: Martin Pecka
```

## magnetometer_compass

```
* Fixed license issues preventing bloom-release.
* Fixed documentation generation.
* Restructured the repo, created compass_conversions, magnetic_model and magnetometer_pipeline packages.
  The behavior of the compass nodelet should not change.
  The visualize_azimuth Python script was substituted by a C++ node with the same name and compatible behavior.
  The data directory with WMM was moved from magnetometer_compass to magnetic_model.
* Contributors: Martin Pecka
```

## magnetometer_pipeline (new package)

```
* Fixed license issues preventing bloom-release.
* Fixed documentation generation.
* Restructured the repo, created compass_conversions, magnetic_model and magnetometer_pipeline packages.
* Contributors: Martin Pecka
```
