### PR TITLE
rqt_publisher: 1.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7065,7 +7065,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.9.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`

## rqt_publisher

```
* Add in the remaining standard ament_python tests. (#49 <https://github.com/ros-visualization/rqt_publisher/issues/49>)
* Add in LICENSE. (#46 <https://github.com/ros-visualization/rqt_publisher/issues/46>)
* Remove CODEOWNERS (#47 <https://github.com/ros-visualization/rqt_publisher/issues/47>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
