### PR TITLE
neonavigation: 0.17.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6817,7 +6817,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.17.2-1
+      version: 0.17.3-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `neonavigation` to `0.17.3-1`:

- upstream repository: https://github.com/at-wat/neonavigation.git
- release repository: https://github.com/at-wat/neonavigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.17.2-1`

## costmap_cspace

```
* costmap_cspace: publish empty costmap_update on out-of-bound (#743 <https://github.com/at-wat/neonavigation/issues/743>)
* Contributors: Atsushi Watanabe
```

## joystick_interrupt

- No changes

## map_organizer

- No changes

## neonavigation

- No changes

## neonavigation_common

- No changes

## neonavigation_launch

- No changes

## obj_to_pointcloud

- No changes

## planner_cspace

```
* planner_cspace: add costmap_cspace integration test for out-of-bound position (#746 <https://github.com/at-wat/neonavigation/issues/746>)
* costmap_cspace: publish empty costmap_update on out-of-bound (#743 <https://github.com/at-wat/neonavigation/issues/743>)
* planner_cspace: reduce remember_updates calculation cost (#742 <https://github.com/at-wat/neonavigation/issues/742>)
* Contributors: Atsushi Watanabe
```

## safety_limiter

- No changes

## track_odometry

- No changes

## trajectory_tracker

- No changes
