### PR TITLE
rosidl_typesupport_fastrtps: 3.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7367,7 +7367,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.6.0-2
+      version: 3.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.6.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.0-2`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Remove deprecated functions benchmark tests (#122 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/122>) (#123 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/123>)
  Co-authored-by: Miguel Company <mailto:miguelcompany@eprosima.com>
* Contributors: Cristóbal Arroyo
```

## rosidl_typesupport_fastrtps_cpp

```
* Remove deprecated functions benchmark tests (#122 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/122>) (#123 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/123>)
  Co-authored-by: Miguel Company <mailto:miguelcompany@eprosima.com>
* Contributors: Cristóbal Arroyo
```
