### PR TITLE
feetech_ros2_driver: 0.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2393,6 +2393,17 @@ repositories:
       url: https://github.com/eProsima/Fast-DDS.git
       version: 2.6.x
     status: maintained
+  feetech_ros2_driver:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      version: main
+    status: developed
   ffmpeg_encoder_decoder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `feetech_ros2_driver` to `0.1.0-2`:

- upstream repository: https://github.com/JafarAbdi/feetech_ros2_driver.git
- release repository: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## feetech_ros2_driver

```
* Add feetech ros2 driver
* Contributors: Jafar Uruç
```
