### PR TITLE
ur_robot_driver: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10947,7 +10947,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.16-5
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.5.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.16-5`

## ur

```
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Contributors: mergify[bot]
```

## ur_bringup

```
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Forward trajectory controller (backport of #944 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/944>)
* Contributors: mergify[bot]
```

## ur_calibration

```
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Initialize segments in constructor of DHRobot in calibration.hpp (backport of #1197 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1197>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* Freedrive Controller (#1114 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1114>) (#1211 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1211>)
* Add force mode controller (#1049 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1049>) (#1193 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1193>)
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Forward trajectory controller (backport of #944 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/944>)
* [SJTC] Make scaling interface optional (#1145 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1145>) (#1172 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1172>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

```
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Contributors: mergify[bot]
```

## ur_moveit_config

```
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Freedrive Controller (#1114 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1114>) (#1211 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1211>)
* Add force mode controller (#1049 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1049>) (#1193 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1193>)
* Update package maintainers (backport of #1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Forward trajectory controller (backport of #944 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/944>)
* Use pose_broadcaster to publish the TCP pose (backport of #1108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1108>)
* Contributors: mergify[bot]
```
