### PR TITLE
rqt_plot: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7050,7 +7050,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.5.0-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.6.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.0-1`

## rqt_plot

```
* Add in the rest of the standard ament_python tests. (#98 <https://github.com/ros-visualization/rqt_plot/issues/98>)
* Remove CODEOWNERS (#96 <https://github.com/ros-visualization/rqt_plot/issues/96>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
