### PR TITLE
interactive_markers: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2737,7 +2737,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.6.1-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.7.0-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.1-1`

## interactive_markers

```
* Deprecating tf2 C Headers (#109 <https://github.com/ros-visualization/interactive_markers/issues/109>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#110 <https://github.com/ros-visualization/interactive_markers/issues/110>)
* Contributors: Alejandro Hernández Cordero, Lucas Wendland
```
