### PR TITLE
image_pipeline: 6.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2655,7 +2655,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.6-1
+      version: 6.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.7-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.6-1`

## camera_calibration

- No changes

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

```
* Deprecating tf2 C Headers (#1039 <https://github.com/ros-perception/image_pipeline/issues/1039>)
  Related to this [pull
  request](https://github.com/ros2/geometry2/pull/720) in geometry2 in
  which we deprecated the .h style headers in favor of .hpp.
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Lucas Wendland
```

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
