### PR TITLE
rqt_console: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6975,7 +6975,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.3.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## rqt_console

```
* Add in standard tests. (#48 <https://github.com/ros-visualization/rqt_console/issues/48>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#46 <https://github.com/ros-visualization/rqt_console/issues/46>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
