### PR TITLE
mp2p_icp: 1.6.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3840,7 +3840,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.6.3-1
+      version: 1.6.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.6.4-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.3-1`

## mp2p_icp

```
* merge two docs pages in one to shorten the docs TOC
* Update README.md: Mark ROS2 Iron as EOL
* Also use TBB for parallel solving point-to-plane pairings
* Contributors: Jose Luis Blanco-Claraco
```
