### PR TITLE
autoware_internal_msgs: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -579,10 +579,14 @@ repositories:
     status: developed
   autoware_internal_msgs:
     release:
+      packages:
+      - autoware_internal_debug_msgs
+      - autoware_internal_msgs
+      - autoware_internal_perception_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.1.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## autoware_internal_debug_msgs

```
* feat: add String.srv (#37 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/37>)
* chore: sync files (#25 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/25>)
  * chore: sync files
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Takayuki Murooka, awf-autoware-bot[bot]
```

## autoware_internal_msgs

```
* chore: sync files (#25 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/25>)
  * chore: sync files
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: awf-autoware-bot[bot]
```

## autoware_internal_perception_msgs

```
* chore: sync files (#25 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/25>)
  * chore: sync files
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: awf-autoware-bot[bot]
```
