### PR TITLE
Add Embodied Agents package to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -731,6 +731,16 @@ repositories:
       url: https://github.com/fkie/async_web_server_cpp.git
       version: ros2-develop
     status: maintained
+  automatika_embodied_agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   automatika_ros_sugar:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -505,6 +505,16 @@ repositories:
       url: https://github.com/hatchbed/asyncapi_gencpp.git
       version: main
     status: developed
+  automatika_embodied_agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   automatika_ros_sugar:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -500,6 +500,16 @@ repositories:
       url: https://github.com/hatchbed/asyncapi_gencpp.git
       version: main
     status: developed
+  automatika_embodied_agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
   automatika_ros_sugar:
     doc:
       type: git


### PR DESCRIPTION
# Please add Automatika Embodied Agents to be indexed in the rosdistro

## Package name:

automatika_embodied_agents

## Package Upstream Source:

[https://github.com/automatika-robotics/ros-agents.git](https://github.com/automatika-robotics/ros-agents.git)

## Purpose of using this:

`agents` is a fully-loaded framework for creating interactive embodied agents that can understand, remember, and act upon contextual information from their environment

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
