### PR TITLE
Add coal source for Humble

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -932,6 +932,12 @@ repositories:
       url: https://github.com/carologistics/clips_vendor.git
       version: main
     status: maintained
+  coal:
+    source:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: master
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Hi,

The hpp-fcl package has been renamed to coal for its v3.0.0.
It was requested to add a new source: https://github.com/ros2-gbp/ros2-gbp-github-org/pull/671