### PR TITLE
rosdep: Add missing entries for OpenEmbedded

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2,6 +2,7 @@ ace:
   debian: [libace-dev]
   gentoo: [dev-libs/ace]
   nixos: [ace]
+  openembedded: [ace@meta-oe]
   ubuntu: [libace-dev]
 ack:
   arch: [ack]
@@ -39,6 +40,7 @@ acpitool:
   fedora: [acpitool]
   gentoo: [sys-power/acpitool]
   nixos: [acpitool]
+  openembedded: [acpitool@meta-oe]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
@@ -53,6 +55,7 @@ alsa-utils:
   fedora: [alsa-utils]
   gentoo: [media-sound/alsa-utils]
   nixos: [alsaUtils]
+  openembedded: [alsa-utils@openembedded-core]
   opensuse: [alsa-utils]
   rhel: [alsa-utils]
   ubuntu: [alsa-utils]
@@ -76,6 +79,7 @@ apache2:
   fedora: [httpd]
   gentoo: [www-servers/apache]
   nixos: [apacheHttpd]
+  openembedded: [apache2@meta-webserver]
   ubuntu: [apache2]
 apache2-mpm-prefork:
   debian:
@@ -86,6 +90,7 @@ apparmor:
   arch: [apparmor]
   debian: [apparmor]
   fedora: null
+  openembedded: [apparmor@meta-security]
   ubuntu: [apparmor]
 apr:
   alpine: [apr, apr-util]
@@ -112,6 +117,7 @@ aravis:
   debian: [libaravis-0.6-0, aravis-tools]
   gentoo: [media-video/aravis]
   nixos: [aravis]
+  openembedded: [aravis@meta-multimedia]
   ubuntu:
     '*': [libaravis-0.8-0, aravis-tools]
     bionic: null
@@ -120,6 +126,7 @@ aravis-dev:
   debian: [libaravis-dev]
   gentoo: [media-video/aravis]
   nixos: [aravis]
+  openembedded: [aravis@meta-multimedia]
   ubuntu:
     '*': [libaravis-dev]
     bionic: null
@@ -188,6 +195,7 @@ at-spi2-core:
   fedora: [at-spi2-core]
   gentoo: [app-accessibility/at-spi2-core]
   nixos: [at-spi2-core]
+  openembedded: [at-spi2-core@openembedded-core]
   rhel: [at-spi2-core]
   ubuntu: [at-spi2-core]
 atlas:
@@ -246,6 +254,7 @@ autossh:
   gentoo: [net-misc/autossh]
   macports: [autossh]
   nixos: [autossh]
+  openembedded: [autossh@meta-networking]
   opensuse: [autossh]
   rhel: [autossh]
   ubuntu: [autossh]
@@ -292,6 +301,7 @@ babeltrace:
   fedora: [babeltrace]
   gentoo: [dev-util/babeltrace]
   nixos: [babeltrace]
+  openembedded: [babeltrace@openembedded-core]
   ubuntu: [babeltrace]
 bandit:
   arch: [bandit]
@@ -395,6 +405,7 @@ box2d-dev:
   debian: [libbox2d-dev]
   fedora: [Box2D-devel]
   nixos: [box2d]
+  openembedded: [box2d@meta-ros2]
   ubuntu: [libbox2d-dev]
 bullet:
   alpine: [bullet-dev]
@@ -450,6 +461,7 @@ can-utils:
   debian: [can-utils]
   fedora: [can-utils]
   nixos: [can-utils]
+  openembedded: [can-utils@meta-oe]
   ubuntu: [can-utils]
 cargo:
   arch: [rust]
@@ -466,6 +478,7 @@ castxml:
   fedora: [castxml]
   macports: [castxml]
   nixos: [castxml]
+  openembedded: [castxml@meta-clang]
   ubuntu: [castxml]
 catch2:
   alpine: [catch2]
@@ -475,6 +488,7 @@ catch2:
   freebsd: [catch2]
   gentoo: [dev-cpp/catch]
   nixos: [catch2]
+  openembedded: [catch2@meta-oe]
   rhel:
     '*': [catch2-devel]
     '8': null
@@ -540,6 +554,7 @@ chrony:
   fedora: [chrony]
   gentoo: [net-misc/chrony]
   nixos: [chrony]
+  openembedded: [chrony@meta-networking]
   opensuse: [chrony]
   rhel: [chrony]
   ubuntu: [chrony]
@@ -549,7 +564,7 @@ clang:
   fedora: [clang]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  openembedded: [clang-native@meta-clang]
+  openembedded: [clang@meta-clang]
   rhel:
     '*': [clang]
     '7': null
@@ -562,6 +577,7 @@ clang-format:
   freebsd: [llvm]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  openembedded: [clang@meta-clang]
   opensuse: [clang]
   osx:
     homebrew:
@@ -578,6 +594,7 @@ clang-tidy:
   freebsd: [llvm]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  openembedded: [clang@meta-clang]
   opensuse: [clang]
   rhel:
     '*': [clang-tools-extra]
@@ -600,6 +617,7 @@ cli11:
   fedora: [cli11-devel]
   gentoo: [dev-cpp/cli11]
   nixos: [cli11]
+  openembedded: [cli11@meta-oe]
   rhel: [cli11-devel]
   ubuntu:
     '*': [libcli11-dev]
@@ -823,6 +841,7 @@ devilspie2:
   fedora: [devilspie2]
   gentoo: [x11-misc/devilspie2]
   nixos: [devilspie2]
+  openembedded: [devilspie2@meta-gnome]
   rhel: [devilspie2]
   ubuntu: [devilspie2]
 devscripts:
@@ -837,6 +856,7 @@ dfu-util:
   fedora: [dfu-util]
   gentoo: [app-mobilephone/dfu-util]
   nixos: [dfu-util]
+  openembedded: [dfu-util@meta-oe]
   ubuntu: [dfu-util]
 dh-python:
   debian: [dh-python]
@@ -868,6 +888,7 @@ docker-compose:
   debian: [docker-compose]
   fedora: [docker-compose]
   nixos: [docker-compose]
+  openembedded: [docker-compose@meta-virtualization]
   ubuntu: [docker-compose]
 docker.io:
   debian:
@@ -902,6 +923,7 @@ dpkg-dev:
   debian: [dpkg-dev]
   fedora: [dpkg-dev]
   nixos: [dpkg]
+  openembedded: [dpkg@openembedded-core]
   ubuntu: [dpkg-dev]
 dvipng:
   arch: [texlive-bin]
@@ -993,6 +1015,7 @@ espeak:
   fedora: [espeak]
   gentoo: [app-accessibility/espeak]
   nixos: [espeak]
+  openembedded: [espeak@meta-oe]
   ubuntu: [espeak]
 ethtool:
   alpine: [ethtool]
@@ -1001,6 +1024,7 @@ ethtool:
   fedora: [ethtool]
   gentoo: [ethtool]
   nixos: [ethtool]
+  openembedded: [ethtool@openembedded-core]
   opensuse: [ethtool]
   rhel: [ethtool]
   ubuntu: [ethtool]
@@ -1046,6 +1070,7 @@ fcgi:
   debian: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
   fedora: [fcgi, mod_fcgid, spawn-fcgi]
   gentoo: [dev-ruby/fcgi]
+  openembedded: [fcgi@meta-webserver]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
 festival:
   arch: [festival, festival-english]
@@ -1158,6 +1183,7 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   gentoo: [=x11-libs/fltk-1*]
   macports: [fltk]
   nixos: [fltk]
+  openembedded: [fltk@meta-oe]
   opensuse: [fltk-devel]
   slackware: [fltk]
   ubuntu:
@@ -1179,6 +1205,7 @@ fluidsynth:
   debian: [fluidsynth]
   fedora: [fluidsynth]
   nixos: [fluidsynth]
+  openembedded: [fluidsynth@meta-multimedia]
   opensuse: [fluidsynth]
   rhel: [fluidsynth]
   ubuntu: [fluidsynth]
@@ -1213,6 +1240,7 @@ fping:
   fedora: [fping]
   gentoo: [net-analyzer/fping]
   nixos: [fping]
+  openembedded: [fping@meta-networking]
   ubuntu: [fping]
 freeimage:
   arch: [freeimage]
