### PR TITLE
compass: 2.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1578,13 +1578,14 @@ repositories:
       packages:
       - compass_conversions
       - compass_msgs
+      - compass_stack
       - magnetic_model
       - magnetometer_compass
       - magnetometer_pipeline
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
-      version: 2.0.1-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `2.0.3-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/compass.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## compass_conversions

- No changes

## compass_msgs

- No changes

## compass_stack

```
* Added compass_stack.
* Contributors: Martin Pecka
```

## magnetic_model

```
* Added WMM2025.
* Contributors: Martin Pecka
```

## magnetometer_compass

- No changes

## magnetometer_pipeline

- No changes
