### PR TITLE
rclcpp: 28.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5973,7 +5973,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.5-1
+      version: 28.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.6-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `28.1.5-1`

## rclcpp

```
* apply actual QoS from rmw to the IPC publisher. (#2707 <https://github.com/ros2/rclcpp/issues/2707>) (#2712 <https://github.com/ros2/rclcpp/issues/2712>)
  * apply actual QoS from rmw to the IPC publisher.
  * address uncrustify warning.
  ---------
  (cherry picked from commit 016cfeac99e4b67f58abdf247e57f05b85c09ec4)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Adding in topic name to logging on IPC issues (#2706 <https://github.com/ros2/rclcpp/issues/2706>) (#2710 <https://github.com/ros2/rclcpp/issues/2710>)
  * Adding in topic name to logging on IPC issues
  * Update test matching output logging
  * adding in single quotes
  ---------
  (cherry picked from commit a13e16e2cbaeacb14ff31272d01cbb21bd8ac037)
  Co-authored-by: Steve Macenski <mailto:stevenmacenski@gmail.com>
* enable testRaceConditionAddNode for rmw_connextdds. (#2698 <https://github.com/ros2/rclcpp/issues/2698>)
* Re-enable executor test on rmw_connextdds. (#2693 <https://github.com/ros2/rclcpp/issues/2693>) (#2695 <https://github.com/ros2/rclcpp/issues/2695>)
  It supports the events executor now, so re-enable the test.
  (cherry picked from commit d7245365ed867db9b309ed3efbfb0391bda09bd5)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Fix warnings on Windows. (backport #2692 <https://github.com/ros2/rclcpp/issues/2692>) (#2694 <https://github.com/ros2/rclcpp/issues/2694>)
  * Fix warnings on Windows. (#2692 <https://github.com/ros2/rclcpp/issues/2692>)
  For reasons I admit I do not understand, the deprecation
  warnings for StaticSingleThreadedExecutor on Windows
  happen when we construct a shared_ptr for it in the tests.
  If we construct a regular object, then it is fine.  Luckily
  this test does not require a shared_ptr, so just make it
  a regular object here, which rixes the warning.
  While we are in here, make all of the tests camel case to
  be consistent.
  (cherry picked from commit 3310f9eaed967e0c18d17bb2f82d2def838bb7a5)
  # Conflicts:
  #     rclcpp/test/rclcpp/executors/test_executors.cpp
  * resolve backport conflict.
  ---------
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Omnibus fixes for running tests with Connext. (backport #2684 <https://github.com/ros2/rclcpp/issues/2684>) (#2690 <https://github.com/ros2/rclcpp/issues/2690>)
  * Omnibus fixes for running tests with Connext. (#2684 <https://github.com/ros2/rclcpp/issues/2684>)
  * Omnibus fixes for running tests with Connext.
  When running the tests with RTI Connext as the default
  RMW, some of the tests are failing.  There are three
  different failures fixed here:
  1.  Setting the liveliness duration to a value smaller than
  a microsecond causes Connext to throw an error.  Set it to
  a millisecond.
  2.  Using the SystemDefaultsQoS sets the QoS to KEEP_LAST 1.
  Connext is somewhat slow in this regard, so it can be the case
  that we are overwriting a previous service introspection event
  with the next one.  Switch to the ServicesDefaultQoS in the test,
  which ensures we will not lose events.
  3.  Connext is slow to match publishers and subscriptions.  Thus,
  when creating a subscription "on-the-fly", we should wait for the
  publisher to match it before expecting the subscription to actually
  receive data from it.
  With these fixes in place, the test_client_common, test_generic_service,
  test_service_introspection, and test_executors tests all pass for
  me with rmw_connextdds.
  * Fixes for executors.
  * One more fix for services.
  * More fixes for service_introspection.
  * More fixes for introspection.
  ---------
  (cherry picked from commit 9984197c292d6c5ae0e7661aaea245ffb0fea057)
  # Conflicts:
  #     rclcpp/test/rclcpp/executors/test_executors.cpp
  #     rclcpp/test/rclcpp/test_generic_service.cpp
  * address backport merge conflicts.
  ---------
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* fix(Executor): Fix segfault if callback group is deleted during rmw_wait (#2682 <https://github.com/ros2/rclcpp/issues/2682>)
* Fix NodeOptions assignment operator (#2656 <https://github.com/ros2/rclcpp/issues/2656>) (#2660 <https://github.com/ros2/rclcpp/issues/2660>)
  * Fix NodeOptions assignment operator
  Also copy the enable_logger_service_ member during the assignment operation
  * Add more checks for NodeOptions copy test
  * Set non default values by avoiding the copy-assignement
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit 9b654942f99f17850e0e95480958abdbb508bc00)
  Co-authored-by: Romain DESILLE <mailto:r.desille@gmail.com>
* set QoS History KEEP_ALL explicitly for statistics publisher. (#2650 <https://github.com/ros2/rclcpp/issues/2650>) (#2657 <https://github.com/ros2/rclcpp/issues/2657>)
  * set QoS History KEEP_ALL explicitly for statistics publisher.
  * test_subscription_options adjustment.
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: Cristóbal Arroyo, Tomoya Fujita, jmachowinski, mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
