### PR TITLE
launch: 3.4.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3353,7 +3353,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.2-2
+      version: 3.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.3-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.2-2`

## launch

```
* Fix 'set up' typo (#813 <https://github.com/ros2/launch/issues/813>) (#814 <https://github.com/ros2/launch/issues/814>)
  (cherry picked from commit fda41a218b990c8e3bcc6c3d61f2862704529257)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
