### PR TITLE
Fix Nix packages that incorrectly used Python 2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7963,7 +7963,7 @@ pybind11-dev:
   fedora: [pybind11-devel]
   freebsd: [pybind11]
   gentoo: [dev-python/pybind11]
-  nixos: [pythonPackages.pybind11]
+  nixos: [python3Packages.pybind11]
   openembedded: [python3-pybind11@meta-python]
   rhel:
     '*': [pybind11-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -108,7 +108,7 @@ black:
   debian: [black]
   fedora: [black]
   gentoo: [dev-python/black]
-  nixos: [pythonPackages.black]
+  nixos: [python3Packages.black]
   openembedded: [python3-black@meta-ros]
   ubuntu:
     '*': [black]
@@ -8876,7 +8876,7 @@ python3-pytest:
   fedora: [python3-pytest]
   freebsd: [devel/py-pytest]
   gentoo: [dev-python/pytest]
-  nixos: [pythonPackages.pytest]
+  nixos: [python3Packages.pytest]
   openembedded: [python3-pytest@meta-python]
   opensuse: [python3-pytest]
   osx:


### PR DESCRIPTION
`pythonPackages` normally refers to Python 2 in nixpkgs, but I have had an override in nix-ros-overlay that remaps it to Python 3, dating back to the days when I had to support both Python 2 and Python 3 for different distros. This has led to several packages in rosdep mistakenly using `pythonPackages` rather than `python3Packages`. Fix these to allow me to remove the override for ROS 2.