@@ -1231,11 +1259,13 @@ freetype:
   gentoo: [media-libs/freetype]
   macports: [freetype]
   nixos: [freetype]
+  openembedded: [freetype@openembedded-core]
   ubuntu: [libfreetype6]
 fsharp:
   debian: [fsharp]
   gentoo: [dev-lang/fsharp]
   nixos: [fsharp]
+  openembedded: [fsharp@meta-mono]
   ubuntu: [fsharp]
 fswebcam:
   fedora: [fswebcam]
@@ -1342,6 +1372,7 @@ gcc-arm-none-eabi:
   debian: [gcc-arm-none-eabi]
   fedora: [arm-none-eabi-gcc-cs]
   gentoo: [sys-devel/crossdev]
+  openembedded: [gcc-arm-none-eabi@meta-arm-toolchain]
   ubuntu: [gcc-arm-none-eabi]
 gcc-avr:
   arch: [avr-gcc]
@@ -1404,6 +1435,7 @@ geos:
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
   nixos: [geos]
+  openembedded: [geos@meta-oe]
   rhel: [geos-devel]
   ubuntu: [libgeos-dev]
 gettext-base:
@@ -1555,6 +1587,7 @@ gnome-terminal:
   freebsd: [gnome-terminal]
   gentoo: [x11-terms/gnome-terminal]
   nixos: [gnome.gnome-terminal]
+  openembedded: [gnome-terminal@meta-gnome]
   opensuse: [gnome-terminal]
   rhel: [gnome-terminal]
   ubuntu: [gnome-terminal]
@@ -1621,6 +1654,7 @@ gperftools:
   fedora: [gperftools, gperftools-devel]
   gentoo: [dev-util/gperf]
   nixos: [gperftools]
+  openembedded: [gperftools@meta-oe]
   ubuntu: [google-perftools, libgoogle-perftools-dev]
 gpg-agent:
   arch: [gnupg]
@@ -1634,6 +1668,7 @@ gphoto2:
   fedora: [gphoto2]
   gentoo: [media-gfx/gphoto2]
   nixos: [gphoto2]
+  openembedded: [gphoto2@meta-oe]
   ubuntu: [gphoto2]
 gprbuild:
   debian: [gprbuild]
@@ -1645,6 +1680,7 @@ gpsd:
   fedora: [gpsd]
   gentoo: [sci-geosciences/gpsd]
   nixos: [gpsd]
+  openembedded: [gpsd@meta-oe]
   ubuntu: [gpsd]
 gradle:
   arch: [gradle]
@@ -1673,7 +1709,7 @@ graphviz:
   gentoo: [media-gfx/graphviz]
   macports: [graphviz]
   nixos: [graphviz]
-  openembedded: [graphviz@meta-ros-common]
+  openembedded: [graphviz@meta-oe]
   opensuse: [graphviz]
   rhel: [graphviz]
   slackware: [graphviz]
@@ -1683,6 +1719,7 @@ graphviz-dev:
   debian: [libgraphviz-dev]
   fedora: [graphviz-devel]
   nixos: [graphviz]
+  openembedded: [graphviz@meta-oe]
   rhel: [graphviz-devel]
   ubuntu: [libgraphviz-dev]
 gringo:
@@ -2076,6 +2113,7 @@ htop:
   fedora: [htop]
   gentoo: [sys-process/htop]
   nixos: [htop]
+  openembedded: [htop@meta-oe]
   ubuntu: [htop]
 hugin-tools:
   arch: [hugin]
@@ -2345,6 +2383,7 @@ imagemagick:
   fedora: [ImageMagick]
   gentoo: [virtual/imagemagick-tools]
   nixos: [imagemagick]
+  openembedded: [imagemagick@meta-oe]
   ubuntu: [imagemagick]
 intel-opencl-icd:
   arch: [intel-compute-runtime]
@@ -2361,6 +2400,7 @@ intltool:
   freebsd: [intltool]
   gentoo: [dev-util/intltool]
   nixos: [intltool]
+  openembedded: [intltool@openembedded-core]
   opensuse: [intltool]
   ubuntu: [intltool]
 inxi:
@@ -2415,6 +2455,7 @@ jack:
   fedora: [jack-audio-connection-kit-devel]
   gentoo: [virtual/jack]
   nixos: [jack2]
+  openembedded: [jack@meta-oe]
   ubuntu: [libjack-jackd2-dev]
 jasper:
   arch: [jasper]
@@ -2425,6 +2466,7 @@ jasper:
   gentoo: [media-libs/jasper]
   macports: [jasper]
   nixos: [jasper]
+  openembedded: [jasper@meta-oe]
   opensuse: [libjasper-devel]
   rhel: [jasper-devel]
   slackware:
@@ -2586,6 +2628,7 @@ libao-dev:
   arch: [libao]
   debian: [libao-dev]
   fedora: [libao-devel]
+  openembedded: [libao@meta-multimedia]
   opensuse: [libao-devel]
   rhel: [libao-devel]
   ubuntu: [libao-dev]
@@ -2635,6 +2678,7 @@ libav:
   fedora: []
   gentoo: [virtual/ffmpeg]
   nixos: [libav]
+  openembedded: [ffmpeg@openembedded-core]
   ubuntu:
     '*': null
 libavahi-client-dev:
@@ -2658,6 +2702,7 @@ libavdevice-dev:
   debian: [libavdevice-dev]
   fedora: [libavdevice-free-devel]
   nixos: [ffmpeg]
+  openembedded: [ffmpeg@openembedded-core]
   rhel:
     '*': [libavdevice-free-devel]
     '8': null
@@ -2668,9 +2713,11 @@ libb64-dev:
   fedora: [libb64-devel]
   gentoo: [libb64]
   nixos: [libb64]
+  openembedded: [libb64@meta-oe]
   ubuntu: [libb64-dev]
 libbackward-cpp-dev:
   debian: [libbackward-cpp-dev]
+  openembedded: [backward-cpp@meta-ros-common]
   opensuse: [backward-cpp]
   ubuntu:
     '*': [libbackward-cpp-dev]
@@ -2711,6 +2758,7 @@ libbluetooth:
   fedora: [bluez-libs]
   gentoo: [net-wireless/bluez-libs]
   nixos: [bluez]
+  openembedded: [bluez5@openembedded-core]
   rhel: [bluez-libs]
   ubuntu: [libbluetooth3]
 libbluetooth-dev:
@@ -2719,6 +2767,7 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   nixos: [bluez]
+  openembedded: [bluez5@openembedded-core]
   rhel: [bluez-libs-devel]
   ubuntu: [libbluetooth-dev]
 libboost-atomic:
@@ -3148,6 +3197,7 @@ libbsd-dev:
   fedora: [libbsd-devel]
   gentoo: [dev-libs/libbsd]
   nixos: [libbsd]
+  openembedded: [libbsd@openembedded-core]
   osx:
     homebrew:
       packages: [libbsd]
@@ -3212,6 +3262,7 @@ libccid:
   fedora: [pcsc-lite-ccid]
   gentoo: [app-crypt/ccid]
   nixos: [ccid]
+  openembedded: [ccid@meta-oe]
   rhel: [pcsc-lite-ccid]
   ubuntu: [libccid]
 libcdd-dev:
@@ -3232,6 +3283,7 @@ libcereal-dev:
   debian: [libcereal-dev]
   fedora: [cereal-devel]
   gentoo: [dev-libs/cereal]
+  openembedded: [libcereal@meta-oe]
   ubuntu: [libcereal-dev]
 libceres-dev:
   arch: [ceres-solver]
@@ -3257,6 +3309,7 @@ libclang-dev:
   fedora: [clang-devel]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  openembedded: [clang@meta-clang]
   rhel: [clang-devel]
   ubuntu: [libclang-dev]
 libcoin60-dev:
@@ -3289,6 +3342,7 @@ libconfig-dev:
   fedora: [libconfig-devel]
   gentoo: ['dev-libs/libconfig[cxx]']
   nixos: [libconfig]
+  openembedded: [libconfig@meta-oe]
   rhel: [libconfig-devel]
   ubuntu: [libconfig-dev]
 libconsole-bridge-dev:
@@ -3325,6 +3379,7 @@ libcpprest-dev:
     buster: [libcpprest-dev]
     stretch: [libcpprest-dev]
   fedora: [cpprest-devel]
