### PR TITLE
dataspeed_can: 2.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1298,7 +1298,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `2.0.5-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-1`

## dataspeed_can

- No changes

## dataspeed_can_msg_filters

- No changes

## dataspeed_can_msgs

```
* Add CAN-FD messages with fixed size data arrays
  Update DBC tools for new fixed sizes
  PlotJuggler can't import large amounts of messages with dynamic sized arrays
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

```
* Add CAN-FD messages with fixed size data arrays
* Update DBC tools for new fixed sizes
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_usb

- No changes
