### PR TITLE
nav2_minimal_turtlebot_simulation: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4111,6 +4111,10 @@ repositories:
       version: rolling
     status: developed
   nav2_minimal_turtlebot_simulation:
+    doc:
+      type: git
+      url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
+      version: main
     release:
       packages:
       - nav2_minimal_tb3_sim
@@ -4119,7 +4123,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_minimal_turtlebot_simulation` to `1.0.2-1`:

- upstream repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
- release repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`
