### PR TITLE
ament_cmake: 2.5.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -152,7 +152,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.5.2-2
+      version: 2.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.5.3-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.2-2`

## ament_cmake

- No changes

## ament_cmake_auto

- No changes

## ament_cmake_core

- No changes

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

```
* Add explicit git dependency from ament_cmake_vendor_package (#555 <https://github.com/ament/ament_cmake/issues/555>)
  The vcstool package can be used with multiple package managers, not just
  git. Best to be explicit about which of those package managers we want
  to use.
  (cherry picked from commit 032dc51e558cc046b2c6e5af7a9d38bdc30ba191)
  Co-authored-by: Scott K Logan <mailto:logans@cottsay.net>
* Contributors: mergify[bot]
```

## ament_cmake_version

- No changes
