### PR TITLE
launch_ros: 0.26.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3388,7 +3388,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.5-2
+      version: 0.26.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.26.5-2`

## launch_ros

```
* Fix url in setup.py (#413 <https://github.com/ros2/launch_ros/issues/413>) (#414 <https://github.com/ros2/launch_ros/issues/414>)
  (cherry picked from commit edb63764c39993645fd6bc7e0fc31ed7316f0b45)
  Co-authored-by: Wei HU <mailto:37072526+huweiATgithub@users.noreply.github.com>
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

```
* Fix url in setup.py (#413 <https://github.com/ros2/launch_ros/issues/413>) (#414 <https://github.com/ros2/launch_ros/issues/414>)
  (cherry picked from commit edb63764c39993645fd6bc7e0fc31ed7316f0b45)
  Co-authored-by: Wei HU <mailto:37072526+huweiATgithub@users.noreply.github.com>
* Contributors: mergify[bot]
```
