### PR TITLE
robot_state_publisher: 3.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6036,7 +6036,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.4.2-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.1-1`

## robot_state_publisher

```
* Use emplace() with std::map`s (`#231 <https://github.com/ros/robot_state_publisher/issues/231>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#229 <https://github.com/ros/robot_state_publisher/issues/229>)
* Contributors: Alejandro Hernández Cordero, Patrick Roncagliolo
```
