### PR TITLE
tuw_msgs: 0.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10707,15 +10707,19 @@ repositories:
     release:
       packages:
       - tuw_airskin_msgs
+      - tuw_geo_msgs
       - tuw_geometry_msgs
+      - tuw_graph_msgs
       - tuw_msgs
       - tuw_multi_robot_msgs
       - tuw_nav_msgs
+      - tuw_object_map_msgs
       - tuw_object_msgs
+      - tuw_std_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
-      version: 0.2.1-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tuw_msgs` to `0.2.5-1`:

- upstream repository: https://github.com/tuw-robotics/tuw_msgs.git
- release repository: https://github.com/tuw-robotics/tuw_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.1-1`

## tuw_airskin_msgs

```
* ament_lint_auto on build dependency added
* Contributors: Markus Bader
```

## tuw_geo_msgs

```
* ament_lint_auto on test_depend added
* Contributors: Markus Bader
```

## tuw_geometry_msgs

```
* ament_lint_auto on test_depend added
* Contributors: Markus Bader
```

## tuw_graph_msgs

```
* ament_lint_auto on test_depend added
* Contributors: Markus Bader
```

## tuw_msgs

```
* ament_lint_auto on build dependency added
* Contributors: Markus Bader
```

## tuw_multi_robot_msgs

```
* ament_lint_auto on build dependency added
* Contributors: Markus Bader
```

## tuw_nav_msgs

```
* ament_lint_auto on build dependency added
* Contributors: Markus Bader
```

## tuw_object_map_msgs

```
* ament_lint_auto on build dependency added
* Contributors: Markus Bader
```

## tuw_object_msgs

```
* ament_lint_auto on test_depend added
* Contributors: Markus Bader
```

## tuw_std_msgs

- No changes
