### PR TITLE
ros2_controllers: 2.40.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8118,6 +8118,7 @@ repositories:
       - effort_controllers
       - force_torque_sensor_broadcaster
       - forward_command_controller
+      - gpio_controllers
       - gripper_controllers
       - imu_sensor_broadcaster
       - joint_state_broadcaster
@@ -8136,7 +8137,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.39.0-1
+      version: 2.40.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.40.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.39.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Improve tf_prefix based on namespace (#1420 <https://github.com/ros-controls/ros2_controllers/issues/1420>) (#1421 <https://github.com/ros-controls/ros2_controllers/issues/1421>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Contributors: mergify[bot]
```

## gpio_controllers

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Gpio command controller (backport #1251 <https://github.com/ros-controls/ros2_controllers/issues/1251>) (#1372 <https://github.com/ros-controls/ros2_controllers/issues/1372>)
* Contributors: mergify[bot]
```

## gripper_controllers

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Increase margin for state_publish_rate  (#1430 <https://github.com/ros-controls/ros2_controllers/issues/1430>)
* Add an error msg if empty message is received (backport #1424 <https://github.com/ros-controls/ros2_controllers/issues/1424>) (#1428 <https://github.com/ros-controls/ros2_controllers/issues/1428>)
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## pid_controller

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: mergify[bot]
```

## pose_broadcaster

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Contributors: mergify[bot]
```

## position_controllers

```
* Update position controller package.xml (backport #1431 <https://github.com/ros-controls/ros2_controllers/issues/1431>) (#1432 <https://github.com/ros-controls/ros2_controllers/issues/1432>)
* Contributors: mergify[bot]
```

## range_sensor_broadcaster

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* Contributors: mergify[bot]
```

## ros2_controllers

```
* Add missing plugins to ros2_controllers dependencies (#1413 <https://github.com/ros-controls/ros2_controllers/issues/1413>) (#1415 <https://github.com/ros-controls/ros2_controllers/issues/1415>)
* Gpio command controller (backport #1251 <https://github.com/ros-controls/ros2_controllers/issues/1251>) (#1372 <https://github.com/ros-controls/ros2_controllers/issues/1372>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## ros2_controllers_test_nodes

```
* Don't call shutdown() after an exception (#1400 <https://github.com/ros-controls/ros2_controllers/issues/1400>) (#1411 <https://github.com/ros-controls/ros2_controllers/issues/1411>)
* Contributors: mergify[bot]
```

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* fix(timeout): do not reset steer wheels to 0. on timeout (backport #1289 <https://github.com/ros-controls/ros2_controllers/issues/1289>) (#1452 <https://github.com/ros-controls/ros2_controllers/issues/1452>)
* steering_controllers_library: Add reduce_wheel_speed_until_steering_reached parameter (backport #1314 <https://github.com/ros-controls/ros2_controllers/issues/1314>) (#1429 <https://github.com/ros-controls/ros2_controllers/issues/1429>)
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Use the .hpp headers from realtime_tools package (backport #1406 <https://github.com/ros-controls/ros2_controllers/issues/1406>) (#1427 <https://github.com/ros-controls/ros2_controllers/issues/1427>)
* [CI] Add clang job and setup concurrency (backport #1407 <https://github.com/ros-controls/ros2_controllers/issues/1407>) (#1418 <https://github.com/ros-controls/ros2_controllers/issues/1418>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
