### PR TITLE
rviz: 14.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8008,7 +8008,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.5-1
+      version: 14.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* remove unused variable (#1301 <https://github.com/ros2/rviz/issues/1301>) (#1303 <https://github.com/ros2/rviz/issues/1303>)
  (cherry picked from commit f1bb35318e4d3efe6443e30e75c7bc78b505ed17)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Use consistent conditionals in render_system.hpp (#1294 <https://github.com/ros2/rviz/issues/1294>) (#1295 <https://github.com/ros2/rviz/issues/1295>)
  These header files define the XVisualInfo type, which is used later in
  this header based on different conditionals. In particular, the
  evaluation of these conditionals differ on BSD, which appears to have
  the headers needed so I don't believe that __linux__ is the correct
  conditional to use.
  (cherry picked from commit 0d95ae1f1227ab9aa0327d0945d9aec8ed9f88e1)
  Co-authored-by: Scott K Logan <mailto:logans@cottsay.net>
* Avoid redefinition of default color materials (#1281 <https://github.com/ros2/rviz/issues/1281>) (#1282 <https://github.com/ros2/rviz/issues/1282>)
  (cherry picked from commit 8e757c2c39e382a0523e4ce230e5719ea450f483)
  Co-authored-by: Masayoshi Dohi <mailto:66519864+Masa0u0@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
