### PR TITLE
gz_math_vendor: 0.2.2-1 in 'rolling/distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2294,7 +2294,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_math_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_math_vendor` to `0.2.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_math_vendor.git
- release repository: https://github.com/ros2-gbp/gz_math_vendor-release.git
- distro file: `rolling/distribution.yaml`
- previous version for package: `0.2.1-1`

## gz_math_vendor

```
* Bump version to 8.1.0 (`#8 <https://github.com/gazebo-release/gz_math_vendor/issues/8>`_)
  * This is a rerelease since #7 did not actually bump the version of the vendored package.
* Contributors: Addisu Z. Taddese
```
