### PR TITLE
mola: 1.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3986,8 +3986,6 @@ repositories:
       - mola_launcher
       - mola_metric_maps
       - mola_msgs
-      - mola_navstate_fg
-      - mola_navstate_fuse
       - mola_pose_list
       - mola_relocalization
       - mola_traj_tools
@@ -3996,7 +3994,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.5.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.0-1`

## kitti_metrics_eval

- No changes

## mola

```
* Move state estimation packages out of this repo to its own: https://github.com/MOLAorg/mola_state_estimation
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

- No changes

## mola_demos

- No changes

## mola_imu_preintegration

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_kernel

```
* NavStateFilter Interface now also inherits from ExecutableBase for convenience
* MinimalModuleContainer ctor should not be explicit
* Add mola::MinimalModuleContainer
* Drop dependency on mrpt-gui in kernel by abstracting MolaViz subwindow layout operations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

- No changes

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* Drop dependency on mrpt-gui in kernel by abstracting MolaViz subwindow layout operations
* MolaViz: show package name in GUI windows
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
