### PR TITLE
mvsim: 0.13.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4343,7 +4343,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.12.0-1
+      version: 0.13.0-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.13.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.12.0-1`

## mvsim

```
* Add ROS1 generic launcher
* Port demos to the generic ros2 launch file so all rosargs are now exposed in all demos
* create generic launch_world ros2 file
* ROS node: new param "publish_tf_odom2baselink"
* ROS2 warehouse demo launch: add use_rviz argument
* Update README.md: Mark ROS2 Iron as EOL
* Readme: remove obsolete ROS1 wiki link
* ElevationMap from XML: Ensure trimmed input string in kernel
* Alternative reference method for UTM world coordinates
* Implement world georeferenciation via UTM zone number
* Fix targets order for prev commit
* Fix build without ZMQ
* Contributors: Jose Luis Blanco-Claraco
```
