### PR TITLE
realtime_tools: 2.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7454,7 +7454,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.10.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.0-1`

## realtime_tools

```
* sleep after starting thread to fix flaky tests (backport #235 <https://github.com/ros-controls/realtime_tools/issues/235>) (#237 <https://github.com/ros-controls/realtime_tools/issues/237>)
* Fix the badges in the readme (backport #234 <https://github.com/ros-controls/realtime_tools/issues/234>) (#236 <https://github.com/ros-controls/realtime_tools/issues/236>)
* Remove duplicate wf (backport #230 <https://github.com/ros-controls/realtime_tools/issues/230>) (#231 <https://github.com/ros-controls/realtime_tools/issues/231>)
* Adapt API style of lock_memory to match the one of the other functions (backport #209 <https://github.com/ros-controls/realtime_tools/issues/209>) (#229 <https://github.com/ros-controls/realtime_tools/issues/229>)
* [Humble] Move the header files to .hpp extension (#206 <https://github.com/ros-controls/realtime_tools/issues/206>) - No deprecation notice (#225 <https://github.com/ros-controls/realtime_tools/issues/225>)
* Add support to parse multiple cores for setting CPU affinity (backport #208 <https://github.com/ros-controls/realtime_tools/issues/208>) (#223 <https://github.com/ros-controls/realtime_tools/issues/223>)
* remove unused state_ field (backport #215 <https://github.com/ros-controls/realtime_tools/issues/215>) (#218 <https://github.com/ros-controls/realtime_tools/issues/218>)
* Changes after branching humble (backport #217 <https://github.com/ros-controls/realtime_tools/issues/217>) (#224 <https://github.com/ros-controls/realtime_tools/issues/224>)
* Add downstream build CI job (backport #201 <https://github.com/ros-controls/realtime_tools/issues/201>) (#222 <https://github.com/ros-controls/realtime_tools/issues/222>)
* Use windows CI build (backport #204 <https://github.com/ros-controls/realtime_tools/issues/204>) (#221 <https://github.com/ros-controls/realtime_tools/issues/221>)
* Add job for clang build (backport #207 <https://github.com/ros-controls/realtime_tools/issues/207>) (#220 <https://github.com/ros-controls/realtime_tools/issues/220>)
* Bump version of pre-commit hooks (backport #213 <https://github.com/ros-controls/realtime_tools/issues/213>) (#219 <https://github.com/ros-controls/realtime_tools/issues/219>)
* Contributors: Sai Kishor Kothakota, Lennart Nachtigall, Christoph Fröhlich
```
