### PR TITLE
jsk_common: 2.2.15-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4689,7 +4689,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_common-release.git
-      version: 2.2.15-1
+      version: 2.2.15-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_common` to `2.2.15-2`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_common
- release repository: https://github.com/tork-a/jsk_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.15-1`

## audio_video_recorder

- No changes

## dynamic_tf_publisher

- No changes

## image_view2

- No changes

## jsk_common

- No changes

## jsk_data

```
* [jsk_data] Automatically add the host key and Check stdout.read() type (#1810 <https://github.com/jsk-ros-pkg/jsk_common/issues/1810>)
  - stdout.read() returns a bytes object in Python 3, whereas in Python 2, it returned a str
  - The error indicates that the new version of Paramiko (2.6.0) is stricter about host key checking, requiring the server to be present in the known_hosts file by default. This is a security feature to prevent man-in-the-middle attacks.
* Contributors: Kei Okada
```

## jsk_network_tools

- No changes

## jsk_rosbag_tools

- No changes

## jsk_tilt_laser

- No changes

## jsk_tools

- No changes

## jsk_topic_tools

- No changes

## multi_map_server

- No changes

## virtual_force_publisher

- No changes
