### PR TITLE
autoware_internal_msgs: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -804,11 +804,19 @@ repositories:
       version: main
     status: developed
   autoware_internal_msgs:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+      version: main
     release:
+      packages:
+      - autoware_internal_debug_msgs
+      - autoware_internal_msgs
+      - autoware_internal_perception_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.2.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## autoware_internal_debug_msgs

```
* feat(autoware_internal_debug_msgs): move stamped messages (#31 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/31>)
* feat: add autoware_internal_debug_msgs package (#30 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/30>)
* Contributors: Takayuki Murooka
```

## autoware_internal_msgs

```
* feat: move the package to its own folder (#28 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/28>)
* Contributors: M. Fatih Cırıt
```

## autoware_internal_perception_msgs

```
* chore: clean up unnecessary CHANGELOGS.rst
* feat(autoware_internal_perception_msgs): add SegmentationMask.msg (#29 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/29>)
* Contributors: M. Fatih Cırıt, Ryohsuke Mitsudome
```
