### PR TITLE
ros2_control: 2.46.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8067,7 +8067,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.45.0-1
+      version: 2.46.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.46.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.45.0-1`

## controller_interface

```
* generate version.h file per package using the ament_generate_version_header  (backport #1449 <https://github.com/ros-controls/ros2_control/issues/1449>) (#1938 <https://github.com/ros-controls/ros2_control/issues/1938>)
* [CI] Add clang job, setup concurrency, use rt_tools humble branch (backport #1910 <https://github.com/ros-controls/ros2_control/issues/1910>) (#1924 <https://github.com/ros-controls/ros2_control/issues/1924>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Add service call timeout argument in spawner (#1808 <https://github.com/ros-controls/ros2_control/issues/1808>) (#1886 <https://github.com/ros-controls/ros2_control/issues/1886>)
* Fix the spawner to support full wildcard parameter entries (backport #1933 <https://github.com/ros-controls/ros2_control/issues/1933>) (#1939 <https://github.com/ros-controls/ros2_control/issues/1939>)
* generate version.h file per package using the ament_generate_version_header  (backport #1449 <https://github.com/ros-controls/ros2_control/issues/1449>) (#1938 <https://github.com/ros-controls/ros2_control/issues/1938>)
* Add documentation on ros2_control_node and make lock_memory false by default (backport #1890 <https://github.com/ros-controls/ros2_control/issues/1890>) (#1895 <https://github.com/ros-controls/ros2_control/issues/1895>)
* [Spawner] Accept parsing multiple --param-file arguments to spawner  (backport #1805 <https://github.com/ros-controls/ros2_control/issues/1805>) (#1894 <https://github.com/ros-controls/ros2_control/issues/1894>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* generate version.h file per package using the ament_generate_version_header  (backport #1449 <https://github.com/ros-controls/ros2_control/issues/1449>) (#1938 <https://github.com/ros-controls/ros2_control/issues/1938>)
* [CI] Add clang job, setup concurrency, use rt_tools humble branch (backport #1910 <https://github.com/ros-controls/ros2_control/issues/1910>) (#1924 <https://github.com/ros-controls/ros2_control/issues/1924>)
* [Spawner] Accept parsing multiple --param-file arguments to spawner  (backport #1805 <https://github.com/ros-controls/ros2_control/issues/1805>) (#1894 <https://github.com/ros-controls/ros2_control/issues/1894>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* generate version.h file per package using the ament_generate_version_header  (backport #1449 <https://github.com/ros-controls/ros2_control/issues/1449>) (#1938 <https://github.com/ros-controls/ros2_control/issues/1938>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* generate version.h file per package using the ament_generate_version_header  (backport #1449 <https://github.com/ros-controls/ros2_control/issues/1449>) (#1938 <https://github.com/ros-controls/ros2_control/issues/1938>)
* Contributors: mergify[bot]
```
