### PR TITLE
jacro: 0.2.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3102,6 +3102,17 @@ repositories:
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
       version: rolling
     status: developed
+  jacro:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/jacro-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/jacro.git
+      version: main
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jacro` to `0.2.0-2`:

- upstream repository: https://github.com/JafarAbdi/jacro.git
- release repository: https://github.com/ros2-gbp/jacro-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## jacro

```
* Replace minijinja with jinja2
* Contributors: JafarAbdi
```
