### PR TITLE
geometry_tutorials: 0.6.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2063,7 +2063,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.6.3-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros2-gbp/geometry_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.2-1`

## geometry_tutorials

- No changes

## turtle_tf2_cpp

```
* Deprecating tf2 C Headers (#87 <https://github.com/ros/geometry_tutorials/issues/87>)
* Contributors: Lucas Wendland
```

## turtle_tf2_py

```
* Switch to using a context manager for rclpy initialization. (#85 <https://github.com/ros/geometry_tutorials/issues/85>)
  This ensures that everything will be properly cleaned up
  when we leave the context manager.
* Contributors: Chris Lalancette
```
