### PR TITLE
cras_ros_utils: 2.4.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1812,7 +1812,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.7-1
+      version: 2.4.8-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.4.8-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.7-1`

## cras_cpp_common

```
* Added GetParamConvertingOptions() to ease defining converting getParam() that works with GCC 7.
* Added NodeWithOptionalMaster.
* Improved compatibility with newer compilers.
  Resolves https://github.com/RoboStack/ros-noetic/pull/501#issuecomment-2567224502 .
* Contributors: Martin Pecka
```

## cras_docs_common

- No changes

## cras_py_common

- No changes

## cras_topic_tools

```
* Added support for ros::message_traits operations on cras::ShapeShifter on Melodic.
* Contributors: Martin Pecka
```

## image_transport_codecs

```
* Improved compatibility with newer compilers.
  Resolves https://github.com/RoboStack/ros-noetic/pull/501#issuecomment-2567224502 .
* Contributors: Martin Pecka
```
