### PR TITLE
robot_calibration: 0.10.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6538,7 +6538,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.9.3-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.10.0-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.3-1`

## robot_calibration

```
* massive speedup of plane finder (#191 <https://github.com/mikeferguson/robot_calibration/issues/191>)
  * roughly 30x faster on VGA point cloud filtering
  * KDL was 3x faster than using Eigen
* improve base calibration (#190 <https://github.com/mikeferguson/robot_calibration/issues/190>)
  * add rollout calibration using linear movements
  * parameterize the calibration_steps
* improve LED finder (#189 <https://github.com/mikeferguson/robot_calibration/issues/189>)
  if the single pixel that is most changed has NANs,
  don't immediately throw out the sample
* revert dependency on libfcl-dev (#188 <https://github.com/mikeferguson/robot_calibration/issues/188>)
* Contributors: Michael Ferguson
```

## robot_calibration_msgs

- No changes
