### PR TITLE
moveit: 2.12.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4116,7 +4116,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.12.0-1
+      version: 2.12.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.12.1-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.0-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* handle continuous joints in getLowerAndUpperLimits (#3153 <https://github.com/ros-planning/moveit2/issues/3153>) (#3155 <https://github.com/ros-planning/moveit2/issues/3155>)
* Contributors: Mario Prats
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_planners_stomp

- No changes

## moveit_plugins

- No changes

## moveit_py

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Fix logic in CheckStartStateBounds adapter (#3143 <https://github.com/ros-planning/moveit2/issues/3143>) (#3148 <https://github.com/ros-planning/moveit2/issues/3148>)
* Contributors: Sebastian Castro
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

- No changes

## moveit_ros_visualization

```
* Fix MeshShape::clear() for safer mesh removal (#3164 <https://github.com/ros-planning/moveit2/issues/3164>) (#3167 <https://github.com/ros-planning/moveit2/issues/3167>)
* Contributors: Matt Wang
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* re-enable cmake warnings (#3028 <https://github.com/ros-planning/moveit2/issues/3028>) (backport #3172 <https://github.com/ros-planning/moveit2/issues/3172>) (#3173 <https://github.com/ros-planning/moveit2/issues/3173>)
  * Add conditional include for realtime_helpers.hpp
* Contributors: Michael Ferguson, Sebastian Castro
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

- No changes

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

- No changes

## pilz_industrial_motion_planner_testutils

- No changes
