### PR TITLE
point_cloud_transport: 4.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5266,7 +5266,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.3-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.2-1`

## point_cloud_transport

- No changes

## point_cloud_transport_py

```
* remove extra semicolon (#98 <https://github.com/ros-perception/point_cloud_transport/issues/98>) (#99 <https://github.com/ros-perception/point_cloud_transport/issues/99>)
  (cherry picked from commit 7cc2e9731e6c89aef8107f252cd2c1561be4612d)
  Co-authored-by: Manu <mailto:manuel.mueller.mts@gmail.com>
* Contributors: mergify[bot]
```
