### PR TITLE
qt_gui_core: 2.7.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5606,7 +5606,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.7.4-2
+      version: 2.7.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.7.5-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.4-2`

## qt_dotgraph

```
* Cleanup qt_dotgraph and make the tests more robust. (#296 <https://github.com/ros-visualization/qt_gui_core/issues/296>) (#298 <https://github.com/ros-visualization/qt_gui_core/issues/298>)
  1.  Remove all uses of LooseVersion here.  The issue it
  was protecting against is long gone, and LooseVersion is
  deprecated.  Just remove it.
  2.  Remove the "simplify" parameter from "add_edge_to_graph".
  While this is technically an API change, there are no downstream
  users as far as I can tell and it had no effect.
  3.  During the test, make sure to replace carriage return with
  spaces.  This ensures that on Windows, the tests will pass
  correctly.
  (cherry picked from commit 4a11ebc5d97ebe718c5a09c98814c186bfb7a4f4)
* Contributors: mergify[bot]
```

## qt_gui

- No changes

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
