### PR TITLE
service_load_balancing: 0.1.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7421,6 +7421,15 @@ repositories:
       version: master
     status: maintained
   service_load_balancing:
+    doc:
+      type: git
+      url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/service_load_balancing-release.git
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `service_load_balancing` to `0.1.1-2`:

- upstream repository: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
- release repository: https://github.com/ros2-gbp/service_load_balancing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## service_load_balancing

```
* Change application name and update related document (#4 <https://github.com/Barry-Xu-2018/ros2_service_load_balancing/issues/4>)
* Update information in package.xml
* Change to a more appropriate function name
* Add test codes for MessageForwardProcess
* Add test codes for ServiceClientProxyManager
* Optimized the code for ServiceClientProxyManager
* Add test codes for ServiceServerProxy
* Remove unused header file
* Use std_srvs/srv/Empty.srv instead of test_msgs/srv/Empty.srv
* Add test codes for ForwardManagement
* Add test codes for common functions and QueueBase
* Fix a bug and add queue_size() for QueueBase
* overview slide description update, and cosmetic fixes. (#3 <https://github.com/Barry-Xu-2018/ros2_service_load_balancing/issues/3>)
* Fix a bug on discovering service server
* Show the change log of service server by default
* Remove unused images
* Add overview document (#2 <https://github.com/Barry-Xu-2018/ros2_service_load_balancing/issues/2>)
* Fix some typos
* Add overview document
* Change class name, add doxy comment and fix a bug
* Merge develop branch to main (#1 <https://github.com/Barry-Xu-2018/ros2_service_load_balancing/issues/1>)
* Update README.md
  Describe the current development status.
* Update request_response_table.hpp
* Add request response table
* Initial version
* Update README.md
* Initial commit
* Contributors: Barry Xu, Tomoya Fujita
```
