### PR TITLE
ros2cli: 0.32.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6886,7 +6886,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.1-1
+      version: 0.32.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.2-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.32.1-1`

## ros2action

- No changes

## ros2cli

```
* replace removeprefix with string slicing. (#953 <https://github.com/ros2/ros2cli/issues/953>) (#955 <https://github.com/ros2/ros2cli/issues/955>)
  (cherry picked from commit 35d6abd50a55181099aab82134fc507d8fd162bd)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* New flag and code update for its use (#942 <https://github.com/ros2/ros2cli/issues/942>) (#943 <https://github.com/ros2/ros2cli/issues/943>)
  (cherry picked from commit a3198b80f8a993ac01501d8e3fbdd76e7aaf92dc)
  Co-authored-by: Angel LoGa <mailto:98213868+AngeLoGa@users.noreply.github.com>
* Contributors: mergify[bot]
```

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* cosmetic fixes for ros2param dump command. (#933 <https://github.com/ros2/ros2cli/issues/933>) (#940 <https://github.com/ros2/ros2cli/issues/940>)
  * cosmetic fixes for ros2param dump command.
  * pass through no parameters available case.
  * bug fix from review comment.
  * remove unnecessary initial assignment.
  ---------
  (cherry picked from commit 8e46bf2608d04e81a3d088ccc5087dbde9f3e32f)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
