### PR TITLE
mola_state_estimation: 1.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4085,6 +4085,16 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git
       version: develop
+    release:
+      packages:
+      - mola_imu_preintegration
+      - mola_state_estimation
+      - mola_state_estimation_simple
+      - mola_state_estimation_smoother
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_state_estimation-release.git
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.6.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mola_imu_preintegration

- No changes

## mola_state_estimation

```
* docs: link to main sphinx page
* add metapackage for easy installation of all packages
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_simple

```
* Simple estimator: Integrate IMU angular velocity readings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

- No changes
