### PR TITLE
realtime_tools: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5566,7 +5566,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.1.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## realtime_tools

```
* Fix ref for scheduled build (#248 <https://github.com/ros-controls/realtime_tools/issues/248>)
* Add realtime priority inheritance mutexes (#197 <https://github.com/ros-controls/realtime_tools/issues/197>)
* Deprecate RealtimeClock class (#244 <https://github.com/ros-controls/realtime_tools/issues/244>)
* Remove wrong comments (#240 <https://github.com/ros-controls/realtime_tools/issues/240>)
* Add get_thread method to RealtimePublisher (#228 <https://github.com/ros-controls/realtime_tools/issues/228>)
* sleep after starting thread to fix flaky tests (#235 <https://github.com/ros-controls/realtime_tools/issues/235>)
* Fix the badges in the readme (#234 <https://github.com/ros-controls/realtime_tools/issues/234>)
* First step towards modernizing the rt publisher (#210 <https://github.com/ros-controls/realtime_tools/issues/210>)
* Add missing change to .hpp for realtime_clock (#227 <https://github.com/ros-controls/realtime_tools/issues/227>)
* Remove duplicate downstream build workflow (#230 <https://github.com/ros-controls/realtime_tools/issues/230>)
* Changes after branching humble (#217 <https://github.com/ros-controls/realtime_tools/issues/217>)
* CI downstream build (#214 <https://github.com/ros-controls/realtime_tools/issues/214>)
* Contributors: Christoph Fröhlich, Lennart Nachtigall, Patrick Roncagliolo, Sai Kishor Kothakota
```
