### PR TITLE
yasmin: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8895,6 +8895,17 @@ repositories:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git
       version: main
+    release:
+      packages:
+      - yasmin
+      - yasmin_demos
+      - yasmin_msgs
+      - yasmin_ros
+      - yasmin_viewer
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/yasmin-release.git
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `3.0.2-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
