### PR TITLE
ros2_control: 4.23.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6135,7 +6135,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.22.0-1
+      version: 4.23.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.23.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.22.0-1`

## controller_interface

```
* Remove boilerplate visibility macros (#1972 <https://github.com/ros-controls/ros2_control/issues/1972>)
* Semantic components cleanup (#1940 <https://github.com/ros-controls/ros2_control/issues/1940>)
* Contributors: Bence Magyar, Wiktor Bajor
```

## controller_manager

```
* Remove boilerplate visibility macros (#1972 <https://github.com/ros-controls/ros2_control/issues/1972>)
* Move test_utils module from demos repo (#1955 <https://github.com/ros-controls/ros2_control/issues/1955>)
* Fix deprecated usage of lock_memory API (#1970 <https://github.com/ros-controls/ros2_control/issues/1970>)
* Fix spawner behaviour on failing controller activation or deactivation (#1941 <https://github.com/ros-controls/ros2_control/issues/1941>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota, Sudip Roy
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Remove boilerplate visibility macros (#1972 <https://github.com/ros-controls/ros2_control/issues/1972>)
* Add asynchronous hardware components documentation (#1961 <https://github.com/ros-controls/ros2_control/issues/1961>)
* Reuse TriggerType enum in hardware components (#1962 <https://github.com/ros-controls/ros2_control/issues/1962>)
* Fix pre-commit clang changes (#1963 <https://github.com/ros-controls/ros2_control/issues/1963>)
* Contributors: Bence Magyar, Sai Kishor Kothakota, Sanjeev
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Remove boilerplate visibility macros (#1972 <https://github.com/ros-controls/ros2_control/issues/1972>)
* Contributors: Bence Magyar
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Move test_utils module from demos repo (#1955 <https://github.com/ros-controls/ros2_control/issues/1955>)
* Contributors: Christoph Fröhlich
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Remove boilerplate visibility macros (#1972 <https://github.com/ros-controls/ros2_control/issues/1972>)
* Contributors: Bence Magyar
```
