### PR TITLE
geometry2: 0.40.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2028,7 +2028,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.39.3-1
+      version: 0.40.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.40.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.39.3-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Removed unused var in tf2 (#735 <https://github.com/ros2/geometry2/issues/735>)
* Contributors: Alejandro Hernández Cordero, Lucas Wendland
```

## tf2_bullet

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_eigen

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_eigen_kdl

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_geometry_msgs

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_kdl

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_msgs

- No changes

## tf2_py

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_ros

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_ros_py

```
* Add in the linters for tf2_ros_py. (#740 <https://github.com/ros2/geometry2/issues/740>)
* Contributors: Chris Lalancette
```

## tf2_sensor_msgs

```
* Deprecate C Headers (#720 <https://github.com/ros2/geometry2/issues/720>)
* Contributors: Lucas Wendland
```

## tf2_tools

- No changes
