### PR TITLE
kinematics_interface_pinocchio: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2888,6 +2888,21 @@ repositories:
       url: https://github.com/ros-controls/kinematics_interface.git
       version: master
     status: developed
+  kinematics_interface_pinocchio:
+    doc:
+      type: git
+      url: https://github.com/justagist/kinematics_interface_pinocchio.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/justagist/kinematics_interface_pinocchio-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/justagist/kinematics_interface_pinocchio.git
+      version: main
+    status: maintained
   kobuki_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface_pinocchio` to `0.0.1-1`:

- upstream repository: https://github.com/justagist/kinematics_interface_pinocchio.git
- release repository: https://github.com/justagist/kinematics_interface_pinocchio-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
