### PR TITLE
Revert "tuw_msgs: 0.2.4-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10719,7 +10719,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_msgs-release.git
-      version: 0.2.4-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_msgs.git


### PR DESCRIPTION
FYI, @maxbader.

Here's an example failure:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__tuw_object_msgs__ubuntu_jammy_amd64__binary/114/

Reverts ros/rosdistro#43920