### PR TITLE
moveit: 2.5.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5026,7 +5026,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.5.6-1
+      version: 2.5.7-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.7-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.6-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* Added joint limits to rviz launch file. (#3091 <https://github.com/ros-planning/moveit2/issues/3091>) (#3136 <https://github.com/ros-planning/moveit2/issues/3136>)
* Contributors: Matthew Elwin
```

## moveit_core

```
* Bug fix: RobotTrajectory append() (#1813 <https://github.com/ros-planning/moveit2/issues/1813>) (#1821 <https://github.com/ros-planning/moveit2/issues/1821>)
* Contributors: AndyZe
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Add sleep in setup of flaky PSM test fixture (#3126 <https://github.com/ros-planning/moveit2/issues/3126>)
* Contributors: Sebastian Castro
```

## moveit_ros_planning_interface

```
* Enhancement/moveit ros1 ports (backport #3041 <https://github.com/ros-planning/moveit2/issues/3041>) (#3118 <https://github.com/ros-planning/moveit2/issues/3118>)
* Contributors: Tom Noble, Mark Johnson
```

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Fix MeshShape::clear() for safer mesh removal (#3164 <https://github.com/ros-planning/moveit2/issues/3164>) (#3166 <https://github.com/ros-planning/moveit2/issues/3166>)
* Contributors: Matt Wang
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

- No changes

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Fix: Resolve race condition in MoveGroupSequenceAction (backport #3125 <https://github.com/ros-planning/moveit2/issues/3125>) (#3127 <https://github.com/ros-planning/moveit2/issues/3127>)
* Enhancement/moveit ros1 ports (backport #3041 <https://github.com/ros-planning/moveit2/issues/3041>) (#3118 <https://github.com/ros-planning/moveit2/issues/3118>)
* Contributors: Maxwell.L, Tom Noble, Mark Johnson
```

## pilz_industrial_motion_planner_testutils

- No changes
