### PR TITLE
rosbag2: 0.26.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7130,7 +7130,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.5-1
+      version: 0.26.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.6-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.26.5-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* Publish clock after delay is over and disable delay on next loops (#1861 <https://github.com/ros2/rosbag2/issues/1861>) (#1878 <https://github.com/ros2/rosbag2/issues/1878>)
  Co-authored-by: Nicola Loi <mailto:nicolaloi@outlook.com>
* [jazzy] Add support for replaying multiple bags (backport #1848 <https://github.com/ros2/rosbag2/issues/1848>) (#1873 <https://github.com/ros2/rosbag2/issues/1873>)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add "--sort" CLI option to the "ros2 bag info" command (backport #1804 <https://github.com/ros2/rosbag2/issues/1804>) (#1838 <https://github.com/ros2/rosbag2/issues/1838>)
  Co-authored-by: Soenke Prophet <mailto:soenke.prophet@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: Sanoronas <mailto:soenke.prophet@gmail.com>
* [jazzy] Add computation of size contribution to info verb (backport #1726 <https://github.com/ros2/rosbag2/issues/1726>) (#1872 <https://github.com/ros2/rosbag2/issues/1872>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
  Co-authored-by: Nicola Loi <mailto:nicolaloi@outlook.com>
* Rename rclpy.qos.QoS*Policy to rclpy.qos.*Policy (#1832 <https://github.com/ros2/rosbag2/issues/1832>) (#1841 <https://github.com/ros2/rosbag2/issues/1841>)
  (cherry picked from commit 786c3c4b8ab05271630371cf515130ba02a9cde8)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2

```
* [jazzy] Add support for replaying multiple bags (backport #1848 <https://github.com/ros2/rosbag2/issues/1848>) (#1873 <https://github.com/ros2/rosbag2/issues/1873>)
  (cherry picked from commit 125db50b4d9a585bab33f2908008fe1168bb9cf3)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_compression

```
* Bugfix: Update metadata with new file_info before saving it first time (#1843 <https://github.com/ros2/rosbag2/issues/1843>) (#1853 <https://github.com/ros2/rosbag2/issues/1853>)
  (cherry picked from commit b5098eff15281c9e79853e8bb2ae9a0a104e6ea5)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Make snapshot writing into a new file each time it is triggered (#1842 <https://github.com/ros2/rosbag2/issues/1842>) (#1849 <https://github.com/ros2/rosbag2/issues/1849>)
  (cherry picked from commit 1877b53847bda4d1f2668187b79fa27a796c3438)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add more logging info to storage and reader/writer open operations (#1881 <https://github.com/ros2/rosbag2/issues/1881>) (#1882 <https://github.com/ros2/rosbag2/issues/1882>)
  (cherry picked from commit 0823be2723e04715baacf99625b844cb88f58c21)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add PlayerClock::wakeup() to interrupt sleeping (backport #1869 <https://github.com/ros2/rosbag2/issues/1869>) (#1875 <https://github.com/ros2/rosbag2/issues/1875>)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add support for replaying multiple bags (backport #1848 <https://github.com/ros2/rosbag2/issues/1848>) (#1873 <https://github.com/ros2/rosbag2/issues/1873>)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add computation of size contribution to info verb (backport #1726 <https://github.com/ros2/rosbag2/issues/1726>) (#1872 <https://github.com/ros2/rosbag2/issues/1872>)
  Co-authored-by: Nicola Loi <mailto:nicolaloi@outlook.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Bugfix: Update metadata with new file_info before saving it first time (#1843 <https://github.com/ros2/rosbag2/issues/1843>) (#1853 <https://github.com/ros2/rosbag2/issues/1853>)
  (cherry picked from commit b5098eff15281c9e79853e8bb2ae9a0a104e6ea5)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Make snapshot writing into a new file each time it is triggered (#1842 <https://github.com/ros2/rosbag2/issues/1842>) (#1849 <https://github.com/ros2/rosbag2/issues/1849>)
* Bugfix for rosbag2_cpp serialization converter (#1814 <https://github.com/ros2/rosbag2/issues/1814>) (#1822 <https://github.com/ros2/rosbag2/issues/1822>)
  (cherry picked from commit 6e82f52f3917c365ce60f9ffd8f5248e25c0fe55)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Allow unknown types in bag rewrite (#1812 <https://github.com/ros2/rosbag2/issues/1812>) (#1817 <https://github.com/ros2/rosbag2/issues/1817>)
  (cherry picked from commit cd7bd63696604973e23c739afa6387556f3e7781)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* [jazzy] Add support for replaying multiple bags (backport #1848 <https://github.com/ros2/rosbag2/issues/1848>) (#1873 <https://github.com/ros2/rosbag2/issues/1873>)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add "--sort" CLI option to the "ros2 bag info" command (backport #1804 <https://github.com/ros2/rosbag2/issues/1804>) (#1838 <https://github.com/ros2/rosbag2/issues/1838>)
  Co-authored-by: Soenke Prophet <mailto:soenke.prophet@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: Sanoronas <mailto:soenke.prophet@gmail.com>
* Add in python3-dev build dependency. (#1863 <https://github.com/ros2/rosbag2/issues/1863>) (#1864 <https://github.com/ros2/rosbag2/issues/1864>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* [jazzy] Add computation of size contribution to info verb (backport #1726 <https://github.com/ros2/rosbag2/issues/1726>) (#1872 <https://github.com/ros2/rosbag2/issues/1872>)
  Co-authored-by: Nicola Loi <mailto:nicolaloi@outlook.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_storage

```
* Add more logging info to storage and reader/writer open operations (#1881 <https://github.com/ros2/rosbag2/issues/1881>) (#1882 <https://github.com/ros2/rosbag2/issues/1882>)
  (cherry picked from commit 0823be2723e04715baacf99625b844cb88f58c21)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

```
* Add debug information for flaky can_record_again_after_stop test (#1871 <https://github.com/ros2/rosbag2/issues/1871>) (#1874 <https://github.com/ros2/rosbag2/issues/1874>)
  (cherry picked from commit 4602b2ce829842e17ccb8bf4a74c135d6c8f2623)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Improve the reliability of rosbag2 tests (#1796 <https://github.com/ros2/rosbag2/issues/1796>) (#1806 <https://github.com/ros2/rosbag2/issues/1806>)
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* [jazzy] Add "--sort" CLI option to the "ros2 bag info" command (backport #1804 <https://github.com/ros2/rosbag2/issues/1804>) (#1838 <https://github.com/ros2/rosbag2/issues/1838>)
  Co-authored-by: Soenke Prophet <mailto:soenke.prophet@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
  Co-authored-by: Sanoronas <mailto:soenke.prophet@gmail.com>
* [jazzy] Add computation of size contribution to info verb (backport #1726 <https://github.com/ros2/rosbag2/issues/1726>) (#1872 <https://github.com/ros2/rosbag2/issues/1872>)
  Co-authored-by: Nicola Loi <mailto:nicolaloi@outlook.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Improve the reliability of rosbag2 tests (#1796 <https://github.com/ros2/rosbag2/issues/1796>) (#1806 <https://github.com/ros2/rosbag2/issues/1806>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## rosbag2_transport

```
* Publish clock after delay is over and disable delay on next loops (#1861 <https://github.com/ros2/rosbag2/issues/1861>) (#1878 <https://github.com/ros2/rosbag2/issues/1878>)
  (cherry picked from commit 15b82607d0e36a6ff87f60405b072919d16fb03d)
  Co-authored-by: Nicola Loi <mailto:nicolaloi@outlook.com>
* [jazzy] Add PlayerClock::wakeup() to interrupt sleeping (backport #1869 <https://github.com/ros2/rosbag2/issues/1869>) (#1875 <https://github.com/ros2/rosbag2/issues/1875>)
  (cherry picked from commit c8feaea5b64e824bbe76e920f48a3ca39b72f9fc)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Add debug information for flaky can_record_again_after_stop test (#1871 <https://github.com/ros2/rosbag2/issues/1871>) (#1874 <https://github.com/ros2/rosbag2/issues/1874>)
  (cherry picked from commit 4602b2ce829842e17ccb8bf4a74c135d6c8f2623)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Add support for replaying multiple bags (backport #1848 <https://github.com/ros2/rosbag2/issues/1848>) (#1873 <https://github.com/ros2/rosbag2/issues/1873>)
  (cherry picked from commit 125db50b4d9a585bab33f2908008fe1168bb9cf3)
  Co-authored-by: Christophe Bedard <mailto:christophe.bedard@apex.ai>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Reintroduce Don't warn for unknown types if topics are not selected (#1825 <https://github.com/ros2/rosbag2/issues/1825>) (#1827 <https://github.com/ros2/rosbag2/issues/1827>)
  (cherry picked from commit e75d6d659fcae243b8486a94173255b237817f22)
  Co-authored-by: Ramon Wijnands <mailto:ramon.wijnands007@gmail.com>
* Allow unknown types in bag rewrite (#1812 <https://github.com/ros2/rosbag2/issues/1812>) (#1817 <https://github.com/ros2/rosbag2/issues/1817>)
  (cherry picked from commit cd7bd63696604973e23c739afa6387556f3e7781)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Improve the reliability of rosbag2 tests (#1796 <https://github.com/ros2/rosbag2/issues/1796>) (#1806 <https://github.com/ros2/rosbag2/issues/1806>)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Removed warnings (#1794 <https://github.com/ros2/rosbag2/issues/1794>) (#1810 <https://github.com/ros2/rosbag2/issues/1810>)
  (cherry picked from commit 88c51a133a9a9aa3ef65a851f4d2aed448803fa1)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Marco A. Gutierrez, mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
