### PR TITLE
coal: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1068,6 +1068,21 @@ repositories:
       url: https://github.com/carologistics/clips_vendor.git
       version: main
     status: maintained
+  coal:
+    doc:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/coal-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: devel
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.0-1`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
