### PR TITLE
Add python3-alsaaudio

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4893,6 +4893,10 @@ python3-alive-progress-pip:
   '*':
     pip:
       packages: [alive-progress]
+python3-alsaaudio:
+  debian: [python3-alsaaudio]
+  fedora: [python3-alsaaudio]
+  ubuntu: [python3-alsaaudio]
 python3-ansible-runner-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-alsaaudio

## Package Upstream Source:

https://github.com/larsimmisch/pyalsaaudio/

## Purpose of using this:

I use it to reference and modify ALSA framework settings from Python.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-alsaaudio&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-alsaaudio&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-alsaaudio/python3-alsaaudio/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
