### PR TITLE
pluginlib: 5.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4778,7 +4778,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.5.2-1
+      version: 5.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.6.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.5.2-1`

## pluginlib

```
* Heavily cleanup pluginlib. (#265 <https://github.com/ros/pluginlib/issues/265>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#268 <https://github.com/ros/pluginlib/issues/268>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
