### PR TITLE
ament_cmake: 2.7.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -142,7 +142,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.7.2-1
+      version: 2.7.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.7.2-2`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.2-1`

## ament_cmake

- No changes

## ament_cmake_auto

- No changes

## ament_cmake_core

```
* Support generator expressions when symlinking install(FILES) (#560 <https://github.com/ament/ament_cmake/issues/560>)
* Always symlink TARGET_{LINKER,SONAME}_FILE on libraries (#535 <https://github.com/ament/ament_cmake/issues/535>)
* Fix symlink install of versioned libs on macOS (#558 <https://github.com/ament/ament_cmake/issues/558>)
* Contributors: Scott K Logan
```

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

```
* Add explicit git dependency from ament_cmake_vendor_package (#554 <https://github.com/ament/ament_cmake/issues/554>)
* Contributors: Scott K Logan
```

## ament_cmake_version

- No changes
