### PR TITLE
ur_robot_driver: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9304,7 +9304,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.4.13-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.13-1`

## ur

```
* Update package maintainers (#1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Contributors: Felix Exner
```

## ur_calibration

```
* Update package maintainers (#1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Initialize segments in constructor of DHRobot in calibration.hpp (#1197 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1197>)
* Contributors: Benjamin, Felix Exner
```

## ur_controllers

```
* Freedrive Controller (#1114 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1114>)
* Make ur_controllers compilable on humble (#1207 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1207>)
* Update package maintainers (#1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Add force mode controller (#1049 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1049>)
* ur_controllers: Update RealTimeBox (#1189 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1189>)
* Add trajectory passthrough controller (#944 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/944>)
* Contributors: Christoph Fröhlich, Felix Exner, URJala, Vincenzo Di Pentima
```

## ur_dashboard_msgs

```
* Update package maintainers (#1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Contributors: Felix Exner
```

## ur_moveit_config

```
* Update package maintainers (#1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Freedrive Controller (#1114 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1114>)
* Fix running force_mode controller alongside passthrough trajectory controller (#1210 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1210>)
* Update package maintainers (#1203 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1203>)
* Add force mode controller (#1049 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1049>)
* Add trajectory passthrough controller (#944 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/944>)
* Use pose_broadcaster to publish the TCP pose (#1108 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1108>)
* Contributors: Felix Exner, URJala, Vincenzo Di Pentima
```
