### PR TITLE
ros2_control: 2.47.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8098,7 +8098,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.46.0-1
+      version: 2.47.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.47.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.46.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix deprecated usage of lock_memory API (#1970 <https://github.com/ros-controls/ros2_control/issues/1970>) (#1971 <https://github.com/ros-controls/ros2_control/issues/1971>)
* Log an error if update() call returns ERROR (#1969 <https://github.com/ros-controls/ros2_control/issues/1969>)
* Fix spawner behaviour on failing controller activation or deactivation (#1941 <https://github.com/ros-controls/ros2_control/issues/1941>) (#1968 <https://github.com/ros-controls/ros2_control/issues/1968>)
* Use the .hpp headers from realtime_tools package (#1916 <https://github.com/ros-controls/ros2_control/issues/1916>) (#1920 <https://github.com/ros-controls/ros2_control/issues/1920>)
* Use singleton approach to store and reuse the service clients (#1949 <https://github.com/ros-controls/ros2_control/issues/1949>) (#1953 <https://github.com/ros-controls/ros2_control/issues/1953>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the lock_guard placement (#1960 <https://github.com/ros-controls/ros2_control/issues/1960>)
* Update initial_value parameters of generic_system tests (#1943 <https://github.com/ros-controls/ros2_control/issues/1943>)
* Contributors: Sai Kishor Kothakota, Sanjeev
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
