### PR TITLE
rqt_shell: 1.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7236,7 +7236,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `1.3.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## rqt_shell

```
* Add in standard tests to rqt_shell. (#24 <https://github.com/ros-visualization/rqt_shell/issues/24>)
  That way we know it conforms to our standards.
* Remove CODEOWNERS (#22 <https://github.com/ros-visualization/rqt_shell/issues/22>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
