### PR TITLE
soar_ros: Add jazzy and rolling versions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9807,6 +9807,7 @@ repositories:
       type: git
       url: https://github.com/THA-Embedded-Systems-Lab/soar_ros.git
       version: main
+    status: maintained
   soccer_interfaces:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8379,6 +8379,12 @@ repositories:
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
       version: ros2
     status: maintained
+  soar_ros:
+    doc:
+      type: git
+      url: https://github.com/THA-Embedded-Systems-Lab/soar_ros.git
+      version: main
+    status: maintained
   soccer_interfaces:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7617,6 +7617,12 @@ repositories:
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
       version: ros2
     status: maintained
+  soar_ros:
+    doc:
+      type: git
+      url: https://github.com/THA-Embedded-Systems-Lab/soar_ros.git
+      version: main
+    status: maintained
   soccer_interfaces:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

- Jazzy
- Rolling

# The source is here:

https://github.com/THA-Embedded-Systems-Lab/soar_ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro, see https://github.com/THA-Embedded-Systems-Lab/soar_ros/actions/runs/12297142498
