### PR TITLE
coal: 3.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1428,6 +1428,21 @@ repositories:
       url: https://github.com/carologistics/clips_vendor.git
       version: main
     status: maintained
+  coal:
+    doc:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/coal-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: devel
+    status: developed
   cob_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.0-1`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
