### PR TITLE
rqt_bag: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6945,7 +6945,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## rqt_bag

```
* Add standard tests for rqt_bag and rqt_bag_plugins (#171 <https://github.com/ros-visualization/rqt_bag/issues/171>)
* Contributors: Chris Lalancette
```

## rqt_bag_plugins

```
* Add standard tests for rqt_bag and rqt_bag_plugins (#171 <https://github.com/ros-visualization/rqt_bag/issues/171>)
* Contributors: Chris Lalancette
```