+  openembedded: [cpprest@meta-oe]
   ubuntu: [libcpprest-dev]
 libcunit-dev:
   alpine: [cunit-dev]
@@ -3333,6 +3388,7 @@ libcunit-dev:
   fedora: [CUnit-devel]
   gentoo: [dev-util/cunit]
   nixos: [cunit]
+  openembedded: [cunit@meta-oe]
   rhel: [CUnit-devel]
   ubuntu: [libcunit1-dev]
 libcurl:
@@ -3361,6 +3417,7 @@ libdbus-dev:
   fedora: [dbus-devel]
   gentoo: [sys-apps/dbus]
   nixos: [dbus]
+  openembedded: [dbus@openembedded-core]
   rhel: [dbus-devel]
   ubuntu: [libdbus-1-dev]
 libdc1394-dev:
@@ -3410,6 +3467,7 @@ libdpkg-dev:
   debian: [libdpkg-dev]
   fedora: [dpkg-devel]
   nixos: [dpkg]
+  openembedded: [dpkg@openembedded-core]
   rhel: [dpkg-devel]
   ubuntu: [libdpkg-dev]
 libdraco-dev:
@@ -3455,6 +3513,7 @@ libedit:
   gentoo: [dev-libs/libedit]
   macports: [libedit]
   nixos: [libedit]
+  openembedded: [libedit@openembedded-core]
   rhel: [libedit]
   ubuntu: [libedit2]
 libedit-dev:
@@ -3464,6 +3523,7 @@ libedit-dev:
   gentoo: [dev-libs/libedit]
   macports: [libedit]
   nixos: [libedit]
+  openembedded: [libedit@openembedded-core]
   rhel: [libedit-devel]
   ubuntu: [libedit-dev]
 libepoxy-dev:
@@ -3472,6 +3532,7 @@ libepoxy-dev:
   debian: [libepoxy-dev]
   fedora: [libepoxy-devel]
   nixos: [libepoxy]
+  openembedded: [libepoxy@openembedded-core]
   opensuse: [libepoxy-devel]
   rhel: [libepoxy-devel]
   ubuntu: [libepoxy-dev]
@@ -3484,6 +3545,7 @@ libespeak-dev:
   fedora: [espeak-devel]
   gentoo: [app-accessibility/espeak]
   nixos: [espeak]
+  openembedded: [espeak@meta-oe]
   ubuntu: [libespeak-dev]
 libespeak-ng1:
   arch: [espeak-ng]
@@ -3509,6 +3571,7 @@ libev-dev:
   fedora: [libev-devel]
   gentoo: [dev-libs/libev]
   nixos: [libev]
+  openembedded: [libev@meta-oe]
   ubuntu: [libev-dev]
 libevdev-dev:
   arch: [libevdev]
@@ -3516,6 +3579,7 @@ libevdev-dev:
   fedora: [libevdev-devel]
   gentoo: [dev-libs/libevdev]
   nixos: [libevdev]
+  openembedded: [libevdev@openembedded-core]
   ubuntu: [libevdev-dev]
 libevent-dev:
   alpine: [libevent-dev]
@@ -3523,6 +3587,7 @@ libevent-dev:
   debian: [libevent-dev]
   fedora: [libevent-devel]
   nixos: [libevent]
+  openembedded: [libevent@openembedded-core]
   opensuse: [libevent-devel]
   rhel: [libevent-devel]
   ubuntu: [libevent-dev]
@@ -3533,6 +3598,7 @@ libexif:
   fedora: [libexif]
   gentoo: [media-libs/libexif]
   nixos: [libexif]
+  openembedded: [libexif@openembedded-core]
   opensuse: [libexif]
   osx:
     homebrew:
@@ -3546,6 +3612,7 @@ libexif-dev:
   fedora: [libexif-devel]
   gentoo: [media-libs/libexif]
   nixos: [libexif]
+  openembedded: [libexif@openembedded-core]
   opensuse: [libexif]
   osx:
     homebrew:
@@ -3788,6 +3855,7 @@ libftgl-dev:
   fedora: [ftgl-devel]
   gentoo: [media-libs/ftgl]
   nixos: [ftgl]
+  openembedded: [ftgl@meta-oe]
   ubuntu: [libftgl-dev]
 libfyaml-dev:
   alpine: [libfyaml-dev]
@@ -3796,6 +3864,7 @@ libfyaml-dev:
     bullseye: null
   fedora: [libfyaml-devel]
   nixos: [libfyaml]
+  openembedded: [libfyaml@meta-ros2]
   opensuse:
     '*': [libfyaml]
     '15.2': null
@@ -3852,6 +3921,7 @@ libgdal-dev:
   debian: [libgdal-dev]
   fedora: [gdal-devel]
   nixos: [gdal]
+  openembedded: [gdal@meta-ros-common]
   opensuse: [gdal-devel]
   rhel: [gdal-devel]
   ubuntu: [libgdal-dev]
@@ -4022,6 +4092,7 @@ libgpiod-dev:
   fedora: [libgpiod-devel]
   gentoo: [dev-libs/libgpiod]
   nixos: [libgpiod_1]
+  openembedded: [libgpiod@meta-oe]
   opensuse: [libgpiod-devel]
   rhel:
     '*': [libgpiod-devel]
@@ -4132,6 +4203,7 @@ libgtkmm:
   debian: [libgtkmm-2.4-dev]
   fedora: [gtkmm24]
   gentoo: [dev-cpp/gtkmm]
+  openembedded: [gtkmm@meta-oe]
   ubuntu: [libgtkmm-2.4-dev]
 libgtkmm3.0-dev:
   alpine: [gtkmm3-dev]
@@ -4147,6 +4219,7 @@ libgts:
   fedora: [gts]
   gentoo: [sci-libs/gts]
   nixos: [gts]
+  openembedded: [gts@meta-ros-common]
   ubuntu: [libgts-dev]
 libhal-dev:
   arch:
@@ -4169,6 +4242,7 @@ libhidapi-dev:
   fedora: [hidapi-devel]
   gentoo: [dev-libs/hidapi]
   nixos: [hidapi]
+  openembedded: [hidapi@meta-oe]
   ubuntu: [libhidapi-dev]
 libhpptools-dev:
   debian: [libhpptools-dev]
@@ -4328,11 +4402,13 @@ libiw-dev:
   fedora: [wireless-tools-devel]
   gentoo: [net-wireless/wireless-tools]
   nixos: [wirelesstools]
+  openembedded: [iw@openembedded-core]
   ubuntu: [libiw-dev]
 libjack-dev:
   arch: [jack2]
   debian: [libjack-dev]
   fedora: [jack-audio-connection-kit-devel]
+  openembedded: [jack@meta-oe]
   rhel: [jack-audio-connection-kit-devel]
   ubuntu: [libjack-dev]
 libjackson-json-java:
@@ -4371,6 +4447,7 @@ libjson-glib:
   fedora: [json-glib]
   gentoo: [dev-libs/json-glib]
   nixos: [json-glib]
+  openembedded: [json-glib@openembedded-core]
   ubuntu: [libjson-glib-dev]
 libjson-java:
   debian: [libjson-java]
@@ -4468,6 +4545,7 @@ libleptonica-dev:
   fedora: [leptonica-devel]
   gentoo: [media-libs/leptonica]
   nixos: [leptonica]
+  openembedded: [leptonica@meta-oe]
   ubuntu: [libleptonica-dev]
 liblinear-dev:
   debian: [liblinear-dev]
@@ -4516,6 +4594,7 @@ liblz4:
   fedora: [lz4-libs]
   freebsd: [liblz4]
   nixos: [lz4]
+  openembedded: [lz4@openembedded-core]
   opensuse:
     '*': [liblz4]
     '15.2': null
@@ -4527,6 +4606,7 @@ liblz4-dev:
   fedora: [lz4-devel]
   freebsd: [liblz4]
   nixos: [lz4]
+  openembedded: [lz4@openembedded-core]
   opensuse:
     '*': [liblz4-devel]
     '15.2': null
@@ -4573,6 +4653,7 @@ libmnl-dev:
   arch: [libmnl]
   debian: [libmnl-dev]
   fedora: [libmnl-devel]
+  openembedded: [libmnl@openembedded-core]
   opensuse: [libmnl-devel]
   rhel: [libmnl-devel]
   ubuntu: [libmnl-dev]
