### PR TITLE
osrf_pycommon: 2.1.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4931,7 +4931,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 2.1.4-3
+      version: 2.1.5-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `2.1.5-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.4-3`

## osrf_pycommon

```
* Align stdeb dependencies with setup.py (#101 <https://github.com/osrf/osrf_pycommon/issues/101>)
  Follow-up to 4b2f3a8e4969f33dced1dc2db2296230e7a55b1d
* Add '+upstream' suffix to published deb version (#102 <https://github.com/osrf/osrf_pycommon/issues/102>)
  Using a debian version suffix which falls late alphabetically appears to
  give our packages preference by apt. If a user enables a repository
  which distributes packages created by OSRF or ROS, it is likely that
  they wish to use these packages instead of the ones packaged by their
  platform.
* Upload coverage results to codecov (#100 <https://github.com/osrf/osrf_pycommon/issues/100>)
* Update ci.yaml (#96 <https://github.com/osrf/osrf_pycommon/issues/96>)
  fix node.js <20 deprecation
  Co-authored-by: Scott K Logan <mailto:logans@cottsay.net>
* Updated python version (#97 <https://github.com/osrf/osrf_pycommon/issues/97>)
  Python version 3.7 is no longer supported as of June 27, 2023
  Co-authored-by: Scott K Logan <mailto:logans@cottsay.net>
* Resolve outstanding resource warnings when running tests (#99 <https://github.com/osrf/osrf_pycommon/issues/99>)
* Update deb platforms for release (#95 <https://github.com/osrf/osrf_pycommon/issues/95>)
  Added:
  * Ubuntu Noble (24.04 LTS pre-release)
  * Debian Trixie (testing)
  Dropped:
  * Debian Bullseye (oldstable)
  Retained:
  * Debian Bookworm (stable)
  * Ubuntu Focal (20.04 LTS)
  * Ubuntu Jammy (22.04 LTS)
* Remove CODEOWNERS. (#98 <https://github.com/osrf/osrf_pycommon/issues/98>)
  It is out of date and no longer serving its intended purpose.
* Contributors: Chris Lalancette, Scott K Logan, Steven! Ragnarök, mosfet80
```
