### PR TITLE
Update Nav2 TB3/4 Sim package's release repository location

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4118,7 +4118,7 @@ repositories:
       - nav2_minimal_tb4_sim
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
+      url: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
       version: 1.0.1-1
     source:
       type: git


### PR DESCRIPTION
Updated location: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release

Previous archived location: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release