### PR TITLE
rpyutils: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6839,7 +6839,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rpyutils` to `0.6.1-1`:

- upstream repository: https://github.com/ros2/rpyutils.git
- release repository: https://github.com/ros2-gbp/rpyutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-1`

## rpyutils

```
* Add Create py.typed (#15 <https://github.com/ros2/rpyutils/issues/15>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#13 <https://github.com/ros2/rpyutils/issues/13>)
* Contributors: Chris Lalancette, Michael Carlstrom
```