@@ -4630,12 +4711,14 @@ libmpg123-dev:
   debian: [libmpg123-dev]
   fedora: [mpg123-devel]
   nixos: [mpg123]
+  openembedded: [mpg123@openembedded-core]
   ubuntu: [libmpg123-dev]
 libmpich-dev:
   debian: [libmpich-dev]
   fedora: [mpich-devel]
   gentoo: [sys-cluster/mpich]
   nixos: [mpich]
+  openembedded: [mpich@meta-oe]
   ubuntu: [libmpich-dev]
 libmpich2-dev:
   debian: [libmpich2-dev]
@@ -4687,6 +4770,7 @@ libnanoflann-dev:
 libnanopb-dev:
   debian: [libnanopb-dev]
   nixos: [nanopb]
+  openembedded: [nanopb@meta-oe]
   ubuntu:
     '*': [libnanopb-dev]
     bionic: null
@@ -4738,6 +4822,7 @@ libnl-3-dev:
 libnl-dev:
   debian: [libnl-dev]
   gentoo: [dev-libs/libnl]
+  openembedded: [libnl@openembedded-core]
   ubuntu: [libnl-dev]
 libnlopt-cxx-dev:
   arch: [nlopt]
@@ -4770,6 +4855,7 @@ libnotify:
   fedora: [libnotify-devel]
   gentoo: [x11-libs/libnotify]
   nixos: [libnotify]
+  openembedded: [libnotify@openembedded-core]
   ubuntu: [libnotify-dev]
 libnss3-dev:
   arch: [nss]
@@ -4852,6 +4938,7 @@ libomp-dev:
   fedora: [libomp-devel]
   gentoo: [sys-libs/libomp]
   nixos: [llvmPackages.openmp]
+  openembedded: [openmp@meta-clang]
   rhel:
     '*': [libomp-devel]
     '7': null
@@ -4920,12 +5007,14 @@ libopenexr-dev:
   fedora: [OpenEXR-devel]
   gentoo: [media-libs/openexr]
   nixos: [openexr]
