### PR TITLE
rmw_implementation: 2.15.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6528,7 +6528,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.15.3-1
+      version: 2.15.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.15.4-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.15.3-1`

## rmw_implementation

```
* Make sure to find_package(rmw) in rmw_implementation. (#242 <https://github.com/ros2/rmw_implementation/issues/242>) (#245 <https://github.com/ros2/rmw_implementation/issues/245>)
  This is required to get access to the register_rmw_implementation
  CMake macro.
  (cherry picked from commit e9f60082b76e0621629c146d160b72bdac82ae45)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
