### PR TITLE
Revert "pinocchio: 3.3.0-1 in 'jazzy/distribution.yaml' [bloom] (#438…

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5172,7 +5172,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pinocchio-release.git
-      version: 3.3.0-1
+      version: 2.6.21-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
This reverts commit 1786a2e3afdddbc2e5e15789823c319c54052415.

The new version brings a regression due to a linking error in `jazzy`: https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__pinocchio__ubuntu_noble_amd64__binary/34/console

I'm reverting this update so the package don't get wiped out in the upcoming `jazzy` patch sync.

FYI: @nim65s please take a look.