+  openembedded: [openexr@meta-ros-common]
   rhel: [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
   debian: [libopenni-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
+  openembedded: [openni@meta-ros2]
   rhel: [openni-devel]
   ubuntu: [libopenni-dev]
 libopenni-nite-dev:
@@ -4940,6 +5029,7 @@ libopenni2-dev:
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI2]
   nixos: [openni2]
+  openembedded: [openni2@meta-ros2]
   rhel:
     '*': [libfreenect-openni]
     '7': null
@@ -4950,6 +5040,7 @@ libopenscenegraph:
   fedora: [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
   gentoo: [dev-games/openscenegraph]
   nixos: [openscenegraph]
+  openembedded: [openscenegraph@meta-ros2]
   opensuse: [OpenSceneGraph, libOpenSceneGraph-devel, libOpenThreads-devel]
   rhel:
     '*': [OpenSceneGraph, OpenSceneGraph-devel, OpenThreads, OpenThreads-devel]
@@ -4998,6 +5089,7 @@ libopus-dev:
   gentoo: [media-sound/opus]
   macports: [opus]
   nixos: [libopus]
+  openembedded: [libopus@meta-oe]
   opensuse: [libopus-devel]
   rhel: [opus-devel]
   ubuntu: [libopus-dev]
@@ -5577,6 +5669,7 @@ libpopt-dev:
   fedora: [popt-devel]
   gentoo: [dev-libs/popt]
   nixos: [popt]
+  openembedded: [popt@openembedded-core]
   ubuntu: [libpopt-dev]
 libpq-dev:
   arch: [postgresql-libs]
@@ -5609,6 +5702,7 @@ libprocps-dev:
   debian: [libprocps-dev]
   fedora: [procps-ng-devel]
   nixos: [procps]
+  openembedded: [procps@openembedded-core]
   ubuntu: [libprocps-dev]
 libprocps6:
   debian:
@@ -5979,6 +6073,7 @@ libqtwebkit-dev:
   fedora: [qtwebkit-devel]
   gentoo: [dev-qt/qtwebkit]
   nixos: [qt5.qtwebkit]
+  openembedded: [qtwebkit@meta-qt5]
   ubuntu: [libqtwebkit-dev]
 libqwt-qt5-dev:
   arch: [qwt]
@@ -6046,6 +6141,7 @@ librdkafka-dev:
   fedora: [librdkafka-devel]
   gentoo: [dev-libs/librdkafka]
   nixos: [rdkafka]
+  openembedded: [librdkafka@meta-oe]
   ubuntu: [librdkafka-dev]
 libreadline:
   arch: [readline]
@@ -6106,6 +6202,7 @@ libshaderc-dev:
   fedora: [libshaderc-devel]
   gentoo: [media-libs/shaderc]
   nixos: [shaderc]
+  openembedded: [shaderc@openembedded-core]
   opensuse: [shaderc-devel]
   rhel:
     '*': [libshaderc-devel]
@@ -6133,6 +6230,7 @@ libsodium-dev:
   debian: [libsodium-dev]
   fedora: [libsodium-devel]
   gentoo: [libsodium]
+  openembedded: [libsodium@meta-oe]
   opensuse: [libsodium-devel]
   rhel: [libsodium-devel]
   ubuntu: [libsodium-dev]
@@ -6173,6 +6271,7 @@ libspatialite:
   fedora: [libspatialite]
   gentoo: ['dev-db/spatialite:0']
   nixos: [libspatialite]
+  openembedded: [libspatialite@meta-oe]
   ubuntu:
     '*': [libsqlite3-mod-spatialite]
 libspnav-dev:
@@ -6206,6 +6305,7 @@ libssh-dev:
   fedora: [libssh-devel]
   gentoo: [net-libs/libssh]
   nixos: [libssh]
+  openembedded: [libssh@meta-oe]
   ubuntu: [libssh-dev]
 libssh2:
   arch: [libssh2]
@@ -6213,6 +6313,7 @@ libssh2:
   fedora: [libssh2]
   gentoo: [net-libs/libssh2]
   nixos: [libssh2]
+  openembedded: [libssh2@openembedded-core]
   ubuntu: [libssh2-1]
 libssh2-dev:
   arch: [libssh2]
@@ -6220,6 +6321,7 @@ libssh2-dev:
   fedora: [libssh2-devel]
   gentoo: [net-libs/libssh2]
   nixos: [libssh2]
+  openembedded: [libssh2@openembedded-core]
   ubuntu: [libssh2-1-dev]
 libssl-dev:
   alpine: [libressl-dev]
@@ -6278,6 +6380,7 @@ libsystemd-dev:
   arch: [systemd-libs]
   debian: [libsystemd-dev]
   fedora: [systemd-devel]
+  openembedded: [systemd@openembedded-core]
   ubuntu:
     '*': [libsystemd-dev]
 libtclap-dev:
@@ -6287,6 +6390,7 @@ libtclap-dev:
   gentoo: [dev-cpp/tclap]
   macports: [tclap]
   nixos: [tclap]
+  openembedded: [tclap@meta-oe]
   ubuntu: [libtclap-dev]
 libtesseract:
   arch: [tesseract]
@@ -6294,6 +6398,7 @@ libtesseract:
   fedora: [tesseract-devel]
   gentoo: [app-text/tesseract]
   nixos: [tesseract]
+  openembedded: [tesseract@meta-oe]
   ubuntu: [libtesseract-dev]
 libtheora:
   arch: [libtheora]
@@ -6318,6 +6423,7 @@ libtiff-dev:
   gentoo: [media-libs/tiff]
   macports: [tiff]
   nixos: [libtiff]
+  openembedded: [tiff@openembedded-core]
   opensuse: [libtiff-devel]
   slackware:
     slackpkg:
@@ -6395,6 +6501,7 @@ libunwind:
   fedora: [libunwind]
   gentoo: [sys-libs/libunwind]
   nixos: [libunwind]
+  openembedded: [libunwind@openembedded-core]
   ubuntu:
     '*': [libunwind8]
 libunwind-dev:
@@ -6406,6 +6513,7 @@ libunwind-dev:
   fedora: [libunwind-devel]
   gentoo: [sys-libs/libunwind]
   nixos: [libunwind]
+  openembedded: [libunwind@openembedded-core]
   ubuntu:
     '*': [libunwind-dev]
 liburdfdom-dev:
@@ -6546,6 +6654,7 @@ libvorbis-dev:
   arch: [libvorbis]
   debian: [libvorbis-dev]
   fedora: [libvorbis-devel]
+  openembedded: [libvorbis@openembedded-core]
   opensuse: [libvorbis-devel]
   rhel: [libvorbis-devel]
   ubuntu: [libvorbis-dev]
@@ -6698,6 +6807,7 @@ libx264-dev:
   fedora: [x264-devel]
   gentoo: [media-libs/x264]
   nixos: [x264]
+  openembedded: [x264@openembedded-core]
   ubuntu: [libx264-dev]
 libxaw:
   alpine: [libxaw-dev]
@@ -6725,6 +6835,7 @@ libxcursor-dev:
   debian: [libxcursor-dev]
   fedora: [libXcursor-devel]
   nixos: [xorg.libXcursor]
+  openembedded: [libxcursor@openembedded-core]
   ubuntu: [libxcursor-dev]
 libxenomai-dev:
   debian:
@@ -6748,6 +6859,7 @@ libxft-dev:
   fedora: [libXft-devel]
   gentoo: [x11-libs/libXft]
   nixos: [xorg.libXft]
+  openembedded: [libxft@openembedded-core]
   ubuntu: [libxft-dev]
 libxi-dev:
   arch: [libxi]
@@ -6764,12 +6876,14 @@ libxinerama-dev:
   fedora: [libXinerama-devel]
   gentoo: [x11-libs/libXinerama]
   nixos: [xorg.libXinerama]
+  openembedded: [libxinerama@openembedded-core]
   ubuntu: [libxinerama-dev]
 libxkbcommon-dev:
   arch: [libxkbcommon]
   debian: [libxkbcommon-dev]
   fedora: [libxkbcommon-devel]
   nixos: [libxkbcommon]
+  openembedded: [libxkbcommon@openembedded-core]
   rhel: [libxkbcommon-devel]
   ubuntu: [libxkbcommon-dev]
 libxml++-2.6:
@@ -6860,6 +6974,7 @@ libxtst-dev:
   debian: [libxtst-dev]
   fedora: [libXtst-devel]
   gentoo: [x11-libs/libXtst]
+  openembedded: [libxtst@openembedded-core]
   ubuntu: [libxtst-dev]
 libxxf86vm:
   arch: [libxxf86vm]
@@ -6903,6 +7018,7 @@ libzip-dev:
   fedora: [libzip-devel]
   gentoo: [dev-libs/libzip]
   nixos: [libzip]
+  openembedded: [libzip@meta-oe]
   ubuntu: [libzip-dev]
 libzmq3-dev:
   arch: [zeromq]
@@ -6948,6 +7064,7 @@ lighttpd:
   debian: [lighttpd]
   fedora: [lighttpd]
   nixos: [lighttpd]
+  openembedded: [lighttpd@openembedded-core]
   ubuntu: [lighttpd]
 lilypond:
   arch: [lilypond]
@@ -7069,6 +7186,7 @@ lsb-release:
 lttng-modules:
   debian: [lttng-modules-dkms]
   gentoo: [dev-util/lttng-modules]
+  openembedded: [lttng-modules@openembedded-core]
   ubuntu: [lttng-modules-dkms]
 lttng-tools:
   debian: [lttng-tools]
@@ -7085,6 +7203,7 @@ lua-dev:
   gentoo: [dev-lang/lua]
   macports: [lua51]
   nixos: [lua]
+  openembedded: [lua@openembedded-core]
   ubuntu: [liblua5.1-0-dev]
 lua5.2-dev:
   arch: [lua52]
@@ -7181,6 +7300,7 @@ mercurial:
   gentoo: [dev-vcs/mercurial]
   macports: [mercurial]
   nixos: [mercurial]
+  openembedded: [mercurial@meta-oe]
   opensuse: [mercurial]
   ubuntu: [mercurial]
 mesa-common-dev:
@@ -7282,6 +7402,7 @@ mpfr:
   fedora: [mpfr]
   gentoo: [dev-libs/mpfr]
   nixos: [mpfr]
+  openembedded: [mpfr@openembedded-core]
   ubuntu: [libmpfr-dev]
 mpg123:
   arch: [mpg123]
@@ -7289,6 +7410,7 @@ mpg123:
   fedora: [mpg123-devel]
   gentoo: [media-sound/mpg123]
   nixos: [mpg123]
+  openembedded: [mpg123@openembedded-core]
   ubuntu: [mpg123]
 mplayer:
   arch: [mplayer]
@@ -7316,6 +7438,7 @@ msr-tools:
   fedora: [msr-tools]
   gentoo: [sys-apps/msr-tools]
   nixos: [msr-tools]
+  openembedded: [msr-tools@meta-oe]
   opensuse: [msr-tools]
   rhel: [msr-tools]
   ubuntu: [msr-tools]
@@ -7328,6 +7451,7 @@ muparser:
   fedora: [muParser-devel]
   gentoo: [dev-cpp/muParser]
   nixos: [muparser]
+  openembedded: [muparser@meta-qt5-extra]
   opensuse: [muparser-devel]
   ubuntu: [libmuparser-dev]
 nanobind-dev:
@@ -7363,6 +7487,7 @@ nasm:
   gentoo: [dev-lang/nasm]
   macports: [nasm]
   nixos: [nasm]
+  openembedded: [nasm@openembedded-core]
   opensuse: [nasm]
   rhel: [nasm]
   ubuntu: [nasm]
@@ -7509,6 +7634,7 @@ ocl-icd-opencl-dev:
   fedora: [ocl-icd-devel]
   gentoo: [virtual/opencl]
   nixos: [ocl-icd]
+  openembedded: [opencl-icd-loader@meta-oe]
   rhel: [ocl-icd-devel]
   ubuntu: [ocl-icd-opencl-dev]
 octave:
@@ -7517,6 +7643,7 @@ octave:
   debian: [octave]
   fedora: [octave]
   gentoo: [sci-mathematics/octave]
+  openembedded: [octave@meta-oe]
   opensuse: [octave]
   rhel: [octave]
   ubuntu: [octave]
@@ -7602,6 +7729,7 @@ openni-dev:
   debian: [libopenni-dev]
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
+  openembedded: [openni@meta-ros2]
   rhel: [openni-devel]
   ubuntu: [libopenni-dev]
 openocd:
@@ -7726,12 +7854,14 @@ php:
   fedora: [php]
   gentoo: [dev-lang/php]
   nixos: [php]
+  openembedded: [php@meta-oe]
 pigz:
   arch: [pigz]
   debian: [pigz]
   fedora: [pigz]
   gentoo: [app-arch/pigz]
   nixos: [pigz]
+  openembedded: [pigz@openembedded-core]
   ubuntu: [pigz]
 pkg-config:
   alpine: [pkgconf]
@@ -7808,6 +7938,7 @@ postfix:
   debian: [postfix]
   fedora: [postfix]
   nixos: [postfix]
+  openembedded: [postfix@meta-networking]
   opensuse: [postfix]
   rhel: [postfix]
   ubuntu: [postfix]
@@ -7853,6 +7984,7 @@ powertop:
   debian: [powertop]
   fedora: [powertop]
   nixos: [powertop]
+  openembedded: [powertop@openembedded-core]
   ubuntu: [powertop]
 procps:
   arch: [procps-ng]
@@ -7947,6 +8079,7 @@ psutils:
   fedora: [psutils]
   gentoo: [app-text/psutils]
   nixos: [psutils]
+  openembedded: [psutils@meta-oe]
   ubuntu: [psutils]
 pugixml-dev:
   arch: [pugixml]
@@ -8070,6 +8203,7 @@ qml-module-qtquick-extras:
   fedora: [qt5-qtquickcontrols]
   gentoo: [dev-qt/qtquickcontrols]
   nixos: [qt5.qtquickcontrols]
+  openembedded: [qtquickcontrols2@meta-qt5]
   rhel: [qt5-qtquickcontrols]
   ubuntu: [qml-module-qtquick-extras]
 qml-module-qtquick-layouts:
@@ -8239,6 +8373,7 @@ range-v3:
   fedora: [range-v3-devel]
   gentoo: [dev-cpp/range-v3]
   nixos: [range-v3]
+  openembedded: [range-v3@meta-ros2]
   osx:
     homebrew:
       packages: [range-v3]
@@ -8253,6 +8388,7 @@ rapidjson-dev:
   fedora: [rapidjson]
   gentoo: [dev-libs/rapidjson]
   nixos: [rapidjson]
+  openembedded: [rapidjson@meta-oe]
   rhel: [rapidjson-devel]
   ubuntu: [rapidjson-dev]
 readline-dev:
@@ -8316,6 +8452,7 @@ rt-tests:
   fedora: [rt-tests]
   gentoo: [dev-util/rt-tests]
   nixos: [rt-tests]
+  openembedded: [rt-tests@openembedded-core]
   opensuse: [rt-tests]
   ubuntu: [rt-tests]
 rti-connext-dds-5.3.1:
@@ -8379,6 +8516,7 @@ sdformat:
   fedora: [sdformat-devel]
   gentoo: [dev-libs/sdformat]
   nixos: [sdformat]
+  openembedded: [sdformat@meta-ros-common]
   rhel:
     '7': [sdformat-devel]
   ubuntu:
@@ -8488,6 +8626,7 @@ setserial:
   fedora: [setserial]
   gentoo: [sys-apps/setserial]
   nixos: [setserial]
+  openembedded: [setserial@openembedded-core]
   ubuntu: [setserial]
 sfml-dev:
   arch: [sfml]
@@ -8503,6 +8642,7 @@ simde:
     buster: null
   fedora: [simde-devel]
   nixos: [simde]
+  openembedded: [simde@meta-ros2]
   rhel:
     '*': [simde-devel]
     '9': null
@@ -8525,6 +8665,7 @@ smartmontools:
   fedora: [smartmontools]
   gentoo: [sys-apps/smartmontools]
   nixos: [smartmontools]
+  openembedded: [smartmontools@meta-oe]
   ubuntu: [smartmontools]
 smbclient:
   arch: [smbclient]
@@ -8555,6 +8696,7 @@ sound-theme-freedesktop:
   debian: [sound-theme-freedesktop]
   fedora: [sound-theme-freedesktop]
   gentoo: [x11-themes/sound-theme-freedesktop]
+  openembedded: [sound-theme-freedesktop@meta-oe]
   ubuntu: [sound-theme-freedesktop]
 sox:
   arch: [sox]
@@ -8562,6 +8704,7 @@ sox:
   fedora: [sox]
   gentoo: [media-sound/sox]
   nixos: [sox]
+  openembedded: [sox@meta-multimedia]
   ubuntu: [sox]
 spacenavd:
   debian: [spacenavd]
@@ -8601,6 +8744,7 @@ speex:
   fedora: [speex, speex-tools, speexdsp]
   gentoo: [media-libs/speex]
   nixos: [speex]
+  openembedded: [speex@openembedded-core]
 spirv-headers:
   arch: [spirv-headers]
   debian: [spirv-headers]
@@ -8760,6 +8904,7 @@ sysbench:
   fedora: [sysbench]
   gentoo: [app-benchmarks/sysbench]
   nixos: [sysbench]
+  openembedded: [sysbench@meta-oe]
   opensuse: [sysbench]
   osx:
     homebrew:
@@ -8780,6 +8925,7 @@ systemd:
   fedora: [systemd]
   gentoo: [sys-apps/systemd]
   nixos: [systemd]
+  openembedded: [systemd@openembedded-core]
   opensuse: [systemd]
   osx:
     homebrew:
@@ -8835,6 +8981,7 @@ tcsh:
   fedora: [tcsh]
   gentoo: [app-shells/tcsh]
   nixos: [tcsh]
+  openembedded: [tcsh@meta-oe]
   ubuntu: [tcsh]
 terminator:
   arch: [terminator]
@@ -8958,6 +9105,7 @@ tmux:
   fedora: [tmux]
   gentoo: [app-misc/tmux]
   nixos: [tmux]
+  openembedded: [tmux@meta-oe]
   ubuntu: [tmux]
 touchegg:
   arch: [touchegg]
@@ -8976,6 +9124,7 @@ tree:
   fedora: [tree]
   gentoo: [app-text/tree]
   nixos: [tree]
+  openembedded: [tree@meta-oe]
   ubuntu: [tree]
 tshark:
   alpine: [tshark]
@@ -9146,6 +9295,7 @@ vim:
   fedora: [vim-enhanced]
   gentoo: [app-editors/vim]
   nixos: [vim]
+  openembedded: [vim@openembedded-core]
   ubuntu: [vim]
 vlc:
   arch: [vlc]
@@ -9161,6 +9311,7 @@ vorbis-tools:
   fedora: [vorbis-tools]
   gentoo: [media-sound/vorbis-tools]
   nixos: [vorbis-tools]
+  openembedded: [vorbis-tools@meta-multimedia]
   ubuntu: [vorbis-tools]
 wayland:
   arch: [wayland]
@@ -9218,6 +9369,7 @@ wireshark:
   fedora: [wireshark]
   gentoo: [net-analyzer/wireshark]
   nixos: [wireshark]
+  openembedded: [wireshark@meta-networking]
   ubuntu: [wireshark]
 wireshark-common:
   arch: [wireshark-cli]
@@ -9311,6 +9463,7 @@ xdg-utils:
   fedora: [xdg-utils]
   gentoo: [x11-misc/xdg-utils]
   nixos: [xdg-utils]
+  openembedded: [xdg-utils@openembedded-core]
   opensuse: [xdg-utils]
   rhel: [xdg-utils]
   ubuntu: [xdg-utils]
@@ -9362,6 +9515,7 @@ xsimd:
   fedora: [xsimd-devel]
   gentoo: [dev-cpp/xsimd]
   nixos: [xsimd]
+  openembedded: [xsimd@meta-ros2]
   rhel:
     '*': [xsimd-devel]
     '7': null
@@ -9380,6 +9534,7 @@ xtensor:
   debian: [libxtensor-dev]
   fedora: [xtensor-devel]
   nixos: [xtensor]
+  openembedded: [xtensor@meta-ros2]
   rhel:
     '*': [xtensor-devel]
     '8': null
@@ -9472,6 +9627,7 @@ yasm:
   fedora: [yasm]
   gentoo: [dev-lang/yasm]
   nixos: [yasm]
+  openembedded: [yasm@meta-oe]
   ubuntu: [yasm]
 zbar:
   arch: [zbar]
@@ -9488,6 +9644,7 @@ zenity:
   fedora: [zenity]
   gentoo: [gnome-extra/zenity]
   nixos: [gnome.zenity]
+  openembedded: [zenity@meta-gnome]
   ubuntu: [zenity]
 zeromq3:
   arch: [zeromq]
@@ -9502,6 +9659,7 @@ zip:
   fedora: [zip]
   gentoo: [app-arch/zip]
   nixos: [zip]
+  openembedded: [zip@openembedded-core]
   ubuntu: [zip]
 zlib:
   alpine: [zlib-dev]
@@ -9529,6 +9687,7 @@ zsh:
   gentoo: [shells/zsh]
   macports: [zsh]
   nixos: [zsh]
+  openembedded: [zsh@meta-oe]
   opensuse: [zsh]
   rhel: [zsh]
   ubuntu: [zsh]
@@ -9540,6 +9699,7 @@ zziplib:
   gentoo: [dev-libs/zziplib]
   macports: [libzzip]
   nixos: [zziplib]
+  openembedded: [zziplib@meta-ros-common]
   opensuse: [zziplib-devel]
   rhel: [zziplib-devel]
   ubuntu: [libzzip-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4991,6 +4991,7 @@ python3-babeltrace:
   fedora: [python3-babeltrace]
   gentoo: [dev-util/babeltrace]
   nixos: [babeltrace]
+  openembedded: [babeltrace@openembedded-core]
   opensuse: [python3-babeltrace]
   rhel:
     '*': [python3-babeltrace]
@@ -5417,6 +5418,7 @@ python3-construct:
   fedora: [python3-construct]
   gentoo: [dev-python/construct]
   nixos: [python3Packages.construct]
+  openembedded: [python3-construct@meta-ros2]
   rhel:
     '*': [python3-construct]
     '7': null
@@ -5599,6 +5601,7 @@ python3-distro:
   fedora: [python3-distro, lsb_release]
   gentoo: [dev-python/distro]
   nixos: [python3Packages.distro]
+  openembedded: [python3-distro@meta-python]
   rhel:
     '*': [python3-distro, lsb_release]
     '8': [python3-distro, redhat-lsb-core]
@@ -8020,6 +8023,7 @@ python3-ply:
   fedora: [python3-ply]
   gentoo: [dev-python/ply]
   nixos: [python3Packages.ply]
+  openembedded: [python3-ply@openembedded-core]
   opensuse: [python3-ply]
   rhel:
     '*': [python3-ply]
@@ -8250,6 +8254,7 @@ python3-pydantic:
   fedora: [python3-pydantic]
   gentoo: [dev-python/pydantic]
   nixos: [python3Packages.pydantic]
+  openembedded: [python3-pydantic@meta-python]
   rhel:
     '*': [python3-pydantic]
     '8': null
@@ -8430,6 +8435,7 @@ python3-pymap3d:
     buster: null
     stretch: null
   gentoo: [sci-geosciences/pymap3d]
+  openembedded: [python3-pymap3d@meta-ros2]
   ubuntu:
     '*': [python3-pymap3d]
     bionic: null
@@ -9464,6 +9470,7 @@ python3-scipy:
   gentoo: [sci-libs/scipy]
   macports: [py37-scipy]
   nixos: [python3Packages.scipy]
+  openembedded: [python3-scipy@meta-scipy]
   opensuse: [python3-scipy]
   osx:
     pip:
@@ -9715,6 +9722,7 @@ python3-smbus:
   debian: [python3-smbus]
   fedora: [python3-i2c-tools]
   nixos: [python3Packages.i2c-tools]
+  openembedded: [python3-smbus@meta-python]
   opensuse: [python3-smbus]
   rhel:
     '*': [python3-i2c-tools]
@@ -10472,6 +10480,7 @@ python3-venv:
   fedora: [python3-libs]
   gentoo: [dev-lang/python]
   nixos: [python3]
+  openembedded: [python3@openembedded-core]
   opensuse: [python3-virtualenv]
   osx:
     pip:
@@ -10518,6 +10527,7 @@ python3-watchdog:
   fedora: [python3-watchdog]
   gentoo: [dev-python/watchdog]
   nixos: [python3Packages.watchdog]
+  openembedded: [python3-watchdog@meta-python]
   ubuntu: [python3-watchdog]
 python3-waymo-open-dataset-tf-2-6-0-pip:
   debian:


### PR DESCRIPTION
This adds missing entries for OpenEmbedded to the rosdep database.

This was generated by automatically querying the OpenEmbedded Layer Index (https://layers.openembedded.org/)

In cases where a layer was not specified, this is because it exists in multiple ROS 2 specific layers (eg meta-ros2-humble, iron, jazzy, rolling, etc).  A future change may be required if meta-ros consolidates these recipes into the meta-ros2 sublayer.

## Package name:

- ace
- alsa-utils
- apache2
- apparmor
- aravis
- at-spi2-core
- autossh
- babeltrace
- backward-cpp
- can-utils
- castxml
- catch2
- ccid
- chrony
- clang
- cli11
- cpprest
- cunit
- dbus
- devilspie2
- dfu-util
- docker-compose
- dpkg
- espeak
- ethtool
- fcgi
- fltk
- fluidsynth
- fping
- freetype
- fsharp
- ftgl
- gcc-arm-none-eabi
- gdal
- geos
- gnome-terminal
- gperftools
- gphoto2
- gpsd
- graphviz
- gtkmm
- gts
- hidapi
- htop
- imagemagick
- intltool
- iw
- jack
- jasper
- json-glib
- leptonica
- libao
- libb64
- libbsd
- libcereal
- libconfig
- libedit
- libepoxy
- libevdev
- libevent
- libev
- libexif
- libmnl
- libnl
- libnotify
- libopus
- librdkafka
- libsodium
- libspatialite
- libssh2
- libssh
- libunwind
- libvorbis
- libxft
- libxinerama
- libxtst
- libzip
- lighttpd
- lttng-modules
- lua
- lz4
- mercurial
- mpfr
- mpg123
- mpich
- msr-tools
- muparser
- nanopb
- nasm
- octave
- openexr
- openni2
- openni
- openscenegraph
- php
- pigz
- popt
- postfix
- powertop
- procps
- psutils
- qtwebkit
- rapidjson
- rt-tests
- setserial
- shaderc
- simde
- smartmontools
- sound-theme-freedesktop
- sox
- speex
- sysbench
- systemd
- tclap
- tcsh
- tesseract
- tiff
- tmux
- tree
- vim
- vorbis-tools
- wireshark
- x264
- xdg-utils
- yasm
- zenity
- zip
- zsh
- zziplib

## Purpose of using this:

This will allow the Superflore build tool to correctly resolve these dependencies when generating BitBake recipes.

## Links to Distribution Packages

- ace@meta-oe https://layers.openembedded.org/layerindex/recipe/132112/
- alsa-utils@openembedded-core https://layers.openembedded.org/layerindex/recipe/5556/
- apache2@meta-webserver https://layers.openembedded.org/layerindex/recipe/5976/
- apparmor@meta-security https://layers.openembedded.org/layerindex/recipe/60225/
- aravis@meta-multimedia https://layers.openembedded.org/layerindex/recipe/404746/
- at-spi2-core@openembedded-core https://layers.openembedded.org/layerindex/recipe/5138/
- autossh@meta-networking https://layers.openembedded.org/layerindex/recipe/133444/
- babeltrace@openembedded-core https://layers.openembedded.org/layerindex/recipe/5259/
- backward-cpp@meta-ros-common https://layers.openembedded.org/layerindex/recipe/420245/
- can-utils@meta-oe https://layers.openembedded.org/layerindex/recipe/24252/
- castxml@meta-clang https://layers.openembedded.org/layerindex/recipe/149664/
- catch2@meta-oe https://layers.openembedded.org/layerindex/recipe/88776/
- ccid@meta-oe https://layers.openembedded.org/layerindex/recipe/1055/
- chrony@meta-networking https://layers.openembedded.org/layerindex/recipe/51402/
- clang@meta-clang https://layers.openembedded.org/layerindex/recipe/31565/
- cli11@meta-oe https://layers.openembedded.org/layerindex/recipe/95640/
- cpprest@meta-oe https://layers.openembedded.org/layerindex/recipe/82173/
- cunit@meta-oe https://layers.openembedded.org/layerindex/recipe/33575/
- dbus@openembedded-core https://layers.openembedded.org/layerindex/recipe/5344/
- devilspie2@meta-gnome https://layers.openembedded.org/layerindex/recipe/414971/
- dfu-util@meta-oe https://layers.openembedded.org/layerindex/recipe/46764/
- docker-compose@meta-virtualization https://layers.openembedded.org/layerindex/recipe/327567/
- dpkg@openembedded-core https://layers.openembedded.org/layerindex/recipe/5540/
- espeak@meta-oe https://layers.openembedded.org/layerindex/recipe/1084/
- ethtool@openembedded-core https://layers.openembedded.org/layerindex/recipe/5311/
- fcgi@meta-webserver https://layers.openembedded.org/layerindex/recipe/28567/
- fltk@meta-oe https://layers.openembedded.org/layerindex/recipe/1114/
- fluidsynth@meta-multimedia https://layers.openembedded.org/layerindex/recipe/2274/
- fping@meta-networking https://layers.openembedded.org/layerindex/recipe/20430/
- freetype@openembedded-core https://layers.openembedded.org/layerindex/recipe/5021/
- fsharp@meta-mono https://layers.openembedded.org/layerindex/recipe/39080/
- ftgl@meta-oe https://layers.openembedded.org/layerindex/recipe/95797/
- gcc-arm-none-eabi@meta-arm-toolchain https://layers.openembedded.org/layerindex/recipe/181181/
- gdal@meta-ros-common https://layers.openembedded.org/layerindex/recipe/403091/
- geos@meta-oe https://layers.openembedded.org/layerindex/recipe/1127/
- gnome-terminal@meta-gnome https://layers.openembedded.org/layerindex/recipe/415025/
- gperftools@meta-oe https://layers.openembedded.org/layerindex/recipe/3988/
- gphoto2@meta-oe https://layers.openembedded.org/layerindex/recipe/39529/
- gpsd@meta-oe https://layers.openembedded.org/layerindex/recipe/1120/
- graphviz@meta-oe https://layers.openembedded.org/layerindex/recipe/95656/
- gtkmm@meta-oe https://layers.openembedded.org/layerindex/recipe/4945/
- gts@meta-ros-common https://layers.openembedded.org/layerindex/recipe/420297/
- hidapi@meta-oe https://layers.openembedded.org/layerindex/recipe/39326/
- htop@meta-oe https://layers.openembedded.org/layerindex/recipe/995/
- imagemagick@meta-oe https://layers.openembedded.org/layerindex/recipe/5891/
- intltool@openembedded-core https://layers.openembedded.org/layerindex/recipe/242/
- iw@openembedded-core https://layers.openembedded.org/layerindex/recipe/39870/
- jack@meta-oe https://layers.openembedded.org/layerindex/recipe/1154/
- jasper@meta-oe https://layers.openembedded.org/layerindex/recipe/977/
- json-glib@openembedded-core https://layers.openembedded.org/layerindex/recipe/4911/
- leptonica@meta-oe https://layers.openembedded.org/layerindex/recipe/27946/
- libao@meta-multimedia https://layers.openembedded.org/layerindex/recipe/20465/
- libb64@meta-oe https://layers.openembedded.org/layerindex/recipe/166933/
- libbsd@openembedded-core https://layers.openembedded.org/layerindex/recipe/5185/
- libcereal@meta-oe https://layers.openembedded.org/layerindex/recipe/87348/
- libconfig@meta-oe https://layers.openembedded.org/layerindex/recipe/822/
- libedit@openembedded-core https://layers.openembedded.org/layerindex/recipe/105008/
- libepoxy@openembedded-core https://layers.openembedded.org/layerindex/recipe/33587/
- libevdev@openembedded-core https://layers.openembedded.org/layerindex/recipe/28518/
- libevent@openembedded-core https://layers.openembedded.org/layerindex/recipe/529/
- libev@meta-oe https://layers.openembedded.org/layerindex/recipe/60169/
- libexif@openembedded-core https://layers.openembedded.org/layerindex/recipe/512/
- libmnl@openembedded-core https://layers.openembedded.org/layerindex/recipe/69187/
- libnl@openembedded-core https://layers.openembedded.org/layerindex/recipe/4967/
- libnotify@openembedded-core https://layers.openembedded.org/layerindex/recipe/5982/
- libopus@meta-oe https://layers.openembedded.org/layerindex/recipe/1163/
- librdkafka@meta-oe https://layers.openembedded.org/layerindex/recipe/168226/
- libsodium@meta-oe https://layers.openembedded.org/layerindex/recipe/39852/
- libspatialite@meta-oe https://layers.openembedded.org/layerindex/recipe/1129/
- libssh2@openembedded-core https://layers.openembedded.org/layerindex/recipe/164603/
- libssh@meta-oe https://layers.openembedded.org/layerindex/recipe/23547/
- libunwind@openembedded-core https://layers.openembedded.org/layerindex/recipe/28832/
- libvorbis@openembedded-core https://layers.openembedded.org/layerindex/recipe/727/
- libxft@openembedded-core https://layers.openembedded.org/layerindex/recipe/398/
- libxinerama@openembedded-core https://layers.openembedded.org/layerindex/recipe/5237/
- libxtst@openembedded-core https://layers.openembedded.org/layerindex/recipe/5239/
- libzip@meta-oe https://layers.openembedded.org/layerindex/recipe/89425/
- lighttpd@openembedded-core https://layers.openembedded.org/layerindex/recipe/174/
- lttng-modules@openembedded-core https://layers.openembedded.org/layerindex/recipe/5373/
- lua@openembedded-core https://layers.openembedded.org/layerindex/recipe/189291/
- lz4@openembedded-core https://layers.openembedded.org/layerindex/recipe/23646/
- mercurial@meta-oe https://layers.openembedded.org/layerindex/recipe/72420/
- mpfr@openembedded-core https://layers.openembedded.org/layerindex/recipe/4867/
- mpg123@openembedded-core https://layers.openembedded.org/layerindex/recipe/51335/
- mpich@meta-oe https://layers.openembedded.org/layerindex/recipe/33348/
- msr-tools@meta-oe https://layers.openembedded.org/layerindex/recipe/32859/
- muparser@meta-qt5-extra https://layers.openembedded.org/layerindex/recipe/53089/
- nanopb@meta-oe https://layers.openembedded.org/layerindex/recipe/117817/
- nasm@openembedded-core https://layers.openembedded.org/layerindex/recipe/5543/
- octave@meta-oe https://layers.openembedded.org/layerindex/recipe/96176/
- openexr@meta-ros-common https://layers.openembedded.org/layerindex/recipe/420299/
- openni2@meta-ros2 https://layers.openembedded.org/layerindex/recipe/396813/
- openni@meta-ros2 https://layers.openembedded.org/layerindex/recipe/396812/
- openscenegraph@meta-ros2 https://layers.openembedded.org/layerindex/recipe/396814/
- php@meta-oe https://layers.openembedded.org/layerindex/recipe/39864/
- pigz@openembedded-core https://layers.openembedded.org/layerindex/recipe/123/
- popt@openembedded-core https://layers.openembedded.org/layerindex/recipe/519/
- postfix@meta-networking https://layers.openembedded.org/layerindex/recipe/28444/
- powertop@openembedded-core https://layers.openembedded.org/layerindex/recipe/5553/
- procps@openembedded-core https://layers.openembedded.org/layerindex/recipe/119/
- psutils@meta-oe https://layers.openembedded.org/layerindex/recipe/339292/
- qtwebkit@meta-qt5 https://layers.openembedded.org/layerindex/recipe/119219/
- rapidjson@meta-oe https://layers.openembedded.org/layerindex/recipe/58446/
- rt-tests@openembedded-core https://layers.openembedded.org/layerindex/recipe/742/
- setserial@openembedded-core https://layers.openembedded.org/layerindex/recipe/768/
- shaderc@openembedded-core https://layers.openembedded.org/layerindex/recipe/152454/
- simde@meta-ros2 https://layers.openembedded.org/layerindex/recipe/396816/
- smartmontools@meta-oe https://layers.openembedded.org/layerindex/recipe/4794/
- sound-theme-freedesktop@meta-oe https://layers.openembedded.org/layerindex/recipe/20516/
- sox@meta-multimedia https://layers.openembedded.org/layerindex/recipe/2270/
- speex@openembedded-core https://layers.openembedded.org/layerindex/recipe/709/
- sysbench@meta-oe https://layers.openembedded.org/layerindex/recipe/52203/
- systemd@openembedded-core https://layers.openembedded.org/layerindex/recipe/5979/
- tclap@meta-oe https://layers.openembedded.org/layerindex/recipe/4464/
- tcsh@meta-oe https://layers.openembedded.org/layerindex/recipe/851/
- tesseract@meta-oe https://layers.openembedded.org/layerindex/recipe/28012/
- tiff@openembedded-core https://layers.openembedded.org/layerindex/recipe/734/
- tmux@meta-oe https://layers.openembedded.org/layerindex/recipe/854/
- tree@meta-oe https://layers.openembedded.org/layerindex/recipe/37212/
- vim@openembedded-core https://layers.openembedded.org/layerindex/recipe/96649/
- vorbis-tools@meta-multimedia https://layers.openembedded.org/layerindex/recipe/39697/
- wireshark@meta-networking https://layers.openembedded.org/layerindex/recipe/28535/
- x264@openembedded-core https://layers.openembedded.org/layerindex/recipe/5642/
- xdg-utils@openembedded-core https://layers.openembedded.org/layerindex/recipe/5347/
- yasm@meta-oe https://layers.openembedded.org/layerindex/recipe/88518/
- zenity@meta-gnome https://layers.openembedded.org/layerindex/recipe/415006/
- zip@openembedded-core https://layers.openembedded.org/layerindex/recipe/158/
- zsh@meta-oe https://layers.openembedded.org/layerindex/recipe/855/
- zziplib@meta-ros-common https://layers.openembedded.org/layerindex/recipe/420304/
- 