### PR TITLE
rclpy: 8.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5431,7 +5431,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.7.0-1
+      version: 8.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `8.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.7.0-1`

## rclpy

```
* Add support for operator overloading of Duration (#1387 <https://github.com/ros2/rclpy/issues/1387>)
* Service/Client Implementation types (#1384 <https://github.com/ros2/rclpy/issues/1384>)
* avoid lifecycle node transition exception (#1319 <https://github.com/ros2/rclpy/issues/1319>)
* Client:call generates TimeoutError exception when it is timed out. (#1271 <https://github.com/ros2/rclpy/issues/1271>)
* Add in python3-dev build dependency. (#1380 <https://github.com/ros2/rclpy/issues/1380>)
* Contributors: Arjo Chakravarty, Chris Lalancette, Michael Carlstrom, Tomoya Fujita
```
