### PR TITLE
imu_pipeline: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2701,7 +2701,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
-      version: 0.5.0-2
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.5.1-1`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros2-gbp/imu_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-2`

## imu_pipeline

- No changes

## imu_processors

- No changes

## imu_transformer

```
* Deprecate c headers (#25 <https://github.com/ros-perception/imu_pipeline/issues/25>)
  Related to this [pull
  request](https://github.com/ros2/geometry2/pull/720) in geometry2 in
  which we deprecated the .h style headers in favor of .hpp.
  ---------
* Contributors: Lucas Wendland
```
