### PR TITLE
Update branch of realtime_tools for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7449,7 +7449,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -7458,7 +7458,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: master
+      version: humble
     status: maintained
   resource_retriever:
     doc:


### PR DESCRIPTION
We changed the branch of realtime_tools for humble
https://github.com/ros2-gbp/realtime_tools-release/commit/5839b79ad46abb0a0e4220482567a62fe37ff6f4