### PR TITLE
clearpath_msgs: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1005,6 +1005,25 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clearpath_msgs:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: main
+    release:
+      packages:
+      - clearpath_motor_msgs
+      - clearpath_msgs
+      - clearpath_platform_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_msgs.git
+      version: main
+    status: maintained
   clearpath_ros2_socketcan_interface:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_motor_msgs

```
* [clearpath_motor_msgs] Updated package version.
* Initial clearpath_motor_msgs
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_msgs

```
* Added clearpath_motor_msgs dependency in clearpath_msgs
* Contributors: Roni Kreinin
```

## clearpath_platform_msgs

- No changes
