### PR TITLE
mola_lidar_odometry: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3704,7 +3704,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.5.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## mola_lidar_odometry

```
* cmake test logic: add find_package() for state_estimation_simple
* Merge pull request #7 from MOLAorg/wip/new-state-estimators
  New state estimators (Merge after MOLA 1.5.0 is installable via apt)
* Split state estimation params so each implementation has its own yaml file
* CI: build against both, ROS testing and stable
* Add new state estimator module in all MOLA-CLI yaml files
* Update to new state estimation packages
* Reorganization such as state estimator is now an independent external module
* docs: add new ros-arg publish_localization_following_rep105
* FIX: publish local map even when not active
* Contributors: Jose Luis Blanco-Claraco
```
