### PR TITLE
laser_geometry: 2.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2978,7 +2978,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.10.0-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.0-1`

## laser_geometry

```
* Deprecating tf2 C Headers (#98 <https://github.com/ros-perception/laser_geometry/issues/98>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#100 <https://github.com/ros-perception/laser_geometry/issues/100>)
* Contributors: Alejandro Hernández Cordero, Lucas Wendland
```
