### PR TITLE
yaml_cpp_vendor: 9.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9816,7 +9816,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 9.0.0-2
+      version: 9.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `9.0.1-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.0.0-2`

## yaml_cpp_vendor

```
* Removed warnigns (#49 <https://github.com/ros2/yaml_cpp_vendor/issues/49>) (#50 <https://github.com/ros2/yaml_cpp_vendor/issues/50>)
  (cherry picked from commit 4b6808fd0f9b0b5e05928c0c8e44fd976a043d33)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
