### PR TITLE
Index mrpt_ros_headless for noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6491,6 +6491,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_ros.git
       version: main
     status: developed
+  mrpt_ros_headless:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros_headless
+      version: main
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros_headless
+      version: main
+    status: developed
   mrpt_sensors:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6494,11 +6494,11 @@ repositories:
   mrpt_ros_headless:
     doc:
       type: git
-      url: https://github.com/MRPT/mrpt_ros_headless
+      url: https://github.com/MRPT/mrpt_ros_headless.git
       version: main
     source:
       type: git
-      url: https://github.com/MRPT/mrpt_ros_headless
+      url: https://github.com/MRPT/mrpt_ros_headless.git
       version: main
     status: developed
   mrpt_sensors:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

noetic

# The source is here:

https://github.com/MRPT/mrpt_ros_headless

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
