### PR TITLE
add kompass_interfaces package to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4,9 +4,9 @@
 ---
 release_platforms:
   rhel:
-  - '8'
+    - "8"
   ubuntu:
-  - jammy
+    - jammy
 repositories:
   aandd_ekew_driver_py:
     doc:
@@ -114,33 +114,33 @@ repositories:
       version: main
     release:
       packages:
-      - aerostack2
-      - as2_alphanumeric_viewer
-      - as2_behavior
-      - as2_behavior_tree
-      - as2_behaviors_motion
-      - as2_behaviors_path_planning
-      - as2_behaviors_perception
-      - as2_behaviors_platform
-      - as2_behaviors_trajectory_generation
-      - as2_cli
-      - as2_core
-      - as2_external_object_to_tf
-      - as2_gazebo_assets
-      - as2_geozones
-      - as2_keyboard_teleoperation
-      - as2_map_server
-      - as2_motion_controller
-      - as2_motion_reference_handlers
-      - as2_msgs
-      - as2_platform_gazebo
-      - as2_platform_multirotor_simulator
-      - as2_python_api
-      - as2_realsense_interface
-      - as2_rviz_plugins
-      - as2_state_estimator
-      - as2_usb_camera_interface
-      - as2_visualization
+        - aerostack2
+        - as2_alphanumeric_viewer
+        - as2_behavior
+        - as2_behavior_tree
+        - as2_behaviors_motion
+        - as2_behaviors_path_planning
+        - as2_behaviors_perception
+        - as2_behaviors_platform
+        - as2_behaviors_trajectory_generation
+        - as2_cli
+        - as2_core
+        - as2_external_object_to_tf
+        - as2_gazebo_assets
+        - as2_geozones
+        - as2_keyboard_teleoperation
+        - as2_map_server
+        - as2_motion_controller
+        - as2_motion_reference_handlers
+        - as2_msgs
+        - as2_platform_gazebo
+        - as2_platform_multirotor_simulator
+        - as2_python_api
+        - as2_realsense_interface
+        - as2_rviz_plugins
+        - as2_state_estimator
+        - as2_usb_camera_interface
+        - as2_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
@@ -190,8 +190,8 @@ repositories:
   ament_black:
     release:
       packages:
-      - ament_black
-      - ament_cmake_black
+        - ament_black
+        - ament_cmake_black
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
@@ -208,29 +208,29 @@ repositories:
       version: humble
     release:
       packages:
-      - ament_cmake
-      - ament_cmake_auto
-      - ament_cmake_core
-      - ament_cmake_export_definitions
-      - ament_cmake_export_dependencies
-      - ament_cmake_export_include_directories
-      - ament_cmake_export_interfaces
-      - ament_cmake_export_libraries
-      - ament_cmake_export_link_flags
-      - ament_cmake_export_targets
-      - ament_cmake_gen_version_h
-      - ament_cmake_gmock
-      - ament_cmake_google_benchmark
-      - ament_cmake_gtest
-      - ament_cmake_include_directories
-      - ament_cmake_libraries
-      - ament_cmake_nose
-      - ament_cmake_pytest
-      - ament_cmake_python
-      - ament_cmake_target_dependencies
-      - ament_cmake_test
-      - ament_cmake_vendor_package
-      - ament_cmake_version
+        - ament_cmake
+        - ament_cmake_auto
+        - ament_cmake_core
+        - ament_cmake_export_definitions
+        - ament_cmake_export_dependencies
+        - ament_cmake_export_include_directories
+        - ament_cmake_export_interfaces
+        - ament_cmake_export_libraries
+        - ament_cmake_export_link_flags
+        - ament_cmake_export_targets
+        - ament_cmake_gen_version_h
+        - ament_cmake_gmock
+        - ament_cmake_google_benchmark
+        - ament_cmake_gtest
+        - ament_cmake_include_directories
+        - ament_cmake_libraries
+        - ament_cmake_nose
+        - ament_cmake_pytest
+        - ament_cmake_python
+        - ament_cmake_target_dependencies
+        - ament_cmake_test
+        - ament_cmake_vendor_package
+        - ament_cmake_version
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
@@ -263,8 +263,8 @@ repositories:
       version: humble
     release:
       packages:
-      - ament_cmake_ros
-      - domain_coordinator
+        - ament_cmake_ros
+        - domain_coordinator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
@@ -297,8 +297,8 @@ repositories:
       version: humble
     release:
       packages:
-      - ament_index_cpp
-      - ament_index_python
+        - ament_index_cpp
+        - ament_index_python
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
@@ -316,37 +316,37 @@ repositories:
       version: humble
     release:
       packages:
-      - ament_clang_format
-      - ament_clang_tidy
-      - ament_cmake_clang_format
-      - ament_cmake_clang_tidy
-      - ament_cmake_copyright
-      - ament_cmake_cppcheck
-      - ament_cmake_cpplint
-      - ament_cmake_flake8
-      - ament_cmake_lint_cmake
-      - ament_cmake_mypy
-      - ament_cmake_pclint
-      - ament_cmake_pep257
-      - ament_cmake_pycodestyle
-      - ament_cmake_pyflakes
-      - ament_cmake_uncrustify
-      - ament_cmake_xmllint
-      - ament_copyright
-      - ament_cppcheck
-      - ament_cpplint
-      - ament_flake8
-      - ament_lint
-      - ament_lint_auto
-      - ament_lint_cmake
-      - ament_lint_common
-      - ament_mypy
-      - ament_pclint
-      - ament_pep257
-      - ament_pycodestyle
-      - ament_pyflakes
-      - ament_uncrustify
-      - ament_xmllint
+        - ament_clang_format
+        - ament_clang_tidy
+        - ament_cmake_clang_format
+        - ament_cmake_clang_tidy
+        - ament_cmake_copyright
+        - ament_cmake_cppcheck
+        - ament_cmake_cpplint
+        - ament_cmake_flake8
+        - ament_cmake_lint_cmake
+        - ament_cmake_mypy
+        - ament_cmake_pclint
+        - ament_cmake_pep257
+        - ament_cmake_pycodestyle
+        - ament_cmake_pyflakes
+        - ament_cmake_uncrustify
+        - ament_cmake_xmllint
+        - ament_copyright
+        - ament_cppcheck
+        - ament_cpplint
+        - ament_flake8
+        - ament_lint
+        - ament_lint_auto
+        - ament_lint_cmake
+        - ament_lint_common
+        - ament_mypy
+        - ament_pclint
+        - ament_pep257
+        - ament_pycodestyle
+        - ament_pyflakes
+        - ament_uncrustify
+        - ament_xmllint
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
@@ -407,16 +407,16 @@ repositories:
       version: humble
     release:
       packages:
-      - andino_apps
-      - andino_base
-      - andino_bringup
-      - andino_control
-      - andino_description
-      - andino_firmware
-      - andino_gz_classic
-      - andino_hardware
-      - andino_navigation
-      - andino_slam
+        - andino_apps
+        - andino_base
+        - andino_bringup
+        - andino_control
+        - andino_description
+        - andino_firmware
+        - andino_gz_classic
+        - andino_hardware
+        - andino_navigation
+        - andino_slam
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/andino-release.git
@@ -481,8 +481,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - apex_test_tools
-      - test_apex_test_tools
+        - apex_test_tools
+        - test_apex_test_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
@@ -514,10 +514,10 @@ repositories:
       version: humble
     release:
       packages:
-      - apriltag_detector
-      - apriltag_detector_mit
-      - apriltag_detector_umich
-      - apriltag_draw
+        - apriltag_detector
+        - apriltag_detector_mit
+        - apriltag_detector_umich
+        - apriltag_draw
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
@@ -571,8 +571,8 @@ repositories:
       version: humble
     release:
       packages:
-      - aruco_opencv
-      - aruco_opencv_msgs
+        - aruco_opencv
+        - aruco_opencv_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
@@ -589,9 +589,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - aruco
-      - aruco_msgs
-      - aruco_ros
+        - aruco
+        - aruco_msgs
+        - aruco_ros
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
@@ -699,14 +699,14 @@ repositories:
       version: master
     release:
       packages:
-      - delphi_esr_msgs
-      - delphi_mrr_msgs
-      - delphi_srr_msgs
-      - derived_object_msgs
-      - ibeo_msgs
-      - kartech_linear_actuator_msgs
-      - mobileye_560_660_msgs
-      - neobotix_usboard_msgs
+        - delphi_esr_msgs
+        - delphi_mrr_msgs
+        - delphi_srr_msgs
+        - derived_object_msgs
+        - ibeo_msgs
+        - kartech_linear_actuator_msgs
+        - mobileye_560_660_msgs
+        - neobotix_usboard_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
@@ -753,9 +753,9 @@ repositories:
       version: master
     release:
       packages:
-      - automotive_autonomy_msgs
-      - automotive_navigation_msgs
-      - automotive_platform_msgs
+        - automotive_autonomy_msgs
+        - automotive_navigation_msgs
+        - automotive_platform_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
@@ -768,8 +768,8 @@ repositories:
   autoware_adapi_msgs:
     release:
       packages:
-      - autoware_adapi_v1_msgs
-      - autoware_adapi_version_msgs
+        - autoware_adapi_v1_msgs
+        - autoware_adapi_version_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
@@ -797,8 +797,8 @@ repositories:
   autoware_cmake:
     release:
       packages:
-      - autoware_cmake
-      - autoware_lint_common
+        - autoware_cmake
+        - autoware_lint_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
@@ -815,9 +815,9 @@ repositories:
       version: main
     release:
       packages:
-      - autoware_internal_debug_msgs
-      - autoware_internal_msgs
-      - autoware_internal_perception_msgs
+        - autoware_internal_debug_msgs
+        - autoware_internal_msgs
+        - autoware_internal_perception_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
@@ -830,8 +830,8 @@ repositories:
   autoware_lanelet2_extension:
     release:
       packages:
-      - autoware_lanelet2_extension
-      - autoware_lanelet2_extension_python
+        - autoware_lanelet2_extension
+        - autoware_lanelet2_extension_python
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
@@ -848,16 +848,16 @@ repositories:
       version: main
     release:
       packages:
-      - autoware_common_msgs
-      - autoware_control_msgs
-      - autoware_localization_msgs
-      - autoware_map_msgs
-      - autoware_perception_msgs
-      - autoware_planning_msgs
-      - autoware_sensing_msgs
-      - autoware_system_msgs
-      - autoware_v2x_msgs
-      - autoware_vehicle_msgs
+        - autoware_common_msgs
+        - autoware_control_msgs
+        - autoware_localization_msgs
+        - autoware_map_msgs
+        - autoware_perception_msgs
+        - autoware_planning_msgs
+        - autoware_sensing_msgs
+        - autoware_system_msgs
+        - autoware_v2x_msgs
+        - autoware_vehicle_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
@@ -900,7 +900,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - aws_robomaker_small_warehouse_world
+        - aws_robomaker_small_warehouse_world
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
@@ -932,9 +932,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - axis_camera
-      - axis_description
-      - axis_msgs
+        - axis_camera
+        - axis_description
+        - axis_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
@@ -1011,7 +1011,7 @@ repositories:
       version: master
     release:
       packages:
-      - behaviortree_cpp
+        - behaviortree_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
@@ -1028,9 +1028,9 @@ repositories:
       version: main
     release:
       packages:
-      - beluga
-      - beluga_amcl
-      - beluga_ros
+        - beluga
+        - beluga_amcl
+        - beluga_ros
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
@@ -1064,10 +1064,10 @@ repositories:
       version: galactic
     release:
       packages:
-      - bond
-      - bond_core
-      - bondcpp
-      - smclib
+        - bond
+        - bond_core
+        - bondcpp
+        - smclib
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
@@ -1111,8 +1111,8 @@ repositories:
       version: main
     release:
       packages:
-      - camera_aravis2
-      - camera_aravis2_msgs
+        - camera_aravis2
+        - camera_aravis2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/camera_aravis2-release.git
@@ -1176,7 +1176,7 @@ repositories:
       version: main
     release:
       packages:
-      - caret_msgs
+        - caret_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/caret_trace-release.git
@@ -1209,9 +1209,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - cartographer_ros
-      - cartographer_ros_msgs
-      - cartographer_rviz
+        - cartographer_ros
+        - cartographer_ros_msgs
+        - cartographer_rviz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
@@ -1229,8 +1229,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - cascade_lifecycle_msgs
-      - rclcpp_cascade_lifecycle
+        - cascade_lifecycle_msgs
+        - rclcpp_cascade_lifecycle
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
@@ -1294,16 +1294,16 @@ repositories:
       version: humble
     release:
       packages:
-      - clearpath_common
-      - clearpath_control
-      - clearpath_customization
-      - clearpath_description
-      - clearpath_generator_common
-      - clearpath_manipulators
-      - clearpath_manipulators_description
-      - clearpath_mounts_description
-      - clearpath_platform_description
-      - clearpath_sensors_description
+        - clearpath_common
+        - clearpath_control
+        - clearpath_customization
+        - clearpath_description
+        - clearpath_generator_common
+        - clearpath_manipulators
+        - clearpath_manipulators_description
+        - clearpath_mounts_description
+        - clearpath_platform_description
+        - clearpath_sensors_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
@@ -1335,9 +1335,9 @@ repositories:
       version: main
     release:
       packages:
-      - clearpath_config_live
-      - clearpath_desktop
-      - clearpath_viz
+        - clearpath_config_live
+        - clearpath_desktop
+        - clearpath_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
@@ -1361,9 +1361,9 @@ repositories:
       version: main
     release:
       packages:
-      - clearpath_motor_msgs
-      - clearpath_msgs
-      - clearpath_platform_msgs
+        - clearpath_motor_msgs
+        - clearpath_msgs
+        - clearpath_platform_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
@@ -1410,9 +1410,9 @@ repositories:
       version: main
     release:
       packages:
-      - clearpath_generator_gz
-      - clearpath_gz
-      - clearpath_simulator
+        - clearpath_generator_gz
+        - clearpath_gz
+        - clearpath_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
@@ -1435,9 +1435,9 @@ repositories:
       version: foxy
     release:
       packages:
-      - cob_actions
-      - cob_msgs
-      - cob_srvs
+        - cob_actions
+        - cob_msgs
+        - cob_srvs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/4am-robotics/cob_common-release.git
@@ -1485,19 +1485,19 @@ repositories:
       version: humble
     release:
       packages:
-      - actionlib_msgs
-      - common_interfaces
-      - diagnostic_msgs
-      - geometry_msgs
-      - nav_msgs
-      - sensor_msgs
-      - sensor_msgs_py
-      - shape_msgs
-      - std_msgs
-      - std_srvs
-      - stereo_msgs
-      - trajectory_msgs
-      - visualization_msgs
+        - actionlib_msgs
+        - common_interfaces
+        - diagnostic_msgs
+        - geometry_msgs
+        - nav_msgs
+        - sensor_msgs
+        - sensor_msgs_py
+        - shape_msgs
+        - std_msgs
+        - std_srvs
+        - stereo_msgs
+        - trajectory_msgs
+        - visualization_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
@@ -1573,8 +1573,8 @@ repositories:
   cpp_polyfills:
     release:
       packages:
-      - tcb_span
-      - tl_expected
+        - tcb_span
+        - tl_expected
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
@@ -1591,12 +1591,12 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - crane_plus
-      - crane_plus_control
-      - crane_plus_description
-      - crane_plus_examples
-      - crane_plus_gazebo
-      - crane_plus_moveit_config
+        - crane_plus
+        - crane_plus_control
+        - crane_plus_description
+        - crane_plus_examples
+        - crane_plus_gazebo
+        - crane_plus_moveit_config
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/crane_plus-release.git
@@ -1609,12 +1609,12 @@ repositories:
   create3_examples:
     release:
       packages:
-      - create3_coverage
-      - create3_examples_msgs
-      - create3_examples_py
-      - create3_lidar_slam
-      - create3_republisher
-      - create3_teleop
+        - create3_coverage
+        - create3_examples_msgs
+        - create3_examples_py
+        - create3_lidar_slam
+        - create3_republisher
+        - create3_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/create3_examples-release.git
@@ -1627,18 +1627,18 @@ repositories:
   create3_sim:
     release:
       packages:
-      - irobot_create_common_bringup
-      - irobot_create_control
-      - irobot_create_description
-      - irobot_create_gazebo_bringup
-      - irobot_create_gazebo_plugins
-      - irobot_create_gazebo_sim
-      - irobot_create_ignition_bringup
-      - irobot_create_ignition_plugins
-      - irobot_create_ignition_sim
-      - irobot_create_ignition_toolbox
-      - irobot_create_nodes
-      - irobot_create_toolbox
+        - irobot_create_common_bringup
+        - irobot_create_control
+        - irobot_create_description
+        - irobot_create_gazebo_bringup
+        - irobot_create_gazebo_plugins
+        - irobot_create_gazebo_sim
+        - irobot_create_ignition_bringup
+        - irobot_create_ignition_plugins
+        - irobot_create_ignition_sim
+        - irobot_create_ignition_toolbox
+        - irobot_create_nodes
+        - irobot_create_toolbox
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
@@ -1655,11 +1655,11 @@ repositories:
       version: humble
     release:
       packages:
-      - create_bringup
-      - create_description
-      - create_driver
-      - create_msgs
-      - create_robot
+        - create_bringup
+        - create_description
+        - create_driver
+        - create_msgs
+        - create_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/AutonomyLab/create_autonomy-release.git
@@ -1702,8 +1702,8 @@ repositories:
       version: main
     release:
       packages:
-      - data_tamer_cpp
-      - data_tamer_msgs
+        - data_tamer_cpp
+        - data_tamer_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
@@ -1720,11 +1720,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - dataspeed_can
-      - dataspeed_can_msg_filters
-      - dataspeed_can_msgs
-      - dataspeed_can_tools
-      - dataspeed_can_usb
+        - dataspeed_can
+        - dataspeed_can_msg_filters
+        - dataspeed_can_msgs
+        - dataspeed_can_tools
+        - dataspeed_can_usb
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
@@ -1741,29 +1741,29 @@ repositories:
       version: ros2
     release:
       packages:
-      - dataspeed_dbw_common
-      - dataspeed_ulc
-      - dataspeed_ulc_can
-      - dataspeed_ulc_msgs
-      - dbw_fca
-      - dbw_fca_can
-      - dbw_fca_description
-      - dbw_fca_joystick_demo
-      - dbw_fca_msgs
-      - dbw_ford
-      - dbw_ford_can
-      - dbw_ford_description
-      - dbw_ford_joystick_demo
-      - dbw_ford_msgs
-      - dbw_polaris
-      - dbw_polaris_can
-      - dbw_polaris_description
-      - dbw_polaris_joystick_demo
-      - dbw_polaris_msgs
-      - ds_dbw
-      - ds_dbw_can
-      - ds_dbw_joystick_demo
-      - ds_dbw_msgs
+        - dataspeed_dbw_common
+        - dataspeed_ulc
+        - dataspeed_ulc_can
+        - dataspeed_ulc_msgs
+        - dbw_fca
+        - dbw_fca_can
+        - dbw_fca_description
+        - dbw_fca_joystick_demo
+        - dbw_fca_msgs
+        - dbw_ford
+        - dbw_ford_can
+        - dbw_ford_description
+        - dbw_ford_joystick_demo
+        - dbw_ford_msgs
+        - dbw_polaris
+        - dbw_polaris_can
+        - dbw_polaris_description
+        - dbw_polaris_joystick_demo
+        - dbw_polaris_msgs
+        - ds_dbw
+        - ds_dbw_can
+        - ds_dbw_joystick_demo
+        - ds_dbw_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
@@ -1780,27 +1780,27 @@ repositories:
       version: humble
     release:
       packages:
-      - action_tutorials_cpp
-      - action_tutorials_interfaces
-      - action_tutorials_py
-      - composition
-      - demo_nodes_cpp
-      - demo_nodes_cpp_native
-      - demo_nodes_py
-      - dummy_map_server
-      - dummy_robot_bringup
-      - dummy_sensors
-      - image_tools
-      - intra_process_demo
-      - lifecycle
-      - lifecycle_py
-      - logging_demo
-      - pendulum_control
-      - pendulum_msgs
-      - quality_of_service_demo_cpp
-      - quality_of_service_demo_py
-      - topic_monitor
-      - topic_statistics_demo
+        - action_tutorials_cpp
+        - action_tutorials_interfaces
+        - action_tutorials_py
+        - composition
+        - demo_nodes_cpp
+        - demo_nodes_cpp_native
+        - demo_nodes_py
+        - dummy_map_server
+        - dummy_robot_bringup
+        - dummy_sensors
+        - image_tools
+        - intra_process_demo
+        - lifecycle
+        - lifecycle_py
+        - logging_demo
+        - pendulum_control
+        - pendulum_msgs
+        - quality_of_service_demo_cpp
+        - quality_of_service_demo_py
+        - topic_monitor
+        - topic_statistics_demo
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
@@ -1834,13 +1834,13 @@ repositories:
       version: humble
     release:
       packages:
-      - depthai-ros
-      - depthai_bridge
-      - depthai_descriptions
-      - depthai_examples
-      - depthai_filters
-      - depthai_ros_driver
-      - depthai_ros_msgs
+        - depthai-ros
+        - depthai_bridge
+        - depthai_descriptions
+        - depthai_examples
+        - depthai_filters
+        - depthai_ros_driver
+        - depthai_ros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
@@ -1874,11 +1874,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - diagnostic_aggregator
-      - diagnostic_common_diagnostics
-      - diagnostic_updater
-      - diagnostics
-      - self_test
+        - diagnostic_aggregator
+        - diagnostic_common_diagnostics
+        - diagnostic_updater
+        - diagnostics
+        - self_test
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
@@ -1896,10 +1896,10 @@ repositories:
       version: galactic
     release:
       packages:
-      - dolly
-      - dolly_follow
-      - dolly_gazebo
-      - dolly_ignition
+        - dolly
+        - dolly_follow
+        - dolly_gazebo
+        - dolly_ignition
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
@@ -1958,9 +1958,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - dynamixel_sdk
-      - dynamixel_sdk_custom_interfaces
-      - dynamixel_sdk_examples
+        - dynamixel_sdk
+        - dynamixel_sdk_custom_interfaces
+        - dynamixel_sdk_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
@@ -1977,8 +1977,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - dynamixel_workbench
-      - dynamixel_workbench_toolbox
+        - dynamixel_workbench
+        - dynamixel_workbench_toolbox
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
@@ -2025,31 +2025,31 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-      - ecl_command_line
-      - ecl_concepts
-      - ecl_containers
-      - ecl_converters
-      - ecl_core
-      - ecl_core_apps
-      - ecl_devices
-      - ecl_eigen
-      - ecl_exceptions
-      - ecl_filesystem
-      - ecl_formatters
-      - ecl_geometry
-      - ecl_ipc
-      - ecl_linear_algebra
-      - ecl_manipulators
-      - ecl_math
-      - ecl_mobile_robot
-      - ecl_mpl
-      - ecl_sigslots
-      - ecl_statistics
-      - ecl_streams
-      - ecl_threads
-      - ecl_time
-      - ecl_type_traits
-      - ecl_utilities
+        - ecl_command_line
+        - ecl_concepts
+        - ecl_containers
+        - ecl_converters
+        - ecl_core
+        - ecl_core_apps
+        - ecl_devices
+        - ecl_eigen
+        - ecl_exceptions
+        - ecl_filesystem
+        - ecl_formatters
+        - ecl_geometry
+        - ecl_ipc
+        - ecl_linear_algebra
+        - ecl_manipulators
+        - ecl_math
+        - ecl_mobile_robot
+        - ecl_mpl
+        - ecl_sigslots
+        - ecl_statistics
+        - ecl_streams
+        - ecl_threads
+        - ecl_time
+        - ecl_type_traits
+        - ecl_utilities
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
@@ -2066,14 +2066,14 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-      - ecl_config
-      - ecl_console
-      - ecl_converters_lite
-      - ecl_errors
-      - ecl_io
-      - ecl_lite
-      - ecl_sigslots_lite
-      - ecl_time_lite
+        - ecl_config
+        - ecl_console
+        - ecl_converters_lite
+        - ecl_errors
+        - ecl_io
+        - ecl_lite
+        - ecl_sigslots_lite
+        - ecl_time_lite
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
@@ -2090,9 +2090,9 @@ repositories:
       version: release/1.0.x
     release:
       packages:
-      - ecl_build
-      - ecl_license
-      - ecl_tools
+        - ecl_build
+        - ecl_license
+        - ecl_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
@@ -2185,34 +2185,34 @@ repositories:
       version: main
     release:
       packages:
-      - etsi_its_cam_coding
-      - etsi_its_cam_conversion
-      - etsi_its_cam_msgs
-      - etsi_its_cam_ts_coding
-      - etsi_its_cam_ts_conversion
-      - etsi_its_cam_ts_msgs
-      - etsi_its_coding
-      - etsi_its_conversion
-      - etsi_its_cpm_ts_coding
-      - etsi_its_cpm_ts_conversion
-      - etsi_its_cpm_ts_msgs
-      - etsi_its_denm_coding
-      - etsi_its_denm_conversion
-      - etsi_its_denm_msgs
-      - etsi_its_mapem_ts_coding
-      - etsi_its_mapem_ts_conversion
-      - etsi_its_mapem_ts_msgs
-      - etsi_its_messages
-      - etsi_its_msgs
-      - etsi_its_msgs_utils
-      - etsi_its_primitives_conversion
-      - etsi_its_rviz_plugins
-      - etsi_its_spatem_ts_coding
-      - etsi_its_spatem_ts_conversion
-      - etsi_its_spatem_ts_msgs
-      - etsi_its_vam_ts_coding
-      - etsi_its_vam_ts_conversion
-      - etsi_its_vam_ts_msgs
+        - etsi_its_cam_coding
+        - etsi_its_cam_conversion
+        - etsi_its_cam_msgs
+        - etsi_its_cam_ts_coding
+        - etsi_its_cam_ts_conversion
+        - etsi_its_cam_ts_msgs
+        - etsi_its_coding
+        - etsi_its_conversion
+        - etsi_its_cpm_ts_coding
+        - etsi_its_cpm_ts_conversion
+        - etsi_its_cpm_ts_msgs
+        - etsi_its_denm_coding
+        - etsi_its_denm_conversion
+        - etsi_its_denm_msgs
+        - etsi_its_mapem_ts_coding
+        - etsi_its_mapem_ts_conversion
+        - etsi_its_mapem_ts_msgs
+        - etsi_its_messages
+        - etsi_its_msgs
+        - etsi_its_msgs_utils
+        - etsi_its_primitives_conversion
+        - etsi_its_rviz_plugins
+        - etsi_its_spatem_ts_coding
+        - etsi_its_spatem_ts_conversion
+        - etsi_its_spatem_ts_msgs
+        - etsi_its_vam_ts_coding
+        - etsi_its_vam_ts_conversion
+        - etsi_its_vam_ts_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
@@ -2305,28 +2305,28 @@ repositories:
       version: humble
     release:
       packages:
-      - examples_rclcpp_async_client
-      - examples_rclcpp_cbg_executor
-      - examples_rclcpp_minimal_action_client
-      - examples_rclcpp_minimal_action_server
-      - examples_rclcpp_minimal_client
-      - examples_rclcpp_minimal_composition
-      - examples_rclcpp_minimal_publisher
-      - examples_rclcpp_minimal_service
-      - examples_rclcpp_minimal_subscriber
-      - examples_rclcpp_minimal_timer
-      - examples_rclcpp_multithreaded_executor
-      - examples_rclcpp_wait_set
-      - examples_rclpy_executors
-      - examples_rclpy_guard_conditions
-      - examples_rclpy_minimal_action_client
-      - examples_rclpy_minimal_action_server
-      - examples_rclpy_minimal_client
-      - examples_rclpy_minimal_publisher
-      - examples_rclpy_minimal_service
-      - examples_rclpy_minimal_subscriber
-      - examples_rclpy_pointcloud_publisher
-      - launch_testing_examples
+        - examples_rclcpp_async_client
+        - examples_rclcpp_cbg_executor
+        - examples_rclcpp_minimal_action_client
+        - examples_rclcpp_minimal_action_server
+        - examples_rclcpp_minimal_client
+        - examples_rclcpp_minimal_composition
+        - examples_rclcpp_minimal_publisher
+        - examples_rclcpp_minimal_service
+        - examples_rclcpp_minimal_subscriber
+        - examples_rclcpp_minimal_timer
+        - examples_rclcpp_multithreaded_executor
+        - examples_rclcpp_wait_set
+        - examples_rclpy_executors
+        - examples_rclpy_guard_conditions
+        - examples_rclpy_minimal_action_client
+        - examples_rclpy_minimal_action_server
+        - examples_rclpy_minimal_client
+        - examples_rclpy_minimal_publisher
+        - examples_rclpy_minimal_service
+        - examples_rclpy_minimal_subscriber
+        - examples_rclpy_pointcloud_publisher
+        - launch_testing_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
@@ -2354,8 +2354,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - fadecandy_driver
-      - fadecandy_msgs
+        - fadecandy_driver
+        - fadecandy_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/eurogroep/fadecandy_ros-release.git
@@ -2556,15 +2556,15 @@ repositories:
       version: humble
     release:
       packages:
-      - flexbe_behavior_engine
-      - flexbe_core
-      - flexbe_input
-      - flexbe_mirror
-      - flexbe_msgs
-      - flexbe_onboard
-      - flexbe_states
-      - flexbe_testing
-      - flexbe_widget
+        - flexbe_behavior_engine
+        - flexbe_core
+        - flexbe_input
+        - flexbe_mirror
+        - flexbe_msgs
+        - flexbe_onboard
+        - flexbe_states
+        - flexbe_testing
+        - flexbe_widget
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
@@ -2581,10 +2581,10 @@ repositories:
       version: ros2-release
     release:
       packages:
-      - flir_camera_description
-      - flir_camera_msgs
-      - spinnaker_camera_driver
-      - spinnaker_synchronized_camera_driver
+        - flir_camera_description
+        - flir_camera_msgs
+        - spinnaker_camera_driver
+        - spinnaker_synchronized_camera_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
@@ -2617,8 +2617,8 @@ repositories:
       version: humble
     release:
       packages:
-      - fmi_adapter
-      - fmi_adapter_examples
+        - fmi_adapter
+        - fmi_adapter_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
@@ -2642,8 +2642,8 @@ repositories:
   fogros2:
     release:
       packages:
-      - fogros2
-      - fogros2_examples
+        - fogros2
+        - fogros2_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fogros2-release.git
@@ -2671,10 +2671,10 @@ repositories:
       version: humble
     release:
       packages:
-      - foros
-      - foros_examples
-      - foros_inspector
-      - foros_msgs
+        - foros
+        - foros_examples
+        - foros_inspector
+        - foros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foros-release.git
@@ -2768,15 +2768,15 @@ repositories:
       version: humble
     release:
       packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
+        - game_controller_spl
+        - game_controller_spl_interfaces
+        - gc_spl
+        - gc_spl_2022
+        - gc_spl_interfaces
+        - rcgcd_spl_14
+        - rcgcd_spl_14_conversion
+        - rcgcrd_spl_4
+        - rcgcrd_spl_4_conversion
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
@@ -2793,8 +2793,8 @@ repositories:
       version: humble
     release:
       packages:
-      - gazebo_model_attachment_plugin
-      - gazebo_model_attachment_plugin_msgs
+        - gazebo_model_attachment_plugin
+        - gazebo_model_attachment_plugin_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
@@ -2841,8 +2841,8 @@ repositories:
       version: humble
     release:
       packages:
-      - gazebo_ros2_control
-      - gazebo_ros2_control_demos
+        - gazebo_ros2_control
+        - gazebo_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
@@ -2859,11 +2859,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - gazebo_dev
-      - gazebo_msgs
-      - gazebo_plugins
-      - gazebo_ros
-      - gazebo_ros_pkgs
+        - gazebo_dev
+        - gazebo_msgs
+        - gazebo_plugins
+        - gazebo_ros
+        - gazebo_ros_pkgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
@@ -2896,10 +2896,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - gazebo_video_monitor_interfaces
-      - gazebo_video_monitor_plugins
-      - gazebo_video_monitor_utils
-      - gazebo_video_monitors
+        - gazebo_video_monitor_interfaces
+        - gazebo_video_monitor_plugins
+        - gazebo_video_monitor_utils
+        - gazebo_video_monitors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_video_monitors-release.git
@@ -2916,12 +2916,12 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
-      - generate_parameter_library
-      - generate_parameter_library_example
-      - generate_parameter_library_py
-      - generate_parameter_module_example
-      - parameter_traits
+        - cmake_generate_parameter_module_example
+        - generate_parameter_library
+        - generate_parameter_library_example
+        - generate_parameter_library_py
+        - generate_parameter_module_example
+        - parameter_traits
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
@@ -2938,9 +2938,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - geodesy
-      - geographic_info
-      - geographic_msgs
+        - geodesy
+        - geographic_info
+        - geographic_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -2973,20 +2973,20 @@ repositories:
       version: humble
     release:
       packages:
-      - examples_tf2_py
-      - geometry2
-      - tf2
-      - tf2_bullet
-      - tf2_eigen
-      - tf2_eigen_kdl
-      - tf2_geometry_msgs
-      - tf2_kdl
-      - tf2_msgs
-      - tf2_py
-      - tf2_ros
-      - tf2_ros_py
-      - tf2_sensor_msgs
-      - tf2_tools
+        - examples_tf2_py
+        - geometry2
+        - tf2
+        - tf2_bullet
+        - tf2_eigen
+        - tf2_eigen_kdl
+        - tf2_geometry_msgs
+        - tf2_kdl
+        - tf2_msgs
+        - tf2_py
+        - tf2_ros
+        - tf2_ros_py
+        - tf2_sensor_msgs
+        - tf2_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
@@ -3004,9 +3004,9 @@ repositories:
       version: humble
     release:
       packages:
-      - geometry_tutorials
-      - turtle_tf2_cpp
-      - turtle_tf2_py
+        - geometry_tutorials
+        - turtle_tf2_cpp
+        - turtle_tf2_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
@@ -3035,8 +3035,8 @@ repositories:
   googletest:
     release:
       packages:
-      - gmock_vendor
-      - gtest_vendor
+        - gmock_vendor
+        - gtest_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
@@ -3053,10 +3053,10 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - gps_msgs
-      - gps_tools
-      - gps_umd
-      - gpsd_client
+        - gps_msgs
+        - gps_tools
+        - gps_umd
+        - gpsd_client
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
@@ -3134,21 +3134,21 @@ repositories:
       version: humble
     release:
       packages:
-      - grid_map
-      - grid_map_cmake_helpers
-      - grid_map_core
-      - grid_map_costmap_2d
-      - grid_map_cv
-      - grid_map_demos
-      - grid_map_filters
-      - grid_map_loader
-      - grid_map_msgs
-      - grid_map_octomap
-      - grid_map_pcl
-      - grid_map_ros
-      - grid_map_rviz_plugin
-      - grid_map_sdf
-      - grid_map_visualization
+        - grid_map
+        - grid_map_cmake_helpers
+        - grid_map_core
+        - grid_map_costmap_2d
+        - grid_map_cv
+        - grid_map_demos
+        - grid_map_filters
+        - grid_map_loader
+        - grid_map_msgs
+        - grid_map_octomap
+        - grid_map_pcl
+        - grid_map_ros
+        - grid_map_rviz_plugin
+        - grid_map_sdf
+        - grid_map_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/grid_map-release.git
@@ -3321,8 +3321,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - hri
-      - pyhri
+        - hri
+        - pyhri
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
@@ -3434,10 +3434,10 @@ repositories:
   iceoryx:
     release:
       packages:
-      - iceoryx_binding_c
-      - iceoryx_hoofs
-      - iceoryx_introspection
-      - iceoryx_posh
+        - iceoryx_binding_c
+        - iceoryx_hoofs
+        - iceoryx_introspection
+        - iceoryx_posh
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
@@ -3461,9 +3461,9 @@ repositories:
       version: humble
     release:
       packages:
-      - gz_ros2_control_tests
-      - ign_ros2_control
-      - ign_ros2_control_demos
+        - gz_ros2_control_tests
+        - ign_ros2_control
+        - ign_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
@@ -3480,9 +3480,9 @@ repositories:
       version: main
     release:
       packages:
-      - ign_rviz
-      - ign_rviz_common
-      - ign_rviz_plugins
+        - ign_rviz
+        - ign_rviz_common
+        - ign_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
@@ -3531,11 +3531,11 @@ repositories:
       version: humble
     release:
       packages:
-      - camera_calibration_parsers
-      - camera_info_manager
-      - camera_info_manager_py
-      - image_common
-      - image_transport
+        - camera_calibration_parsers
+        - camera_info_manager
+        - camera_info_manager_py
+        - image_common
+        - image_transport
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
@@ -3553,15 +3553,15 @@ repositories:
       version: humble
     release:
       packages:
-      - camera_calibration
-      - depth_image_proc
-      - image_pipeline
-      - image_proc
-      - image_publisher
-      - image_rotate
-      - image_view
-      - stereo_image_proc
-      - tracetools_image_pipeline
+        - camera_calibration
+        - depth_image_proc
+        - image_pipeline
+        - image_proc
+        - image_publisher
+        - image_rotate
+        - image_view
+        - stereo_image_proc
+        - tracetools_image_pipeline
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
@@ -3579,10 +3579,10 @@ repositories:
       version: humble
     release:
       packages:
-      - compressed_depth_image_transport
-      - compressed_image_transport
-      - image_transport_plugins
-      - theora_image_transport
+        - compressed_depth_image_transport
+        - compressed_image_transport
+        - image_transport_plugins
+        - theora_image_transport
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
@@ -3600,9 +3600,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - imu_pipeline
-      - imu_processors
-      - imu_transformer
+        - imu_pipeline
+        - imu_processors
+        - imu_transformer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
@@ -3619,10 +3619,10 @@ repositories:
       version: humble
     release:
       packages:
-      - imu_complementary_filter
-      - imu_filter_madgwick
-      - imu_tools
-      - rviz_imu_plugin
+        - imu_complementary_filter
+        - imu_filter_madgwick
+        - imu_tools
+        - rviz_imu_plugin
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
@@ -3692,8 +3692,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - joint_state_publisher
-      - joint_state_publisher_gui
+        - joint_state_publisher
+        - joint_state_publisher_gui
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
@@ -3726,12 +3726,12 @@ repositories:
       version: ros2
     release:
       packages:
-      - joy
-      - joy_linux
-      - sdl2_vendor
-      - spacenav
-      - wiimote
-      - wiimote_msgs
+        - joy
+        - joy_linux
+        - sdl2_vendor
+        - spacenav
+        - wiimote
+        - wiimote_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
@@ -3781,8 +3781,8 @@ repositories:
       version: humble
     release:
       packages:
-      - kinematics_interface
-      - kinematics_interface_kdl
+        - kinematics_interface
+        - kinematics_interface_kdl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
@@ -3864,6 +3864,16 @@ repositories:
       url: https://github.com/automatika-robotics/kompass.git
       version: main
     status: developed
+  kompass_interfaces:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   kuka_drivers:
     doc:
       type: git
@@ -3871,20 +3881,20 @@ repositories:
       version: humble
     release:
       packages:
-      - fri_configuration_controller
-      - fri_state_broadcaster
-      - iiqka_moveit_example
-      - joint_group_impedance_controller
-      - kuka_control_mode_handler
-      - kuka_controllers
-      - kuka_driver_interfaces
-      - kuka_drivers
-      - kuka_drivers_core
-      - kuka_event_broadcaster
-      - kuka_iiqka_eac_driver
-      - kuka_kss_rsi_driver
-      - kuka_rsi_simulator
-      - kuka_sunrise_fri_driver
+        - fri_configuration_controller
+        - fri_state_broadcaster
+        - iiqka_moveit_example
+        - joint_group_impedance_controller
+        - kuka_control_mode_handler
+        - kuka_controllers
+        - kuka_driver_interfaces
+        - kuka_drivers
+        - kuka_drivers_core
+        - kuka_event_broadcaster
+        - kuka_iiqka_eac_driver
+        - kuka_kss_rsi_driver
+        - kuka_rsi_simulator
+        - kuka_sunrise_fri_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_drivers-release.git
@@ -3901,8 +3911,8 @@ repositories:
       version: master
     release:
       packages:
-      - kuka_external_control_sdk
-      - kuka_external_control_sdk_examples
+        - kuka_external_control_sdk
+        - kuka_external_control_sdk_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
@@ -3919,19 +3929,19 @@ repositories:
       version: humble
     release:
       packages:
-      - kuka_agilus_support
-      - kuka_cybertech_support
-      - kuka_fortec_support
-      - kuka_iontec_support
-      - kuka_kr_moveit_config
-      - kuka_lbr_iisy_moveit_config
-      - kuka_lbr_iisy_support
-      - kuka_lbr_iiwa_moveit_config
-      - kuka_lbr_iiwa_support
-      - kuka_mock_hardware_interface
-      - kuka_quantec_support
-      - kuka_resources
-      - kuka_robot_descriptions
+        - kuka_agilus_support
+        - kuka_cybertech_support
+        - kuka_fortec_support
+        - kuka_iontec_support
+        - kuka_kr_moveit_config
+        - kuka_lbr_iisy_moveit_config
+        - kuka_lbr_iisy_support
+        - kuka_lbr_iiwa_moveit_config
+        - kuka_lbr_iiwa_support
+        - kuka_mock_hardware_interface
+        - kuka_quantec_support
+        - kuka_resources
+        - kuka_robot_descriptions
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_robot_descriptions-release.git
@@ -3948,17 +3958,17 @@ repositories:
       version: master
     release:
       packages:
-      - lanelet2
-      - lanelet2_core
-      - lanelet2_examples
-      - lanelet2_io
-      - lanelet2_maps
-      - lanelet2_matching
-      - lanelet2_projection
-      - lanelet2_python
-      - lanelet2_routing
-      - lanelet2_traffic_rules
-      - lanelet2_validation
+        - lanelet2
+        - lanelet2_core
+        - lanelet2_examples
+        - lanelet2_io
+        - lanelet2_maps
+        - lanelet2_matching
+        - lanelet2_projection
+        - lanelet2_python
+        - lanelet2_routing
+        - lanelet2_traffic_rules
+        - lanelet2_validation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
@@ -4033,12 +4043,12 @@ repositories:
       version: humble
     release:
       packages:
-      - launch
-      - launch_pytest
-      - launch_testing
-      - launch_testing_ament_cmake
-      - launch_xml
-      - launch_yaml
+        - launch
+        - launch_pytest
+        - launch_testing
+        - launch_testing_ament_cmake
+        - launch_xml
+        - launch_yaml
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
@@ -4086,9 +4096,9 @@ repositories:
       version: humble
     release:
       packages:
-      - launch_ros
-      - launch_testing_ros
-      - ros2launch
+        - launch_ros
+        - launch_testing_ros
+        - ros2launch
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
@@ -4106,10 +4116,10 @@ repositories:
       version: humble
     release:
       packages:
-      - leo
-      - leo_description
-      - leo_msgs
-      - leo_teleop
+        - leo
+        - leo_description
+        - leo_msgs
+        - leo_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
@@ -4126,8 +4136,8 @@ repositories:
       version: humble
     release:
       packages:
-      - leo_desktop
-      - leo_viz
+        - leo_desktop
+        - leo_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
@@ -4144,9 +4154,9 @@ repositories:
       version: humble
     release:
       packages:
-      - leo_bringup
-      - leo_fw
-      - leo_robot
+        - leo_bringup
+        - leo_fw
+        - leo_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
@@ -4163,10 +4173,10 @@ repositories:
       version: humble
     release:
       packages:
-      - leo_gz_bringup
-      - leo_gz_plugins
-      - leo_gz_worlds
-      - leo_simulator
+        - leo_gz_bringup
+        - leo_gz_plugins
+        - leo_gz_worlds
+        - leo_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
@@ -4388,8 +4398,8 @@ repositories:
       version: humble
     release:
       packages:
-      - bosch_locator_bridge
-      - bosch_locator_bridge_utils
+        - bosch_locator_bridge
+        - bosch_locator_bridge_utils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
@@ -4466,11 +4476,11 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - mapviz
-      - mapviz_interfaces
-      - mapviz_plugins
-      - multires_image
-      - tile_map
+        - mapviz
+        - mapviz_interfaces
+        - mapviz_plugins
+        - multires_image
+        - tile_map
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
@@ -4487,8 +4497,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - marine_acoustic_msgs
-      - marine_sensor_msgs
+        - marine_acoustic_msgs
+        - marine_sensor_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
@@ -4520,18 +4530,18 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - swri_cli_tools
-      - swri_console_util
-      - swri_dbw_interface
-      - swri_geometry_util
-      - swri_image_util
-      - swri_math_util
-      - swri_opencv_util
-      - swri_roscpp
-      - swri_route_util
-      - swri_serial_util
-      - swri_system_util
-      - swri_transform_util
+        - swri_cli_tools
+        - swri_console_util
+        - swri_dbw_interface
+        - swri_geometry_util
+        - swri_image_util
+        - swri_math_util
+        - swri_opencv_util
+        - swri_roscpp
+        - swri_route_util
+        - swri_serial_util
+        - swri_system_util
+        - swri_transform_util
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
@@ -4549,15 +4559,15 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - marti_can_msgs
-      - marti_common_msgs
-      - marti_dbw_msgs
-      - marti_introspection_msgs
-      - marti_nav_msgs
-      - marti_perception_msgs
-      - marti_sensor_msgs
-      - marti_status_msgs
-      - marti_visualization_msgs
+        - marti_can_msgs
+        - marti_common_msgs
+        - marti_dbw_msgs
+        - marti_introspection_msgs
+        - marti_nav_msgs
+        - marti_perception_msgs
+        - marti_sensor_msgs
+        - marti_status_msgs
+        - marti_visualization_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
@@ -4577,7 +4587,7 @@ repositories:
   marvelmind_ros2_release:
     release:
       packages:
-      - marvelmind_ros2
+        - marvelmind_ros2
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo.git
@@ -4608,10 +4618,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - libmavconn
-      - mavros
-      - mavros_extras
-      - mavros_msgs
+        - libmavconn
+        - mavros
+        - mavros_extras
+        - mavros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
@@ -4689,9 +4699,9 @@ repositories:
       version: main
     release:
       packages:
-      - collision_log_msgs
-      - metro_benchmark_msgs
-      - metro_benchmark_pub
+        - collision_log_msgs
+        - metro_benchmark_msgs
+        - metro_benchmark_pub
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/metrics_msgs-release.git
@@ -4714,8 +4724,8 @@ repositories:
       version: main
     release:
       packages:
-      - base2d_kinematics
-      - base2d_kinematics_msgs
+        - base2d_kinematics
+        - base2d_kinematics_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/metro_nav-release.git
@@ -4732,8 +4742,8 @@ repositories:
       version: master
     release:
       packages:
-      - micro_ros_diagnostic_bridge
-      - micro_ros_diagnostic_msgs
+        - micro_ros_diagnostic_bridge
+        - micro_ros_diagnostic_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
@@ -4765,11 +4775,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - microstrain_inertial_description
-      - microstrain_inertial_driver
-      - microstrain_inertial_examples
-      - microstrain_inertial_msgs
-      - microstrain_inertial_rqt
+        - microstrain_inertial_description
+        - microstrain_inertial_driver
+        - microstrain_inertial_examples
+        - microstrain_inertial_msgs
+        - microstrain_inertial_rqt
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
@@ -4813,15 +4823,15 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - mocap4r2_control
-      - mocap4r2_control_msgs
-      - mocap4r2_dummy_driver
-      - mocap4r2_marker_publisher
-      - mocap4r2_marker_viz
-      - mocap4r2_marker_viz_srvs
-      - mocap4r2_robot_gt
-      - mocap4r2_robot_gt_msgs
-      - rqt_mocap4r2_control
+        - mocap4r2_control
+        - mocap4r2_control_msgs
+        - mocap4r2_dummy_driver
+        - mocap4r2_marker_publisher
+        - mocap4r2_marker_viz
+        - mocap4r2_marker_viz_srvs
+        - mocap4r2_robot_gt
+        - mocap4r2_robot_gt_msgs
+        - rqt_mocap4r2_control
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
@@ -4880,26 +4890,26 @@ repositories:
       version: develop
     release:
       packages:
-      - kitti_metrics_eval
-      - mola
-      - mola_bridge_ros2
-      - mola_demos
-      - mola_input_euroc_dataset
-      - mola_input_kitti360_dataset
-      - mola_input_kitti_dataset
-      - mola_input_mulran_dataset
-      - mola_input_paris_luco_dataset
-      - mola_input_rawlog
-      - mola_input_rosbag2
-      - mola_kernel
-      - mola_launcher
-      - mola_metric_maps
-      - mola_msgs
-      - mola_pose_list
-      - mola_relocalization
-      - mola_traj_tools
-      - mola_viz
-      - mola_yaml
+        - kitti_metrics_eval
+        - mola
+        - mola_bridge_ros2
+        - mola_demos
+        - mola_input_euroc_dataset
+        - mola_input_kitti360_dataset
+        - mola_input_kitti_dataset
+        - mola_input_mulran_dataset
+        - mola_input_paris_luco_dataset
+        - mola_input_rawlog
+        - mola_input_rosbag2
+        - mola_kernel
+        - mola_launcher
+        - mola_metric_maps
+        - mola_msgs
+        - mola_pose_list
+        - mola_relocalization
+        - mola_traj_tools
+        - mola_viz
+        - mola_yaml
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
@@ -4971,8 +4981,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - motion_capture_tracking
-      - motion_capture_tracking_interfaces
+        - motion_capture_tracking
+        - motion_capture_tracking_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
@@ -4989,44 +4999,44 @@ repositories:
       version: main
     release:
       packages:
-      - chomp_motion_planner
-      - moveit
-      - moveit_chomp_optimizer_adapter
-      - moveit_common
-      - moveit_configs_utils
-      - moveit_core
-      - moveit_hybrid_planning
-      - moveit_kinematics
-      - moveit_planners
-      - moveit_planners_chomp
-      - moveit_planners_ompl
-      - moveit_plugins
-      - moveit_resources_prbt_ikfast_manipulator_plugin
-      - moveit_resources_prbt_moveit_config
-      - moveit_resources_prbt_pg70_support
-      - moveit_resources_prbt_support
-      - moveit_ros
-      - moveit_ros_benchmarks
-      - moveit_ros_control_interface
-      - moveit_ros_move_group
-      - moveit_ros_occupancy_map_monitor
-      - moveit_ros_perception
-      - moveit_ros_planning
-      - moveit_ros_planning_interface
-      - moveit_ros_robot_interaction
-      - moveit_ros_visualization
-      - moveit_ros_warehouse
-      - moveit_runtime
-      - moveit_servo
-      - moveit_setup_app_plugins
-      - moveit_setup_assistant
-      - moveit_setup_controllers
-      - moveit_setup_core_plugins
-      - moveit_setup_framework
-      - moveit_setup_srdf_plugins
-      - moveit_simple_controller_manager
-      - pilz_industrial_motion_planner
-      - pilz_industrial_motion_planner_testutils
+        - chomp_motion_planner
+        - moveit
+        - moveit_chomp_optimizer_adapter
+        - moveit_common
+        - moveit_configs_utils
+        - moveit_core
+        - moveit_hybrid_planning
+        - moveit_kinematics
+        - moveit_planners
+        - moveit_planners_chomp
+        - moveit_planners_ompl
+        - moveit_plugins
+        - moveit_resources_prbt_ikfast_manipulator_plugin
+        - moveit_resources_prbt_moveit_config
+        - moveit_resources_prbt_pg70_support
+        - moveit_resources_prbt_support
+        - moveit_ros
+        - moveit_ros_benchmarks
+        - moveit_ros_control_interface
+        - moveit_ros_move_group
+        - moveit_ros_occupancy_map_monitor
+        - moveit_ros_perception
+        - moveit_ros_planning
+        - moveit_ros_planning_interface
+        - moveit_ros_robot_interaction
+        - moveit_ros_visualization
+        - moveit_ros_warehouse
+        - moveit_runtime
+        - moveit_servo
+        - moveit_setup_app_plugins
+        - moveit_setup_assistant
+        - moveit_setup_controllers
+        - moveit_setup_core_plugins
+        - moveit_setup_framework
+        - moveit_setup_srdf_plugins
+        - moveit_simple_controller_manager
+        - pilz_industrial_motion_planner
+        - pilz_industrial_motion_planner_testutils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
@@ -5060,12 +5070,12 @@ repositories:
       version: ros2
     release:
       packages:
-      - moveit_resources
-      - moveit_resources_fanuc_description
-      - moveit_resources_fanuc_moveit_config
-      - moveit_resources_panda_description
-      - moveit_resources_panda_moveit_config
-      - moveit_resources_pr2_description
+        - moveit_resources
+        - moveit_resources_fanuc_description
+        - moveit_resources_fanuc_moveit_config
+        - moveit_resources_panda_description
+        - moveit_resources_panda_moveit_config
+        - moveit_resources_pr2_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -5112,8 +5122,8 @@ repositories:
       version: main
     release:
       packages:
-      - mqtt_client
-      - mqtt_client_interfaces
+        - mqtt_client
+        - mqtt_client_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
@@ -5145,16 +5155,16 @@ repositories:
       version: ros2
     release:
       packages:
-      - mrpt_map_server
-      - mrpt_msgs_bridge
-      - mrpt_nav_interfaces
-      - mrpt_navigation
-      - mrpt_pf_localization
-      - mrpt_pointcloud_pipeline
-      - mrpt_rawlog
-      - mrpt_reactivenav2d
-      - mrpt_tps_astar_planner
-      - mrpt_tutorials
+        - mrpt_map_server
+        - mrpt_msgs_bridge
+        - mrpt_nav_interfaces
+        - mrpt_navigation
+        - mrpt_pf_localization
+        - mrpt_pointcloud_pipeline
+        - mrpt_rawlog
+        - mrpt_reactivenav2d
+        - mrpt_tps_astar_planner
+        - mrpt_tutorials
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
@@ -5186,20 +5196,20 @@ repositories:
       version: main
     release:
       packages:
-      - mrpt_apps
-      - mrpt_libapps
-      - mrpt_libbase
-      - mrpt_libgui
-      - mrpt_libhwdrivers
-      - mrpt_libmaps
-      - mrpt_libmath
-      - mrpt_libnav
-      - mrpt_libobs
-      - mrpt_libopengl
-      - mrpt_libposes
-      - mrpt_libros_bridge
-      - mrpt_libslam
-      - mrpt_libtclap
+        - mrpt_apps
+        - mrpt_libapps
+        - mrpt_libbase
+        - mrpt_libgui
+        - mrpt_libhwdrivers
+        - mrpt_libmaps
+        - mrpt_libmath
+        - mrpt_libnav
+        - mrpt_libobs
+        - mrpt_libopengl
+        - mrpt_libposes
+        - mrpt_libros_bridge
+        - mrpt_libslam
+        - mrpt_libtclap
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
@@ -5216,13 +5226,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - mrpt_generic_sensor
-      - mrpt_sensor_bumblebee_stereo
-      - mrpt_sensor_gnss_nmea
-      - mrpt_sensor_gnss_novatel
-      - mrpt_sensor_imu_taobotics
-      - mrpt_sensorlib
-      - mrpt_sensors
+        - mrpt_generic_sensor
+        - mrpt_sensor_bumblebee_stereo
+        - mrpt_sensor_gnss_nmea
+        - mrpt_sensor_gnss_novatel
+        - mrpt_sensor_imu_taobotics
+        - mrpt_sensorlib
+        - mrpt_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
@@ -5309,8 +5319,8 @@ repositories:
       version: humble
     release:
       packages:
-      - nao_command_msgs
-      - nao_sensor_msgs
+        - nao_command_msgs
+        - nao_sensor_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
@@ -5358,7 +5368,7 @@ repositories:
       version: main
     release:
       packages:
-      - naoqi_bridge_msgs
+        - naoqi_bridge_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
@@ -5421,45 +5431,45 @@ repositories:
       version: humble
     release:
       packages:
-      - costmap_queue
-      - dwb_core
-      - dwb_critics
-      - dwb_msgs
-      - dwb_plugins
-      - nav2_amcl
-      - nav2_behavior_tree
-      - nav2_behaviors
-      - nav2_bringup
-      - nav2_bt_navigator
-      - nav2_collision_monitor
-      - nav2_common
-      - nav2_constrained_smoother
-      - nav2_controller
-      - nav2_core
-      - nav2_costmap_2d
-      - nav2_dwb_controller
-      - nav2_graceful_controller
-      - nav2_lifecycle_manager
-      - nav2_map_server
-      - nav2_mppi_controller
-      - nav2_msgs
-      - nav2_navfn_planner
-      - nav2_planner
-      - nav2_regulated_pure_pursuit_controller
-      - nav2_rotation_shim_controller
-      - nav2_rviz_plugins
-      - nav2_simple_commander
-      - nav2_smac_planner
-      - nav2_smoother
-      - nav2_system_tests
-      - nav2_theta_star_planner
-      - nav2_util
-      - nav2_velocity_smoother
-      - nav2_voxel_grid
-      - nav2_waypoint_follower
-      - nav_2d_msgs
-      - nav_2d_utils
-      - navigation2
+        - costmap_queue
+        - dwb_core
+        - dwb_critics
+        - dwb_msgs
+        - dwb_plugins
+        - nav2_amcl
+        - nav2_behavior_tree
+        - nav2_behaviors
+        - nav2_bringup
+        - nav2_bt_navigator
+        - nav2_collision_monitor
+        - nav2_common
+        - nav2_constrained_smoother
+        - nav2_controller
+        - nav2_core
+        - nav2_costmap_2d
+        - nav2_dwb_controller
+        - nav2_graceful_controller
+        - nav2_lifecycle_manager
+        - nav2_map_server
+        - nav2_mppi_controller
+        - nav2_msgs
+        - nav2_navfn_planner
+        - nav2_planner
+        - nav2_regulated_pure_pursuit_controller
+        - nav2_rotation_shim_controller
+        - nav2_rviz_plugins
+        - nav2_simple_commander
+        - nav2_smac_planner
+        - nav2_smoother
+        - nav2_system_tests
+        - nav2_theta_star_planner
+        - nav2_util
+        - nav2_velocity_smoother
+        - nav2_voxel_grid
+        - nav2_waypoint_follower
+        - nav_2d_msgs
+        - nav_2d_utils
+        - navigation2
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
@@ -5476,7 +5486,7 @@ repositories:
       version: humble
     release:
       packages:
-      - map_msgs
+        - map_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -5539,7 +5549,7 @@ repositories:
       version: default
     release:
       packages:
-      - nerian_stereo
+        - nerian_stereo
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
@@ -5646,8 +5656,8 @@ repositories:
       version: master
     release:
       packages:
-      - nodl_python
-      - ros2nodl
+        - nodl_python
+        - ros2nodl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
@@ -5680,8 +5690,8 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - novatel_gps_driver
-      - novatel_gps_msgs
+        - novatel_gps_driver
+        - novatel_gps_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
@@ -5698,8 +5708,8 @@ repositories:
       version: humble
     release:
       packages:
-      - novatel_oem7_driver
-      - novatel_oem7_msgs
+        - novatel_oem7_driver
+        - novatel_oem7_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
@@ -5759,9 +5769,9 @@ repositories:
       version: devel
     release:
       packages:
-      - dynamic_edt_3d
-      - octomap
-      - octovis
+        - dynamic_edt_3d
+        - octomap
+        - octovis
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
@@ -5778,8 +5788,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - octomap_mapping
-      - octomap_server
+        - octomap_mapping
+        - octomap_server
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
@@ -5856,17 +5866,17 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - off_highway_can
-      - off_highway_general_purpose_radar
-      - off_highway_general_purpose_radar_msgs
-      - off_highway_premium_radar_sample
-      - off_highway_premium_radar_sample_msgs
-      - off_highway_radar
-      - off_highway_radar_msgs
-      - off_highway_sensor_drivers
-      - off_highway_sensor_drivers_examples
-      - off_highway_uss
-      - off_highway_uss_msgs
+        - off_highway_can
+        - off_highway_general_purpose_radar
+        - off_highway_general_purpose_radar_msgs
+        - off_highway_premium_radar_sample
+        - off_highway_premium_radar_sample_msgs
+        - off_highway_radar
+        - off_highway_radar_msgs
+        - off_highway_sensor_drivers
+        - off_highway_sensor_drivers_examples
+        - off_highway_uss
+        - off_highway_uss_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
@@ -5883,10 +5893,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - omni_base_2dnav
-      - omni_base_laser_sensors
-      - omni_base_navigation
-      - omni_base_rgbd_sensors
+        - omni_base_2dnav
+        - omni_base_laser_sensors
+        - omni_base_navigation
+        - omni_base_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_navigation-release.git
@@ -5903,10 +5913,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - omni_base_bringup
-      - omni_base_controller_configuration
-      - omni_base_description
-      - omni_base_robot
+        - omni_base_bringup
+        - omni_base_controller_configuration
+        - omni_base_description
+        - omni_base_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
@@ -5923,8 +5933,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - omni_base_gazebo
-      - omni_base_simulation
+        - omni_base_gazebo
+        - omni_base_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_simulation-release.git
@@ -5962,10 +5972,10 @@ repositories:
       version: humble
     release:
       packages:
-      - opennav_docking
-      - opennav_docking_bt
-      - opennav_docking_core
-      - opennav_docking_msgs
+        - opennav_docking
+        - opennav_docking_bt
+        - opennav_docking_core
+        - opennav_docking_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/open-navigation/opennav_docking-release.git
@@ -5993,8 +6003,8 @@ repositories:
   orocos_kdl_vendor:
     release:
       packages:
-      - orocos_kdl_vendor
-      - python_orocos_kdl_vendor
+        - orocos_kdl_vendor
+        - python_orocos_kdl_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
@@ -6064,8 +6074,8 @@ repositories:
       version: master
     release:
       packages:
-      - ouxt_common
-      - ouxt_lint_common
+        - ouxt_common
+        - ouxt_lint_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
@@ -6112,10 +6122,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_gripper
-      - pal_gripper_controller_configuration
-      - pal_gripper_description
-      - pal_gripper_simulation
+        - pal_gripper
+        - pal_gripper_controller_configuration
+        - pal_gripper_description
+        - pal_gripper_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
@@ -6132,9 +6142,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_hey5
-      - pal_hey5_controller_configuration
-      - pal_hey5_description
+        - pal_hey5
+        - pal_hey5_controller_configuration
+        - pal_hey5_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_hey5-release.git
@@ -6166,9 +6176,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_navigation_cfg
-      - pal_navigation_cfg_bringup
-      - pal_navigation_cfg_params
+        - pal_navigation_cfg
+        - pal_navigation_cfg_bringup
+        - pal_navigation_cfg_params
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
@@ -6185,9 +6195,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_robotiq_controller_configuration
-      - pal_robotiq_description
-      - pal_robotiq_gripper
+        - pal_robotiq_controller_configuration
+        - pal_robotiq_description
+        - pal_robotiq_gripper
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
@@ -6204,8 +6214,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_statistics
-      - pal_statistics_msgs
+        - pal_statistics
+        - pal_statistics_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
@@ -6270,7 +6280,7 @@ repositories:
   perception_open3d:
     release:
       packages:
-      - open3d_conversions
+        - open3d_conversions
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
@@ -6287,9 +6297,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - pcl_conversions
-      - pcl_ros
-      - perception_pcl
+        - pcl_conversions
+        - pcl_ros
+        - perception_pcl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
@@ -6334,22 +6344,22 @@ repositories:
       version: humble
     release:
       packages:
-      - libphidget22
-      - phidgets_accelerometer
-      - phidgets_analog_inputs
-      - phidgets_analog_outputs
-      - phidgets_api
-      - phidgets_digital_inputs
-      - phidgets_digital_outputs
-      - phidgets_drivers
-      - phidgets_gyroscope
-      - phidgets_high_speed_encoder
-      - phidgets_ik
-      - phidgets_magnetometer
-      - phidgets_motors
-      - phidgets_msgs
-      - phidgets_spatial
-      - phidgets_temperature
+        - libphidget22
+        - phidgets_accelerometer
+        - phidgets_analog_inputs
+        - phidgets_analog_outputs
+        - phidgets_api
+        - phidgets_digital_inputs
+        - phidgets_digital_outputs
+        - phidgets_drivers
+        - phidgets_gyroscope
+        - phidgets_high_speed_encoder
+        - phidgets_ik
+        - phidgets_magnetometer
+        - phidgets_motors
+        - phidgets_msgs
+        - phidgets_spatial
+        - phidgets_temperature
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
@@ -6388,8 +6398,8 @@ repositories:
       version: main
     release:
       packages:
-      - picknik_reset_fault_controller
-      - picknik_twist_controller
+        - picknik_reset_fault_controller
+        - picknik_twist_controller
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
@@ -6421,8 +6431,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - play_motion2
-      - play_motion2_msgs
+        - play_motion2
+        - play_motion2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
@@ -6500,9 +6510,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pmb2_2dnav
-      - pmb2_laser_sensors
-      - pmb2_navigation
+        - pmb2_2dnav
+        - pmb2_laser_sensors
+        - pmb2_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
@@ -6519,10 +6529,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pmb2_bringup
-      - pmb2_controller_configuration
-      - pmb2_description
-      - pmb2_robot
+        - pmb2_bringup
+        - pmb2_controller_configuration
+        - pmb2_description
+        - pmb2_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
@@ -6539,8 +6549,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pmb2_gazebo
-      - pmb2_simulation
+        - pmb2_gazebo
+        - pmb2_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
@@ -6572,8 +6582,8 @@ repositories:
       version: humble
     release:
       packages:
-      - point_cloud_transport
-      - point_cloud_transport_py
+        - point_cloud_transport
+        - point_cloud_transport_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -6590,11 +6600,11 @@ repositories:
       version: humble
     release:
       packages:
-      - draco_point_cloud_transport
-      - point_cloud_interfaces
-      - point_cloud_transport_plugins
-      - zlib_point_cloud_transport
-      - zstd_point_cloud_transport
+        - draco_point_cloud_transport
+        - point_cloud_interfaces
+        - point_cloud_transport_plugins
+        - zlib_point_cloud_transport
+        - zstd_point_cloud_transport
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
@@ -6626,10 +6636,10 @@ repositories:
       version: main
     release:
       packages:
-      - polygon_demos
-      - polygon_msgs
-      - polygon_rviz_plugins
-      - polygon_utils
+        - polygon_demos
+        - polygon_msgs
+        - polygon_rviz_plugins
+        - polygon_utils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
@@ -6707,8 +6717,8 @@ repositories:
       version: main
     release:
       packages:
-      - psdk_interfaces
-      - psdk_wrapper
+        - psdk_interfaces
+        - psdk_wrapper
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
@@ -6725,7 +6735,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - ptz_action_server_msgs
+        - ptz_action_server_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
@@ -6742,9 +6752,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-      - clearpath_socketcan_interface
-      - puma_motor_driver
-      - puma_motor_msgs
+        - clearpath_socketcan_interface
+        - puma_motor_driver
+        - puma_motor_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
@@ -6882,7 +6892,7 @@ repositories:
       version: main
     release:
       packages:
-      - python_mrpt
+        - python_mrpt
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
@@ -6911,12 +6921,12 @@ repositories:
   qb_device:
     release:
       packages:
-      - qb_device
-      - qb_device_bringup
-      - qb_device_driver
-      - qb_device_msgs
-      - qb_device_ros2_control
-      - qb_device_test_controllers
+        - qb_device
+        - qb_device_bringup
+        - qb_device_driver
+        - qb_device_msgs
+        - qb_device_ros2_control
+        - qb_device_test_controllers
       tags:
         release: release/humble/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros2-release.git
@@ -6929,12 +6939,12 @@ repositories:
   qb_softhand_industry:
     release:
       packages:
-      - qb_softhand_industry
-      - qb_softhand_industry_description
-      - qb_softhand_industry_driver
-      - qb_softhand_industry_msgs
-      - qb_softhand_industry_ros2_control
-      - qb_softhand_industry_srvs
+        - qb_softhand_industry
+        - qb_softhand_industry_description
+        - qb_softhand_industry_driver
+        - qb_softhand_industry_msgs
+        - qb_softhand_industry_ros2_control
+        - qb_softhand_industry_srvs
       tags:
         release: release/humble/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbshin-ros2-release.git
@@ -6977,12 +6987,12 @@ repositories:
       version: humble
     release:
       packages:
-      - qt_dotgraph
-      - qt_gui
-      - qt_gui_app
-      - qt_gui_core
-      - qt_gui_cpp
-      - qt_gui_py_common
+        - qt_dotgraph
+        - qt_gui
+        - qt_gui_app
+        - qt_gui_core
+        - qt_gui_cpp
+        - qt_gui_py_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
@@ -7015,14 +7025,14 @@ repositories:
       version: humble
     release:
       packages:
-      - r2r_spl
-      - r2r_spl_7
-      - r2r_spl_8
-      - r2r_spl_test_interfaces
-      - splsm_7
-      - splsm_7_conversion
-      - splsm_8
-      - splsm_8_conversion
+        - r2r_spl
+        - r2r_spl_7
+        - r2r_spl_8
+        - r2r_spl_test_interfaces
+        - splsm_7
+        - splsm_7_conversion
+        - splsm_8
+        - splsm_8_conversion
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
@@ -7061,8 +7071,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - raspimouse
-      - raspimouse_msgs
+        - raspimouse
+        - raspimouse_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
@@ -7110,9 +7120,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - raspimouse_fake
-      - raspimouse_gazebo
-      - raspimouse_sim
+        - raspimouse_fake
+        - raspimouse_gazebo
+        - raspimouse_sim
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_sim-release.git
@@ -7129,9 +7139,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - raspimouse_navigation
-      - raspimouse_slam
-      - raspimouse_slam_navigation
+        - raspimouse_navigation
+        - raspimouse_slam
+        - raspimouse_slam_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
@@ -7213,8 +7223,8 @@ repositories:
       version: master
     release:
       packages:
-      - rc_reason_clients
-      - rc_reason_msgs
+        - rc_reason_clients
+        - rc_reason_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
@@ -7248,10 +7258,10 @@ repositories:
       version: humble
     release:
       packages:
-      - rcl
-      - rcl_action
-      - rcl_lifecycle
-      - rcl_yaml_param_parser
+        - rcl
+        - rcl_action
+        - rcl_lifecycle
+        - rcl_yaml_param_parser
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
@@ -7269,14 +7279,14 @@ repositories:
       version: humble
     release:
       packages:
-      - action_msgs
-      - builtin_interfaces
-      - composition_interfaces
-      - lifecycle_msgs
-      - rcl_interfaces
-      - rosgraph_msgs
-      - statistics_msgs
-      - test_msgs
+        - action_msgs
+        - builtin_interfaces
+        - composition_interfaces
+        - lifecycle_msgs
+        - rcl_interfaces
+        - rosgraph_msgs
+        - statistics_msgs
+        - test_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
@@ -7294,9 +7304,9 @@ repositories:
       version: humble
     release:
       packages:
-      - rcl_logging_interface
-      - rcl_logging_noop
-      - rcl_logging_spdlog
+        - rcl_logging_interface
+        - rcl_logging_noop
+        - rcl_logging_spdlog
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
@@ -7314,10 +7324,10 @@ repositories:
       version: humble
     release:
       packages:
-      - rclc
-      - rclc_examples
-      - rclc_lifecycle
-      - rclc_parameter
+        - rclc
+        - rclc_examples
+        - rclc_lifecycle
+        - rclc_parameter
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
@@ -7335,10 +7345,10 @@ repositories:
       version: humble
     release:
       packages:
-      - rclcpp
-      - rclcpp_action
-      - rclcpp_components
-      - rclcpp_lifecycle
+        - rclcpp
+        - rclcpp_action
+        - rclcpp_components
+        - rclcpp_lifecycle
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
@@ -7388,9 +7398,9 @@ repositories:
       version: humble
     release:
       packages:
-      - rcss3d_agent
-      - rcss3d_agent_basic
-      - rcss3d_agent_msgs
+        - rcss3d_agent
+        - rcss3d_agent_basic
+        - rcss3d_agent_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
@@ -7445,9 +7455,9 @@ repositories:
       version: ros2-master
     release:
       packages:
-      - realsense2_camera
-      - realsense2_camera_msgs
-      - realsense2_description
+        - realsense2_camera
+        - realsense2_camera_msgs
+        - realsense2_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
@@ -7464,8 +7474,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rttest
-      - tlsf_cpp
+        - rttest
+        - tlsf_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
@@ -7498,8 +7508,8 @@ repositories:
       version: humble
     release:
       packages:
-      - libcurl_vendor
-      - resource_retriever
+        - libcurl_vendor
+        - resource_retriever
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
@@ -7599,18 +7609,18 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_charger_msgs
-      - rmf_dispenser_msgs
-      - rmf_door_msgs
-      - rmf_fleet_msgs
-      - rmf_ingestor_msgs
-      - rmf_lift_msgs
-      - rmf_obstacle_msgs
-      - rmf_scheduler_msgs
-      - rmf_site_map_msgs
-      - rmf_task_msgs
-      - rmf_traffic_msgs
-      - rmf_workcell_msgs
+        - rmf_charger_msgs
+        - rmf_dispenser_msgs
+        - rmf_door_msgs
+        - rmf_fleet_msgs
+        - rmf_ingestor_msgs
+        - rmf_lift_msgs
+        - rmf_obstacle_msgs
+        - rmf_scheduler_msgs
+        - rmf_site_map_msgs
+        - rmf_task_msgs
+        - rmf_traffic_msgs
+        - rmf_workcell_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
@@ -7627,11 +7637,11 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_fleet_adapter
-      - rmf_fleet_adapter_python
-      - rmf_task_ros2
-      - rmf_traffic_ros2
-      - rmf_websocket
+        - rmf_fleet_adapter
+        - rmf_fleet_adapter_python
+        - rmf_task_ros2
+        - rmf_traffic_ros2
+        - rmf_websocket
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
@@ -7648,12 +7658,12 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_building_sim_common
-      - rmf_building_sim_gz_classic_plugins
-      - rmf_building_sim_gz_plugins
-      - rmf_robot_sim_common
-      - rmf_robot_sim_gz_classic_plugins
-      - rmf_robot_sim_gz_plugins
+        - rmf_building_sim_common
+        - rmf_building_sim_gz_classic_plugins
+        - rmf_building_sim_gz_plugins
+        - rmf_robot_sim_common
+        - rmf_robot_sim_gz_classic_plugins
+        - rmf_robot_sim_gz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
@@ -7670,8 +7680,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_task
-      - rmf_task_sequence
+        - rmf_task
+        - rmf_task_sequence
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
@@ -7688,8 +7698,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_traffic
-      - rmf_traffic_examples
+        - rmf_traffic
+        - rmf_traffic_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
@@ -7706,10 +7716,10 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_building_map_tools
-      - rmf_traffic_editor
-      - rmf_traffic_editor_assets
-      - rmf_traffic_editor_test_maps
+        - rmf_building_map_tools
+        - rmf_traffic_editor
+        - rmf_traffic_editor_assets
+        - rmf_traffic_editor_test_maps
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
@@ -7741,7 +7751,7 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_dev
+        - rmf_dev
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
@@ -7758,14 +7768,14 @@ repositories:
       version: humble
     release:
       packages:
-      - rmf_visualization
-      - rmf_visualization_building_systems
-      - rmf_visualization_fleet_states
-      - rmf_visualization_floorplans
-      - rmf_visualization_navgraphs
-      - rmf_visualization_obstacles
-      - rmf_visualization_rviz2_plugins
-      - rmf_visualization_schedule
+        - rmf_visualization
+        - rmf_visualization_building_systems
+        - rmf_visualization_fleet_states
+        - rmf_visualization_floorplans
+        - rmf_visualization_navgraphs
+        - rmf_visualization_obstacles
+        - rmf_visualization_rviz2_plugins
+        - rmf_visualization_schedule
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
@@ -7797,8 +7807,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rmw
-      - rmw_implementation_cmake
+        - rmw
+        - rmw_implementation_cmake
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
@@ -7816,9 +7826,9 @@ repositories:
       version: humble
     release:
       packages:
-      - rmw_connextdds
-      - rmw_connextdds_common
-      - rti_connext_dds_cmake_module
+        - rmw_connextdds
+        - rmw_connextdds_common
+        - rti_connext_dds_cmake_module
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
@@ -7835,7 +7845,7 @@ repositories:
       version: humble
     release:
       packages:
-      - rmw_cyclonedds_cpp
+        - rmw_cyclonedds_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
@@ -7869,9 +7879,9 @@ repositories:
       version: humble
     release:
       packages:
-      - rmw_fastrtps_cpp
-      - rmw_fastrtps_dynamic_cpp
-      - rmw_fastrtps_shared_cpp
+        - rmw_fastrtps_cpp
+        - rmw_fastrtps_dynamic_cpp
+        - rmw_fastrtps_shared_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
@@ -7889,8 +7899,8 @@ repositories:
       version: humble
     release:
       packages:
-      - gurumdds_cmake_module
-      - rmw_gurumdds_cpp
+        - gurumdds_cmake_module
+        - rmw_gurumdds_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
@@ -7923,8 +7933,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rmw_zenoh_cpp
-      - zenoh_cpp_vendor
+        - rmw_zenoh_cpp
+        - zenoh_cpp_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
@@ -7951,8 +7961,8 @@ repositories:
       version: humble
     release:
       packages:
-      - robot_calibration
-      - robot_calibration_msgs
+        - robot_calibration
+        - robot_calibration_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
@@ -7969,9 +7979,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - robot_controllers
-      - robot_controllers_interface
-      - robot_controllers_msgs
+        - robot_controllers
+        - robot_controllers_interface
+        - robot_controllers_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
@@ -8073,19 +8083,19 @@ repositories:
       version: humble
     release:
       packages:
-      - canopen
-      - canopen_402_driver
-      - canopen_base_driver
-      - canopen_core
-      - canopen_fake_slaves
-      - canopen_interfaces
-      - canopen_master_driver
-      - canopen_proxy_driver
-      - canopen_ros2_control
-      - canopen_ros2_controllers
-      - canopen_tests
-      - canopen_utils
-      - lely_core_libraries
+        - canopen
+        - canopen_402_driver
+        - canopen_base_driver
+        - canopen_core
+        - canopen_fake_slaves
+        - canopen_interfaces
+        - canopen_master_driver
+        - canopen_proxy_driver
+        - canopen_ros2_control
+        - canopen_ros2_controllers
+        - canopen_tests
+        - canopen_utils
+        - lely_core_libraries
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
@@ -8102,17 +8112,17 @@ repositories:
       version: humble
     release:
       packages:
-      - controller_interface
-      - controller_manager
-      - controller_manager_msgs
-      - hardware_interface
-      - hardware_interface_testing
-      - joint_limits
-      - ros2_control
-      - ros2_control_test_assets
-      - ros2controlcli
-      - rqt_controller_manager
-      - transmission_interface
+        - controller_interface
+        - controller_manager
+        - controller_manager_msgs
+        - hardware_interface
+        - hardware_interface_testing
+        - joint_limits
+        - ros2_control
+        - ros2_control_test_assets
+        - ros2controlcli
+        - rqt_controller_manager
+        - transmission_interface
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
@@ -8129,29 +8139,29 @@ repositories:
       version: humble
     release:
       packages:
-      - ackermann_steering_controller
-      - admittance_controller
-      - bicycle_steering_controller
-      - diff_drive_controller
-      - effort_controllers
-      - force_torque_sensor_broadcaster
-      - forward_command_controller
-      - gpio_controllers
-      - gripper_controllers
-      - imu_sensor_broadcaster
-      - joint_state_broadcaster
-      - joint_trajectory_controller
-      - pid_controller
-      - pose_broadcaster
-      - position_controllers
-      - range_sensor_broadcaster
-      - ros2_controllers
-      - ros2_controllers_test_nodes
-      - rqt_joint_trajectory_controller
-      - steering_controllers_library
-      - tricycle_controller
-      - tricycle_steering_controller
-      - velocity_controllers
+        - ackermann_steering_controller
+        - admittance_controller
+        - bicycle_steering_controller
+        - diff_drive_controller
+        - effort_controllers
+        - force_torque_sensor_broadcaster
+        - forward_command_controller
+        - gpio_controllers
+        - gripper_controllers
+        - imu_sensor_broadcaster
+        - joint_state_broadcaster
+        - joint_trajectory_controller
+        - pid_controller
+        - pose_broadcaster
+        - position_controllers
+        - range_sensor_broadcaster
+        - ros2_controllers
+        - ros2_controllers_test_nodes
+        - rqt_joint_trajectory_controller
+        - steering_controllers_library
+        - tricycle_controller
+        - tricycle_steering_controller
+        - velocity_controllers
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
@@ -8168,12 +8178,12 @@ repositories:
       version: main
     release:
       packages:
-      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-      - kortex_api
-      - kortex_bringup
-      - kortex_description
-      - kortex_driver
+        - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+        - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+        - kortex_api
+        - kortex_bringup
+        - kortex_description
+        - kortex_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
@@ -8190,8 +8200,8 @@ repositories:
       version: foxy-devel
     release:
       packages:
-      - ouster_msgs
-      - ros2_ouster
+        - ouster_msgs
+        - ros2_ouster
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
@@ -8209,19 +8219,19 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - plansys2_bringup
-      - plansys2_bt_actions
-      - plansys2_core
-      - plansys2_domain_expert
-      - plansys2_executor
-      - plansys2_lifecycle_manager
-      - plansys2_msgs
-      - plansys2_pddl_parser
-      - plansys2_planner
-      - plansys2_popf_plan_solver
-      - plansys2_problem_expert
-      - plansys2_terminal
-      - plansys2_tools
+        - plansys2_bringup
+        - plansys2_bt_actions
+        - plansys2_core
+        - plansys2_domain_expert
+        - plansys2_executor
+        - plansys2_lifecycle_manager
+        - plansys2_msgs
+        - plansys2_pddl_parser
+        - plansys2_planner
+        - plansys2_popf_plan_solver
+        - plansys2_problem_expert
+        - plansys2_terminal
+        - plansys2_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
@@ -8238,8 +8248,8 @@ repositories:
       version: main
     release:
       packages:
-      - robotiq_controllers
-      - robotiq_description
+        - robotiq_controllers
+        - robotiq_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
@@ -8256,8 +8266,8 @@ repositories:
       version: main
     release:
       packages:
-      - ros2_socketcan
-      - ros2_socketcan_msgs
+        - ros2_socketcan
+        - ros2_socketcan_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
@@ -8274,12 +8284,12 @@ repositories:
       version: humble
     release:
       packages:
-      - ros2trace
-      - tracetools
-      - tracetools_launch
-      - tracetools_read
-      - tracetools_test
-      - tracetools_trace
+        - ros2trace
+        - tracetools
+        - tracetools_launch
+        - tracetools_read
+        - tracetools_test
+        - tracetools_trace
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
@@ -8327,21 +8337,21 @@ repositories:
       version: humble
     release:
       packages:
-      - ros2action
-      - ros2cli
-      - ros2cli_test_interfaces
-      - ros2component
-      - ros2doctor
-      - ros2interface
-      - ros2lifecycle
-      - ros2lifecycle_test_fixtures
-      - ros2multicast
-      - ros2node
-      - ros2param
-      - ros2pkg
-      - ros2run
-      - ros2service
-      - ros2topic
+        - ros2action
+        - ros2cli
+        - ros2cli_test_interfaces
+        - ros2component
+        - ros2doctor
+        - ros2interface
+        - ros2lifecycle
+        - ros2lifecycle_test_fixtures
+        - ros2multicast
+        - ros2node
+        - ros2param
+        - ros2pkg
+        - ros2run
+        - ros2service
+        - ros2topic
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
@@ -8374,8 +8384,8 @@ repositories:
       version: main
     release:
       packages:
-      - ros2launch_security
-      - ros2launch_security_examples
+        - ros2launch_security
+        - ros2launch_security_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
@@ -8393,8 +8403,8 @@ repositories:
       version: humble
     release:
       packages:
-      - ros_babel_fish
-      - ros_babel_fish_test_msgs
+        - ros_babel_fish
+        - ros_babel_fish_test_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
@@ -8407,7 +8417,7 @@ repositories:
   ros_canopen:
     release:
       packages:
-      - can_msgs
+        - can_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
@@ -8440,19 +8450,19 @@ repositories:
       version: humble
     release:
       packages:
-      - ros_gz
-      - ros_gz_bridge
-      - ros_gz_image
-      - ros_gz_interfaces
-      - ros_gz_sim
-      - ros_gz_sim_demos
-      - ros_ign
-      - ros_ign_bridge
-      - ros_ign_gazebo
-      - ros_ign_gazebo_demos
-      - ros_ign_image
-      - ros_ign_interfaces
-      - test_ros_gz_bridge
+        - ros_gz
+        - ros_gz_bridge
+        - ros_gz_image
+        - ros_gz_interfaces
+        - ros_gz_sim
+        - ros_gz_sim_demos
+        - ros_ign
+        - ros_ign_bridge
+        - ros_ign_gazebo
+        - ros_ign_gazebo_demos
+        - ros_ign_image
+        - ros_ign_interfaces
+        - test_ros_gz_bridge
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
@@ -8490,8 +8500,8 @@ repositories:
       version: humble
     release:
       packages:
-      - ros2test
-      - ros_testing
+        - ros2test
+        - ros_testing
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
@@ -8509,7 +8519,7 @@ repositories:
       version: humble
     release:
       packages:
-      - turtlesim
+        - turtlesim
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
@@ -8538,25 +8548,25 @@ repositories:
       version: humble
     release:
       packages:
-      - mcap_vendor
-      - ros2bag
-      - rosbag2
-      - rosbag2_compression
-      - rosbag2_compression_zstd
-      - rosbag2_cpp
-      - rosbag2_interfaces
-      - rosbag2_performance_benchmarking
-      - rosbag2_py
-      - rosbag2_storage
-      - rosbag2_storage_default_plugins
-      - rosbag2_storage_mcap
-      - rosbag2_storage_mcap_testdata
-      - rosbag2_test_common
-      - rosbag2_tests
-      - rosbag2_transport
-      - shared_queues_vendor
-      - sqlite3_vendor
-      - zstd_vendor
+        - mcap_vendor
+        - ros2bag
+        - rosbag2
+        - rosbag2_compression
+        - rosbag2_compression_zstd
+        - rosbag2_cpp
+        - rosbag2_interfaces
+        - rosbag2_performance_benchmarking
+        - rosbag2_py
+        - rosbag2_storage
+        - rosbag2_storage_default_plugins
+        - rosbag2_storage_mcap
+        - rosbag2_storage_mcap_testdata
+        - rosbag2_test_common
+        - rosbag2_tests
+        - rosbag2_transport
+        - shared_queues_vendor
+        - sqlite3_vendor
+        - zstd_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
@@ -8574,8 +8584,8 @@ repositories:
       version: master
     release:
       packages:
-      - ros1_rosbag_storage_vendor
-      - rosbag2_bag_v2_plugins
+        - ros1_rosbag_storage_vendor
+        - rosbag2_bag_v2_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
@@ -8607,13 +8617,13 @@ repositories:
       version: humble
     release:
       packages:
-      - rosapi
-      - rosapi_msgs
-      - rosbridge_library
-      - rosbridge_msgs
-      - rosbridge_server
-      - rosbridge_suite
-      - rosbridge_test_msgs
+        - rosapi
+        - rosapi_msgs
+        - rosbridge_library
+        - rosbridge_msgs
+        - rosbridge_server
+        - rosbridge_suite
+        - rosbridge_test_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
@@ -8630,17 +8640,17 @@ repositories:
       version: humble
     release:
       packages:
-      - rosidl_adapter
-      - rosidl_cli
-      - rosidl_cmake
-      - rosidl_generator_c
-      - rosidl_generator_cpp
-      - rosidl_parser
-      - rosidl_runtime_c
-      - rosidl_runtime_cpp
-      - rosidl_typesupport_interface
-      - rosidl_typesupport_introspection_c
-      - rosidl_typesupport_introspection_cpp
+        - rosidl_adapter
+        - rosidl_cli
+        - rosidl_cmake
+        - rosidl_generator_c
+        - rosidl_generator_cpp
+        - rosidl_parser
+        - rosidl_runtime_c
+        - rosidl_runtime_cpp
+        - rosidl_typesupport_interface
+        - rosidl_typesupport_introspection_c
+        - rosidl_typesupport_introspection_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
@@ -8658,7 +8668,7 @@ repositories:
       version: humble
     release:
       packages:
-      - rosidl_generator_dds_idl
+        - rosidl_generator_dds_idl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
@@ -8676,8 +8686,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rosidl_default_generators
-      - rosidl_default_runtime
+        - rosidl_default_generators
+        - rosidl_default_runtime
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
@@ -8695,7 +8705,7 @@ repositories:
       version: humble
     release:
       packages:
-      - rosidl_generator_py
+        - rosidl_generator_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
@@ -8729,8 +8739,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rosidl_typesupport_c
-      - rosidl_typesupport_cpp
+        - rosidl_typesupport_c
+        - rosidl_typesupport_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
@@ -8748,9 +8758,9 @@ repositories:
       version: humble
     release:
       packages:
-      - fastrtps_cmake_module
-      - rosidl_typesupport_fastrtps_c
-      - rosidl_typesupport_fastrtps_cpp
+        - fastrtps_cmake_module
+        - rosidl_typesupport_fastrtps_c
+        - rosidl_typesupport_fastrtps_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
@@ -8768,8 +8778,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rclpy_message_converter
-      - rclpy_message_converter_msgs
+        - rclpy_message_converter
+        - rclpy_message_converter_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
@@ -8798,7 +8808,7 @@ repositories:
   rot_conv_lib:
     release:
       packages:
-      - rot_conv
+        - rot_conv
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
@@ -8847,11 +8857,11 @@ repositories:
       version: humble
     release:
       packages:
-      - rqt
-      - rqt_gui
-      - rqt_gui_cpp
-      - rqt_gui_py
-      - rqt_py_common
+        - rqt
+        - rqt_gui
+        - rqt_gui_cpp
+        - rqt_gui_py
+        - rqt_py_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
@@ -8884,8 +8894,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rqt_bag
-      - rqt_bag_plugins
+        - rqt_bag
+        - rqt_bag_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
@@ -8979,8 +8989,8 @@ repositories:
       version: humble
     release:
       packages:
-      - rqt_image_overlay
-      - rqt_image_overlay_layer
+        - rqt_image_overlay
+        - rqt_image_overlay_layer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
@@ -9255,8 +9265,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - rt_manipulators_cpp
-      - rt_manipulators_examples
+        - rt_manipulators_cpp
+        - rt_manipulators_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
@@ -9303,19 +9313,19 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - rtabmap_conversions
-      - rtabmap_demos
-      - rtabmap_examples
-      - rtabmap_launch
-      - rtabmap_msgs
-      - rtabmap_odom
-      - rtabmap_python
-      - rtabmap_ros
-      - rtabmap_rviz_plugins
-      - rtabmap_slam
-      - rtabmap_sync
-      - rtabmap_util
-      - rtabmap_viz
+        - rtabmap_conversions
+        - rtabmap_demos
+        - rtabmap_examples
+        - rtabmap_launch
+        - rtabmap_msgs
+        - rtabmap_odom
+        - rtabmap_python
+        - rtabmap_ros
+        - rtabmap_rviz_plugins
+        - rtabmap_slam
+        - rtabmap_sync
+        - rtabmap_util
+        - rtabmap_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
@@ -9358,14 +9368,14 @@ repositories:
       version: humble
     release:
       packages:
-      - rviz2
-      - rviz_assimp_vendor
-      - rviz_common
-      - rviz_default_plugins
-      - rviz_ogre_vendor
-      - rviz_rendering
-      - rviz_rendering_tests
-      - rviz_visual_testing_framework
+        - rviz2
+        - rviz_assimp_vendor
+        - rviz_common
+        - rviz_default_plugins
+        - rviz_ogre_vendor
+        - rviz_rendering
+        - rviz_rendering_tests
+        - rviz_visual_testing_framework
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
@@ -9383,8 +9393,8 @@ repositories:
       version: main
     release:
       packages:
-      - rviz_2d_overlay_msgs
-      - rviz_2d_overlay_plugins
+        - rviz_2d_overlay_msgs
+        - rviz_2d_overlay_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
@@ -9448,17 +9458,17 @@ repositories:
       version: humble
     release:
       packages:
-      - scenario_execution
-      - scenario_execution_control
-      - scenario_execution_coverage
-      - scenario_execution_gazebo
-      - scenario_execution_interfaces
-      - scenario_execution_nav2
-      - scenario_execution_os
-      - scenario_execution_py_trees_ros
-      - scenario_execution_ros
-      - scenario_execution_rviz
-      - scenario_execution_x11
+        - scenario_execution
+        - scenario_execution_control
+        - scenario_execution_coverage
+        - scenario_execution_gazebo
+        - scenario_execution_interfaces
+        - scenario_execution_nav2
+        - scenario_execution_os
+        - scenario_execution_py_trees_ros
+        - scenario_execution_ros
+        - scenario_execution_rviz
+        - scenario_execution_x11
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
@@ -9490,9 +9500,9 @@ repositories:
       version: ros2-humble
     release:
       packages:
-      - schunk_svh_description
-      - schunk_svh_driver
-      - schunk_svh_tests
+        - schunk_svh_description
+        - schunk_svh_driver
+        - schunk_svh_tests
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/schunk_svh_ros_driver-release.git
@@ -9509,8 +9519,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - sdformat_test_files
-      - sdformat_urdf
+        - sdformat_test_files
+        - sdformat_urdf
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
@@ -9604,9 +9614,9 @@ repositories:
       version: main
     release:
       packages:
-      - sick_safevisionary_driver
-      - sick_safevisionary_interfaces
-      - sick_safevisionary_tests
+        - sick_safevisionary_driver
+        - sick_safevisionary_interfaces
+        - sick_safevisionary_tests
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
@@ -9806,8 +9816,8 @@ repositories:
       version: humble
     release:
       packages:
-      - smacc2
-      - smacc2_msgs
+        - smacc2
+        - smacc2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
@@ -9824,10 +9834,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - executive_smach
-      - smach
-      - smach_msgs
-      - smach_ros
+        - executive_smach
+        - smach
+        - smach_msgs
+        - smach_ros
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
@@ -9865,10 +9875,10 @@ repositories:
       version: humble
     release:
       packages:
-      - soccer_interfaces
-      - soccer_vision_2d_msgs
-      - soccer_vision_3d_msgs
-      - soccer_vision_attribute_msgs
+        - soccer_interfaces
+        - soccer_vision_2d_msgs
+        - soccer_vision_3d_msgs
+        - soccer_vision_attribute_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
@@ -9900,7 +9910,7 @@ repositories:
       version: rolling
     release:
       packages:
-      - soccer_marker_generation
+        - soccer_marker_generation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_visualization-release.git
@@ -9917,8 +9927,8 @@ repositories:
       version: main
     release:
       packages:
-      - social_nav_msgs
-      - social_nav_util
+        - social_nav_msgs
+        - social_nav_util
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/social_nav_ros-release.git
@@ -9966,8 +9976,8 @@ repositories:
       version: humble
     release:
       packages:
-      - openvdb_vendor
-      - spatio_temporal_voxel_layer
+        - openvdb_vendor
+        - spatio_temporal_voxel_layer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
@@ -10011,8 +10021,8 @@ repositories:
       version: humble
     release:
       packages:
-      - sros2
-      - sros2_cmake
+        - sros2
+        - sros2_cmake
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
@@ -10055,8 +10065,8 @@ repositories:
       version: main
     release:
       packages:
-      - stubborn_buddies
-      - stubborn_buddies_msgs
+        - stubborn_buddies
+        - stubborn_buddies_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/stubborn_buddies-release.git
@@ -10120,10 +10130,10 @@ repositories:
       version: master
     release:
       packages:
-      - launch_system_modes
-      - system_modes
-      - system_modes_examples
-      - system_modes_msgs
+        - launch_system_modes
+        - system_modes
+        - system_modes_examples
+        - system_modes_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
@@ -10155,12 +10165,12 @@ repositories:
   talos_robot:
     release:
       packages:
-      - talos_bringup
-      - talos_controller_configuration
-      - talos_description
-      - talos_description_calibration
-      - talos_description_inertial
-      - talos_robot
+        - talos_bringup
+        - talos_controller_configuration
+        - talos_description
+        - talos_description_calibration
+        - talos_description_inertial
+        - talos_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
@@ -10173,7 +10183,7 @@ repositories:
   talos_simulation:
     release:
       packages:
-      - talos_gazebo
+        - talos_gazebo
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_simulation-release.git
@@ -10201,11 +10211,11 @@ repositories:
       version: master
     release:
       packages:
-      - joy_teleop
-      - key_teleop
-      - mouse_teleop
-      - teleop_tools
-      - teleop_tools_msgs
+        - joy_teleop
+        - key_teleop
+        - mouse_teleop
+        - teleop_tools
+        - teleop_tools_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
@@ -10322,9 +10332,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - tiago_2dnav
-      - tiago_laser_sensors
-      - tiago_navigation
+        - tiago_2dnav
+        - tiago_laser_sensors
+        - tiago_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
@@ -10341,10 +10351,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - tiago_bringup
-      - tiago_controller_configuration
-      - tiago_description
-      - tiago_robot
+        - tiago_bringup
+        - tiago_controller_configuration
+        - tiago_description
+        - tiago_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
@@ -10361,8 +10371,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - tiago_gazebo
-      - tiago_simulation
+        - tiago_gazebo
+        - tiago_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
@@ -10444,8 +10454,8 @@ repositories:
       version: humble
     release:
       packages:
-      - topic_tools
-      - topic_tools_interfaces
+        - topic_tools
+        - topic_tools_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
@@ -10478,8 +10488,8 @@ repositories:
       version: humble
     release:
       packages:
-      - ros2trace_analysis
-      - tracetools_analysis
+        - ros2trace_analysis
+        - tracetools_analysis
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
@@ -10496,10 +10506,10 @@ repositories:
       version: main
     release:
       packages:
-      - asio_cmake_module
-      - io_context
-      - serial_driver
-      - udp_driver
+        - asio_cmake_module
+        - io_context
+        - serial_driver
+        - udp_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
@@ -10546,14 +10556,14 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - turtlebot3
-      - turtlebot3_bringup
-      - turtlebot3_cartographer
-      - turtlebot3_description
-      - turtlebot3_example
-      - turtlebot3_navigation2
-      - turtlebot3_node
-      - turtlebot3_teleop
+        - turtlebot3
+        - turtlebot3_bringup
+        - turtlebot3_cartographer
+        - turtlebot3_description
+        - turtlebot3_example
+        - turtlebot3_navigation2
+        - turtlebot3_node
+        - turtlebot3_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3-release.git
@@ -10570,14 +10580,14 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - turtlebot3_manipulation
-      - turtlebot3_manipulation_bringup
-      - turtlebot3_manipulation_cartographer
-      - turtlebot3_manipulation_description
-      - turtlebot3_manipulation_hardware
-      - turtlebot3_manipulation_moveit_config
-      - turtlebot3_manipulation_navigation2
-      - turtlebot3_manipulation_teleop
+        - turtlebot3_manipulation
+        - turtlebot3_manipulation_bringup
+        - turtlebot3_manipulation_cartographer
+        - turtlebot3_manipulation_description
+        - turtlebot3_manipulation_hardware
+        - turtlebot3_manipulation_moveit_config
+        - turtlebot3_manipulation_navigation2
+        - turtlebot3_manipulation_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
@@ -10609,9 +10619,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - turtlebot3_fake_node
-      - turtlebot3_gazebo
-      - turtlebot3_simulations
+        - turtlebot3_fake_node
+        - turtlebot3_gazebo
+        - turtlebot3_simulations
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
@@ -10628,10 +10638,10 @@ repositories:
       version: humble
     release:
       packages:
-      - turtlebot4_description
-      - turtlebot4_msgs
-      - turtlebot4_navigation
-      - turtlebot4_node
+        - turtlebot4_description
+        - turtlebot4_msgs
+        - turtlebot4_navigation
+        - turtlebot4_node
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
@@ -10648,8 +10658,8 @@ repositories:
       version: humble
     release:
       packages:
-      - turtlebot4_desktop
-      - turtlebot4_viz
+        - turtlebot4_desktop
+        - turtlebot4_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
@@ -10666,11 +10676,11 @@ repositories:
       version: humble
     release:
       packages:
-      - turtlebot4_base
-      - turtlebot4_bringup
-      - turtlebot4_diagnostics
-      - turtlebot4_robot
-      - turtlebot4_tests
+        - turtlebot4_base
+        - turtlebot4_bringup
+        - turtlebot4_diagnostics
+        - turtlebot4_robot
+        - turtlebot4_tests
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
@@ -10702,10 +10712,10 @@ repositories:
       version: humble
     release:
       packages:
-      - turtlebot4_ignition_bringup
-      - turtlebot4_ignition_gui_plugins
-      - turtlebot4_ignition_toolbox
-      - turtlebot4_simulator
+        - turtlebot4_ignition_bringup
+        - turtlebot4_ignition_gui_plugins
+        - turtlebot4_ignition_toolbox
+        - turtlebot4_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
@@ -10722,9 +10732,9 @@ repositories:
       version: humble
     release:
       packages:
-      - turtlebot4_cpp_tutorials
-      - turtlebot4_python_tutorials
-      - turtlebot4_tutorials
+        - turtlebot4_cpp_tutorials
+        - turtlebot4_python_tutorials
+        - turtlebot4_tutorials
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
@@ -10756,16 +10766,16 @@ repositories:
       version: ros2
     release:
       packages:
-      - tuw_airskin_msgs
-      - tuw_geo_msgs
-      - tuw_geometry_msgs
-      - tuw_graph_msgs
-      - tuw_msgs
-      - tuw_multi_robot_msgs
-      - tuw_nav_msgs
-      - tuw_object_map_msgs
-      - tuw_object_msgs
-      - tuw_std_msgs
+        - tuw_airskin_msgs
+        - tuw_geo_msgs
+        - tuw_geometry_msgs
+        - tuw_graph_msgs
+        - tuw_msgs
+        - tuw_multi_robot_msgs
+        - tuw_nav_msgs
+        - tuw_object_map_msgs
+        - tuw_object_msgs
+        - tuw_std_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
@@ -10842,10 +10852,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - ublox
-      - ublox_gps
-      - ublox_msgs
-      - ublox_serialization
+        - ublox
+        - ublox_gps
+        - ublox_msgs
+        - ublox_serialization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
@@ -10863,12 +10873,12 @@ repositories:
       version: main
     release:
       packages:
-      - ntrip_client_node
-      - ublox_dgnss
-      - ublox_dgnss_node
-      - ublox_nav_sat_fix_hp_node
-      - ublox_ubx_interfaces
-      - ublox_ubx_msgs
+        - ntrip_client_node
+        - ublox_dgnss
+        - ublox_dgnss_node
+        - ublox_nav_sat_fix_hp_node
+        - ublox_ubx_interfaces
+        - ublox_ubx_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
@@ -10987,13 +10997,13 @@ repositories:
       version: humble
     release:
       packages:
-      - ur
-      - ur_bringup
-      - ur_calibration
-      - ur_controllers
-      - ur_dashboard_msgs
-      - ur_moveit_config
-      - ur_robot_driver
+        - ur
+        - ur_bringup
+        - ur_calibration
+        - ur_controllers
+        - ur_dashboard_msgs
+        - ur_moveit_config
+        - ur_robot_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
@@ -11021,8 +11031,8 @@ repositories:
       version: humble
     release:
       packages:
-      - urdf
-      - urdf_parser_plugin
+        - urdf
+        - urdf_parser_plugin
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
@@ -11056,7 +11066,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - urdfdom_py
+        - urdfdom_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
@@ -11229,12 +11239,12 @@ repositories:
       version: humble
     release:
       packages:
-      - desktop
-      - desktop_full
-      - perception
-      - ros_base
-      - ros_core
-      - simulation
+        - desktop
+        - desktop_full
+        - perception
+        - ros_base
+        - ros_core
+        - simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
@@ -11267,11 +11277,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - velodyne
-      - velodyne_driver
-      - velodyne_laserscan
-      - velodyne_msgs
-      - velodyne_pointcloud
+        - velodyne
+        - velodyne_driver
+        - velodyne_laserscan
+        - velodyne_msgs
+        - velodyne_pointcloud
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
@@ -11288,9 +11298,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-      - velodyne_description
-      - velodyne_gazebo_plugins
-      - velodyne_simulator
+        - velodyne_description
+        - velodyne_gazebo_plugins
+        - velodyne_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
@@ -11307,11 +11317,11 @@ repositories:
       version: humble
     release:
       packages:
-      - vimbax_camera
-      - vimbax_camera_events
-      - vimbax_camera_examples
-      - vimbax_camera_msgs
-      - vmbc_interface
+        - vimbax_camera
+        - vimbax_camera_events
+        - vimbax_camera_examples
+        - vimbax_camera_msgs
+        - vmbc_interface
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vimbax_ros2_driver-release.git
@@ -11328,8 +11338,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - vision_msgs
-      - vision_msgs_rviz_plugins
+        - vision_msgs
+        - vision_msgs_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
@@ -11362,9 +11372,9 @@ repositories:
       version: humble
     release:
       packages:
-      - cv_bridge
-      - image_geometry
-      - vision_opencv
+        - cv_bridge
+        - image_geometry
+        - vision_opencv
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -11526,18 +11536,18 @@ repositories:
       version: master
     release:
       packages:
-      - webots_ros2
-      - webots_ros2_control
-      - webots_ros2_driver
-      - webots_ros2_epuck
-      - webots_ros2_importer
-      - webots_ros2_mavic
-      - webots_ros2_msgs
-      - webots_ros2_tesla
-      - webots_ros2_tests
-      - webots_ros2_tiago
-      - webots_ros2_turtlebot
-      - webots_ros2_universal_robot
+        - webots_ros2
+        - webots_ros2_control
+        - webots_ros2_driver
+        - webots_ros2_epuck
+        - webots_ros2_importer
+        - webots_ros2_mavic
+        - webots_ros2_msgs
+        - webots_ros2_tesla
+        - webots_ros2_tests
+        - webots_ros2_tiago
+        - webots_ros2_turtlebot
+        - webots_ros2_universal_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
@@ -11590,8 +11600,8 @@ repositories:
       version: foxy-devel
     release:
       packages:
-      - wireless_msgs
-      - wireless_watcher
+        - wireless_msgs
+        - wireless_watcher
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
@@ -11650,11 +11660,11 @@ repositories:
       version: main
     release:
       packages:
-      - yasmin
-      - yasmin_demos
-      - yasmin_msgs
-      - yasmin_ros
-      - yasmin_viewer
+        - yasmin
+        - yasmin_demos
+        - yasmin_msgs
+        - yasmin_ros
+        - yasmin_viewer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
@@ -11686,7 +11696,7 @@ repositories:
       version: master
     release:
       packages:
-      - zed_msgs
+        - zed_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4,9 +4,9 @@
 ---
 release_platforms:
   rhel:
-    - "8"
+  - '8'
   ubuntu:
-    - jammy
+  - jammy
 repositories:
   aandd_ekew_driver_py:
     doc:
@@ -114,33 +114,33 @@ repositories:
       version: main
     release:
       packages:
-        - aerostack2
-        - as2_alphanumeric_viewer
-        - as2_behavior
-        - as2_behavior_tree
-        - as2_behaviors_motion
-        - as2_behaviors_path_planning
-        - as2_behaviors_perception
-        - as2_behaviors_platform
-        - as2_behaviors_trajectory_generation
-        - as2_cli
-        - as2_core
-        - as2_external_object_to_tf
-        - as2_gazebo_assets
-        - as2_geozones
-        - as2_keyboard_teleoperation
-        - as2_map_server
-        - as2_motion_controller
-        - as2_motion_reference_handlers
-        - as2_msgs
-        - as2_platform_gazebo
-        - as2_platform_multirotor_simulator
-        - as2_python_api
-        - as2_realsense_interface
-        - as2_rviz_plugins
-        - as2_state_estimator
-        - as2_usb_camera_interface
-        - as2_visualization
+      - aerostack2
+      - as2_alphanumeric_viewer
+      - as2_behavior
+      - as2_behavior_tree
+      - as2_behaviors_motion
+      - as2_behaviors_path_planning
+      - as2_behaviors_perception
+      - as2_behaviors_platform
+      - as2_behaviors_trajectory_generation
+      - as2_cli
+      - as2_core
+      - as2_external_object_to_tf
+      - as2_gazebo_assets
+      - as2_geozones
+      - as2_keyboard_teleoperation
+      - as2_map_server
+      - as2_motion_controller
+      - as2_motion_reference_handlers
+      - as2_msgs
+      - as2_platform_gazebo
+      - as2_platform_multirotor_simulator
+      - as2_python_api
+      - as2_realsense_interface
+      - as2_rviz_plugins
+      - as2_state_estimator
+      - as2_usb_camera_interface
+      - as2_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aerostack2-release.git
@@ -190,8 +190,8 @@ repositories:
   ament_black:
     release:
       packages:
-        - ament_black
-        - ament_cmake_black
+      - ament_black
+      - ament_cmake_black
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
@@ -208,29 +208,29 @@ repositories:
       version: humble
     release:
       packages:
-        - ament_cmake
-        - ament_cmake_auto
-        - ament_cmake_core
-        - ament_cmake_export_definitions
-        - ament_cmake_export_dependencies
-        - ament_cmake_export_include_directories
-        - ament_cmake_export_interfaces
-        - ament_cmake_export_libraries
-        - ament_cmake_export_link_flags
-        - ament_cmake_export_targets
-        - ament_cmake_gen_version_h
-        - ament_cmake_gmock
-        - ament_cmake_google_benchmark
-        - ament_cmake_gtest
-        - ament_cmake_include_directories
-        - ament_cmake_libraries
-        - ament_cmake_nose
-        - ament_cmake_pytest
-        - ament_cmake_python
-        - ament_cmake_target_dependencies
-        - ament_cmake_test
-        - ament_cmake_vendor_package
-        - ament_cmake_version
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_export_targets
+      - ament_cmake_gen_version_h
+      - ament_cmake_gmock
+      - ament_cmake_google_benchmark
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_vendor_package
+      - ament_cmake_version
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
@@ -263,8 +263,8 @@ repositories:
       version: humble
     release:
       packages:
-        - ament_cmake_ros
-        - domain_coordinator
+      - ament_cmake_ros
+      - domain_coordinator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
@@ -297,8 +297,8 @@ repositories:
       version: humble
     release:
       packages:
-        - ament_index_cpp
-        - ament_index_python
+      - ament_index_cpp
+      - ament_index_python
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
@@ -316,37 +316,37 @@ repositories:
       version: humble
     release:
       packages:
-        - ament_clang_format
-        - ament_clang_tidy
-        - ament_cmake_clang_format
-        - ament_cmake_clang_tidy
-        - ament_cmake_copyright
-        - ament_cmake_cppcheck
-        - ament_cmake_cpplint
-        - ament_cmake_flake8
-        - ament_cmake_lint_cmake
-        - ament_cmake_mypy
-        - ament_cmake_pclint
-        - ament_cmake_pep257
-        - ament_cmake_pycodestyle
-        - ament_cmake_pyflakes
-        - ament_cmake_uncrustify
-        - ament_cmake_xmllint
-        - ament_copyright
-        - ament_cppcheck
-        - ament_cpplint
-        - ament_flake8
-        - ament_lint
-        - ament_lint_auto
-        - ament_lint_cmake
-        - ament_lint_common
-        - ament_mypy
-        - ament_pclint
-        - ament_pep257
-        - ament_pycodestyle
-        - ament_pyflakes
-        - ament_uncrustify
-        - ament_xmllint
+      - ament_clang_format
+      - ament_clang_tidy
+      - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_mypy
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pycodestyle
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_mypy
+      - ament_pclint
+      - ament_pep257
+      - ament_pycodestyle
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
@@ -407,16 +407,16 @@ repositories:
       version: humble
     release:
       packages:
-        - andino_apps
-        - andino_base
-        - andino_bringup
-        - andino_control
-        - andino_description
-        - andino_firmware
-        - andino_gz_classic
-        - andino_hardware
-        - andino_navigation
-        - andino_slam
+      - andino_apps
+      - andino_base
+      - andino_bringup
+      - andino_control
+      - andino_description
+      - andino_firmware
+      - andino_gz_classic
+      - andino_hardware
+      - andino_navigation
+      - andino_slam
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/andino-release.git
@@ -481,8 +481,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - apex_test_tools
-        - test_apex_test_tools
+      - apex_test_tools
+      - test_apex_test_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
@@ -514,10 +514,10 @@ repositories:
       version: humble
     release:
       packages:
-        - apriltag_detector
-        - apriltag_detector_mit
-        - apriltag_detector_umich
-        - apriltag_draw
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
@@ -571,8 +571,8 @@ repositories:
       version: humble
     release:
       packages:
-        - aruco_opencv
-        - aruco_opencv_msgs
+      - aruco_opencv
+      - aruco_opencv_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
@@ -589,9 +589,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - aruco
-        - aruco_msgs
-        - aruco_ros
+      - aruco
+      - aruco_msgs
+      - aruco_ros
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
@@ -699,14 +699,14 @@ repositories:
       version: master
     release:
       packages:
-        - delphi_esr_msgs
-        - delphi_mrr_msgs
-        - delphi_srr_msgs
-        - derived_object_msgs
-        - ibeo_msgs
-        - kartech_linear_actuator_msgs
-        - mobileye_560_660_msgs
-        - neobotix_usboard_msgs
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
@@ -753,9 +753,9 @@ repositories:
       version: master
     release:
       packages:
-        - automotive_autonomy_msgs
-        - automotive_navigation_msgs
-        - automotive_platform_msgs
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
@@ -768,8 +768,8 @@ repositories:
   autoware_adapi_msgs:
     release:
       packages:
-        - autoware_adapi_v1_msgs
-        - autoware_adapi_version_msgs
+      - autoware_adapi_v1_msgs
+      - autoware_adapi_version_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
@@ -797,8 +797,8 @@ repositories:
   autoware_cmake:
     release:
       packages:
-        - autoware_cmake
-        - autoware_lint_common
+      - autoware_cmake
+      - autoware_lint_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
@@ -815,9 +815,9 @@ repositories:
       version: main
     release:
       packages:
-        - autoware_internal_debug_msgs
-        - autoware_internal_msgs
-        - autoware_internal_perception_msgs
+      - autoware_internal_debug_msgs
+      - autoware_internal_msgs
+      - autoware_internal_perception_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
@@ -830,8 +830,8 @@ repositories:
   autoware_lanelet2_extension:
     release:
       packages:
-        - autoware_lanelet2_extension
-        - autoware_lanelet2_extension_python
+      - autoware_lanelet2_extension
+      - autoware_lanelet2_extension_python
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
@@ -848,16 +848,16 @@ repositories:
       version: main
     release:
       packages:
-        - autoware_common_msgs
-        - autoware_control_msgs
-        - autoware_localization_msgs
-        - autoware_map_msgs
-        - autoware_perception_msgs
-        - autoware_planning_msgs
-        - autoware_sensing_msgs
-        - autoware_system_msgs
-        - autoware_v2x_msgs
-        - autoware_vehicle_msgs
+      - autoware_common_msgs
+      - autoware_control_msgs
+      - autoware_localization_msgs
+      - autoware_map_msgs
+      - autoware_perception_msgs
+      - autoware_planning_msgs
+      - autoware_sensing_msgs
+      - autoware_system_msgs
+      - autoware_v2x_msgs
+      - autoware_vehicle_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
@@ -900,7 +900,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - aws_robomaker_small_warehouse_world
+      - aws_robomaker_small_warehouse_world
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
@@ -932,9 +932,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - axis_camera
-        - axis_description
-        - axis_msgs
+      - axis_camera
+      - axis_description
+      - axis_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
@@ -1011,7 +1011,7 @@ repositories:
       version: master
     release:
       packages:
-        - behaviortree_cpp
+      - behaviortree_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
@@ -1028,9 +1028,9 @@ repositories:
       version: main
     release:
       packages:
-        - beluga
-        - beluga_amcl
-        - beluga_ros
+      - beluga
+      - beluga_amcl
+      - beluga_ros
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
@@ -1064,10 +1064,10 @@ repositories:
       version: galactic
     release:
       packages:
-        - bond
-        - bond_core
-        - bondcpp
-        - smclib
+      - bond
+      - bond_core
+      - bondcpp
+      - smclib
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
@@ -1111,8 +1111,8 @@ repositories:
       version: main
     release:
       packages:
-        - camera_aravis2
-        - camera_aravis2_msgs
+      - camera_aravis2
+      - camera_aravis2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/camera_aravis2-release.git
@@ -1176,7 +1176,7 @@ repositories:
       version: main
     release:
       packages:
-        - caret_msgs
+      - caret_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/caret_trace-release.git
@@ -1209,9 +1209,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - cartographer_ros
-        - cartographer_ros_msgs
-        - cartographer_rviz
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
@@ -1229,8 +1229,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - cascade_lifecycle_msgs
-        - rclcpp_cascade_lifecycle
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
@@ -1294,16 +1294,16 @@ repositories:
       version: humble
     release:
       packages:
-        - clearpath_common
-        - clearpath_control
-        - clearpath_customization
-        - clearpath_description
-        - clearpath_generator_common
-        - clearpath_manipulators
-        - clearpath_manipulators_description
-        - clearpath_mounts_description
-        - clearpath_platform_description
-        - clearpath_sensors_description
+      - clearpath_common
+      - clearpath_control
+      - clearpath_customization
+      - clearpath_description
+      - clearpath_generator_common
+      - clearpath_manipulators
+      - clearpath_manipulators_description
+      - clearpath_mounts_description
+      - clearpath_platform_description
+      - clearpath_sensors_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
@@ -1335,9 +1335,9 @@ repositories:
       version: main
     release:
       packages:
-        - clearpath_config_live
-        - clearpath_desktop
-        - clearpath_viz
+      - clearpath_config_live
+      - clearpath_desktop
+      - clearpath_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
@@ -1361,9 +1361,9 @@ repositories:
       version: main
     release:
       packages:
-        - clearpath_motor_msgs
-        - clearpath_msgs
-        - clearpath_platform_msgs
+      - clearpath_motor_msgs
+      - clearpath_msgs
+      - clearpath_platform_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
@@ -1410,9 +1410,9 @@ repositories:
       version: main
     release:
       packages:
-        - clearpath_generator_gz
-        - clearpath_gz
-        - clearpath_simulator
+      - clearpath_generator_gz
+      - clearpath_gz
+      - clearpath_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
@@ -1435,9 +1435,9 @@ repositories:
       version: foxy
     release:
       packages:
-        - cob_actions
-        - cob_msgs
-        - cob_srvs
+      - cob_actions
+      - cob_msgs
+      - cob_srvs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/4am-robotics/cob_common-release.git
@@ -1485,19 +1485,19 @@ repositories:
       version: humble
     release:
       packages:
-        - actionlib_msgs
-        - common_interfaces
-        - diagnostic_msgs
-        - geometry_msgs
-        - nav_msgs
-        - sensor_msgs
-        - sensor_msgs_py
-        - shape_msgs
-        - std_msgs
-        - std_srvs
-        - stereo_msgs
-        - trajectory_msgs
-        - visualization_msgs
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - sensor_msgs_py
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
@@ -1573,8 +1573,8 @@ repositories:
   cpp_polyfills:
     release:
       packages:
-        - tcb_span
-        - tl_expected
+      - tcb_span
+      - tl_expected
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
@@ -1591,12 +1591,12 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - crane_plus
-        - crane_plus_control
-        - crane_plus_description
-        - crane_plus_examples
-        - crane_plus_gazebo
-        - crane_plus_moveit_config
+      - crane_plus
+      - crane_plus_control
+      - crane_plus_description
+      - crane_plus_examples
+      - crane_plus_gazebo
+      - crane_plus_moveit_config
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/crane_plus-release.git
@@ -1609,12 +1609,12 @@ repositories:
   create3_examples:
     release:
       packages:
-        - create3_coverage
-        - create3_examples_msgs
-        - create3_examples_py
-        - create3_lidar_slam
-        - create3_republisher
-        - create3_teleop
+      - create3_coverage
+      - create3_examples_msgs
+      - create3_examples_py
+      - create3_lidar_slam
+      - create3_republisher
+      - create3_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/create3_examples-release.git
@@ -1627,18 +1627,18 @@ repositories:
   create3_sim:
     release:
       packages:
-        - irobot_create_common_bringup
-        - irobot_create_control
-        - irobot_create_description
-        - irobot_create_gazebo_bringup
-        - irobot_create_gazebo_plugins
-        - irobot_create_gazebo_sim
-        - irobot_create_ignition_bringup
-        - irobot_create_ignition_plugins
-        - irobot_create_ignition_sim
-        - irobot_create_ignition_toolbox
-        - irobot_create_nodes
-        - irobot_create_toolbox
+      - irobot_create_common_bringup
+      - irobot_create_control
+      - irobot_create_description
+      - irobot_create_gazebo_bringup
+      - irobot_create_gazebo_plugins
+      - irobot_create_gazebo_sim
+      - irobot_create_ignition_bringup
+      - irobot_create_ignition_plugins
+      - irobot_create_ignition_sim
+      - irobot_create_ignition_toolbox
+      - irobot_create_nodes
+      - irobot_create_toolbox
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
@@ -1655,11 +1655,11 @@ repositories:
       version: humble
     release:
       packages:
-        - create_bringup
-        - create_description
-        - create_driver
-        - create_msgs
-        - create_robot
+      - create_bringup
+      - create_description
+      - create_driver
+      - create_msgs
+      - create_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/AutonomyLab/create_autonomy-release.git
@@ -1702,8 +1702,8 @@ repositories:
       version: main
     release:
       packages:
-        - data_tamer_cpp
-        - data_tamer_msgs
+      - data_tamer_cpp
+      - data_tamer_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
@@ -1720,11 +1720,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - dataspeed_can
-        - dataspeed_can_msg_filters
-        - dataspeed_can_msgs
-        - dataspeed_can_tools
-        - dataspeed_can_usb
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_msgs
+      - dataspeed_can_tools
+      - dataspeed_can_usb
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
@@ -1741,29 +1741,29 @@ repositories:
       version: ros2
     release:
       packages:
-        - dataspeed_dbw_common
-        - dataspeed_ulc
-        - dataspeed_ulc_can
-        - dataspeed_ulc_msgs
-        - dbw_fca
-        - dbw_fca_can
-        - dbw_fca_description
-        - dbw_fca_joystick_demo
-        - dbw_fca_msgs
-        - dbw_ford
-        - dbw_ford_can
-        - dbw_ford_description
-        - dbw_ford_joystick_demo
-        - dbw_ford_msgs
-        - dbw_polaris
-        - dbw_polaris_can
-        - dbw_polaris_description
-        - dbw_polaris_joystick_demo
-        - dbw_polaris_msgs
-        - ds_dbw
-        - ds_dbw_can
-        - ds_dbw_joystick_demo
-        - ds_dbw_msgs
+      - dataspeed_dbw_common
+      - dataspeed_ulc
+      - dataspeed_ulc_can
+      - dataspeed_ulc_msgs
+      - dbw_fca
+      - dbw_fca_can
+      - dbw_fca_description
+      - dbw_fca_joystick_demo
+      - dbw_fca_msgs
+      - dbw_ford
+      - dbw_ford_can
+      - dbw_ford_description
+      - dbw_ford_joystick_demo
+      - dbw_ford_msgs
+      - dbw_polaris
+      - dbw_polaris_can
+      - dbw_polaris_description
+      - dbw_polaris_joystick_demo
+      - dbw_polaris_msgs
+      - ds_dbw
+      - ds_dbw_can
+      - ds_dbw_joystick_demo
+      - ds_dbw_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
@@ -1780,27 +1780,27 @@ repositories:
       version: humble
     release:
       packages:
-        - action_tutorials_cpp
-        - action_tutorials_interfaces
-        - action_tutorials_py
-        - composition
-        - demo_nodes_cpp
-        - demo_nodes_cpp_native
-        - demo_nodes_py
-        - dummy_map_server
-        - dummy_robot_bringup
-        - dummy_sensors
-        - image_tools
-        - intra_process_demo
-        - lifecycle
-        - lifecycle_py
-        - logging_demo
-        - pendulum_control
-        - pendulum_msgs
-        - quality_of_service_demo_cpp
-        - quality_of_service_demo_py
-        - topic_monitor
-        - topic_statistics_demo
+      - action_tutorials_cpp
+      - action_tutorials_interfaces
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - lifecycle_py
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      - topic_statistics_demo
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
@@ -1834,13 +1834,13 @@ repositories:
       version: humble
     release:
       packages:
-        - depthai-ros
-        - depthai_bridge
-        - depthai_descriptions
-        - depthai_examples
-        - depthai_filters
-        - depthai_ros_driver
-        - depthai_ros_msgs
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
@@ -1874,11 +1874,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - diagnostic_aggregator
-        - diagnostic_common_diagnostics
-        - diagnostic_updater
-        - diagnostics
-        - self_test
+      - diagnostic_aggregator
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - self_test
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
@@ -1896,10 +1896,10 @@ repositories:
       version: galactic
     release:
       packages:
-        - dolly
-        - dolly_follow
-        - dolly_gazebo
-        - dolly_ignition
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
@@ -1958,9 +1958,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - dynamixel_sdk
-        - dynamixel_sdk_custom_interfaces
-        - dynamixel_sdk_examples
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
@@ -1977,8 +1977,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - dynamixel_workbench
-        - dynamixel_workbench_toolbox
+      - dynamixel_workbench
+      - dynamixel_workbench_toolbox
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
@@ -2025,31 +2025,31 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-        - ecl_command_line
-        - ecl_concepts
-        - ecl_containers
-        - ecl_converters
-        - ecl_core
-        - ecl_core_apps
-        - ecl_devices
-        - ecl_eigen
-        - ecl_exceptions
-        - ecl_filesystem
-        - ecl_formatters
-        - ecl_geometry
-        - ecl_ipc
-        - ecl_linear_algebra
-        - ecl_manipulators
-        - ecl_math
-        - ecl_mobile_robot
-        - ecl_mpl
-        - ecl_sigslots
-        - ecl_statistics
-        - ecl_streams
-        - ecl_threads
-        - ecl_time
-        - ecl_type_traits
-        - ecl_utilities
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
@@ -2066,14 +2066,14 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-        - ecl_config
-        - ecl_console
-        - ecl_converters_lite
-        - ecl_errors
-        - ecl_io
-        - ecl_lite
-        - ecl_sigslots_lite
-        - ecl_time_lite
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
@@ -2090,9 +2090,9 @@ repositories:
       version: release/1.0.x
     release:
       packages:
-        - ecl_build
-        - ecl_license
-        - ecl_tools
+      - ecl_build
+      - ecl_license
+      - ecl_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
@@ -2185,34 +2185,34 @@ repositories:
       version: main
     release:
       packages:
-        - etsi_its_cam_coding
-        - etsi_its_cam_conversion
-        - etsi_its_cam_msgs
-        - etsi_its_cam_ts_coding
-        - etsi_its_cam_ts_conversion
-        - etsi_its_cam_ts_msgs
-        - etsi_its_coding
-        - etsi_its_conversion
-        - etsi_its_cpm_ts_coding
-        - etsi_its_cpm_ts_conversion
-        - etsi_its_cpm_ts_msgs
-        - etsi_its_denm_coding
-        - etsi_its_denm_conversion
-        - etsi_its_denm_msgs
-        - etsi_its_mapem_ts_coding
-        - etsi_its_mapem_ts_conversion
-        - etsi_its_mapem_ts_msgs
-        - etsi_its_messages
-        - etsi_its_msgs
-        - etsi_its_msgs_utils
-        - etsi_its_primitives_conversion
-        - etsi_its_rviz_plugins
-        - etsi_its_spatem_ts_coding
-        - etsi_its_spatem_ts_conversion
-        - etsi_its_spatem_ts_msgs
-        - etsi_its_vam_ts_coding
-        - etsi_its_vam_ts_conversion
-        - etsi_its_vam_ts_msgs
+      - etsi_its_cam_coding
+      - etsi_its_cam_conversion
+      - etsi_its_cam_msgs
+      - etsi_its_cam_ts_coding
+      - etsi_its_cam_ts_conversion
+      - etsi_its_cam_ts_msgs
+      - etsi_its_coding
+      - etsi_its_conversion
+      - etsi_its_cpm_ts_coding
+      - etsi_its_cpm_ts_conversion
+      - etsi_its_cpm_ts_msgs
+      - etsi_its_denm_coding
+      - etsi_its_denm_conversion
+      - etsi_its_denm_msgs
+      - etsi_its_mapem_ts_coding
+      - etsi_its_mapem_ts_conversion
+      - etsi_its_mapem_ts_msgs
+      - etsi_its_messages
+      - etsi_its_msgs
+      - etsi_its_msgs_utils
+      - etsi_its_primitives_conversion
+      - etsi_its_rviz_plugins
+      - etsi_its_spatem_ts_coding
+      - etsi_its_spatem_ts_conversion
+      - etsi_its_spatem_ts_msgs
+      - etsi_its_vam_ts_coding
+      - etsi_its_vam_ts_conversion
+      - etsi_its_vam_ts_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
@@ -2305,28 +2305,28 @@ repositories:
       version: humble
     release:
       packages:
-        - examples_rclcpp_async_client
-        - examples_rclcpp_cbg_executor
-        - examples_rclcpp_minimal_action_client
-        - examples_rclcpp_minimal_action_server
-        - examples_rclcpp_minimal_client
-        - examples_rclcpp_minimal_composition
-        - examples_rclcpp_minimal_publisher
-        - examples_rclcpp_minimal_service
-        - examples_rclcpp_minimal_subscriber
-        - examples_rclcpp_minimal_timer
-        - examples_rclcpp_multithreaded_executor
-        - examples_rclcpp_wait_set
-        - examples_rclpy_executors
-        - examples_rclpy_guard_conditions
-        - examples_rclpy_minimal_action_client
-        - examples_rclpy_minimal_action_server
-        - examples_rclpy_minimal_client
-        - examples_rclpy_minimal_publisher
-        - examples_rclpy_minimal_service
-        - examples_rclpy_minimal_subscriber
-        - examples_rclpy_pointcloud_publisher
-        - launch_testing_examples
+      - examples_rclcpp_async_client
+      - examples_rclcpp_cbg_executor
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
+      - examples_rclcpp_wait_set
+      - examples_rclpy_executors
+      - examples_rclpy_guard_conditions
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      - examples_rclpy_pointcloud_publisher
+      - launch_testing_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
@@ -2354,8 +2354,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - fadecandy_driver
-        - fadecandy_msgs
+      - fadecandy_driver
+      - fadecandy_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/eurogroep/fadecandy_ros-release.git
@@ -2556,15 +2556,15 @@ repositories:
       version: humble
     release:
       packages:
-        - flexbe_behavior_engine
-        - flexbe_core
-        - flexbe_input
-        - flexbe_mirror
-        - flexbe_msgs
-        - flexbe_onboard
-        - flexbe_states
-        - flexbe_testing
-        - flexbe_widget
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
@@ -2581,10 +2581,10 @@ repositories:
       version: ros2-release
     release:
       packages:
-        - flir_camera_description
-        - flir_camera_msgs
-        - spinnaker_camera_driver
-        - spinnaker_synchronized_camera_driver
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_camera_driver-release.git
@@ -2617,8 +2617,8 @@ repositories:
       version: humble
     release:
       packages:
-        - fmi_adapter
-        - fmi_adapter_examples
+      - fmi_adapter
+      - fmi_adapter_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
@@ -2642,8 +2642,8 @@ repositories:
   fogros2:
     release:
       packages:
-        - fogros2
-        - fogros2_examples
+      - fogros2
+      - fogros2_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/fogros2-release.git
@@ -2671,10 +2671,10 @@ repositories:
       version: humble
     release:
       packages:
-        - foros
-        - foros_examples
-        - foros_inspector
-        - foros_msgs
+      - foros
+      - foros_examples
+      - foros_inspector
+      - foros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foros-release.git
@@ -2768,15 +2768,15 @@ repositories:
       version: humble
     release:
       packages:
-        - game_controller_spl
-        - game_controller_spl_interfaces
-        - gc_spl
-        - gc_spl_2022
-        - gc_spl_interfaces
-        - rcgcd_spl_14
-        - rcgcd_spl_14_conversion
-        - rcgcrd_spl_4
-        - rcgcrd_spl_4_conversion
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
+      - gc_spl_2022
+      - gc_spl_interfaces
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
@@ -2793,8 +2793,8 @@ repositories:
       version: humble
     release:
       packages:
-        - gazebo_model_attachment_plugin
-        - gazebo_model_attachment_plugin_msgs
+      - gazebo_model_attachment_plugin
+      - gazebo_model_attachment_plugin_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
@@ -2841,8 +2841,8 @@ repositories:
       version: humble
     release:
       packages:
-        - gazebo_ros2_control
-        - gazebo_ros2_control_demos
+      - gazebo_ros2_control
+      - gazebo_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
@@ -2859,11 +2859,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - gazebo_dev
-        - gazebo_msgs
-        - gazebo_plugins
-        - gazebo_ros
-        - gazebo_ros_pkgs
+      - gazebo_dev
+      - gazebo_msgs
+      - gazebo_plugins
+      - gazebo_ros
+      - gazebo_ros_pkgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
@@ -2896,10 +2896,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - gazebo_video_monitor_interfaces
-        - gazebo_video_monitor_plugins
-        - gazebo_video_monitor_utils
-        - gazebo_video_monitors
+      - gazebo_video_monitor_interfaces
+      - gazebo_video_monitor_plugins
+      - gazebo_video_monitor_utils
+      - gazebo_video_monitors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_video_monitors-release.git
@@ -2916,12 +2916,12 @@ repositories:
       version: main
     release:
       packages:
-        - cmake_generate_parameter_module_example
-        - generate_parameter_library
-        - generate_parameter_library_example
-        - generate_parameter_library_py
-        - generate_parameter_module_example
-        - parameter_traits
+      - cmake_generate_parameter_module_example
+      - generate_parameter_library
+      - generate_parameter_library_example
+      - generate_parameter_library_py
+      - generate_parameter_module_example
+      - parameter_traits
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
@@ -2938,9 +2938,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - geodesy
-        - geographic_info
-        - geographic_msgs
+      - geodesy
+      - geographic_info
+      - geographic_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -2973,20 +2973,20 @@ repositories:
       version: humble
     release:
       packages:
-        - examples_tf2_py
-        - geometry2
-        - tf2
-        - tf2_bullet
-        - tf2_eigen
-        - tf2_eigen_kdl
-        - tf2_geometry_msgs
-        - tf2_kdl
-        - tf2_msgs
-        - tf2_py
-        - tf2_ros
-        - tf2_ros_py
-        - tf2_sensor_msgs
-        - tf2_tools
+      - examples_tf2_py
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_eigen_kdl
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_ros_py
+      - tf2_sensor_msgs
+      - tf2_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
@@ -3004,9 +3004,9 @@ repositories:
       version: humble
     release:
       packages:
-        - geometry_tutorials
-        - turtle_tf2_cpp
-        - turtle_tf2_py
+      - geometry_tutorials
+      - turtle_tf2_cpp
+      - turtle_tf2_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
@@ -3035,8 +3035,8 @@ repositories:
   googletest:
     release:
       packages:
-        - gmock_vendor
-        - gtest_vendor
+      - gmock_vendor
+      - gtest_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
@@ -3053,10 +3053,10 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - gps_msgs
-        - gps_tools
-        - gps_umd
-        - gpsd_client
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
@@ -3134,21 +3134,21 @@ repositories:
       version: humble
     release:
       packages:
-        - grid_map
-        - grid_map_cmake_helpers
-        - grid_map_core
-        - grid_map_costmap_2d
-        - grid_map_cv
-        - grid_map_demos
-        - grid_map_filters
-        - grid_map_loader
-        - grid_map_msgs
-        - grid_map_octomap
-        - grid_map_pcl
-        - grid_map_ros
-        - grid_map_rviz_plugin
-        - grid_map_sdf
-        - grid_map_visualization
+      - grid_map
+      - grid_map_cmake_helpers
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/grid_map-release.git
@@ -3321,8 +3321,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - hri
-        - pyhri
+      - hri
+      - pyhri
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros4hri/libhri-release.git
@@ -3434,10 +3434,10 @@ repositories:
   iceoryx:
     release:
       packages:
-        - iceoryx_binding_c
-        - iceoryx_hoofs
-        - iceoryx_introspection
-        - iceoryx_posh
+      - iceoryx_binding_c
+      - iceoryx_hoofs
+      - iceoryx_introspection
+      - iceoryx_posh
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
@@ -3461,9 +3461,9 @@ repositories:
       version: humble
     release:
       packages:
-        - gz_ros2_control_tests
-        - ign_ros2_control
-        - ign_ros2_control_demos
+      - gz_ros2_control_tests
+      - ign_ros2_control
+      - ign_ros2_control_demos
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
@@ -3480,9 +3480,9 @@ repositories:
       version: main
     release:
       packages:
-        - ign_rviz
-        - ign_rviz_common
-        - ign_rviz_plugins
+      - ign_rviz
+      - ign_rviz_common
+      - ign_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
@@ -3531,11 +3531,11 @@ repositories:
       version: humble
     release:
       packages:
-        - camera_calibration_parsers
-        - camera_info_manager
-        - camera_info_manager_py
-        - image_common
-        - image_transport
+      - camera_calibration_parsers
+      - camera_info_manager
+      - camera_info_manager_py
+      - image_common
+      - image_transport
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
@@ -3553,15 +3553,15 @@ repositories:
       version: humble
     release:
       packages:
-        - camera_calibration
-        - depth_image_proc
-        - image_pipeline
-        - image_proc
-        - image_publisher
-        - image_rotate
-        - image_view
-        - stereo_image_proc
-        - tracetools_image_pipeline
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      - tracetools_image_pipeline
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
@@ -3579,10 +3579,10 @@ repositories:
       version: humble
     release:
       packages:
-        - compressed_depth_image_transport
-        - compressed_image_transport
-        - image_transport_plugins
-        - theora_image_transport
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
@@ -3600,9 +3600,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - imu_pipeline
-        - imu_processors
-        - imu_transformer
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
@@ -3619,10 +3619,10 @@ repositories:
       version: humble
     release:
       packages:
-        - imu_complementary_filter
-        - imu_filter_madgwick
-        - imu_tools
-        - rviz_imu_plugin
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
@@ -3692,8 +3692,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - joint_state_publisher
-        - joint_state_publisher_gui
+      - joint_state_publisher
+      - joint_state_publisher_gui
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
@@ -3726,12 +3726,12 @@ repositories:
       version: ros2
     release:
       packages:
-        - joy
-        - joy_linux
-        - sdl2_vendor
-        - spacenav
-        - wiimote
-        - wiimote_msgs
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      - spacenav
+      - wiimote
+      - wiimote_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
@@ -3781,8 +3781,8 @@ repositories:
       version: humble
     release:
       packages:
-        - kinematics_interface
-        - kinematics_interface_kdl
+      - kinematics_interface
+      - kinematics_interface_kdl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
@@ -3881,20 +3881,20 @@ repositories:
       version: humble
     release:
       packages:
-        - fri_configuration_controller
-        - fri_state_broadcaster
-        - iiqka_moveit_example
-        - joint_group_impedance_controller
-        - kuka_control_mode_handler
-        - kuka_controllers
-        - kuka_driver_interfaces
-        - kuka_drivers
-        - kuka_drivers_core
-        - kuka_event_broadcaster
-        - kuka_iiqka_eac_driver
-        - kuka_kss_rsi_driver
-        - kuka_rsi_simulator
-        - kuka_sunrise_fri_driver
+      - fri_configuration_controller
+      - fri_state_broadcaster
+      - iiqka_moveit_example
+      - joint_group_impedance_controller
+      - kuka_control_mode_handler
+      - kuka_controllers
+      - kuka_driver_interfaces
+      - kuka_drivers
+      - kuka_drivers_core
+      - kuka_event_broadcaster
+      - kuka_iiqka_eac_driver
+      - kuka_kss_rsi_driver
+      - kuka_rsi_simulator
+      - kuka_sunrise_fri_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_drivers-release.git
@@ -3911,8 +3911,8 @@ repositories:
       version: master
     release:
       packages:
-        - kuka_external_control_sdk
-        - kuka_external_control_sdk_examples
+      - kuka_external_control_sdk
+      - kuka_external_control_sdk_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
@@ -3929,19 +3929,19 @@ repositories:
       version: humble
     release:
       packages:
-        - kuka_agilus_support
-        - kuka_cybertech_support
-        - kuka_fortec_support
-        - kuka_iontec_support
-        - kuka_kr_moveit_config
-        - kuka_lbr_iisy_moveit_config
-        - kuka_lbr_iisy_support
-        - kuka_lbr_iiwa_moveit_config
-        - kuka_lbr_iiwa_support
-        - kuka_mock_hardware_interface
-        - kuka_quantec_support
-        - kuka_resources
-        - kuka_robot_descriptions
+      - kuka_agilus_support
+      - kuka_cybertech_support
+      - kuka_fortec_support
+      - kuka_iontec_support
+      - kuka_kr_moveit_config
+      - kuka_lbr_iisy_moveit_config
+      - kuka_lbr_iisy_support
+      - kuka_lbr_iiwa_moveit_config
+      - kuka_lbr_iiwa_support
+      - kuka_mock_hardware_interface
+      - kuka_quantec_support
+      - kuka_resources
+      - kuka_robot_descriptions
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_robot_descriptions-release.git
@@ -3958,17 +3958,17 @@ repositories:
       version: master
     release:
       packages:
-        - lanelet2
-        - lanelet2_core
-        - lanelet2_examples
-        - lanelet2_io
-        - lanelet2_maps
-        - lanelet2_matching
-        - lanelet2_projection
-        - lanelet2_python
-        - lanelet2_routing
-        - lanelet2_traffic_rules
-        - lanelet2_validation
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_matching
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
@@ -4043,12 +4043,12 @@ repositories:
       version: humble
     release:
       packages:
-        - launch
-        - launch_pytest
-        - launch_testing
-        - launch_testing_ament_cmake
-        - launch_xml
-        - launch_yaml
+      - launch
+      - launch_pytest
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
@@ -4096,9 +4096,9 @@ repositories:
       version: humble
     release:
       packages:
-        - launch_ros
-        - launch_testing_ros
-        - ros2launch
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
@@ -4116,10 +4116,10 @@ repositories:
       version: humble
     release:
       packages:
-        - leo
-        - leo_description
-        - leo_msgs
-        - leo_teleop
+      - leo
+      - leo_description
+      - leo_msgs
+      - leo_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
@@ -4136,8 +4136,8 @@ repositories:
       version: humble
     release:
       packages:
-        - leo_desktop
-        - leo_viz
+      - leo_desktop
+      - leo_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
@@ -4154,9 +4154,9 @@ repositories:
       version: humble
     release:
       packages:
-        - leo_bringup
-        - leo_fw
-        - leo_robot
+      - leo_bringup
+      - leo_fw
+      - leo_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
@@ -4173,10 +4173,10 @@ repositories:
       version: humble
     release:
       packages:
-        - leo_gz_bringup
-        - leo_gz_plugins
-        - leo_gz_worlds
-        - leo_simulator
+      - leo_gz_bringup
+      - leo_gz_plugins
+      - leo_gz_worlds
+      - leo_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
@@ -4398,8 +4398,8 @@ repositories:
       version: humble
     release:
       packages:
-        - bosch_locator_bridge
-        - bosch_locator_bridge_utils
+      - bosch_locator_bridge
+      - bosch_locator_bridge_utils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
@@ -4476,11 +4476,11 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - mapviz
-        - mapviz_interfaces
-        - mapviz_plugins
-        - multires_image
-        - tile_map
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
@@ -4497,8 +4497,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - marine_acoustic_msgs
-        - marine_sensor_msgs
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
@@ -4530,18 +4530,18 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - swri_cli_tools
-        - swri_console_util
-        - swri_dbw_interface
-        - swri_geometry_util
-        - swri_image_util
-        - swri_math_util
-        - swri_opencv_util
-        - swri_roscpp
-        - swri_route_util
-        - swri_serial_util
-        - swri_system_util
-        - swri_transform_util
+      - swri_cli_tools
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
@@ -4559,15 +4559,15 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - marti_can_msgs
-        - marti_common_msgs
-        - marti_dbw_msgs
-        - marti_introspection_msgs
-        - marti_nav_msgs
-        - marti_perception_msgs
-        - marti_sensor_msgs
-        - marti_status_msgs
-        - marti_visualization_msgs
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_introspection_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
@@ -4587,7 +4587,7 @@ repositories:
   marvelmind_ros2_release:
     release:
       packages:
-        - marvelmind_ros2
+      - marvelmind_ros2
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MarvelmindRobotics/marvelmind_ros2_release_repo.git
@@ -4618,10 +4618,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - libmavconn
-        - mavros
-        - mavros_extras
-        - mavros_msgs
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
@@ -4699,9 +4699,9 @@ repositories:
       version: main
     release:
       packages:
-        - collision_log_msgs
-        - metro_benchmark_msgs
-        - metro_benchmark_pub
+      - collision_log_msgs
+      - metro_benchmark_msgs
+      - metro_benchmark_pub
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/metrics_msgs-release.git
@@ -4724,8 +4724,8 @@ repositories:
       version: main
     release:
       packages:
-        - base2d_kinematics
-        - base2d_kinematics_msgs
+      - base2d_kinematics
+      - base2d_kinematics_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/metro_nav-release.git
@@ -4742,8 +4742,8 @@ repositories:
       version: master
     release:
       packages:
-        - micro_ros_diagnostic_bridge
-        - micro_ros_diagnostic_msgs
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
@@ -4775,11 +4775,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - microstrain_inertial_description
-        - microstrain_inertial_driver
-        - microstrain_inertial_examples
-        - microstrain_inertial_msgs
-        - microstrain_inertial_rqt
+      - microstrain_inertial_description
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
@@ -4823,15 +4823,15 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - mocap4r2_control
-        - mocap4r2_control_msgs
-        - mocap4r2_dummy_driver
-        - mocap4r2_marker_publisher
-        - mocap4r2_marker_viz
-        - mocap4r2_marker_viz_srvs
-        - mocap4r2_robot_gt
-        - mocap4r2_robot_gt_msgs
-        - rqt_mocap4r2_control
+      - mocap4r2_control
+      - mocap4r2_control_msgs
+      - mocap4r2_dummy_driver
+      - mocap4r2_marker_publisher
+      - mocap4r2_marker_viz
+      - mocap4r2_marker_viz_srvs
+      - mocap4r2_robot_gt
+      - mocap4r2_robot_gt_msgs
+      - rqt_mocap4r2_control
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2-release.git
@@ -4890,26 +4890,26 @@ repositories:
       version: develop
     release:
       packages:
-        - kitti_metrics_eval
-        - mola
-        - mola_bridge_ros2
-        - mola_demos
-        - mola_input_euroc_dataset
-        - mola_input_kitti360_dataset
-        - mola_input_kitti_dataset
-        - mola_input_mulran_dataset
-        - mola_input_paris_luco_dataset
-        - mola_input_rawlog
-        - mola_input_rosbag2
-        - mola_kernel
-        - mola_launcher
-        - mola_metric_maps
-        - mola_msgs
-        - mola_pose_list
-        - mola_relocalization
-        - mola_traj_tools
-        - mola_viz
-        - mola_yaml
+      - kitti_metrics_eval
+      - mola
+      - mola_bridge_ros2
+      - mola_demos
+      - mola_input_euroc_dataset
+      - mola_input_kitti360_dataset
+      - mola_input_kitti_dataset
+      - mola_input_mulran_dataset
+      - mola_input_paris_luco_dataset
+      - mola_input_rawlog
+      - mola_input_rosbag2
+      - mola_kernel
+      - mola_launcher
+      - mola_metric_maps
+      - mola_msgs
+      - mola_pose_list
+      - mola_relocalization
+      - mola_traj_tools
+      - mola_viz
+      - mola_yaml
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
@@ -4981,8 +4981,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - motion_capture_tracking
-        - motion_capture_tracking_interfaces
+      - motion_capture_tracking
+      - motion_capture_tracking_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
@@ -4999,44 +4999,44 @@ repositories:
       version: main
     release:
       packages:
-        - chomp_motion_planner
-        - moveit
-        - moveit_chomp_optimizer_adapter
-        - moveit_common
-        - moveit_configs_utils
-        - moveit_core
-        - moveit_hybrid_planning
-        - moveit_kinematics
-        - moveit_planners
-        - moveit_planners_chomp
-        - moveit_planners_ompl
-        - moveit_plugins
-        - moveit_resources_prbt_ikfast_manipulator_plugin
-        - moveit_resources_prbt_moveit_config
-        - moveit_resources_prbt_pg70_support
-        - moveit_resources_prbt_support
-        - moveit_ros
-        - moveit_ros_benchmarks
-        - moveit_ros_control_interface
-        - moveit_ros_move_group
-        - moveit_ros_occupancy_map_monitor
-        - moveit_ros_perception
-        - moveit_ros_planning
-        - moveit_ros_planning_interface
-        - moveit_ros_robot_interaction
-        - moveit_ros_visualization
-        - moveit_ros_warehouse
-        - moveit_runtime
-        - moveit_servo
-        - moveit_setup_app_plugins
-        - moveit_setup_assistant
-        - moveit_setup_controllers
-        - moveit_setup_core_plugins
-        - moveit_setup_framework
-        - moveit_setup_srdf_plugins
-        - moveit_simple_controller_manager
-        - pilz_industrial_motion_planner
-        - pilz_industrial_motion_planner_testutils
+      - chomp_motion_planner
+      - moveit
+      - moveit_chomp_optimizer_adapter
+      - moveit_common
+      - moveit_configs_utils
+      - moveit_core
+      - moveit_hybrid_planning
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_plugins
+      - moveit_resources_prbt_ikfast_manipulator_plugin
+      - moveit_resources_prbt_moveit_config
+      - moveit_resources_prbt_pg70_support
+      - moveit_resources_prbt_support
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_setup_app_plugins
+      - moveit_setup_assistant
+      - moveit_setup_controllers
+      - moveit_setup_core_plugins
+      - moveit_setup_framework
+      - moveit_setup_srdf_plugins
+      - moveit_simple_controller_manager
+      - pilz_industrial_motion_planner
+      - pilz_industrial_motion_planner_testutils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
@@ -5070,12 +5070,12 @@ repositories:
       version: ros2
     release:
       packages:
-        - moveit_resources
-        - moveit_resources_fanuc_description
-        - moveit_resources_fanuc_moveit_config
-        - moveit_resources_panda_description
-        - moveit_resources_panda_moveit_config
-        - moveit_resources_pr2_description
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -5122,8 +5122,8 @@ repositories:
       version: main
     release:
       packages:
-        - mqtt_client
-        - mqtt_client_interfaces
+      - mqtt_client
+      - mqtt_client_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
@@ -5155,16 +5155,16 @@ repositories:
       version: ros2
     release:
       packages:
-        - mrpt_map_server
-        - mrpt_msgs_bridge
-        - mrpt_nav_interfaces
-        - mrpt_navigation
-        - mrpt_pf_localization
-        - mrpt_pointcloud_pipeline
-        - mrpt_rawlog
-        - mrpt_reactivenav2d
-        - mrpt_tps_astar_planner
-        - mrpt_tutorials
+      - mrpt_map_server
+      - mrpt_msgs_bridge
+      - mrpt_nav_interfaces
+      - mrpt_navigation
+      - mrpt_pf_localization
+      - mrpt_pointcloud_pipeline
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tps_astar_planner
+      - mrpt_tutorials
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
@@ -5196,20 +5196,20 @@ repositories:
       version: main
     release:
       packages:
-        - mrpt_apps
-        - mrpt_libapps
-        - mrpt_libbase
-        - mrpt_libgui
-        - mrpt_libhwdrivers
-        - mrpt_libmaps
-        - mrpt_libmath
-        - mrpt_libnav
-        - mrpt_libobs
-        - mrpt_libopengl
-        - mrpt_libposes
-        - mrpt_libros_bridge
-        - mrpt_libslam
-        - mrpt_libtclap
+      - mrpt_apps
+      - mrpt_libapps
+      - mrpt_libbase
+      - mrpt_libgui
+      - mrpt_libhwdrivers
+      - mrpt_libmaps
+      - mrpt_libmath
+      - mrpt_libnav
+      - mrpt_libobs
+      - mrpt_libopengl
+      - mrpt_libposes
+      - mrpt_libros_bridge
+      - mrpt_libslam
+      - mrpt_libtclap
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
@@ -5226,13 +5226,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - mrpt_generic_sensor
-        - mrpt_sensor_bumblebee_stereo
-        - mrpt_sensor_gnss_nmea
-        - mrpt_sensor_gnss_novatel
-        - mrpt_sensor_imu_taobotics
-        - mrpt_sensorlib
-        - mrpt_sensors
+      - mrpt_generic_sensor
+      - mrpt_sensor_bumblebee_stereo
+      - mrpt_sensor_gnss_nmea
+      - mrpt_sensor_gnss_novatel
+      - mrpt_sensor_imu_taobotics
+      - mrpt_sensorlib
+      - mrpt_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
@@ -5319,8 +5319,8 @@ repositories:
       version: humble
     release:
       packages:
-        - nao_command_msgs
-        - nao_sensor_msgs
+      - nao_command_msgs
+      - nao_sensor_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
@@ -5368,7 +5368,7 @@ repositories:
       version: main
     release:
       packages:
-        - naoqi_bridge_msgs
+      - naoqi_bridge_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
@@ -5431,45 +5431,45 @@ repositories:
       version: humble
     release:
       packages:
-        - costmap_queue
-        - dwb_core
-        - dwb_critics
-        - dwb_msgs
-        - dwb_plugins
-        - nav2_amcl
-        - nav2_behavior_tree
-        - nav2_behaviors
-        - nav2_bringup
-        - nav2_bt_navigator
-        - nav2_collision_monitor
-        - nav2_common
-        - nav2_constrained_smoother
-        - nav2_controller
-        - nav2_core
-        - nav2_costmap_2d
-        - nav2_dwb_controller
-        - nav2_graceful_controller
-        - nav2_lifecycle_manager
-        - nav2_map_server
-        - nav2_mppi_controller
-        - nav2_msgs
-        - nav2_navfn_planner
-        - nav2_planner
-        - nav2_regulated_pure_pursuit_controller
-        - nav2_rotation_shim_controller
-        - nav2_rviz_plugins
-        - nav2_simple_commander
-        - nav2_smac_planner
-        - nav2_smoother
-        - nav2_system_tests
-        - nav2_theta_star_planner
-        - nav2_util
-        - nav2_velocity_smoother
-        - nav2_voxel_grid
-        - nav2_waypoint_follower
-        - nav_2d_msgs
-        - nav_2d_utils
-        - navigation2
+      - costmap_queue
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_behavior_tree
+      - nav2_behaviors
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_collision_monitor
+      - nav2_common
+      - nav2_constrained_smoother
+      - nav2_controller
+      - nav2_core
+      - nav2_costmap_2d
+      - nav2_dwb_controller
+      - nav2_graceful_controller
+      - nav2_lifecycle_manager
+      - nav2_map_server
+      - nav2_mppi_controller
+      - nav2_msgs
+      - nav2_navfn_planner
+      - nav2_planner
+      - nav2_regulated_pure_pursuit_controller
+      - nav2_rotation_shim_controller
+      - nav2_rviz_plugins
+      - nav2_simple_commander
+      - nav2_smac_planner
+      - nav2_smoother
+      - nav2_system_tests
+      - nav2_theta_star_planner
+      - nav2_util
+      - nav2_velocity_smoother
+      - nav2_voxel_grid
+      - nav2_waypoint_follower
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
@@ -5486,7 +5486,7 @@ repositories:
       version: humble
     release:
       packages:
-        - map_msgs
+      - map_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -5549,7 +5549,7 @@ repositories:
       version: default
     release:
       packages:
-        - nerian_stereo
+      - nerian_stereo
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo_ros2-release.git
@@ -5656,8 +5656,8 @@ repositories:
       version: master
     release:
       packages:
-        - nodl_python
-        - ros2nodl
+      - nodl_python
+      - ros2nodl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
@@ -5690,8 +5690,8 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - novatel_gps_driver
-        - novatel_gps_msgs
+      - novatel_gps_driver
+      - novatel_gps_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
@@ -5708,8 +5708,8 @@ repositories:
       version: humble
     release:
       packages:
-        - novatel_oem7_driver
-        - novatel_oem7_msgs
+      - novatel_oem7_driver
+      - novatel_oem7_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
@@ -5769,9 +5769,9 @@ repositories:
       version: devel
     release:
       packages:
-        - dynamic_edt_3d
-        - octomap
-        - octovis
+      - dynamic_edt_3d
+      - octomap
+      - octovis
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
@@ -5788,8 +5788,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - octomap_mapping
-        - octomap_server
+      - octomap_mapping
+      - octomap_server
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
@@ -5866,17 +5866,17 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - off_highway_can
-        - off_highway_general_purpose_radar
-        - off_highway_general_purpose_radar_msgs
-        - off_highway_premium_radar_sample
-        - off_highway_premium_radar_sample_msgs
-        - off_highway_radar
-        - off_highway_radar_msgs
-        - off_highway_sensor_drivers
-        - off_highway_sensor_drivers_examples
-        - off_highway_uss
-        - off_highway_uss_msgs
+      - off_highway_can
+      - off_highway_general_purpose_radar
+      - off_highway_general_purpose_radar_msgs
+      - off_highway_premium_radar_sample
+      - off_highway_premium_radar_sample_msgs
+      - off_highway_radar
+      - off_highway_radar_msgs
+      - off_highway_sensor_drivers
+      - off_highway_sensor_drivers_examples
+      - off_highway_uss
+      - off_highway_uss_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
@@ -5893,10 +5893,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - omni_base_2dnav
-        - omni_base_laser_sensors
-        - omni_base_navigation
-        - omni_base_rgbd_sensors
+      - omni_base_2dnav
+      - omni_base_laser_sensors
+      - omni_base_navigation
+      - omni_base_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_navigation-release.git
@@ -5913,10 +5913,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - omni_base_bringup
-        - omni_base_controller_configuration
-        - omni_base_description
-        - omni_base_robot
+      - omni_base_bringup
+      - omni_base_controller_configuration
+      - omni_base_description
+      - omni_base_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
@@ -5933,8 +5933,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - omni_base_gazebo
-        - omni_base_simulation
+      - omni_base_gazebo
+      - omni_base_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_simulation-release.git
@@ -5972,10 +5972,10 @@ repositories:
       version: humble
     release:
       packages:
-        - opennav_docking
-        - opennav_docking_bt
-        - opennav_docking_core
-        - opennav_docking_msgs
+      - opennav_docking
+      - opennav_docking_bt
+      - opennav_docking_core
+      - opennav_docking_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/open-navigation/opennav_docking-release.git
@@ -6003,8 +6003,8 @@ repositories:
   orocos_kdl_vendor:
     release:
       packages:
-        - orocos_kdl_vendor
-        - python_orocos_kdl_vendor
+      - orocos_kdl_vendor
+      - python_orocos_kdl_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
@@ -6074,8 +6074,8 @@ repositories:
       version: master
     release:
       packages:
-        - ouxt_common
-        - ouxt_lint_common
+      - ouxt_common
+      - ouxt_lint_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
@@ -6122,10 +6122,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_gripper
-        - pal_gripper_controller_configuration
-        - pal_gripper_description
-        - pal_gripper_simulation
+      - pal_gripper
+      - pal_gripper_controller_configuration
+      - pal_gripper_description
+      - pal_gripper_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
@@ -6142,9 +6142,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_hey5
-        - pal_hey5_controller_configuration
-        - pal_hey5_description
+      - pal_hey5
+      - pal_hey5_controller_configuration
+      - pal_hey5_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_hey5-release.git
@@ -6176,9 +6176,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_navigation_cfg
-        - pal_navigation_cfg_bringup
-        - pal_navigation_cfg_params
+      - pal_navigation_cfg
+      - pal_navigation_cfg_bringup
+      - pal_navigation_cfg_params
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
@@ -6195,9 +6195,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_robotiq_controller_configuration
-        - pal_robotiq_description
-        - pal_robotiq_gripper
+      - pal_robotiq_controller_configuration
+      - pal_robotiq_description
+      - pal_robotiq_gripper
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
@@ -6214,8 +6214,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_statistics
-        - pal_statistics_msgs
+      - pal_statistics
+      - pal_statistics_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
@@ -6280,7 +6280,7 @@ repositories:
   perception_open3d:
     release:
       packages:
-        - open3d_conversions
+      - open3d_conversions
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
@@ -6297,9 +6297,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - pcl_conversions
-        - pcl_ros
-        - perception_pcl
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
@@ -6344,22 +6344,22 @@ repositories:
       version: humble
     release:
       packages:
-        - libphidget22
-        - phidgets_accelerometer
-        - phidgets_analog_inputs
-        - phidgets_analog_outputs
-        - phidgets_api
-        - phidgets_digital_inputs
-        - phidgets_digital_outputs
-        - phidgets_drivers
-        - phidgets_gyroscope
-        - phidgets_high_speed_encoder
-        - phidgets_ik
-        - phidgets_magnetometer
-        - phidgets_motors
-        - phidgets_msgs
-        - phidgets_spatial
-        - phidgets_temperature
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_analog_outputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
@@ -6398,8 +6398,8 @@ repositories:
       version: main
     release:
       packages:
-        - picknik_reset_fault_controller
-        - picknik_twist_controller
+      - picknik_reset_fault_controller
+      - picknik_twist_controller
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
@@ -6431,8 +6431,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - play_motion2
-        - play_motion2_msgs
+      - play_motion2
+      - play_motion2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
@@ -6510,9 +6510,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pmb2_2dnav
-        - pmb2_laser_sensors
-        - pmb2_navigation
+      - pmb2_2dnav
+      - pmb2_laser_sensors
+      - pmb2_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
@@ -6529,10 +6529,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pmb2_bringup
-        - pmb2_controller_configuration
-        - pmb2_description
-        - pmb2_robot
+      - pmb2_bringup
+      - pmb2_controller_configuration
+      - pmb2_description
+      - pmb2_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
@@ -6549,8 +6549,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pmb2_gazebo
-        - pmb2_simulation
+      - pmb2_gazebo
+      - pmb2_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
@@ -6582,8 +6582,8 @@ repositories:
       version: humble
     release:
       packages:
-        - point_cloud_transport
-        - point_cloud_transport_py
+      - point_cloud_transport
+      - point_cloud_transport_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -6600,11 +6600,11 @@ repositories:
       version: humble
     release:
       packages:
-        - draco_point_cloud_transport
-        - point_cloud_interfaces
-        - point_cloud_transport_plugins
-        - zlib_point_cloud_transport
-        - zstd_point_cloud_transport
+      - draco_point_cloud_transport
+      - point_cloud_interfaces
+      - point_cloud_transport_plugins
+      - zlib_point_cloud_transport
+      - zstd_point_cloud_transport
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
@@ -6636,10 +6636,10 @@ repositories:
       version: main
     release:
       packages:
-        - polygon_demos
-        - polygon_msgs
-        - polygon_rviz_plugins
-        - polygon_utils
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
@@ -6717,8 +6717,8 @@ repositories:
       version: main
     release:
       packages:
-        - psdk_interfaces
-        - psdk_wrapper
+      - psdk_interfaces
+      - psdk_wrapper
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/psdk_ros2-release.git
@@ -6735,7 +6735,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - ptz_action_server_msgs
+      - ptz_action_server_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
@@ -6752,9 +6752,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-        - clearpath_socketcan_interface
-        - puma_motor_driver
-        - puma_motor_msgs
+      - clearpath_socketcan_interface
+      - puma_motor_driver
+      - puma_motor_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/puma_motor_driver-release.git
@@ -6892,7 +6892,7 @@ repositories:
       version: main
     release:
       packages:
-        - python_mrpt
+      - python_mrpt
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
@@ -6921,12 +6921,12 @@ repositories:
   qb_device:
     release:
       packages:
-        - qb_device
-        - qb_device_bringup
-        - qb_device_driver
-        - qb_device_msgs
-        - qb_device_ros2_control
-        - qb_device_test_controllers
+      - qb_device
+      - qb_device_bringup
+      - qb_device_driver
+      - qb_device_msgs
+      - qb_device_ros2_control
+      - qb_device_test_controllers
       tags:
         release: release/humble/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbdevice-ros2-release.git
@@ -6939,12 +6939,12 @@ repositories:
   qb_softhand_industry:
     release:
       packages:
-        - qb_softhand_industry
-        - qb_softhand_industry_description
-        - qb_softhand_industry_driver
-        - qb_softhand_industry_msgs
-        - qb_softhand_industry_ros2_control
-        - qb_softhand_industry_srvs
+      - qb_softhand_industry
+      - qb_softhand_industry_description
+      - qb_softhand_industry_driver
+      - qb_softhand_industry_msgs
+      - qb_softhand_industry_ros2_control
+      - qb_softhand_industry_srvs
       tags:
         release: release/humble/{package}/{version}
       url: https://bitbucket.org/qbrobotics/qbshin-ros2-release.git
@@ -6987,12 +6987,12 @@ repositories:
       version: humble
     release:
       packages:
-        - qt_dotgraph
-        - qt_gui
-        - qt_gui_app
-        - qt_gui_core
-        - qt_gui_cpp
-        - qt_gui_py_common
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
@@ -7025,14 +7025,14 @@ repositories:
       version: humble
     release:
       packages:
-        - r2r_spl
-        - r2r_spl_7
-        - r2r_spl_8
-        - r2r_spl_test_interfaces
-        - splsm_7
-        - splsm_7_conversion
-        - splsm_8
-        - splsm_8_conversion
+      - r2r_spl
+      - r2r_spl_7
+      - r2r_spl_8
+      - r2r_spl_test_interfaces
+      - splsm_7
+      - splsm_7_conversion
+      - splsm_8
+      - splsm_8_conversion
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
@@ -7071,8 +7071,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - raspimouse
-        - raspimouse_msgs
+      - raspimouse
+      - raspimouse_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
@@ -7120,9 +7120,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - raspimouse_fake
-        - raspimouse_gazebo
-        - raspimouse_sim
+      - raspimouse_fake
+      - raspimouse_gazebo
+      - raspimouse_sim
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_sim-release.git
@@ -7139,9 +7139,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - raspimouse_navigation
-        - raspimouse_slam
-        - raspimouse_slam_navigation
+      - raspimouse_navigation
+      - raspimouse_slam
+      - raspimouse_slam_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
@@ -7223,8 +7223,8 @@ repositories:
       version: master
     release:
       packages:
-        - rc_reason_clients
-        - rc_reason_msgs
+      - rc_reason_clients
+      - rc_reason_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
@@ -7258,10 +7258,10 @@ repositories:
       version: humble
     release:
       packages:
-        - rcl
-        - rcl_action
-        - rcl_lifecycle
-        - rcl_yaml_param_parser
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
@@ -7279,14 +7279,14 @@ repositories:
       version: humble
     release:
       packages:
-        - action_msgs
-        - builtin_interfaces
-        - composition_interfaces
-        - lifecycle_msgs
-        - rcl_interfaces
-        - rosgraph_msgs
-        - statistics_msgs
-        - test_msgs
+      - action_msgs
+      - builtin_interfaces
+      - composition_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - statistics_msgs
+      - test_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
@@ -7304,9 +7304,9 @@ repositories:
       version: humble
     release:
       packages:
-        - rcl_logging_interface
-        - rcl_logging_noop
-        - rcl_logging_spdlog
+      - rcl_logging_interface
+      - rcl_logging_noop
+      - rcl_logging_spdlog
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
@@ -7324,10 +7324,10 @@ repositories:
       version: humble
     release:
       packages:
-        - rclc
-        - rclc_examples
-        - rclc_lifecycle
-        - rclc_parameter
+      - rclc
+      - rclc_examples
+      - rclc_lifecycle
+      - rclc_parameter
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
@@ -7345,10 +7345,10 @@ repositories:
       version: humble
     release:
       packages:
-        - rclcpp
-        - rclcpp_action
-        - rclcpp_components
-        - rclcpp_lifecycle
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
@@ -7398,9 +7398,9 @@ repositories:
       version: humble
     release:
       packages:
-        - rcss3d_agent
-        - rcss3d_agent_basic
-        - rcss3d_agent_msgs
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
@@ -7455,9 +7455,9 @@ repositories:
       version: ros2-master
     release:
       packages:
-        - realsense2_camera
-        - realsense2_camera_msgs
-        - realsense2_description
+      - realsense2_camera
+      - realsense2_camera_msgs
+      - realsense2_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
@@ -7474,8 +7474,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rttest
-        - tlsf_cpp
+      - rttest
+      - tlsf_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
@@ -7508,8 +7508,8 @@ repositories:
       version: humble
     release:
       packages:
-        - libcurl_vendor
-        - resource_retriever
+      - libcurl_vendor
+      - resource_retriever
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
@@ -7609,18 +7609,18 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_charger_msgs
-        - rmf_dispenser_msgs
-        - rmf_door_msgs
-        - rmf_fleet_msgs
-        - rmf_ingestor_msgs
-        - rmf_lift_msgs
-        - rmf_obstacle_msgs
-        - rmf_scheduler_msgs
-        - rmf_site_map_msgs
-        - rmf_task_msgs
-        - rmf_traffic_msgs
-        - rmf_workcell_msgs
+      - rmf_charger_msgs
+      - rmf_dispenser_msgs
+      - rmf_door_msgs
+      - rmf_fleet_msgs
+      - rmf_ingestor_msgs
+      - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_scheduler_msgs
+      - rmf_site_map_msgs
+      - rmf_task_msgs
+      - rmf_traffic_msgs
+      - rmf_workcell_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
@@ -7637,11 +7637,11 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_fleet_adapter
-        - rmf_fleet_adapter_python
-        - rmf_task_ros2
-        - rmf_traffic_ros2
-        - rmf_websocket
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      - rmf_websocket
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
@@ -7658,12 +7658,12 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_building_sim_common
-        - rmf_building_sim_gz_classic_plugins
-        - rmf_building_sim_gz_plugins
-        - rmf_robot_sim_common
-        - rmf_robot_sim_gz_classic_plugins
-        - rmf_robot_sim_gz_plugins
+      - rmf_building_sim_common
+      - rmf_building_sim_gz_classic_plugins
+      - rmf_building_sim_gz_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gz_classic_plugins
+      - rmf_robot_sim_gz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
@@ -7680,8 +7680,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_task
-        - rmf_task_sequence
+      - rmf_task
+      - rmf_task_sequence
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
@@ -7698,8 +7698,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_traffic
-        - rmf_traffic_examples
+      - rmf_traffic
+      - rmf_traffic_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
@@ -7716,10 +7716,10 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_building_map_tools
-        - rmf_traffic_editor
-        - rmf_traffic_editor_assets
-        - rmf_traffic_editor_test_maps
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - rmf_traffic_editor_test_maps
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
@@ -7751,7 +7751,7 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_dev
+      - rmf_dev
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
@@ -7768,14 +7768,14 @@ repositories:
       version: humble
     release:
       packages:
-        - rmf_visualization
-        - rmf_visualization_building_systems
-        - rmf_visualization_fleet_states
-        - rmf_visualization_floorplans
-        - rmf_visualization_navgraphs
-        - rmf_visualization_obstacles
-        - rmf_visualization_rviz2_plugins
-        - rmf_visualization_schedule
+      - rmf_visualization
+      - rmf_visualization_building_systems
+      - rmf_visualization_fleet_states
+      - rmf_visualization_floorplans
+      - rmf_visualization_navgraphs
+      - rmf_visualization_obstacles
+      - rmf_visualization_rviz2_plugins
+      - rmf_visualization_schedule
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
@@ -7807,8 +7807,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rmw
-        - rmw_implementation_cmake
+      - rmw
+      - rmw_implementation_cmake
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
@@ -7826,9 +7826,9 @@ repositories:
       version: humble
     release:
       packages:
-        - rmw_connextdds
-        - rmw_connextdds_common
-        - rti_connext_dds_cmake_module
+      - rmw_connextdds
+      - rmw_connextdds_common
+      - rti_connext_dds_cmake_module
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
@@ -7845,7 +7845,7 @@ repositories:
       version: humble
     release:
       packages:
-        - rmw_cyclonedds_cpp
+      - rmw_cyclonedds_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
@@ -7879,9 +7879,9 @@ repositories:
       version: humble
     release:
       packages:
-        - rmw_fastrtps_cpp
-        - rmw_fastrtps_dynamic_cpp
-        - rmw_fastrtps_shared_cpp
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
@@ -7899,8 +7899,8 @@ repositories:
       version: humble
     release:
       packages:
-        - gurumdds_cmake_module
-        - rmw_gurumdds_cpp
+      - gurumdds_cmake_module
+      - rmw_gurumdds_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
@@ -7933,8 +7933,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rmw_zenoh_cpp
-        - zenoh_cpp_vendor
+      - rmw_zenoh_cpp
+      - zenoh_cpp_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
@@ -7961,8 +7961,8 @@ repositories:
       version: humble
     release:
       packages:
-        - robot_calibration
-        - robot_calibration_msgs
+      - robot_calibration
+      - robot_calibration_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
@@ -7979,9 +7979,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - robot_controllers
-        - robot_controllers_interface
-        - robot_controllers_msgs
+      - robot_controllers
+      - robot_controllers_interface
+      - robot_controllers_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/fetchrobotics-gbp/robot_controllers-ros2-release.git
@@ -8083,19 +8083,19 @@ repositories:
       version: humble
     release:
       packages:
-        - canopen
-        - canopen_402_driver
-        - canopen_base_driver
-        - canopen_core
-        - canopen_fake_slaves
-        - canopen_interfaces
-        - canopen_master_driver
-        - canopen_proxy_driver
-        - canopen_ros2_control
-        - canopen_ros2_controllers
-        - canopen_tests
-        - canopen_utils
-        - lely_core_libraries
+      - canopen
+      - canopen_402_driver
+      - canopen_base_driver
+      - canopen_core
+      - canopen_fake_slaves
+      - canopen_interfaces
+      - canopen_master_driver
+      - canopen_proxy_driver
+      - canopen_ros2_control
+      - canopen_ros2_controllers
+      - canopen_tests
+      - canopen_utils
+      - lely_core_libraries
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
@@ -8112,17 +8112,17 @@ repositories:
       version: humble
     release:
       packages:
-        - controller_interface
-        - controller_manager
-        - controller_manager_msgs
-        - hardware_interface
-        - hardware_interface_testing
-        - joint_limits
-        - ros2_control
-        - ros2_control_test_assets
-        - ros2controlcli
-        - rqt_controller_manager
-        - transmission_interface
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - hardware_interface_testing
+      - joint_limits
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - rqt_controller_manager
+      - transmission_interface
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
@@ -8139,29 +8139,29 @@ repositories:
       version: humble
     release:
       packages:
-        - ackermann_steering_controller
-        - admittance_controller
-        - bicycle_steering_controller
-        - diff_drive_controller
-        - effort_controllers
-        - force_torque_sensor_broadcaster
-        - forward_command_controller
-        - gpio_controllers
-        - gripper_controllers
-        - imu_sensor_broadcaster
-        - joint_state_broadcaster
-        - joint_trajectory_controller
-        - pid_controller
-        - pose_broadcaster
-        - position_controllers
-        - range_sensor_broadcaster
-        - ros2_controllers
-        - ros2_controllers_test_nodes
-        - rqt_joint_trajectory_controller
-        - steering_controllers_library
-        - tricycle_controller
-        - tricycle_steering_controller
-        - velocity_controllers
+      - ackermann_steering_controller
+      - admittance_controller
+      - bicycle_steering_controller
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_broadcaster
+      - forward_command_controller
+      - gpio_controllers
+      - gripper_controllers
+      - imu_sensor_broadcaster
+      - joint_state_broadcaster
+      - joint_trajectory_controller
+      - pid_controller
+      - pose_broadcaster
+      - position_controllers
+      - range_sensor_broadcaster
+      - ros2_controllers
+      - ros2_controllers_test_nodes
+      - rqt_joint_trajectory_controller
+      - steering_controllers_library
+      - tricycle_controller
+      - tricycle_steering_controller
+      - velocity_controllers
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
@@ -8178,12 +8178,12 @@ repositories:
       version: main
     release:
       packages:
-        - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-        - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-        - kortex_api
-        - kortex_bringup
-        - kortex_description
-        - kortex_driver
+      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kortex_api
+      - kortex_bringup
+      - kortex_description
+      - kortex_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
@@ -8200,8 +8200,8 @@ repositories:
       version: foxy-devel
     release:
       packages:
-        - ouster_msgs
-        - ros2_ouster
+      - ouster_msgs
+      - ros2_ouster
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_ouster_drivers-release.git
@@ -8219,19 +8219,19 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - plansys2_bringup
-        - plansys2_bt_actions
-        - plansys2_core
-        - plansys2_domain_expert
-        - plansys2_executor
-        - plansys2_lifecycle_manager
-        - plansys2_msgs
-        - plansys2_pddl_parser
-        - plansys2_planner
-        - plansys2_popf_plan_solver
-        - plansys2_problem_expert
-        - plansys2_terminal
-        - plansys2_tools
+      - plansys2_bringup
+      - plansys2_bt_actions
+      - plansys2_core
+      - plansys2_domain_expert
+      - plansys2_executor
+      - plansys2_lifecycle_manager
+      - plansys2_msgs
+      - plansys2_pddl_parser
+      - plansys2_planner
+      - plansys2_popf_plan_solver
+      - plansys2_problem_expert
+      - plansys2_terminal
+      - plansys2_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
@@ -8248,8 +8248,8 @@ repositories:
       version: main
     release:
       packages:
-        - robotiq_controllers
-        - robotiq_description
+      - robotiq_controllers
+      - robotiq_description
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
@@ -8266,8 +8266,8 @@ repositories:
       version: main
     release:
       packages:
-        - ros2_socketcan
-        - ros2_socketcan_msgs
+      - ros2_socketcan
+      - ros2_socketcan_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
@@ -8284,12 +8284,12 @@ repositories:
       version: humble
     release:
       packages:
-        - ros2trace
-        - tracetools
-        - tracetools_launch
-        - tracetools_read
-        - tracetools_test
-        - tracetools_trace
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
@@ -8337,21 +8337,21 @@ repositories:
       version: humble
     release:
       packages:
-        - ros2action
-        - ros2cli
-        - ros2cli_test_interfaces
-        - ros2component
-        - ros2doctor
-        - ros2interface
-        - ros2lifecycle
-        - ros2lifecycle_test_fixtures
-        - ros2multicast
-        - ros2node
-        - ros2param
-        - ros2pkg
-        - ros2run
-        - ros2service
-        - ros2topic
+      - ros2action
+      - ros2cli
+      - ros2cli_test_interfaces
+      - ros2component
+      - ros2doctor
+      - ros2interface
+      - ros2lifecycle
+      - ros2lifecycle_test_fixtures
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2topic
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
@@ -8384,8 +8384,8 @@ repositories:
       version: main
     release:
       packages:
-        - ros2launch_security
-        - ros2launch_security_examples
+      - ros2launch_security
+      - ros2launch_security_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
@@ -8403,8 +8403,8 @@ repositories:
       version: humble
     release:
       packages:
-        - ros_babel_fish
-        - ros_babel_fish_test_msgs
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
@@ -8417,7 +8417,7 @@ repositories:
   ros_canopen:
     release:
       packages:
-        - can_msgs
+      - can_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
@@ -8450,19 +8450,19 @@ repositories:
       version: humble
     release:
       packages:
-        - ros_gz
-        - ros_gz_bridge
-        - ros_gz_image
-        - ros_gz_interfaces
-        - ros_gz_sim
-        - ros_gz_sim_demos
-        - ros_ign
-        - ros_ign_bridge
-        - ros_ign_gazebo
-        - ros_ign_gazebo_demos
-        - ros_ign_image
-        - ros_ign_interfaces
-        - test_ros_gz_bridge
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      - ros_ign
+      - ros_ign_bridge
+      - ros_ign_gazebo
+      - ros_ign_gazebo_demos
+      - ros_ign_image
+      - ros_ign_interfaces
+      - test_ros_gz_bridge
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
@@ -8500,8 +8500,8 @@ repositories:
       version: humble
     release:
       packages:
-        - ros2test
-        - ros_testing
+      - ros2test
+      - ros_testing
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
@@ -8519,7 +8519,7 @@ repositories:
       version: humble
     release:
       packages:
-        - turtlesim
+      - turtlesim
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
@@ -8548,25 +8548,25 @@ repositories:
       version: humble
     release:
       packages:
-        - mcap_vendor
-        - ros2bag
-        - rosbag2
-        - rosbag2_compression
-        - rosbag2_compression_zstd
-        - rosbag2_cpp
-        - rosbag2_interfaces
-        - rosbag2_performance_benchmarking
-        - rosbag2_py
-        - rosbag2_storage
-        - rosbag2_storage_default_plugins
-        - rosbag2_storage_mcap
-        - rosbag2_storage_mcap_testdata
-        - rosbag2_test_common
-        - rosbag2_tests
-        - rosbag2_transport
-        - shared_queues_vendor
-        - sqlite3_vendor
-        - zstd_vendor
+      - mcap_vendor
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_compression_zstd
+      - rosbag2_cpp
+      - rosbag2_interfaces
+      - rosbag2_performance_benchmarking
+      - rosbag2_py
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_mcap_testdata
+      - rosbag2_test_common
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      - zstd_vendor
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
@@ -8584,8 +8584,8 @@ repositories:
       version: master
     release:
       packages:
-        - ros1_rosbag_storage_vendor
-        - rosbag2_bag_v2_plugins
+      - ros1_rosbag_storage_vendor
+      - rosbag2_bag_v2_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
@@ -8617,13 +8617,13 @@ repositories:
       version: humble
     release:
       packages:
-        - rosapi
-        - rosapi_msgs
-        - rosbridge_library
-        - rosbridge_msgs
-        - rosbridge_server
-        - rosbridge_suite
-        - rosbridge_test_msgs
+      - rosapi
+      - rosapi_msgs
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      - rosbridge_test_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
@@ -8640,17 +8640,17 @@ repositories:
       version: humble
     release:
       packages:
-        - rosidl_adapter
-        - rosidl_cli
-        - rosidl_cmake
-        - rosidl_generator_c
-        - rosidl_generator_cpp
-        - rosidl_parser
-        - rosidl_runtime_c
-        - rosidl_runtime_cpp
-        - rosidl_typesupport_interface
-        - rosidl_typesupport_introspection_c
-        - rosidl_typesupport_introspection_cpp
+      - rosidl_adapter
+      - rosidl_cli
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_parser
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
@@ -8668,7 +8668,7 @@ repositories:
       version: humble
     release:
       packages:
-        - rosidl_generator_dds_idl
+      - rosidl_generator_dds_idl
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
@@ -8686,8 +8686,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rosidl_default_generators
-        - rosidl_default_runtime
+      - rosidl_default_generators
+      - rosidl_default_runtime
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
@@ -8705,7 +8705,7 @@ repositories:
       version: humble
     release:
       packages:
-        - rosidl_generator_py
+      - rosidl_generator_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
@@ -8739,8 +8739,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rosidl_typesupport_c
-        - rosidl_typesupport_cpp
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
@@ -8758,9 +8758,9 @@ repositories:
       version: humble
     release:
       packages:
-        - fastrtps_cmake_module
-        - rosidl_typesupport_fastrtps_c
-        - rosidl_typesupport_fastrtps_cpp
+      - fastrtps_cmake_module
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
@@ -8778,8 +8778,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rclpy_message_converter
-        - rclpy_message_converter_msgs
+      - rclpy_message_converter
+      - rclpy_message_converter_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
@@ -8808,7 +8808,7 @@ repositories:
   rot_conv_lib:
     release:
       packages:
-        - rot_conv
+      - rot_conv
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
@@ -8857,11 +8857,11 @@ repositories:
       version: humble
     release:
       packages:
-        - rqt
-        - rqt_gui
-        - rqt_gui_cpp
-        - rqt_gui_py
-        - rqt_py_common
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
@@ -8894,8 +8894,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rqt_bag
-        - rqt_bag_plugins
+      - rqt_bag
+      - rqt_bag_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
@@ -8989,8 +8989,8 @@ repositories:
       version: humble
     release:
       packages:
-        - rqt_image_overlay
-        - rqt_image_overlay_layer
+      - rqt_image_overlay
+      - rqt_image_overlay_layer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
@@ -9265,8 +9265,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - rt_manipulators_cpp
-        - rt_manipulators_examples
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
@@ -9313,19 +9313,19 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - rtabmap_conversions
-        - rtabmap_demos
-        - rtabmap_examples
-        - rtabmap_launch
-        - rtabmap_msgs
-        - rtabmap_odom
-        - rtabmap_python
-        - rtabmap_ros
-        - rtabmap_rviz_plugins
-        - rtabmap_slam
-        - rtabmap_sync
-        - rtabmap_util
-        - rtabmap_viz
+      - rtabmap_conversions
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
@@ -9368,14 +9368,14 @@ repositories:
       version: humble
     release:
       packages:
-        - rviz2
-        - rviz_assimp_vendor
-        - rviz_common
-        - rviz_default_plugins
-        - rviz_ogre_vendor
-        - rviz_rendering
-        - rviz_rendering_tests
-        - rviz_visual_testing_framework
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
@@ -9393,8 +9393,8 @@ repositories:
       version: main
     release:
       packages:
-        - rviz_2d_overlay_msgs
-        - rviz_2d_overlay_plugins
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
@@ -9458,17 +9458,17 @@ repositories:
       version: humble
     release:
       packages:
-        - scenario_execution
-        - scenario_execution_control
-        - scenario_execution_coverage
-        - scenario_execution_gazebo
-        - scenario_execution_interfaces
-        - scenario_execution_nav2
-        - scenario_execution_os
-        - scenario_execution_py_trees_ros
-        - scenario_execution_ros
-        - scenario_execution_rviz
-        - scenario_execution_x11
+      - scenario_execution
+      - scenario_execution_control
+      - scenario_execution_coverage
+      - scenario_execution_gazebo
+      - scenario_execution_interfaces
+      - scenario_execution_nav2
+      - scenario_execution_os
+      - scenario_execution_py_trees_ros
+      - scenario_execution_ros
+      - scenario_execution_rviz
+      - scenario_execution_x11
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
@@ -9500,9 +9500,9 @@ repositories:
       version: ros2-humble
     release:
       packages:
-        - schunk_svh_description
-        - schunk_svh_driver
-        - schunk_svh_tests
+      - schunk_svh_description
+      - schunk_svh_driver
+      - schunk_svh_tests
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/schunk_svh_ros_driver-release.git
@@ -9519,8 +9519,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - sdformat_test_files
-        - sdformat_urdf
+      - sdformat_test_files
+      - sdformat_urdf
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
@@ -9614,9 +9614,9 @@ repositories:
       version: main
     release:
       packages:
-        - sick_safevisionary_driver
-        - sick_safevisionary_interfaces
-        - sick_safevisionary_tests
+      - sick_safevisionary_driver
+      - sick_safevisionary_interfaces
+      - sick_safevisionary_tests
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
@@ -9816,8 +9816,8 @@ repositories:
       version: humble
     release:
       packages:
-        - smacc2
-        - smacc2_msgs
+      - smacc2
+      - smacc2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
@@ -9834,10 +9834,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - executive_smach
-        - smach
-        - smach_msgs
-        - smach_ros
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
@@ -9875,10 +9875,10 @@ repositories:
       version: humble
     release:
       packages:
-        - soccer_interfaces
-        - soccer_vision_2d_msgs
-        - soccer_vision_3d_msgs
-        - soccer_vision_attribute_msgs
+      - soccer_interfaces
+      - soccer_vision_2d_msgs
+      - soccer_vision_3d_msgs
+      - soccer_vision_attribute_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
@@ -9910,7 +9910,7 @@ repositories:
       version: rolling
     release:
       packages:
-        - soccer_marker_generation
+      - soccer_marker_generation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_visualization-release.git
@@ -9927,8 +9927,8 @@ repositories:
       version: main
     release:
       packages:
-        - social_nav_msgs
-        - social_nav_util
+      - social_nav_msgs
+      - social_nav_util
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/social_nav_ros-release.git
@@ -9976,8 +9976,8 @@ repositories:
       version: humble
     release:
       packages:
-        - openvdb_vendor
-        - spatio_temporal_voxel_layer
+      - openvdb_vendor
+      - spatio_temporal_voxel_layer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
@@ -10021,8 +10021,8 @@ repositories:
       version: humble
     release:
       packages:
-        - sros2
-        - sros2_cmake
+      - sros2
+      - sros2_cmake
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
@@ -10065,8 +10065,8 @@ repositories:
       version: main
     release:
       packages:
-        - stubborn_buddies
-        - stubborn_buddies_msgs
+      - stubborn_buddies
+      - stubborn_buddies_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/stubborn_buddies-release.git
@@ -10130,10 +10130,10 @@ repositories:
       version: master
     release:
       packages:
-        - launch_system_modes
-        - system_modes
-        - system_modes_examples
-        - system_modes_msgs
+      - launch_system_modes
+      - system_modes
+      - system_modes_examples
+      - system_modes_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
@@ -10165,12 +10165,12 @@ repositories:
   talos_robot:
     release:
       packages:
-        - talos_bringup
-        - talos_controller_configuration
-        - talos_description
-        - talos_description_calibration
-        - talos_description_inertial
-        - talos_robot
+      - talos_bringup
+      - talos_controller_configuration
+      - talos_description
+      - talos_description_calibration
+      - talos_description_inertial
+      - talos_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
@@ -10183,7 +10183,7 @@ repositories:
   talos_simulation:
     release:
       packages:
-        - talos_gazebo
+      - talos_gazebo
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_simulation-release.git
@@ -10211,11 +10211,11 @@ repositories:
       version: master
     release:
       packages:
-        - joy_teleop
-        - key_teleop
-        - mouse_teleop
-        - teleop_tools
-        - teleop_tools_msgs
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
@@ -10332,9 +10332,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - tiago_2dnav
-        - tiago_laser_sensors
-        - tiago_navigation
+      - tiago_2dnav
+      - tiago_laser_sensors
+      - tiago_navigation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
@@ -10351,10 +10351,10 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - tiago_bringup
-        - tiago_controller_configuration
-        - tiago_description
-        - tiago_robot
+      - tiago_bringup
+      - tiago_controller_configuration
+      - tiago_description
+      - tiago_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
@@ -10371,8 +10371,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - tiago_gazebo
-        - tiago_simulation
+      - tiago_gazebo
+      - tiago_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
@@ -10454,8 +10454,8 @@ repositories:
       version: humble
     release:
       packages:
-        - topic_tools
-        - topic_tools_interfaces
+      - topic_tools
+      - topic_tools_interfaces
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
@@ -10488,8 +10488,8 @@ repositories:
       version: humble
     release:
       packages:
-        - ros2trace_analysis
-        - tracetools_analysis
+      - ros2trace_analysis
+      - tracetools_analysis
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
@@ -10506,10 +10506,10 @@ repositories:
       version: main
     release:
       packages:
-        - asio_cmake_module
-        - io_context
-        - serial_driver
-        - udp_driver
+      - asio_cmake_module
+      - io_context
+      - serial_driver
+      - udp_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
@@ -10556,14 +10556,14 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - turtlebot3
-        - turtlebot3_bringup
-        - turtlebot3_cartographer
-        - turtlebot3_description
-        - turtlebot3_example
-        - turtlebot3_navigation2
-        - turtlebot3_node
-        - turtlebot3_teleop
+      - turtlebot3
+      - turtlebot3_bringup
+      - turtlebot3_cartographer
+      - turtlebot3_description
+      - turtlebot3_example
+      - turtlebot3_navigation2
+      - turtlebot3_node
+      - turtlebot3_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3-release.git
@@ -10580,14 +10580,14 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - turtlebot3_manipulation
-        - turtlebot3_manipulation_bringup
-        - turtlebot3_manipulation_cartographer
-        - turtlebot3_manipulation_description
-        - turtlebot3_manipulation_hardware
-        - turtlebot3_manipulation_moveit_config
-        - turtlebot3_manipulation_navigation2
-        - turtlebot3_manipulation_teleop
+      - turtlebot3_manipulation
+      - turtlebot3_manipulation_bringup
+      - turtlebot3_manipulation_cartographer
+      - turtlebot3_manipulation_description
+      - turtlebot3_manipulation_hardware
+      - turtlebot3_manipulation_moveit_config
+      - turtlebot3_manipulation_navigation2
+      - turtlebot3_manipulation_teleop
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
@@ -10619,9 +10619,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - turtlebot3_fake_node
-        - turtlebot3_gazebo
-        - turtlebot3_simulations
+      - turtlebot3_fake_node
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
@@ -10638,10 +10638,10 @@ repositories:
       version: humble
     release:
       packages:
-        - turtlebot4_description
-        - turtlebot4_msgs
-        - turtlebot4_navigation
-        - turtlebot4_node
+      - turtlebot4_description
+      - turtlebot4_msgs
+      - turtlebot4_navigation
+      - turtlebot4_node
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
@@ -10658,8 +10658,8 @@ repositories:
       version: humble
     release:
       packages:
-        - turtlebot4_desktop
-        - turtlebot4_viz
+      - turtlebot4_desktop
+      - turtlebot4_viz
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
@@ -10676,11 +10676,11 @@ repositories:
       version: humble
     release:
       packages:
-        - turtlebot4_base
-        - turtlebot4_bringup
-        - turtlebot4_diagnostics
-        - turtlebot4_robot
-        - turtlebot4_tests
+      - turtlebot4_base
+      - turtlebot4_bringup
+      - turtlebot4_diagnostics
+      - turtlebot4_robot
+      - turtlebot4_tests
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
@@ -10712,10 +10712,10 @@ repositories:
       version: humble
     release:
       packages:
-        - turtlebot4_ignition_bringup
-        - turtlebot4_ignition_gui_plugins
-        - turtlebot4_ignition_toolbox
-        - turtlebot4_simulator
+      - turtlebot4_ignition_bringup
+      - turtlebot4_ignition_gui_plugins
+      - turtlebot4_ignition_toolbox
+      - turtlebot4_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
@@ -10732,9 +10732,9 @@ repositories:
       version: humble
     release:
       packages:
-        - turtlebot4_cpp_tutorials
-        - turtlebot4_python_tutorials
-        - turtlebot4_tutorials
+      - turtlebot4_cpp_tutorials
+      - turtlebot4_python_tutorials
+      - turtlebot4_tutorials
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_tutorials-release.git
@@ -10766,16 +10766,16 @@ repositories:
       version: ros2
     release:
       packages:
-        - tuw_airskin_msgs
-        - tuw_geo_msgs
-        - tuw_geometry_msgs
-        - tuw_graph_msgs
-        - tuw_msgs
-        - tuw_multi_robot_msgs
-        - tuw_nav_msgs
-        - tuw_object_map_msgs
-        - tuw_object_msgs
-        - tuw_std_msgs
+      - tuw_airskin_msgs
+      - tuw_geo_msgs
+      - tuw_geometry_msgs
+      - tuw_graph_msgs
+      - tuw_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_map_msgs
+      - tuw_object_msgs
+      - tuw_std_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tuw-robotics/tuw_msgs-release.git
@@ -10852,10 +10852,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - ublox
-        - ublox_gps
-        - ublox_msgs
-        - ublox_serialization
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
@@ -10873,12 +10873,12 @@ repositories:
       version: main
     release:
       packages:
-        - ntrip_client_node
-        - ublox_dgnss
-        - ublox_dgnss_node
-        - ublox_nav_sat_fix_hp_node
-        - ublox_ubx_interfaces
-        - ublox_ubx_msgs
+      - ntrip_client_node
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_nav_sat_fix_hp_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
@@ -10997,13 +10997,13 @@ repositories:
       version: humble
     release:
       packages:
-        - ur
-        - ur_bringup
-        - ur_calibration
-        - ur_controllers
-        - ur_dashboard_msgs
-        - ur_moveit_config
-        - ur_robot_driver
+      - ur
+      - ur_bringup
+      - ur_calibration
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_moveit_config
+      - ur_robot_driver
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
@@ -11031,8 +11031,8 @@ repositories:
       version: humble
     release:
       packages:
-        - urdf
-        - urdf_parser_plugin
+      - urdf
+      - urdf_parser_plugin
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
@@ -11066,7 +11066,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - urdfdom_py
+      - urdfdom_py
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
@@ -11239,12 +11239,12 @@ repositories:
       version: humble
     release:
       packages:
-        - desktop
-        - desktop_full
-        - perception
-        - ros_base
-        - ros_core
-        - simulation
+      - desktop
+      - desktop_full
+      - perception
+      - ros_base
+      - ros_core
+      - simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
@@ -11277,11 +11277,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - velodyne
-        - velodyne_driver
-        - velodyne_laserscan
-        - velodyne_msgs
-        - velodyne_pointcloud
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
@@ -11298,9 +11298,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-        - velodyne_description
-        - velodyne_gazebo_plugins
-        - velodyne_simulator
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
@@ -11317,11 +11317,11 @@ repositories:
       version: humble
     release:
       packages:
-        - vimbax_camera
-        - vimbax_camera_events
-        - vimbax_camera_examples
-        - vimbax_camera_msgs
-        - vmbc_interface
+      - vimbax_camera
+      - vimbax_camera_events
+      - vimbax_camera_examples
+      - vimbax_camera_msgs
+      - vmbc_interface
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vimbax_ros2_driver-release.git
@@ -11338,8 +11338,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - vision_msgs
-        - vision_msgs_rviz_plugins
+      - vision_msgs
+      - vision_msgs_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
@@ -11372,9 +11372,9 @@ repositories:
       version: humble
     release:
       packages:
-        - cv_bridge
-        - image_geometry
-        - vision_opencv
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -11536,18 +11536,18 @@ repositories:
       version: master
     release:
       packages:
-        - webots_ros2
-        - webots_ros2_control
-        - webots_ros2_driver
-        - webots_ros2_epuck
-        - webots_ros2_importer
-        - webots_ros2_mavic
-        - webots_ros2_msgs
-        - webots_ros2_tesla
-        - webots_ros2_tests
-        - webots_ros2_tiago
-        - webots_ros2_turtlebot
-        - webots_ros2_universal_robot
+      - webots_ros2
+      - webots_ros2_control
+      - webots_ros2_driver
+      - webots_ros2_epuck
+      - webots_ros2_importer
+      - webots_ros2_mavic
+      - webots_ros2_msgs
+      - webots_ros2_tesla
+      - webots_ros2_tests
+      - webots_ros2_tiago
+      - webots_ros2_turtlebot
+      - webots_ros2_universal_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
@@ -11600,8 +11600,8 @@ repositories:
       version: foxy-devel
     release:
       packages:
-        - wireless_msgs
-        - wireless_watcher
+      - wireless_msgs
+      - wireless_watcher
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
@@ -11660,11 +11660,11 @@ repositories:
       version: main
     release:
       packages:
-        - yasmin
-        - yasmin_demos
-        - yasmin_msgs
-        - yasmin_ros
-        - yasmin_viewer
+      - yasmin
+      - yasmin_demos
+      - yasmin_msgs
+      - yasmin_ros
+      - yasmin_viewer
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
@@ -11696,7 +11696,7 @@ repositories:
       version: master
     release:
       packages:
-        - zed_msgs
+      - zed_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4,11 +4,11 @@
 ---
 release_platforms:
   debian:
-    - bookworm
+  - bookworm
   rhel:
-    - "9"
+  - '9'
   ubuntu:
-    - noble
+  - noble
 repositories:
   SMACC2:
     doc:
@@ -17,8 +17,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - smacc2
-        - smacc2_msgs
+      - smacc2
+      - smacc2_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
@@ -109,8 +109,8 @@ repositories:
   ament_black:
     release:
       packages:
-        - ament_black
-        - ament_cmake_black
+      - ament_black
+      - ament_cmake_black
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
@@ -127,28 +127,28 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ament_cmake
-        - ament_cmake_auto
-        - ament_cmake_core
-        - ament_cmake_export_definitions
-        - ament_cmake_export_dependencies
-        - ament_cmake_export_include_directories
-        - ament_cmake_export_interfaces
-        - ament_cmake_export_libraries
-        - ament_cmake_export_link_flags
-        - ament_cmake_export_targets
-        - ament_cmake_gen_version_h
-        - ament_cmake_gmock
-        - ament_cmake_google_benchmark
-        - ament_cmake_gtest
-        - ament_cmake_include_directories
-        - ament_cmake_libraries
-        - ament_cmake_pytest
-        - ament_cmake_python
-        - ament_cmake_target_dependencies
-        - ament_cmake_test
-        - ament_cmake_vendor_package
-        - ament_cmake_version
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_export_targets
+      - ament_cmake_gen_version_h
+      - ament_cmake_gmock
+      - ament_cmake_google_benchmark
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_vendor_package
+      - ament_cmake_version
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
@@ -181,8 +181,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ament_cmake_ros
-        - domain_coordinator
+      - ament_cmake_ros
+      - domain_coordinator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
@@ -215,8 +215,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ament_index_cpp
-        - ament_index_python
+      - ament_index_cpp
+      - ament_index_python
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
@@ -234,37 +234,37 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ament_clang_format
-        - ament_clang_tidy
-        - ament_cmake_clang_format
-        - ament_cmake_clang_tidy
-        - ament_cmake_copyright
-        - ament_cmake_cppcheck
-        - ament_cmake_cpplint
-        - ament_cmake_flake8
-        - ament_cmake_lint_cmake
-        - ament_cmake_mypy
-        - ament_cmake_pclint
-        - ament_cmake_pep257
-        - ament_cmake_pycodestyle
-        - ament_cmake_pyflakes
-        - ament_cmake_uncrustify
-        - ament_cmake_xmllint
-        - ament_copyright
-        - ament_cppcheck
-        - ament_cpplint
-        - ament_flake8
-        - ament_lint
-        - ament_lint_auto
-        - ament_lint_cmake
-        - ament_lint_common
-        - ament_mypy
-        - ament_pclint
-        - ament_pep257
-        - ament_pycodestyle
-        - ament_pyflakes
-        - ament_uncrustify
-        - ament_xmllint
+      - ament_clang_format
+      - ament_clang_tidy
+      - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_mypy
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pycodestyle
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_mypy
+      - ament_pclint
+      - ament_pep257
+      - ament_pycodestyle
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
@@ -341,8 +341,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - apex_test_tools
-        - test_apex_test_tools
+      - apex_test_tools
+      - test_apex_test_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
@@ -431,8 +431,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - aruco_opencv
-        - aruco_opencv_msgs
+      - aruco_opencv
+      - aruco_opencv_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
@@ -449,9 +449,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - aruco
-        - aruco_msgs
-        - aruco_ros
+      - aruco
+      - aruco_msgs
+      - aruco_ros
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
@@ -468,14 +468,14 @@ repositories:
       version: master
     release:
       packages:
-        - delphi_esr_msgs
-        - delphi_mrr_msgs
-        - delphi_srr_msgs
-        - derived_object_msgs
-        - ibeo_msgs
-        - kartech_linear_actuator_msgs
-        - mobileye_560_660_msgs
-        - neobotix_usboard_msgs
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
@@ -532,9 +532,9 @@ repositories:
       version: master
     release:
       packages:
-        - automotive_autonomy_msgs
-        - automotive_navigation_msgs
-        - automotive_platform_msgs
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
@@ -547,8 +547,8 @@ repositories:
   autoware_adapi_msgs:
     release:
       packages:
-        - autoware_adapi_v1_msgs
-        - autoware_adapi_version_msgs
+      - autoware_adapi_v1_msgs
+      - autoware_adapi_version_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
@@ -576,8 +576,8 @@ repositories:
   autoware_cmake:
     release:
       packages:
-        - autoware_cmake
-        - autoware_lint_common
+      - autoware_cmake
+      - autoware_lint_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
@@ -590,9 +590,9 @@ repositories:
   autoware_internal_msgs:
     release:
       packages:
-        - autoware_internal_debug_msgs
-        - autoware_internal_msgs
-        - autoware_internal_perception_msgs
+      - autoware_internal_debug_msgs
+      - autoware_internal_msgs
+      - autoware_internal_perception_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
@@ -605,8 +605,8 @@ repositories:
   autoware_lanelet2_extension:
     release:
       packages:
-        - autoware_lanelet2_extension
-        - autoware_lanelet2_extension_python
+      - autoware_lanelet2_extension
+      - autoware_lanelet2_extension_python
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
@@ -619,16 +619,16 @@ repositories:
   autoware_msgs:
     release:
       packages:
-        - autoware_common_msgs
-        - autoware_control_msgs
-        - autoware_localization_msgs
-        - autoware_map_msgs
-        - autoware_perception_msgs
-        - autoware_planning_msgs
-        - autoware_sensing_msgs
-        - autoware_system_msgs
-        - autoware_v2x_msgs
-        - autoware_vehicle_msgs
+      - autoware_common_msgs
+      - autoware_control_msgs
+      - autoware_localization_msgs
+      - autoware_map_msgs
+      - autoware_perception_msgs
+      - autoware_planning_msgs
+      - autoware_sensing_msgs
+      - autoware_system_msgs
+      - autoware_v2x_msgs
+      - autoware_vehicle_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
@@ -671,7 +671,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - aws_robomaker_small_warehouse_world
+      - aws_robomaker_small_warehouse_world
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
@@ -702,9 +702,9 @@ repositories:
       version: jazzy-devel
     release:
       packages:
-        - axis_camera
-        - axis_description
-        - axis_msgs
+      - axis_camera
+      - axis_description
+      - axis_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
@@ -781,7 +781,7 @@ repositories:
       version: master
     release:
       packages:
-        - behaviortree_cpp
+      - behaviortree_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
@@ -798,9 +798,9 @@ repositories:
       version: main
     release:
       packages:
-        - beluga
-        - beluga_amcl
-        - beluga_ros
+      - beluga
+      - beluga_amcl
+      - beluga_ros
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
@@ -834,11 +834,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - bond
-        - bond_core
-        - bondcpp
-        - bondpy
-        - smclib
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
@@ -891,8 +891,8 @@ repositories:
       version: main
     release:
       packages:
-        - camera_aravis2
-        - camera_aravis2_msgs
+      - camera_aravis2
+      - camera_aravis2_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/camera_aravis2-release.git
@@ -941,9 +941,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - cartographer_ros
-        - cartographer_ros_msgs
-        - cartographer_rviz
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
@@ -961,8 +961,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-        - cascade_lifecycle_msgs
-        - rclcpp_cascade_lifecycle
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
@@ -1026,9 +1026,9 @@ repositories:
       version: main
     release:
       packages:
-        - clearpath_motor_msgs
-        - clearpath_msgs
-        - clearpath_platform_msgs
+      - clearpath_motor_msgs
+      - clearpath_msgs
+      - clearpath_platform_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
@@ -1106,19 +1106,19 @@ repositories:
       version: jazzy
     release:
       packages:
-        - actionlib_msgs
-        - common_interfaces
-        - diagnostic_msgs
-        - geometry_msgs
-        - nav_msgs
-        - sensor_msgs
-        - sensor_msgs_py
-        - shape_msgs
-        - std_msgs
-        - std_srvs
-        - stereo_msgs
-        - trajectory_msgs
-        - visualization_msgs
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - sensor_msgs_py
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
@@ -1194,8 +1194,8 @@ repositories:
   cpp_polyfills:
     release:
       packages:
-        - tcb_span
-        - tl_expected
+      - tcb_span
+      - tl_expected
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
@@ -1212,12 +1212,12 @@ repositories:
       version: jazzy
     release:
       packages:
-        - create3_coverage
-        - create3_examples_msgs
-        - create3_examples_py
-        - create3_lidar_slam
-        - create3_republisher
-        - create3_teleop
+      - create3_coverage
+      - create3_examples_msgs
+      - create3_examples_py
+      - create3_lidar_slam
+      - create3_republisher
+      - create3_teleop
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/create3_examples-release.git
@@ -1234,15 +1234,15 @@ repositories:
       version: jazzy
     release:
       packages:
-        - irobot_create_common_bringup
-        - irobot_create_control
-        - irobot_create_description
-        - irobot_create_gz_bringup
-        - irobot_create_gz_plugins
-        - irobot_create_gz_sim
-        - irobot_create_gz_toolbox
-        - irobot_create_nodes
-        - irobot_create_toolbox
+      - irobot_create_common_bringup
+      - irobot_create_control
+      - irobot_create_description
+      - irobot_create_gz_bringup
+      - irobot_create_gz_plugins
+      - irobot_create_gz_sim
+      - irobot_create_gz_toolbox
+      - irobot_create_nodes
+      - irobot_create_toolbox
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
@@ -1285,8 +1285,8 @@ repositories:
       version: main
     release:
       packages:
-        - data_tamer_cpp
-        - data_tamer_msgs
+      - data_tamer_cpp
+      - data_tamer_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
@@ -1304,11 +1304,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - dataspeed_can
-        - dataspeed_can_msg_filters
-        - dataspeed_can_msgs
-        - dataspeed_can_tools
-        - dataspeed_can_usb
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_msgs
+      - dataspeed_can_tools
+      - dataspeed_can_usb
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
@@ -1325,10 +1325,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - ds_dbw
-        - ds_dbw_can
-        - ds_dbw_joystick_demo
-        - ds_dbw_msgs
+      - ds_dbw
+      - ds_dbw_can
+      - ds_dbw_joystick_demo
+      - ds_dbw_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
@@ -1345,27 +1345,27 @@ repositories:
       version: jazzy
     release:
       packages:
-        - action_tutorials_cpp
-        - action_tutorials_interfaces
-        - action_tutorials_py
-        - composition
-        - demo_nodes_cpp
-        - demo_nodes_cpp_native
-        - demo_nodes_py
-        - dummy_map_server
-        - dummy_robot_bringup
-        - dummy_sensors
-        - image_tools
-        - intra_process_demo
-        - lifecycle
-        - lifecycle_py
-        - logging_demo
-        - pendulum_control
-        - pendulum_msgs
-        - quality_of_service_demo_cpp
-        - quality_of_service_demo_py
-        - topic_monitor
-        - topic_statistics_demo
+      - action_tutorials_cpp
+      - action_tutorials_interfaces
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - lifecycle_py
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      - topic_statistics_demo
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
@@ -1398,13 +1398,13 @@ repositories:
       version: jazzy
     release:
       packages:
-        - depthai-ros
-        - depthai_bridge
-        - depthai_descriptions
-        - depthai_examples
-        - depthai_filters
-        - depthai_ros_driver
-        - depthai_ros_msgs
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
@@ -1438,11 +1438,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - diagnostic_aggregator
-        - diagnostic_common_diagnostics
-        - diagnostic_updater
-        - diagnostics
-        - self_test
+      - diagnostic_aggregator
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - self_test
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
@@ -1460,10 +1460,10 @@ repositories:
       version: galactic
     release:
       packages:
-        - dolly
-        - dolly_follow
-        - dolly_gazebo
-        - dolly_ignition
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
@@ -1527,9 +1527,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - dynamixel_sdk
-        - dynamixel_sdk_custom_interfaces
-        - dynamixel_sdk_examples
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
@@ -1546,8 +1546,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - dynamixel_workbench
-        - dynamixel_workbench_toolbox
+      - dynamixel_workbench
+      - dynamixel_workbench_toolbox
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
@@ -1593,31 +1593,31 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-        - ecl_command_line
-        - ecl_concepts
-        - ecl_containers
-        - ecl_converters
-        - ecl_core
-        - ecl_core_apps
-        - ecl_devices
-        - ecl_eigen
-        - ecl_exceptions
-        - ecl_filesystem
-        - ecl_formatters
-        - ecl_geometry
-        - ecl_ipc
-        - ecl_linear_algebra
-        - ecl_manipulators
-        - ecl_math
-        - ecl_mobile_robot
-        - ecl_mpl
-        - ecl_sigslots
-        - ecl_statistics
-        - ecl_streams
-        - ecl_threads
-        - ecl_time
-        - ecl_type_traits
-        - ecl_utilities
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
@@ -1635,14 +1635,14 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-        - ecl_config
-        - ecl_console
-        - ecl_converters_lite
-        - ecl_errors
-        - ecl_io
-        - ecl_lite
-        - ecl_sigslots_lite
-        - ecl_time_lite
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
@@ -1660,9 +1660,9 @@ repositories:
       version: release/1.0.x
     release:
       packages:
-        - ecl_build
-        - ecl_license
-        - ecl_tools
+      - ecl_build
+      - ecl_license
+      - ecl_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
@@ -1756,34 +1756,34 @@ repositories:
       version: main
     release:
       packages:
-        - etsi_its_cam_coding
-        - etsi_its_cam_conversion
-        - etsi_its_cam_msgs
-        - etsi_its_cam_ts_coding
-        - etsi_its_cam_ts_conversion
-        - etsi_its_cam_ts_msgs
-        - etsi_its_coding
-        - etsi_its_conversion
-        - etsi_its_cpm_ts_coding
-        - etsi_its_cpm_ts_conversion
-        - etsi_its_cpm_ts_msgs
-        - etsi_its_denm_coding
-        - etsi_its_denm_conversion
-        - etsi_its_denm_msgs
-        - etsi_its_mapem_ts_coding
-        - etsi_its_mapem_ts_conversion
-        - etsi_its_mapem_ts_msgs
-        - etsi_its_messages
-        - etsi_its_msgs
-        - etsi_its_msgs_utils
-        - etsi_its_primitives_conversion
-        - etsi_its_rviz_plugins
-        - etsi_its_spatem_ts_coding
-        - etsi_its_spatem_ts_conversion
-        - etsi_its_spatem_ts_msgs
-        - etsi_its_vam_ts_coding
-        - etsi_its_vam_ts_conversion
-        - etsi_its_vam_ts_msgs
+      - etsi_its_cam_coding
+      - etsi_its_cam_conversion
+      - etsi_its_cam_msgs
+      - etsi_its_cam_ts_coding
+      - etsi_its_cam_ts_conversion
+      - etsi_its_cam_ts_msgs
+      - etsi_its_coding
+      - etsi_its_conversion
+      - etsi_its_cpm_ts_coding
+      - etsi_its_cpm_ts_conversion
+      - etsi_its_cpm_ts_msgs
+      - etsi_its_denm_coding
+      - etsi_its_denm_conversion
+      - etsi_its_denm_msgs
+      - etsi_its_mapem_ts_coding
+      - etsi_its_mapem_ts_conversion
+      - etsi_its_mapem_ts_msgs
+      - etsi_its_messages
+      - etsi_its_msgs
+      - etsi_its_msgs_utils
+      - etsi_its_primitives_conversion
+      - etsi_its_rviz_plugins
+      - etsi_its_spatem_ts_coding
+      - etsi_its_spatem_ts_conversion
+      - etsi_its_spatem_ts_msgs
+      - etsi_its_vam_ts_coding
+      - etsi_its_vam_ts_conversion
+      - etsi_its_vam_ts_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
@@ -1876,28 +1876,28 @@ repositories:
       version: jazzy
     release:
       packages:
-        - examples_rclcpp_async_client
-        - examples_rclcpp_cbg_executor
-        - examples_rclcpp_minimal_action_client
-        - examples_rclcpp_minimal_action_server
-        - examples_rclcpp_minimal_client
-        - examples_rclcpp_minimal_composition
-        - examples_rclcpp_minimal_publisher
-        - examples_rclcpp_minimal_service
-        - examples_rclcpp_minimal_subscriber
-        - examples_rclcpp_minimal_timer
-        - examples_rclcpp_multithreaded_executor
-        - examples_rclcpp_wait_set
-        - examples_rclpy_executors
-        - examples_rclpy_guard_conditions
-        - examples_rclpy_minimal_action_client
-        - examples_rclpy_minimal_action_server
-        - examples_rclpy_minimal_client
-        - examples_rclpy_minimal_publisher
-        - examples_rclpy_minimal_service
-        - examples_rclpy_minimal_subscriber
-        - examples_rclpy_pointcloud_publisher
-        - launch_testing_examples
+      - examples_rclcpp_async_client
+      - examples_rclcpp_cbg_executor
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
+      - examples_rclcpp_wait_set
+      - examples_rclpy_executors
+      - examples_rclpy_guard_conditions
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      - examples_rclpy_pointcloud_publisher
+      - launch_testing_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
@@ -2077,15 +2077,15 @@ repositories:
       version: rolling
     release:
       packages:
-        - flexbe_behavior_engine
-        - flexbe_core
-        - flexbe_input
-        - flexbe_mirror
-        - flexbe_msgs
-        - flexbe_onboard
-        - flexbe_states
-        - flexbe_testing
-        - flexbe_widget
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
@@ -2102,10 +2102,10 @@ repositories:
       version: ros2-release
     release:
       packages:
-        - flir_camera_description
-        - flir_camera_msgs
-        - spinnaker_camera_driver
-        - spinnaker_synchronized_camera_driver
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
@@ -2137,8 +2137,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - fmi_adapter
-        - fmi_adapter_examples
+      - fmi_adapter
+      - fmi_adapter_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
@@ -2233,19 +2233,19 @@ repositories:
       version: jazzy
     release:
       packages:
-        - fuse
-        - fuse_constraints
-        - fuse_core
-        - fuse_doc
-        - fuse_graphs
-        - fuse_loss
-        - fuse_models
-        - fuse_msgs
-        - fuse_optimizers
-        - fuse_publishers
-        - fuse_tutorials
-        - fuse_variables
-        - fuse_viz
+      - fuse
+      - fuse_constraints
+      - fuse_core
+      - fuse_doc
+      - fuse_graphs
+      - fuse_loss
+      - fuse_models
+      - fuse_msgs
+      - fuse_optimizers
+      - fuse_publishers
+      - fuse_tutorials
+      - fuse_variables
+      - fuse_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
@@ -2263,15 +2263,15 @@ repositories:
       version: rolling
     release:
       packages:
-        - game_controller_spl
-        - game_controller_spl_interfaces
-        - gc_spl
-        - gc_spl_2022
-        - gc_spl_interfaces
-        - rcgcd_spl_14
-        - rcgcd_spl_14_conversion
-        - rcgcrd_spl_4
-        - rcgcrd_spl_4_conversion
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      - gc_spl
+      - gc_spl_2022
+      - gc_spl_interfaces
+      - rcgcd_spl_14
+      - rcgcd_spl_14_conversion
+      - rcgcrd_spl_4
+      - rcgcrd_spl_4_conversion
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
@@ -2284,7 +2284,7 @@ repositories:
   gazebo_ros_pkgs:
     release:
       packages:
-        - gazebo_msgs
+      - gazebo_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
@@ -2296,12 +2296,12 @@ repositories:
       version: main
     release:
       packages:
-        - cmake_generate_parameter_module_example
-        - generate_parameter_library
-        - generate_parameter_library_example
-        - generate_parameter_library_py
-        - generate_parameter_module_example
-        - parameter_traits
+      - cmake_generate_parameter_module_example
+      - generate_parameter_library
+      - generate_parameter_library_example
+      - generate_parameter_library_py
+      - generate_parameter_module_example
+      - parameter_traits
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
@@ -2318,9 +2318,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - geodesy
-        - geographic_info
-        - geographic_msgs
+      - geodesy
+      - geographic_info
+      - geographic_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -2353,20 +2353,20 @@ repositories:
       version: jazzy
     release:
       packages:
-        - examples_tf2_py
-        - geometry2
-        - tf2
-        - tf2_bullet
-        - tf2_eigen
-        - tf2_eigen_kdl
-        - tf2_geometry_msgs
-        - tf2_kdl
-        - tf2_msgs
-        - tf2_py
-        - tf2_ros
-        - tf2_ros_py
-        - tf2_sensor_msgs
-        - tf2_tools
+      - examples_tf2_py
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_eigen_kdl
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_ros_py
+      - tf2_sensor_msgs
+      - tf2_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
@@ -2384,9 +2384,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - geometry_tutorials
-        - turtle_tf2_cpp
-        - turtle_tf2_py
+      - geometry_tutorials
+      - turtle_tf2_cpp
+      - turtle_tf2_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
@@ -2415,8 +2415,8 @@ repositories:
   googletest:
     release:
       packages:
-        - gmock_vendor
-        - gtest_vendor
+      - gmock_vendor
+      - gtest_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
@@ -2433,10 +2433,10 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - gps_msgs
-        - gps_tools
-        - gps_umd
-        - gpsd_client
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
@@ -2514,21 +2514,21 @@ repositories:
       version: jazzy
     release:
       packages:
-        - grid_map
-        - grid_map_cmake_helpers
-        - grid_map_core
-        - grid_map_costmap_2d
-        - grid_map_cv
-        - grid_map_demos
-        - grid_map_filters
-        - grid_map_loader
-        - grid_map_msgs
-        - grid_map_octomap
-        - grid_map_pcl
-        - grid_map_ros
-        - grid_map_rviz_plugin
-        - grid_map_sdf
-        - grid_map_visualization
+      - grid_map
+      - grid_map_cmake_helpers
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/grid_map-release.git
@@ -2766,8 +2766,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - gz_ros2_control
-        - gz_ros2_control_demos
+      - gz_ros2_control
+      - gz_ros2_control_demos
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
@@ -2936,10 +2936,10 @@ repositories:
   iceoryx:
     release:
       packages:
-        - iceoryx_binding_c
-        - iceoryx_hoofs
-        - iceoryx_introspection
-        - iceoryx_posh
+      - iceoryx_binding_c
+      - iceoryx_hoofs
+      - iceoryx_introspection
+      - iceoryx_posh
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
@@ -2963,9 +2963,9 @@ repositories:
       version: main
     release:
       packages:
-        - ign_rviz
-        - ign_rviz_common
-        - ign_rviz_plugins
+      - ign_rviz
+      - ign_rviz_common
+      - ign_rviz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
@@ -2982,11 +2982,11 @@ repositories:
       version: jazzy
     release:
       packages:
-        - camera_calibration_parsers
-        - camera_info_manager
-        - camera_info_manager_py
-        - image_common
-        - image_transport
+      - camera_calibration_parsers
+      - camera_info_manager
+      - camera_info_manager_py
+      - image_common
+      - image_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
@@ -3004,15 +3004,15 @@ repositories:
       version: jazzy
     release:
       packages:
-        - camera_calibration
-        - depth_image_proc
-        - image_pipeline
-        - image_proc
-        - image_publisher
-        - image_rotate
-        - image_view
-        - stereo_image_proc
-        - tracetools_image_pipeline
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      - tracetools_image_pipeline
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
@@ -3030,11 +3030,11 @@ repositories:
       version: jazzy
     release:
       packages:
-        - compressed_depth_image_transport
-        - compressed_image_transport
-        - image_transport_plugins
-        - theora_image_transport
-        - zstd_image_transport
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      - zstd_image_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
@@ -3052,9 +3052,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - imu_pipeline
-        - imu_processors
-        - imu_transformer
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
@@ -3071,10 +3071,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - imu_complementary_filter
-        - imu_filter_madgwick
-        - imu_tools
-        - rviz_imu_plugin
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
@@ -3145,8 +3145,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - joint_state_publisher
-        - joint_state_publisher_gui
+      - joint_state_publisher
+      - joint_state_publisher_gui
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
@@ -3179,12 +3179,12 @@ repositories:
       version: ros2
     release:
       packages:
-        - joy
-        - joy_linux
-        - sdl2_vendor
-        - spacenav
-        - wiimote
-        - wiimote_msgs
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      - spacenav
+      - wiimote
+      - wiimote_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
@@ -3234,8 +3234,8 @@ repositories:
       version: master
     release:
       packages:
-        - kinematics_interface
-        - kinematics_interface_kdl
+      - kinematics_interface
+      - kinematics_interface_kdl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
@@ -3335,17 +3335,17 @@ repositories:
       version: master
     release:
       packages:
-        - lanelet2
-        - lanelet2_core
-        - lanelet2_examples
-        - lanelet2_io
-        - lanelet2_maps
-        - lanelet2_matching
-        - lanelet2_projection
-        - lanelet2_python
-        - lanelet2_routing
-        - lanelet2_traffic_rules
-        - lanelet2_validation
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_matching
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
@@ -3405,12 +3405,12 @@ repositories:
       version: jazzy
     release:
       packages:
-        - launch
-        - launch_pytest
-        - launch_testing
-        - launch_testing_ament_cmake
-        - launch_xml
-        - launch_yaml
+      - launch
+      - launch_pytest
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
@@ -3443,9 +3443,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - launch_ros
-        - launch_testing_ros
-        - ros2launch
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
@@ -3463,10 +3463,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - leo
-        - leo_description
-        - leo_msgs
-        - leo_teleop
+      - leo
+      - leo_description
+      - leo_msgs
+      - leo_teleop
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
@@ -3483,8 +3483,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - leo_desktop
-        - leo_viz
+      - leo_desktop
+      - leo_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
@@ -3501,9 +3501,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - leo_bringup
-        - leo_fw
-        - leo_robot
+      - leo_bringup
+      - leo_fw
+      - leo_robot
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
@@ -3520,10 +3520,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - leo_gz_bringup
-        - leo_gz_plugins
-        - leo_gz_worlds
-        - leo_simulator
+      - leo_gz_bringup
+      - leo_gz_plugins
+      - leo_gz_worlds
+      - leo_simulator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
@@ -3744,11 +3744,11 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - mapviz
-        - mapviz_interfaces
-        - mapviz_plugins
-        - multires_image
-        - tile_map
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
@@ -3766,8 +3766,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - marine_acoustic_msgs
-        - marine_sensor_msgs
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
@@ -3799,18 +3799,18 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - swri_cli_tools
-        - swri_console_util
-        - swri_dbw_interface
-        - swri_geometry_util
-        - swri_image_util
-        - swri_math_util
-        - swri_opencv_util
-        - swri_roscpp
-        - swri_route_util
-        - swri_serial_util
-        - swri_system_util
-        - swri_transform_util
+      - swri_cli_tools
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
@@ -3828,15 +3828,15 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - marti_can_msgs
-        - marti_common_msgs
-        - marti_dbw_msgs
-        - marti_introspection_msgs
-        - marti_nav_msgs
-        - marti_perception_msgs
-        - marti_sensor_msgs
-        - marti_status_msgs
-        - marti_visualization_msgs
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_introspection_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
@@ -3869,10 +3869,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - libmavconn
-        - mavros
-        - mavros_extras
-        - mavros_msgs
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
@@ -3950,8 +3950,8 @@ repositories:
       version: master
     release:
       packages:
-        - micro_ros_diagnostic_bridge
-        - micro_ros_diagnostic_msgs
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
@@ -3983,11 +3983,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - microstrain_inertial_description
-        - microstrain_inertial_driver
-        - microstrain_inertial_examples
-        - microstrain_inertial_msgs
-        - microstrain_inertial_rqt
+      - microstrain_inertial_description
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
@@ -4031,26 +4031,26 @@ repositories:
       version: develop
     release:
       packages:
-        - kitti_metrics_eval
-        - mola
-        - mola_bridge_ros2
-        - mola_demos
-        - mola_input_euroc_dataset
-        - mola_input_kitti360_dataset
-        - mola_input_kitti_dataset
-        - mola_input_mulran_dataset
-        - mola_input_paris_luco_dataset
-        - mola_input_rawlog
-        - mola_input_rosbag2
-        - mola_kernel
-        - mola_launcher
-        - mola_metric_maps
-        - mola_msgs
-        - mola_pose_list
-        - mola_relocalization
-        - mola_traj_tools
-        - mola_viz
-        - mola_yaml
+      - kitti_metrics_eval
+      - mola
+      - mola_bridge_ros2
+      - mola_demos
+      - mola_input_euroc_dataset
+      - mola_input_kitti360_dataset
+      - mola_input_kitti_dataset
+      - mola_input_mulran_dataset
+      - mola_input_paris_luco_dataset
+      - mola_input_rawlog
+      - mola_input_rosbag2
+      - mola_kernel
+      - mola_launcher
+      - mola_metric_maps
+      - mola_msgs
+      - mola_pose_list
+      - mola_relocalization
+      - mola_traj_tools
+      - mola_viz
+      - mola_yaml
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
@@ -4122,8 +4122,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - motion_capture_tracking
-        - motion_capture_tracking_interfaces
+      - motion_capture_tracking
+      - motion_capture_tracking_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
@@ -4140,47 +4140,47 @@ repositories:
       version: main
     release:
       packages:
-        - chomp_motion_planner
-        - moveit
-        - moveit_common
-        - moveit_configs_utils
-        - moveit_core
-        - moveit_hybrid_planning
-        - moveit_kinematics
-        - moveit_planners
-        - moveit_planners_chomp
-        - moveit_planners_ompl
-        - moveit_planners_stomp
-        - moveit_plugins
-        - moveit_py
-        - moveit_resources_prbt_ikfast_manipulator_plugin
-        - moveit_resources_prbt_moveit_config
-        - moveit_resources_prbt_pg70_support
-        - moveit_resources_prbt_support
-        - moveit_ros
-        - moveit_ros_benchmarks
-        - moveit_ros_control_interface
-        - moveit_ros_move_group
-        - moveit_ros_occupancy_map_monitor
-        - moveit_ros_perception
-        - moveit_ros_planning
-        - moveit_ros_planning_interface
-        - moveit_ros_robot_interaction
-        - moveit_ros_tests
-        - moveit_ros_trajectory_cache
-        - moveit_ros_visualization
-        - moveit_ros_warehouse
-        - moveit_runtime
-        - moveit_servo
-        - moveit_setup_app_plugins
-        - moveit_setup_assistant
-        - moveit_setup_controllers
-        - moveit_setup_core_plugins
-        - moveit_setup_framework
-        - moveit_setup_srdf_plugins
-        - moveit_simple_controller_manager
-        - pilz_industrial_motion_planner
-        - pilz_industrial_motion_planner_testutils
+      - chomp_motion_planner
+      - moveit
+      - moveit_common
+      - moveit_configs_utils
+      - moveit_core
+      - moveit_hybrid_planning
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_planners_stomp
+      - moveit_plugins
+      - moveit_py
+      - moveit_resources_prbt_ikfast_manipulator_plugin
+      - moveit_resources_prbt_moveit_config
+      - moveit_resources_prbt_pg70_support
+      - moveit_resources_prbt_support
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_tests
+      - moveit_ros_trajectory_cache
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_setup_app_plugins
+      - moveit_setup_assistant
+      - moveit_setup_controllers
+      - moveit_setup_core_plugins
+      - moveit_setup_framework
+      - moveit_setup_srdf_plugins
+      - moveit_simple_controller_manager
+      - pilz_industrial_motion_planner
+      - pilz_industrial_motion_planner_testutils
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
@@ -4214,13 +4214,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - dual_arm_panda_moveit_config
-        - moveit_resources
-        - moveit_resources_fanuc_description
-        - moveit_resources_fanuc_moveit_config
-        - moveit_resources_panda_description
-        - moveit_resources_panda_moveit_config
-        - moveit_resources_pr2_description
+      - dual_arm_panda_moveit_config
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -4267,8 +4267,8 @@ repositories:
       version: main
     release:
       packages:
-        - mqtt_client
-        - mqtt_client_interfaces
+      - mqtt_client
+      - mqtt_client_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
@@ -4300,16 +4300,16 @@ repositories:
       version: ros2
     release:
       packages:
-        - mrpt_map_server
-        - mrpt_msgs_bridge
-        - mrpt_nav_interfaces
-        - mrpt_navigation
-        - mrpt_pf_localization
-        - mrpt_pointcloud_pipeline
-        - mrpt_rawlog
-        - mrpt_reactivenav2d
-        - mrpt_tps_astar_planner
-        - mrpt_tutorials
+      - mrpt_map_server
+      - mrpt_msgs_bridge
+      - mrpt_nav_interfaces
+      - mrpt_navigation
+      - mrpt_pf_localization
+      - mrpt_pointcloud_pipeline
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tps_astar_planner
+      - mrpt_tutorials
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
@@ -4341,20 +4341,20 @@ repositories:
       version: main
     release:
       packages:
-        - mrpt_apps
-        - mrpt_libapps
-        - mrpt_libbase
-        - mrpt_libgui
-        - mrpt_libhwdrivers
-        - mrpt_libmaps
-        - mrpt_libmath
-        - mrpt_libnav
-        - mrpt_libobs
-        - mrpt_libopengl
-        - mrpt_libposes
-        - mrpt_libros_bridge
-        - mrpt_libslam
-        - mrpt_libtclap
+      - mrpt_apps
+      - mrpt_libapps
+      - mrpt_libbase
+      - mrpt_libgui
+      - mrpt_libhwdrivers
+      - mrpt_libmaps
+      - mrpt_libmath
+      - mrpt_libnav
+      - mrpt_libobs
+      - mrpt_libopengl
+      - mrpt_libposes
+      - mrpt_libros_bridge
+      - mrpt_libslam
+      - mrpt_libtclap
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
@@ -4371,13 +4371,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - mrpt_generic_sensor
-        - mrpt_sensor_bumblebee_stereo
-        - mrpt_sensor_gnss_nmea
-        - mrpt_sensor_gnss_novatel
-        - mrpt_sensor_imu_taobotics
-        - mrpt_sensorlib
-        - mrpt_sensors
+      - mrpt_generic_sensor
+      - mrpt_sensor_bumblebee_stereo
+      - mrpt_sensor_gnss_nmea
+      - mrpt_sensor_gnss_novatel
+      - mrpt_sensor_imu_taobotics
+      - mrpt_sensorlib
+      - mrpt_sensors
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
@@ -4439,8 +4439,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - nao_command_msgs
-        - nao_sensor_msgs
+      - nao_command_msgs
+      - nao_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
@@ -4457,10 +4457,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - nao_lola
-        - nao_lola_client
-        - nao_lola_command_msgs
-        - nao_lola_sensor_msgs
+      - nao_lola
+      - nao_lola_client
+      - nao_lola_command_msgs
+      - nao_lola_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
@@ -4473,9 +4473,9 @@ repositories:
   nav2_minimal_turtlebot_simulation:
     release:
       packages:
-        - nav2_minimal_tb3_sim
-        - nav2_minimal_tb4_description
-        - nav2_minimal_tb4_sim
+      - nav2_minimal_tb3_sim
+      - nav2_minimal_tb4_description
+      - nav2_minimal_tb4_sim
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
@@ -4492,49 +4492,49 @@ repositories:
       version: jazzy
     release:
       packages:
-        - costmap_queue
-        - dwb_core
-        - dwb_critics
-        - dwb_msgs
-        - dwb_plugins
-        - nav2_amcl
-        - nav2_behavior_tree
-        - nav2_behaviors
-        - nav2_bringup
-        - nav2_bt_navigator
-        - nav2_collision_monitor
-        - nav2_common
-        - nav2_constrained_smoother
-        - nav2_controller
-        - nav2_core
-        - nav2_costmap_2d
-        - nav2_dwb_controller
-        - nav2_graceful_controller
-        - nav2_lifecycle_manager
-        - nav2_loopback_sim
-        - nav2_map_server
-        - nav2_mppi_controller
-        - nav2_msgs
-        - nav2_navfn_planner
-        - nav2_planner
-        - nav2_regulated_pure_pursuit_controller
-        - nav2_rotation_shim_controller
-        - nav2_rviz_plugins
-        - nav2_simple_commander
-        - nav2_smac_planner
-        - nav2_smoother
-        - nav2_system_tests
-        - nav2_theta_star_planner
-        - nav2_util
-        - nav2_velocity_smoother
-        - nav2_voxel_grid
-        - nav2_waypoint_follower
-        - nav_2d_msgs
-        - nav_2d_utils
-        - navigation2
-        - opennav_docking
-        - opennav_docking_bt
-        - opennav_docking_core
+      - costmap_queue
+      - dwb_core
+      - dwb_critics
+      - dwb_msgs
+      - dwb_plugins
+      - nav2_amcl
+      - nav2_behavior_tree
+      - nav2_behaviors
+      - nav2_bringup
+      - nav2_bt_navigator
+      - nav2_collision_monitor
+      - nav2_common
+      - nav2_constrained_smoother
+      - nav2_controller
+      - nav2_core
+      - nav2_costmap_2d
+      - nav2_dwb_controller
+      - nav2_graceful_controller
+      - nav2_lifecycle_manager
+      - nav2_loopback_sim
+      - nav2_map_server
+      - nav2_mppi_controller
+      - nav2_msgs
+      - nav2_navfn_planner
+      - nav2_planner
+      - nav2_regulated_pure_pursuit_controller
+      - nav2_rotation_shim_controller
+      - nav2_rviz_plugins
+      - nav2_simple_commander
+      - nav2_smac_planner
+      - nav2_smoother
+      - nav2_system_tests
+      - nav2_theta_star_planner
+      - nav2_util
+      - nav2_velocity_smoother
+      - nav2_voxel_grid
+      - nav2_waypoint_follower
+      - nav_2d_msgs
+      - nav_2d_utils
+      - navigation2
+      - opennav_docking
+      - opennav_docking_bt
+      - opennav_docking_core
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
@@ -4551,7 +4551,7 @@ repositories:
       version: jazzy
     release:
       packages:
-        - map_msgs
+      - map_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -4688,8 +4688,8 @@ repositories:
       version: master
     release:
       packages:
-        - nodl_python
-        - ros2nodl
+      - nodl_python
+      - ros2nodl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
@@ -4722,8 +4722,8 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - novatel_gps_driver
-        - novatel_gps_msgs
+      - novatel_gps_driver
+      - novatel_gps_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
@@ -4782,9 +4782,9 @@ repositories:
       version: devel
     release:
       packages:
-        - dynamic_edt_3d
-        - octomap
-        - octovis
+      - dynamic_edt_3d
+      - octomap
+      - octovis
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
@@ -4801,8 +4801,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - octomap_mapping
-        - octomap_server
+      - octomap_mapping
+      - octomap_server
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
@@ -4879,7 +4879,7 @@ repositories:
       version: main
     release:
       packages:
-        - odri_master_board_sdk
+      - odri_master_board_sdk
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
@@ -4957,8 +4957,8 @@ repositories:
   orocos_kdl_vendor:
     release:
       packages:
-        - orocos_kdl_vendor
-        - python_orocos_kdl_vendor
+      - orocos_kdl_vendor
+      - python_orocos_kdl_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
@@ -5028,8 +5028,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-        - ouster_ros
-        - ouster_sensor_msgs
+      - ouster_ros
+      - ouster_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
@@ -5047,8 +5047,8 @@ repositories:
       version: master
     release:
       packages:
-        - ouxt_common
-        - ouxt_lint_common
+      - ouxt_common
+      - ouxt_lint_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
@@ -5065,8 +5065,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_statistics
-        - pal_statistics_msgs
+      - pal_statistics
+      - pal_statistics_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
@@ -5101,7 +5101,7 @@ repositories:
   perception_open3d:
     release:
       packages:
-        - open3d_conversions
+      - open3d_conversions
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
@@ -5119,9 +5119,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - pcl_conversions
-        - pcl_ros
-        - perception_pcl
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
@@ -5166,22 +5166,22 @@ repositories:
       version: rolling
     release:
       packages:
-        - libphidget22
-        - phidgets_accelerometer
-        - phidgets_analog_inputs
-        - phidgets_analog_outputs
-        - phidgets_api
-        - phidgets_digital_inputs
-        - phidgets_digital_outputs
-        - phidgets_drivers
-        - phidgets_gyroscope
-        - phidgets_high_speed_encoder
-        - phidgets_ik
-        - phidgets_magnetometer
-        - phidgets_motors
-        - phidgets_msgs
-        - phidgets_spatial
-        - phidgets_temperature
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_analog_outputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
@@ -5220,8 +5220,8 @@ repositories:
       version: main
     release:
       packages:
-        - picknik_reset_fault_controller
-        - picknik_twist_controller
+      - picknik_reset_fault_controller
+      - picknik_twist_controller
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
@@ -5329,8 +5329,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - point_cloud_transport
-        - point_cloud_transport_py
+      - point_cloud_transport
+      - point_cloud_transport_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -5348,11 +5348,11 @@ repositories:
       version: jazzy
     release:
       packages:
-        - draco_point_cloud_transport
-        - point_cloud_interfaces
-        - point_cloud_transport_plugins
-        - zlib_point_cloud_transport
-        - zstd_point_cloud_transport
+      - draco_point_cloud_transport
+      - point_cloud_interfaces
+      - point_cloud_transport_plugins
+      - zlib_point_cloud_transport
+      - zstd_point_cloud_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
@@ -5402,10 +5402,10 @@ repositories:
       version: main
     release:
       packages:
-        - polygon_demos
-        - polygon_msgs
-        - polygon_rviz_plugins
-        - polygon_utils
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
@@ -5468,7 +5468,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - ptz_action_server_msgs
+      - ptz_action_server_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
@@ -5606,7 +5606,7 @@ repositories:
       version: main
     release:
       packages:
-        - python_mrpt
+      - python_mrpt
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
@@ -5665,12 +5665,12 @@ repositories:
       version: jazzy
     release:
       packages:
-        - qt_dotgraph
-        - qt_gui
-        - qt_gui_app
-        - qt_gui_core
-        - qt_gui_cpp
-        - qt_gui_py_common
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
@@ -5703,9 +5703,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - r2r_spl_7
-        - splsm_7
-        - splsm_7_conversion
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
@@ -5744,8 +5744,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - raspimouse
-        - raspimouse_msgs
+      - raspimouse
+      - raspimouse_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
@@ -5795,9 +5795,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - raspimouse_fake
-        - raspimouse_gazebo
-        - raspimouse_sim
+      - raspimouse_fake
+      - raspimouse_gazebo
+      - raspimouse_sim
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_sim-release.git
@@ -5815,9 +5815,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - raspimouse_navigation
-        - raspimouse_slam
-        - raspimouse_slam_navigation
+      - raspimouse_navigation
+      - raspimouse_slam
+      - raspimouse_slam_navigation
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
@@ -5899,8 +5899,8 @@ repositories:
       version: master
     release:
       packages:
-        - rc_reason_clients
-        - rc_reason_msgs
+      - rc_reason_clients
+      - rc_reason_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
@@ -5934,10 +5934,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rcl
-        - rcl_action
-        - rcl_lifecycle
-        - rcl_yaml_param_parser
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
@@ -5955,16 +5955,16 @@ repositories:
       version: jazzy
     release:
       packages:
-        - action_msgs
-        - builtin_interfaces
-        - composition_interfaces
-        - lifecycle_msgs
-        - rcl_interfaces
-        - rosgraph_msgs
-        - service_msgs
-        - statistics_msgs
-        - test_msgs
-        - type_description_interfaces
+      - action_msgs
+      - builtin_interfaces
+      - composition_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - service_msgs
+      - statistics_msgs
+      - test_msgs
+      - type_description_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
@@ -5982,9 +5982,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rcl_logging_interface
-        - rcl_logging_noop
-        - rcl_logging_spdlog
+      - rcl_logging_interface
+      - rcl_logging_noop
+      - rcl_logging_spdlog
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
@@ -6013,10 +6013,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - rclc
-        - rclc_examples
-        - rclc_lifecycle
-        - rclc_parameter
+      - rclc
+      - rclc_examples
+      - rclc_lifecycle
+      - rclc_parameter
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
@@ -6034,10 +6034,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rclcpp
-        - rclcpp_action
-        - rclcpp_components
-        - rclcpp_lifecycle
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
@@ -6087,10 +6087,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - rcss3d_agent
-        - rcss3d_agent_basic
-        - rcss3d_agent_msgs
-        - rcss3d_agent_msgs_to_soccer_interfaces
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
+      - rcss3d_agent_msgs_to_soccer_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
@@ -6148,9 +6148,9 @@ repositories:
       version: ros2-master
     release:
       packages:
-        - realsense2_camera
-        - realsense2_camera_msgs
-        - realsense2_description
+      - realsense2_camera
+      - realsense2_camera_msgs
+      - realsense2_description
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
@@ -6168,8 +6168,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rttest
-        - tlsf_cpp
+      - rttest
+      - tlsf_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
@@ -6202,8 +6202,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - libcurl_vendor
-        - resource_retriever
+      - libcurl_vendor
+      - resource_retriever
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
@@ -6288,18 +6288,18 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_charger_msgs
-        - rmf_dispenser_msgs
-        - rmf_door_msgs
-        - rmf_fleet_msgs
-        - rmf_ingestor_msgs
-        - rmf_lift_msgs
-        - rmf_obstacle_msgs
-        - rmf_scheduler_msgs
-        - rmf_site_map_msgs
-        - rmf_task_msgs
-        - rmf_traffic_msgs
-        - rmf_workcell_msgs
+      - rmf_charger_msgs
+      - rmf_dispenser_msgs
+      - rmf_door_msgs
+      - rmf_fleet_msgs
+      - rmf_ingestor_msgs
+      - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_scheduler_msgs
+      - rmf_site_map_msgs
+      - rmf_task_msgs
+      - rmf_traffic_msgs
+      - rmf_workcell_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
@@ -6316,12 +6316,12 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_charging_schedule
-        - rmf_fleet_adapter
-        - rmf_fleet_adapter_python
-        - rmf_task_ros2
-        - rmf_traffic_ros2
-        - rmf_websocket
+      - rmf_charging_schedule
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      - rmf_websocket
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
@@ -6338,9 +6338,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_building_sim_gz_plugins
-        - rmf_robot_sim_common
-        - rmf_robot_sim_gz_plugins
+      - rmf_building_sim_gz_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
@@ -6357,8 +6357,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_task
-        - rmf_task_sequence
+      - rmf_task
+      - rmf_task_sequence
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
@@ -6375,8 +6375,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_traffic
-        - rmf_traffic_examples
+      - rmf_traffic
+      - rmf_traffic_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
@@ -6393,10 +6393,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_building_map_tools
-        - rmf_traffic_editor
-        - rmf_traffic_editor_assets
-        - rmf_traffic_editor_test_maps
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - rmf_traffic_editor_test_maps
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
@@ -6428,7 +6428,7 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_dev
+      - rmf_dev
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
@@ -6445,14 +6445,14 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmf_visualization
-        - rmf_visualization_building_systems
-        - rmf_visualization_fleet_states
-        - rmf_visualization_floorplans
-        - rmf_visualization_navgraphs
-        - rmf_visualization_obstacles
-        - rmf_visualization_rviz2_plugins
-        - rmf_visualization_schedule
+      - rmf_visualization
+      - rmf_visualization_building_systems
+      - rmf_visualization_fleet_states
+      - rmf_visualization_floorplans
+      - rmf_visualization_navgraphs
+      - rmf_visualization_obstacles
+      - rmf_visualization_rviz2_plugins
+      - rmf_visualization_schedule
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
@@ -6484,8 +6484,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmw
-        - rmw_implementation_cmake
+      - rmw
+      - rmw_implementation_cmake
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
@@ -6503,9 +6503,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmw_connextdds
-        - rmw_connextdds_common
-        - rti_connext_dds_cmake_module
+      - rmw_connextdds
+      - rmw_connextdds_common
+      - rti_connext_dds_cmake_module
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
@@ -6522,7 +6522,7 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmw_cyclonedds_cpp
+      - rmw_cyclonedds_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
@@ -6556,9 +6556,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmw_fastrtps_cpp
-        - rmw_fastrtps_dynamic_cpp
-        - rmw_fastrtps_shared_cpp
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
@@ -6576,8 +6576,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - gurumdds_cmake_module
-        - rmw_gurumdds_cpp
+      - gurumdds_cmake_module
+      - rmw_gurumdds_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
@@ -6610,8 +6610,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rmw_zenoh_cpp
-        - zenoh_cpp_vendor
+      - rmw_zenoh_cpp
+      - zenoh_cpp_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
@@ -6638,8 +6638,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - robot_calibration
-        - robot_calibration_msgs
+      - robot_calibration
+      - robot_calibration_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
@@ -6709,8 +6709,7 @@ repositories:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master
-    status_description:
-      Maintained in source form only since no ROS 1 packages available
+    status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
   ros2_canopen:
     doc:
@@ -6719,19 +6718,19 @@ repositories:
       version: master
     release:
       packages:
-        - canopen
-        - canopen_402_driver
-        - canopen_base_driver
-        - canopen_core
-        - canopen_fake_slaves
-        - canopen_interfaces
-        - canopen_master_driver
-        - canopen_proxy_driver
-        - canopen_ros2_control
-        - canopen_ros2_controllers
-        - canopen_tests
-        - canopen_utils
-        - lely_core_libraries
+      - canopen
+      - canopen_402_driver
+      - canopen_base_driver
+      - canopen_core
+      - canopen_fake_slaves
+      - canopen_interfaces
+      - canopen_master_driver
+      - canopen_proxy_driver
+      - canopen_ros2_control
+      - canopen_ros2_controllers
+      - canopen_tests
+      - canopen_utils
+      - lely_core_libraries
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
@@ -6748,17 +6747,17 @@ repositories:
       version: master
     release:
       packages:
-        - controller_interface
-        - controller_manager
-        - controller_manager_msgs
-        - hardware_interface
-        - hardware_interface_testing
-        - joint_limits
-        - ros2_control
-        - ros2_control_test_assets
-        - ros2controlcli
-        - rqt_controller_manager
-        - transmission_interface
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - hardware_interface_testing
+      - joint_limits
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - rqt_controller_manager
+      - transmission_interface
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
@@ -6775,31 +6774,31 @@ repositories:
       version: master
     release:
       packages:
-        - ackermann_steering_controller
-        - admittance_controller
-        - bicycle_steering_controller
-        - diff_drive_controller
-        - effort_controllers
-        - force_torque_sensor_broadcaster
-        - forward_command_controller
-        - gpio_controllers
-        - gripper_controllers
-        - imu_sensor_broadcaster
-        - joint_state_broadcaster
-        - joint_trajectory_controller
-        - mecanum_drive_controller
-        - parallel_gripper_controller
-        - pid_controller
-        - pose_broadcaster
-        - position_controllers
-        - range_sensor_broadcaster
-        - ros2_controllers
-        - ros2_controllers_test_nodes
-        - rqt_joint_trajectory_controller
-        - steering_controllers_library
-        - tricycle_controller
-        - tricycle_steering_controller
-        - velocity_controllers
+      - ackermann_steering_controller
+      - admittance_controller
+      - bicycle_steering_controller
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_broadcaster
+      - forward_command_controller
+      - gpio_controllers
+      - gripper_controllers
+      - imu_sensor_broadcaster
+      - joint_state_broadcaster
+      - joint_trajectory_controller
+      - mecanum_drive_controller
+      - parallel_gripper_controller
+      - pid_controller
+      - pose_broadcaster
+      - position_controllers
+      - range_sensor_broadcaster
+      - ros2_controllers
+      - ros2_controllers_test_nodes
+      - rqt_joint_trajectory_controller
+      - steering_controllers_library
+      - tricycle_controller
+      - tricycle_steering_controller
+      - velocity_controllers
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
@@ -6816,12 +6815,12 @@ repositories:
       version: main
     release:
       packages:
-        - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-        - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-        - kortex_api
-        - kortex_bringup
-        - kortex_description
-        - kortex_driver
+      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kortex_api
+      - kortex_bringup
+      - kortex_description
+      - kortex_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
@@ -6848,21 +6847,21 @@ repositories:
       version: jazzy-devel
     release:
       packages:
-        - plansys2_bringup
-        - plansys2_bt_actions
-        - plansys2_core
-        - plansys2_domain_expert
-        - plansys2_executor
-        - plansys2_lifecycle_manager
-        - plansys2_msgs
-        - plansys2_pddl_parser
-        - plansys2_planner
-        - plansys2_popf_plan_solver
-        - plansys2_problem_expert
-        - plansys2_support_py
-        - plansys2_terminal
-        - plansys2_tests
-        - plansys2_tools
+      - plansys2_bringup
+      - plansys2_bt_actions
+      - plansys2_core
+      - plansys2_domain_expert
+      - plansys2_executor
+      - plansys2_lifecycle_manager
+      - plansys2_msgs
+      - plansys2_pddl_parser
+      - plansys2_planner
+      - plansys2_popf_plan_solver
+      - plansys2_problem_expert
+      - plansys2_support_py
+      - plansys2_terminal
+      - plansys2_tests
+      - plansys2_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_planning_system-release.git
@@ -6879,8 +6878,8 @@ repositories:
       version: main
     release:
       packages:
-        - robotiq_controllers
-        - robotiq_description
+      - robotiq_controllers
+      - robotiq_description
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
@@ -6897,8 +6896,8 @@ repositories:
       version: main
     release:
       packages:
-        - ros2_socketcan
-        - ros2_socketcan_msgs
+      - ros2_socketcan
+      - ros2_socketcan_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
@@ -6915,13 +6914,13 @@ repositories:
       version: jazzy
     release:
       packages:
-        - lttngpy
-        - ros2trace
-        - tracetools
-        - tracetools_launch
-        - tracetools_read
-        - tracetools_test
-        - tracetools_trace
+      - lttngpy
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
@@ -6955,21 +6954,21 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ros2action
-        - ros2cli
-        - ros2cli_test_interfaces
-        - ros2component
-        - ros2doctor
-        - ros2interface
-        - ros2lifecycle
-        - ros2lifecycle_test_fixtures
-        - ros2multicast
-        - ros2node
-        - ros2param
-        - ros2pkg
-        - ros2run
-        - ros2service
-        - ros2topic
+      - ros2action
+      - ros2cli
+      - ros2cli_test_interfaces
+      - ros2component
+      - ros2doctor
+      - ros2interface
+      - ros2lifecycle
+      - ros2lifecycle_test_fixtures
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2topic
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
@@ -7002,8 +7001,8 @@ repositories:
       version: main
     release:
       packages:
-        - ros2launch_security
-        - ros2launch_security_examples
+      - ros2launch_security
+      - ros2launch_security_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
@@ -7021,8 +7020,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ros_babel_fish
-        - ros_babel_fish_test_msgs
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
@@ -7049,8 +7048,8 @@ repositories:
       version: main
     release:
       packages:
-        - battery_state_broadcaster
-        - battery_state_rviz_overlay
+      - battery_state_broadcaster
+      - battery_state_rviz_overlay
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
@@ -7064,7 +7063,7 @@ repositories:
   ros_canopen:
     release:
       packages:
-        - can_msgs
+      - can_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
@@ -7097,13 +7096,13 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ros_gz
-        - ros_gz_bridge
-        - ros_gz_image
-        - ros_gz_interfaces
-        - ros_gz_sim
-        - ros_gz_sim_demos
-        - test_ros_gz_bridge
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      - test_ros_gz_bridge
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
@@ -7142,8 +7141,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ros2test
-        - ros_testing
+      - ros2test
+      - ros_testing
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
@@ -7161,7 +7160,7 @@ repositories:
       version: jazzy
     release:
       packages:
-        - turtlesim
+      - turtlesim
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
@@ -7190,30 +7189,30 @@ repositories:
       version: jazzy
     release:
       packages:
-        - liblz4_vendor
-        - mcap_vendor
-        - ros2bag
-        - rosbag2
-        - rosbag2_compression
-        - rosbag2_compression_zstd
-        - rosbag2_cpp
-        - rosbag2_examples_cpp
-        - rosbag2_examples_py
-        - rosbag2_interfaces
-        - rosbag2_performance_benchmarking
-        - rosbag2_performance_benchmarking_msgs
-        - rosbag2_py
-        - rosbag2_storage
-        - rosbag2_storage_default_plugins
-        - rosbag2_storage_mcap
-        - rosbag2_storage_sqlite3
-        - rosbag2_test_common
-        - rosbag2_test_msgdefs
-        - rosbag2_tests
-        - rosbag2_transport
-        - shared_queues_vendor
-        - sqlite3_vendor
-        - zstd_vendor
+      - liblz4_vendor
+      - mcap_vendor
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_compression_zstd
+      - rosbag2_cpp
+      - rosbag2_examples_cpp
+      - rosbag2_examples_py
+      - rosbag2_interfaces
+      - rosbag2_performance_benchmarking
+      - rosbag2_performance_benchmarking_msgs
+      - rosbag2_py
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_sqlite3
+      - rosbag2_test_common
+      - rosbag2_test_msgdefs
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      - zstd_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
@@ -7230,8 +7229,7 @@ repositories:
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
-    status_description:
-      Maintained in source form only since no ROS 1 packages available
+    status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
   rosbag2_to_video:
     doc:
@@ -7255,13 +7253,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - rosapi
-        - rosapi_msgs
-        - rosbridge_library
-        - rosbridge_msgs
-        - rosbridge_server
-        - rosbridge_suite
-        - rosbridge_test_msgs
+      - rosapi
+      - rosapi_msgs
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      - rosbridge_test_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
@@ -7278,19 +7276,19 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rosidl_adapter
-        - rosidl_cli
-        - rosidl_cmake
-        - rosidl_generator_c
-        - rosidl_generator_cpp
-        - rosidl_generator_type_description
-        - rosidl_parser
-        - rosidl_pycommon
-        - rosidl_runtime_c
-        - rosidl_runtime_cpp
-        - rosidl_typesupport_interface
-        - rosidl_typesupport_introspection_c
-        - rosidl_typesupport_introspection_cpp
+      - rosidl_adapter
+      - rosidl_cli
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_generator_type_description
+      - rosidl_parser
+      - rosidl_pycommon
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
@@ -7308,8 +7306,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rosidl_core_generators
-        - rosidl_core_runtime
+      - rosidl_core_generators
+      - rosidl_core_runtime
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
@@ -7327,7 +7325,7 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rosidl_generator_dds_idl
+      - rosidl_generator_dds_idl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
@@ -7345,8 +7343,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rosidl_default_generators
-        - rosidl_default_runtime
+      - rosidl_default_generators
+      - rosidl_default_runtime
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
@@ -7396,7 +7394,7 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rosidl_generator_py
+      - rosidl_generator_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
@@ -7430,8 +7428,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rosidl_typesupport_c
-        - rosidl_typesupport_cpp
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
@@ -7449,9 +7447,9 @@ repositories:
       version: jazzy
     release:
       packages:
-        - fastrtps_cmake_module
-        - rosidl_typesupport_fastrtps_c
-        - rosidl_typesupport_fastrtps_cpp
+      - fastrtps_cmake_module
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
@@ -7469,8 +7467,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rclpy_message_converter
-        - rclpy_message_converter_msgs
+      - rclpy_message_converter
+      - rclpy_message_converter_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
@@ -7499,7 +7497,7 @@ repositories:
   rot_conv_lib:
     release:
       packages:
-        - rot_conv
+      - rot_conv
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
@@ -7544,11 +7542,11 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rqt
-        - rqt_gui
-        - rqt_gui_cpp
-        - rqt_gui_py
-        - rqt_py_common
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
@@ -7581,8 +7579,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rqt_bag
-        - rqt_bag_plugins
+      - rqt_bag
+      - rqt_bag_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
@@ -7675,8 +7673,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rqt_image_overlay
-        - rqt_image_overlay_layer
+      - rqt_image_overlay
+      - rqt_image_overlay_layer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
@@ -7981,8 +7979,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - rt_manipulators_cpp
-        - rt_manipulators_examples
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
@@ -8030,19 +8028,19 @@ repositories:
       version: jazzy-devel
     release:
       packages:
-        - rtabmap_conversions
-        - rtabmap_demos
-        - rtabmap_examples
-        - rtabmap_launch
-        - rtabmap_msgs
-        - rtabmap_odom
-        - rtabmap_python
-        - rtabmap_ros
-        - rtabmap_rviz_plugins
-        - rtabmap_slam
-        - rtabmap_sync
-        - rtabmap_util
-        - rtabmap_viz
+      - rtabmap_conversions
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
@@ -8085,14 +8083,14 @@ repositories:
       version: jazzy
     release:
       packages:
-        - rviz2
-        - rviz_assimp_vendor
-        - rviz_common
-        - rviz_default_plugins
-        - rviz_ogre_vendor
-        - rviz_rendering
-        - rviz_rendering_tests
-        - rviz_visual_testing_framework
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
@@ -8110,8 +8108,8 @@ repositories:
       version: main
     release:
       packages:
-        - rviz_2d_overlay_msgs
-        - rviz_2d_overlay_plugins
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
@@ -8174,17 +8172,17 @@ repositories:
       version: jazzy
     release:
       packages:
-        - scenario_execution
-        - scenario_execution_control
-        - scenario_execution_coverage
-        - scenario_execution_gazebo
-        - scenario_execution_interfaces
-        - scenario_execution_nav2
-        - scenario_execution_os
-        - scenario_execution_py_trees_ros
-        - scenario_execution_ros
-        - scenario_execution_rviz
-        - scenario_execution_x11
+      - scenario_execution
+      - scenario_execution_control
+      - scenario_execution_coverage
+      - scenario_execution_gazebo
+      - scenario_execution_interfaces
+      - scenario_execution_nav2
+      - scenario_execution_os
+      - scenario_execution_py_trees_ros
+      - scenario_execution_ros
+      - scenario_execution_rviz
+      - scenario_execution_x11
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
@@ -8201,8 +8199,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - sdformat_test_files
-        - sdformat_urdf
+      - sdformat_test_files
+      - sdformat_urdf
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
@@ -8312,9 +8310,9 @@ repositories:
       version: main
     release:
       packages:
-        - sick_safevisionary_driver
-        - sick_safevisionary_interfaces
-        - sick_safevisionary_tests
+      - sick_safevisionary_driver
+      - sick_safevisionary_interfaces
+      - sick_safevisionary_tests
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
@@ -8438,10 +8436,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - executive_smach
-        - smach
-        - smach_msgs
-        - smach_ros
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
@@ -8480,12 +8478,12 @@ repositories:
       version: rolling
     release:
       packages:
-        - soccer_geometry_msgs
-        - soccer_interfaces
-        - soccer_model_msgs
-        - soccer_vision_2d_msgs
-        - soccer_vision_3d_msgs
-        - soccer_vision_attribute_msgs
+      - soccer_geometry_msgs
+      - soccer_interfaces
+      - soccer_model_msgs
+      - soccer_vision_2d_msgs
+      - soccer_vision_3d_msgs
+      - soccer_vision_attribute_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
@@ -8547,8 +8545,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - openvdb_vendor
-        - spatio_temporal_voxel_layer
+      - openvdb_vendor
+      - spatio_temporal_voxel_layer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
@@ -8592,8 +8590,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - sros2
-        - sros2_cmake
+      - sros2
+      - sros2_cmake
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
@@ -8672,10 +8670,10 @@ repositories:
       version: master
     release:
       packages:
-        - launch_system_modes
-        - system_modes
-        - system_modes_examples
-        - system_modes_msgs
+      - launch_system_modes
+      - system_modes
+      - system_modes_examples
+      - system_modes_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
@@ -8711,11 +8709,11 @@ repositories:
       version: master
     release:
       packages:
-        - joy_teleop
-        - key_teleop
-        - mouse_teleop
-        - teleop_tools
-        - teleop_tools_msgs
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
@@ -8892,8 +8890,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - topic_tools
-        - topic_tools_interfaces
+      - topic_tools
+      - topic_tools_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
@@ -8910,9 +8908,9 @@ repositories:
       version: rolling-devel
     release:
       packages:
-        - trac_ik
-        - trac_ik_kinematics_plugin
-        - trac_ik_lib
+      - trac_ik
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
@@ -8945,8 +8943,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - ros2trace_analysis
-        - tracetools_analysis
+      - ros2trace_analysis
+      - tracetools_analysis
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
@@ -8964,10 +8962,10 @@ repositories:
       version: main
     release:
       packages:
-        - asio_cmake_module
-        - io_context
-        - serial_driver
-        - udp_driver
+      - asio_cmake_module
+      - io_context
+      - serial_driver
+      - udp_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
@@ -9029,9 +9027,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - turtlebot3_fake_node
-        - turtlebot3_gazebo
-        - turtlebot3_simulations
+      - turtlebot3_fake_node
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
@@ -9048,10 +9046,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - turtlebot4_description
-        - turtlebot4_msgs
-        - turtlebot4_navigation
-        - turtlebot4_node
+      - turtlebot4_description
+      - turtlebot4_msgs
+      - turtlebot4_navigation
+      - turtlebot4_node
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
@@ -9068,8 +9066,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - turtlebot4_desktop
-        - turtlebot4_viz
+      - turtlebot4_desktop
+      - turtlebot4_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
@@ -9086,11 +9084,11 @@ repositories:
       version: jazzy
     release:
       packages:
-        - turtlebot4_base
-        - turtlebot4_bringup
-        - turtlebot4_diagnostics
-        - turtlebot4_robot
-        - turtlebot4_tests
+      - turtlebot4_base
+      - turtlebot4_bringup
+      - turtlebot4_diagnostics
+      - turtlebot4_robot
+      - turtlebot4_tests
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
@@ -9122,10 +9120,10 @@ repositories:
       version: jazzy
     release:
       packages:
-        - turtlebot4_gz_bringup
-        - turtlebot4_gz_gui_plugins
-        - turtlebot4_gz_toolbox
-        - turtlebot4_simulator
+      - turtlebot4_gz_bringup
+      - turtlebot4_gz_gui_plugins
+      - turtlebot4_gz_toolbox
+      - turtlebot4_simulator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
@@ -9157,16 +9155,16 @@ repositories:
       version: ros2
     release:
       packages:
-        - tuw_airskin_msgs
-        - tuw_geo_msgs
-        - tuw_geometry_msgs
-        - tuw_graph_msgs
-        - tuw_msgs
-        - tuw_multi_robot_msgs
-        - tuw_nav_msgs
-        - tuw_object_map_msgs
-        - tuw_object_msgs
-        - tuw_std_msgs
+      - tuw_airskin_msgs
+      - tuw_geo_msgs
+      - tuw_geometry_msgs
+      - tuw_graph_msgs
+      - tuw_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_map_msgs
+      - tuw_object_msgs
+      - tuw_std_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_msgs-release.git
@@ -9253,10 +9251,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - ublox
-        - ublox_gps
-        - ublox_msgs
-        - ublox_serialization
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
@@ -9274,12 +9272,12 @@ repositories:
       version: main
     release:
       packages:
-        - ntrip_client_node
-        - ublox_dgnss
-        - ublox_dgnss_node
-        - ublox_nav_sat_fix_hp_node
-        - ublox_ubx_interfaces
-        - ublox_ubx_msgs
+      - ntrip_client_node
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_nav_sat_fix_hp_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
@@ -9383,12 +9381,12 @@ repositories:
       version: main
     release:
       packages:
-        - ur
-        - ur_calibration
-        - ur_controllers
-        - ur_dashboard_msgs
-        - ur_moveit_config
-        - ur_robot_driver
+      - ur
+      - ur_calibration
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_moveit_config
+      - ur_robot_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
@@ -9416,8 +9414,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - urdf
-        - urdf_parser_plugin
+      - urdf
+      - urdf_parser_plugin
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
@@ -9451,7 +9449,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - urdfdom_py
+      - urdfdom_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
@@ -9593,12 +9591,12 @@ repositories:
       version: jazzy
     release:
       packages:
-        - desktop
-        - desktop_full
-        - perception
-        - ros_base
-        - ros_core
-        - simulation
+      - desktop
+      - desktop_full
+      - perception
+      - ros_base
+      - ros_core
+      - simulation
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
@@ -9616,11 +9614,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - velodyne
-        - velodyne_driver
-        - velodyne_laserscan
-        - velodyne_msgs
-        - velodyne_pointcloud
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
@@ -9637,9 +9635,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-        - velodyne_description
-        - velodyne_gazebo_plugins
-        - velodyne_simulator
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
@@ -9656,8 +9654,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - vision_msgs
-        - vision_msgs_rviz_plugins
+      - vision_msgs
+      - vision_msgs_rviz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
@@ -9690,9 +9688,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - cv_bridge
-        - image_geometry
-        - vision_opencv
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -9829,18 +9827,18 @@ repositories:
       version: master
     release:
       packages:
-        - webots_ros2
-        - webots_ros2_control
-        - webots_ros2_driver
-        - webots_ros2_epuck
-        - webots_ros2_importer
-        - webots_ros2_mavic
-        - webots_ros2_msgs
-        - webots_ros2_tesla
-        - webots_ros2_tests
-        - webots_ros2_tiago
-        - webots_ros2_turtlebot
-        - webots_ros2_universal_robot
+      - webots_ros2
+      - webots_ros2_control
+      - webots_ros2_driver
+      - webots_ros2_epuck
+      - webots_ros2_importer
+      - webots_ros2_mavic
+      - webots_ros2_msgs
+      - webots_ros2_tesla
+      - webots_ros2_tests
+      - webots_ros2_tiago
+      - webots_ros2_turtlebot
+      - webots_ros2_universal_robot
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
@@ -9858,8 +9856,8 @@ repositories:
       version: humble
     release:
       packages:
-        - wireless_msgs
-        - wireless_watcher
+      - wireless_msgs
+      - wireless_watcher
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
@@ -9918,11 +9916,11 @@ repositories:
       version: main
     release:
       packages:
-        - yasmin
-        - yasmin_demos
-        - yasmin_msgs
-        - yasmin_ros
-        - yasmin_viewer
+      - yasmin
+      - yasmin_demos
+      - yasmin_msgs
+      - yasmin_ros
+      - yasmin_viewer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
@@ -9939,8 +9937,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - zbar_ros
-        - zbar_ros_interfaces
+      - zbar_ros
+      - zbar_ros_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4,11 +4,11 @@
 ---
 release_platforms:
   debian:
-  - bookworm
+    - bookworm
   rhel:
-  - '9'
+    - "9"
   ubuntu:
-  - noble
+    - noble
 repositories:
   SMACC2:
     doc:
@@ -17,8 +17,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - smacc2
-      - smacc2_msgs
+        - smacc2
+        - smacc2_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
@@ -109,8 +109,8 @@ repositories:
   ament_black:
     release:
       packages:
-      - ament_black
-      - ament_cmake_black
+        - ament_black
+        - ament_cmake_black
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
@@ -127,28 +127,28 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ament_cmake
-      - ament_cmake_auto
-      - ament_cmake_core
-      - ament_cmake_export_definitions
-      - ament_cmake_export_dependencies
-      - ament_cmake_export_include_directories
-      - ament_cmake_export_interfaces
-      - ament_cmake_export_libraries
-      - ament_cmake_export_link_flags
-      - ament_cmake_export_targets
-      - ament_cmake_gen_version_h
-      - ament_cmake_gmock
-      - ament_cmake_google_benchmark
-      - ament_cmake_gtest
-      - ament_cmake_include_directories
-      - ament_cmake_libraries
-      - ament_cmake_pytest
-      - ament_cmake_python
-      - ament_cmake_target_dependencies
-      - ament_cmake_test
-      - ament_cmake_vendor_package
-      - ament_cmake_version
+        - ament_cmake
+        - ament_cmake_auto
+        - ament_cmake_core
+        - ament_cmake_export_definitions
+        - ament_cmake_export_dependencies
+        - ament_cmake_export_include_directories
+        - ament_cmake_export_interfaces
+        - ament_cmake_export_libraries
+        - ament_cmake_export_link_flags
+        - ament_cmake_export_targets
+        - ament_cmake_gen_version_h
+        - ament_cmake_gmock
+        - ament_cmake_google_benchmark
+        - ament_cmake_gtest
+        - ament_cmake_include_directories
+        - ament_cmake_libraries
+        - ament_cmake_pytest
+        - ament_cmake_python
+        - ament_cmake_target_dependencies
+        - ament_cmake_test
+        - ament_cmake_vendor_package
+        - ament_cmake_version
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
@@ -181,8 +181,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ament_cmake_ros
-      - domain_coordinator
+        - ament_cmake_ros
+        - domain_coordinator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
@@ -215,8 +215,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ament_index_cpp
-      - ament_index_python
+        - ament_index_cpp
+        - ament_index_python
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
@@ -234,37 +234,37 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ament_clang_format
-      - ament_clang_tidy
-      - ament_cmake_clang_format
-      - ament_cmake_clang_tidy
-      - ament_cmake_copyright
-      - ament_cmake_cppcheck
-      - ament_cmake_cpplint
-      - ament_cmake_flake8
-      - ament_cmake_lint_cmake
-      - ament_cmake_mypy
-      - ament_cmake_pclint
-      - ament_cmake_pep257
-      - ament_cmake_pycodestyle
-      - ament_cmake_pyflakes
-      - ament_cmake_uncrustify
-      - ament_cmake_xmllint
-      - ament_copyright
-      - ament_cppcheck
-      - ament_cpplint
-      - ament_flake8
-      - ament_lint
-      - ament_lint_auto
-      - ament_lint_cmake
-      - ament_lint_common
-      - ament_mypy
-      - ament_pclint
-      - ament_pep257
-      - ament_pycodestyle
-      - ament_pyflakes
-      - ament_uncrustify
-      - ament_xmllint
+        - ament_clang_format
+        - ament_clang_tidy
+        - ament_cmake_clang_format
+        - ament_cmake_clang_tidy
+        - ament_cmake_copyright
+        - ament_cmake_cppcheck
+        - ament_cmake_cpplint
+        - ament_cmake_flake8
+        - ament_cmake_lint_cmake
+        - ament_cmake_mypy
+        - ament_cmake_pclint
+        - ament_cmake_pep257
+        - ament_cmake_pycodestyle
+        - ament_cmake_pyflakes
+        - ament_cmake_uncrustify
+        - ament_cmake_xmllint
+        - ament_copyright
+        - ament_cppcheck
+        - ament_cpplint
+        - ament_flake8
+        - ament_lint
+        - ament_lint_auto
+        - ament_lint_cmake
+        - ament_lint_common
+        - ament_mypy
+        - ament_pclint
+        - ament_pep257
+        - ament_pycodestyle
+        - ament_pyflakes
+        - ament_uncrustify
+        - ament_xmllint
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
@@ -341,8 +341,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - apex_test_tools
-      - test_apex_test_tools
+        - apex_test_tools
+        - test_apex_test_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
@@ -431,8 +431,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - aruco_opencv
-      - aruco_opencv_msgs
+        - aruco_opencv
+        - aruco_opencv_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
@@ -449,9 +449,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - aruco
-      - aruco_msgs
-      - aruco_ros
+        - aruco
+        - aruco_msgs
+        - aruco_ros
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
@@ -468,14 +468,14 @@ repositories:
       version: master
     release:
       packages:
-      - delphi_esr_msgs
-      - delphi_mrr_msgs
-      - delphi_srr_msgs
-      - derived_object_msgs
-      - ibeo_msgs
-      - kartech_linear_actuator_msgs
-      - mobileye_560_660_msgs
-      - neobotix_usboard_msgs
+        - delphi_esr_msgs
+        - delphi_mrr_msgs
+        - delphi_srr_msgs
+        - derived_object_msgs
+        - ibeo_msgs
+        - kartech_linear_actuator_msgs
+        - mobileye_560_660_msgs
+        - neobotix_usboard_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
@@ -532,9 +532,9 @@ repositories:
       version: master
     release:
       packages:
-      - automotive_autonomy_msgs
-      - automotive_navigation_msgs
-      - automotive_platform_msgs
+        - automotive_autonomy_msgs
+        - automotive_navigation_msgs
+        - automotive_platform_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
@@ -547,8 +547,8 @@ repositories:
   autoware_adapi_msgs:
     release:
       packages:
-      - autoware_adapi_v1_msgs
-      - autoware_adapi_version_msgs
+        - autoware_adapi_v1_msgs
+        - autoware_adapi_version_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
@@ -576,8 +576,8 @@ repositories:
   autoware_cmake:
     release:
       packages:
-      - autoware_cmake
-      - autoware_lint_common
+        - autoware_cmake
+        - autoware_lint_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
@@ -590,9 +590,9 @@ repositories:
   autoware_internal_msgs:
     release:
       packages:
-      - autoware_internal_debug_msgs
-      - autoware_internal_msgs
-      - autoware_internal_perception_msgs
+        - autoware_internal_debug_msgs
+        - autoware_internal_msgs
+        - autoware_internal_perception_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
@@ -605,8 +605,8 @@ repositories:
   autoware_lanelet2_extension:
     release:
       packages:
-      - autoware_lanelet2_extension
-      - autoware_lanelet2_extension_python
+        - autoware_lanelet2_extension
+        - autoware_lanelet2_extension_python
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
@@ -619,16 +619,16 @@ repositories:
   autoware_msgs:
     release:
       packages:
-      - autoware_common_msgs
-      - autoware_control_msgs
-      - autoware_localization_msgs
-      - autoware_map_msgs
-      - autoware_perception_msgs
-      - autoware_planning_msgs
-      - autoware_sensing_msgs
-      - autoware_system_msgs
-      - autoware_v2x_msgs
-      - autoware_vehicle_msgs
+        - autoware_common_msgs
+        - autoware_control_msgs
+        - autoware_localization_msgs
+        - autoware_map_msgs
+        - autoware_perception_msgs
+        - autoware_planning_msgs
+        - autoware_sensing_msgs
+        - autoware_system_msgs
+        - autoware_v2x_msgs
+        - autoware_vehicle_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
@@ -671,7 +671,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - aws_robomaker_small_warehouse_world
+        - aws_robomaker_small_warehouse_world
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
@@ -702,9 +702,9 @@ repositories:
       version: jazzy-devel
     release:
       packages:
-      - axis_camera
-      - axis_description
-      - axis_msgs
+        - axis_camera
+        - axis_description
+        - axis_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/axis_camera-release.git
@@ -781,7 +781,7 @@ repositories:
       version: master
     release:
       packages:
-      - behaviortree_cpp
+        - behaviortree_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
@@ -798,9 +798,9 @@ repositories:
       version: main
     release:
       packages:
-      - beluga
-      - beluga_amcl
-      - beluga_ros
+        - beluga
+        - beluga_amcl
+        - beluga_ros
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
@@ -834,11 +834,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - bond
-      - bond_core
-      - bondcpp
-      - bondpy
-      - smclib
+        - bond
+        - bond_core
+        - bondcpp
+        - bondpy
+        - smclib
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
@@ -891,8 +891,8 @@ repositories:
       version: main
     release:
       packages:
-      - camera_aravis2
-      - camera_aravis2_msgs
+        - camera_aravis2
+        - camera_aravis2_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/camera_aravis2-release.git
@@ -941,9 +941,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - cartographer_ros
-      - cartographer_ros_msgs
-      - cartographer_rviz
+        - cartographer_ros
+        - cartographer_ros_msgs
+        - cartographer_rviz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
@@ -961,8 +961,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-      - cascade_lifecycle_msgs
-      - rclcpp_cascade_lifecycle
+        - cascade_lifecycle_msgs
+        - rclcpp_cascade_lifecycle
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
@@ -1026,9 +1026,9 @@ repositories:
       version: main
     release:
       packages:
-      - clearpath_motor_msgs
-      - clearpath_msgs
-      - clearpath_platform_msgs
+        - clearpath_motor_msgs
+        - clearpath_msgs
+        - clearpath_platform_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
@@ -1106,19 +1106,19 @@ repositories:
       version: jazzy
     release:
       packages:
-      - actionlib_msgs
-      - common_interfaces
-      - diagnostic_msgs
-      - geometry_msgs
-      - nav_msgs
-      - sensor_msgs
-      - sensor_msgs_py
-      - shape_msgs
-      - std_msgs
-      - std_srvs
-      - stereo_msgs
-      - trajectory_msgs
-      - visualization_msgs
+        - actionlib_msgs
+        - common_interfaces
+        - diagnostic_msgs
+        - geometry_msgs
+        - nav_msgs
+        - sensor_msgs
+        - sensor_msgs_py
+        - shape_msgs
+        - std_msgs
+        - std_srvs
+        - stereo_msgs
+        - trajectory_msgs
+        - visualization_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
@@ -1194,8 +1194,8 @@ repositories:
   cpp_polyfills:
     release:
       packages:
-      - tcb_span
-      - tl_expected
+        - tcb_span
+        - tl_expected
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
@@ -1212,12 +1212,12 @@ repositories:
       version: jazzy
     release:
       packages:
-      - create3_coverage
-      - create3_examples_msgs
-      - create3_examples_py
-      - create3_lidar_slam
-      - create3_republisher
-      - create3_teleop
+        - create3_coverage
+        - create3_examples_msgs
+        - create3_examples_py
+        - create3_lidar_slam
+        - create3_republisher
+        - create3_teleop
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/create3_examples-release.git
@@ -1234,15 +1234,15 @@ repositories:
       version: jazzy
     release:
       packages:
-      - irobot_create_common_bringup
-      - irobot_create_control
-      - irobot_create_description
-      - irobot_create_gz_bringup
-      - irobot_create_gz_plugins
-      - irobot_create_gz_sim
-      - irobot_create_gz_toolbox
-      - irobot_create_nodes
-      - irobot_create_toolbox
+        - irobot_create_common_bringup
+        - irobot_create_control
+        - irobot_create_description
+        - irobot_create_gz_bringup
+        - irobot_create_gz_plugins
+        - irobot_create_gz_sim
+        - irobot_create_gz_toolbox
+        - irobot_create_nodes
+        - irobot_create_toolbox
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/create3_sim-release.git
@@ -1285,8 +1285,8 @@ repositories:
       version: main
     release:
       packages:
-      - data_tamer_cpp
-      - data_tamer_msgs
+        - data_tamer_cpp
+        - data_tamer_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
@@ -1304,11 +1304,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - dataspeed_can
-      - dataspeed_can_msg_filters
-      - dataspeed_can_msgs
-      - dataspeed_can_tools
-      - dataspeed_can_usb
+        - dataspeed_can
+        - dataspeed_can_msg_filters
+        - dataspeed_can_msgs
+        - dataspeed_can_tools
+        - dataspeed_can_usb
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
@@ -1325,10 +1325,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - ds_dbw
-      - ds_dbw_can
-      - ds_dbw_joystick_demo
-      - ds_dbw_msgs
+        - ds_dbw
+        - ds_dbw_can
+        - ds_dbw_joystick_demo
+        - ds_dbw_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
@@ -1345,27 +1345,27 @@ repositories:
       version: jazzy
     release:
       packages:
-      - action_tutorials_cpp
-      - action_tutorials_interfaces
-      - action_tutorials_py
-      - composition
-      - demo_nodes_cpp
-      - demo_nodes_cpp_native
-      - demo_nodes_py
-      - dummy_map_server
-      - dummy_robot_bringup
-      - dummy_sensors
-      - image_tools
-      - intra_process_demo
-      - lifecycle
-      - lifecycle_py
-      - logging_demo
-      - pendulum_control
-      - pendulum_msgs
-      - quality_of_service_demo_cpp
-      - quality_of_service_demo_py
-      - topic_monitor
-      - topic_statistics_demo
+        - action_tutorials_cpp
+        - action_tutorials_interfaces
+        - action_tutorials_py
+        - composition
+        - demo_nodes_cpp
+        - demo_nodes_cpp_native
+        - demo_nodes_py
+        - dummy_map_server
+        - dummy_robot_bringup
+        - dummy_sensors
+        - image_tools
+        - intra_process_demo
+        - lifecycle
+        - lifecycle_py
+        - logging_demo
+        - pendulum_control
+        - pendulum_msgs
+        - quality_of_service_demo_cpp
+        - quality_of_service_demo_py
+        - topic_monitor
+        - topic_statistics_demo
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
@@ -1398,13 +1398,13 @@ repositories:
       version: jazzy
     release:
       packages:
-      - depthai-ros
-      - depthai_bridge
-      - depthai_descriptions
-      - depthai_examples
-      - depthai_filters
-      - depthai_ros_driver
-      - depthai_ros_msgs
+        - depthai-ros
+        - depthai_bridge
+        - depthai_descriptions
+        - depthai_examples
+        - depthai_filters
+        - depthai_ros_driver
+        - depthai_ros_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
@@ -1438,11 +1438,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - diagnostic_aggregator
-      - diagnostic_common_diagnostics
-      - diagnostic_updater
-      - diagnostics
-      - self_test
+        - diagnostic_aggregator
+        - diagnostic_common_diagnostics
+        - diagnostic_updater
+        - diagnostics
+        - self_test
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
@@ -1460,10 +1460,10 @@ repositories:
       version: galactic
     release:
       packages:
-      - dolly
-      - dolly_follow
-      - dolly_gazebo
-      - dolly_ignition
+        - dolly
+        - dolly_follow
+        - dolly_gazebo
+        - dolly_ignition
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
@@ -1527,9 +1527,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - dynamixel_sdk
-      - dynamixel_sdk_custom_interfaces
-      - dynamixel_sdk_examples
+        - dynamixel_sdk
+        - dynamixel_sdk_custom_interfaces
+        - dynamixel_sdk_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
@@ -1546,8 +1546,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - dynamixel_workbench
-      - dynamixel_workbench_toolbox
+        - dynamixel_workbench
+        - dynamixel_workbench_toolbox
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
@@ -1593,31 +1593,31 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-      - ecl_command_line
-      - ecl_concepts
-      - ecl_containers
-      - ecl_converters
-      - ecl_core
-      - ecl_core_apps
-      - ecl_devices
-      - ecl_eigen
-      - ecl_exceptions
-      - ecl_filesystem
-      - ecl_formatters
-      - ecl_geometry
-      - ecl_ipc
-      - ecl_linear_algebra
-      - ecl_manipulators
-      - ecl_math
-      - ecl_mobile_robot
-      - ecl_mpl
-      - ecl_sigslots
-      - ecl_statistics
-      - ecl_streams
-      - ecl_threads
-      - ecl_time
-      - ecl_type_traits
-      - ecl_utilities
+        - ecl_command_line
+        - ecl_concepts
+        - ecl_containers
+        - ecl_converters
+        - ecl_core
+        - ecl_core_apps
+        - ecl_devices
+        - ecl_eigen
+        - ecl_exceptions
+        - ecl_filesystem
+        - ecl_formatters
+        - ecl_geometry
+        - ecl_ipc
+        - ecl_linear_algebra
+        - ecl_manipulators
+        - ecl_math
+        - ecl_mobile_robot
+        - ecl_mpl
+        - ecl_sigslots
+        - ecl_statistics
+        - ecl_streams
+        - ecl_threads
+        - ecl_time
+        - ecl_type_traits
+        - ecl_utilities
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
@@ -1635,14 +1635,14 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-      - ecl_config
-      - ecl_console
-      - ecl_converters_lite
-      - ecl_errors
-      - ecl_io
-      - ecl_lite
-      - ecl_sigslots_lite
-      - ecl_time_lite
+        - ecl_config
+        - ecl_console
+        - ecl_converters_lite
+        - ecl_errors
+        - ecl_io
+        - ecl_lite
+        - ecl_sigslots_lite
+        - ecl_time_lite
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
@@ -1660,9 +1660,9 @@ repositories:
       version: release/1.0.x
     release:
       packages:
-      - ecl_build
-      - ecl_license
-      - ecl_tools
+        - ecl_build
+        - ecl_license
+        - ecl_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
@@ -1756,34 +1756,34 @@ repositories:
       version: main
     release:
       packages:
-      - etsi_its_cam_coding
-      - etsi_its_cam_conversion
-      - etsi_its_cam_msgs
-      - etsi_its_cam_ts_coding
-      - etsi_its_cam_ts_conversion
-      - etsi_its_cam_ts_msgs
-      - etsi_its_coding
-      - etsi_its_conversion
-      - etsi_its_cpm_ts_coding
-      - etsi_its_cpm_ts_conversion
-      - etsi_its_cpm_ts_msgs
-      - etsi_its_denm_coding
-      - etsi_its_denm_conversion
-      - etsi_its_denm_msgs
-      - etsi_its_mapem_ts_coding
-      - etsi_its_mapem_ts_conversion
-      - etsi_its_mapem_ts_msgs
-      - etsi_its_messages
-      - etsi_its_msgs
-      - etsi_its_msgs_utils
-      - etsi_its_primitives_conversion
-      - etsi_its_rviz_plugins
-      - etsi_its_spatem_ts_coding
-      - etsi_its_spatem_ts_conversion
-      - etsi_its_spatem_ts_msgs
-      - etsi_its_vam_ts_coding
-      - etsi_its_vam_ts_conversion
-      - etsi_its_vam_ts_msgs
+        - etsi_its_cam_coding
+        - etsi_its_cam_conversion
+        - etsi_its_cam_msgs
+        - etsi_its_cam_ts_coding
+        - etsi_its_cam_ts_conversion
+        - etsi_its_cam_ts_msgs
+        - etsi_its_coding
+        - etsi_its_conversion
+        - etsi_its_cpm_ts_coding
+        - etsi_its_cpm_ts_conversion
+        - etsi_its_cpm_ts_msgs
+        - etsi_its_denm_coding
+        - etsi_its_denm_conversion
+        - etsi_its_denm_msgs
+        - etsi_its_mapem_ts_coding
+        - etsi_its_mapem_ts_conversion
+        - etsi_its_mapem_ts_msgs
+        - etsi_its_messages
+        - etsi_its_msgs
+        - etsi_its_msgs_utils
+        - etsi_its_primitives_conversion
+        - etsi_its_rviz_plugins
+        - etsi_its_spatem_ts_coding
+        - etsi_its_spatem_ts_conversion
+        - etsi_its_spatem_ts_msgs
+        - etsi_its_vam_ts_coding
+        - etsi_its_vam_ts_conversion
+        - etsi_its_vam_ts_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
@@ -1876,28 +1876,28 @@ repositories:
       version: jazzy
     release:
       packages:
-      - examples_rclcpp_async_client
-      - examples_rclcpp_cbg_executor
-      - examples_rclcpp_minimal_action_client
-      - examples_rclcpp_minimal_action_server
-      - examples_rclcpp_minimal_client
-      - examples_rclcpp_minimal_composition
-      - examples_rclcpp_minimal_publisher
-      - examples_rclcpp_minimal_service
-      - examples_rclcpp_minimal_subscriber
-      - examples_rclcpp_minimal_timer
-      - examples_rclcpp_multithreaded_executor
-      - examples_rclcpp_wait_set
-      - examples_rclpy_executors
-      - examples_rclpy_guard_conditions
-      - examples_rclpy_minimal_action_client
-      - examples_rclpy_minimal_action_server
-      - examples_rclpy_minimal_client
-      - examples_rclpy_minimal_publisher
-      - examples_rclpy_minimal_service
-      - examples_rclpy_minimal_subscriber
-      - examples_rclpy_pointcloud_publisher
-      - launch_testing_examples
+        - examples_rclcpp_async_client
+        - examples_rclcpp_cbg_executor
+        - examples_rclcpp_minimal_action_client
+        - examples_rclcpp_minimal_action_server
+        - examples_rclcpp_minimal_client
+        - examples_rclcpp_minimal_composition
+        - examples_rclcpp_minimal_publisher
+        - examples_rclcpp_minimal_service
+        - examples_rclcpp_minimal_subscriber
+        - examples_rclcpp_minimal_timer
+        - examples_rclcpp_multithreaded_executor
+        - examples_rclcpp_wait_set
+        - examples_rclpy_executors
+        - examples_rclpy_guard_conditions
+        - examples_rclpy_minimal_action_client
+        - examples_rclpy_minimal_action_server
+        - examples_rclpy_minimal_client
+        - examples_rclpy_minimal_publisher
+        - examples_rclpy_minimal_service
+        - examples_rclpy_minimal_subscriber
+        - examples_rclpy_pointcloud_publisher
+        - launch_testing_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
@@ -2077,15 +2077,15 @@ repositories:
       version: rolling
     release:
       packages:
-      - flexbe_behavior_engine
-      - flexbe_core
-      - flexbe_input
-      - flexbe_mirror
-      - flexbe_msgs
-      - flexbe_onboard
-      - flexbe_states
-      - flexbe_testing
-      - flexbe_widget
+        - flexbe_behavior_engine
+        - flexbe_core
+        - flexbe_input
+        - flexbe_mirror
+        - flexbe_msgs
+        - flexbe_onboard
+        - flexbe_states
+        - flexbe_testing
+        - flexbe_widget
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
@@ -2102,10 +2102,10 @@ repositories:
       version: ros2-release
     release:
       packages:
-      - flir_camera_description
-      - flir_camera_msgs
-      - spinnaker_camera_driver
-      - spinnaker_synchronized_camera_driver
+        - flir_camera_description
+        - flir_camera_msgs
+        - spinnaker_camera_driver
+        - spinnaker_synchronized_camera_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
@@ -2137,8 +2137,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - fmi_adapter
-      - fmi_adapter_examples
+        - fmi_adapter
+        - fmi_adapter_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
@@ -2233,19 +2233,19 @@ repositories:
       version: jazzy
     release:
       packages:
-      - fuse
-      - fuse_constraints
-      - fuse_core
-      - fuse_doc
-      - fuse_graphs
-      - fuse_loss
-      - fuse_models
-      - fuse_msgs
-      - fuse_optimizers
-      - fuse_publishers
-      - fuse_tutorials
-      - fuse_variables
-      - fuse_viz
+        - fuse
+        - fuse_constraints
+        - fuse_core
+        - fuse_doc
+        - fuse_graphs
+        - fuse_loss
+        - fuse_models
+        - fuse_msgs
+        - fuse_optimizers
+        - fuse_publishers
+        - fuse_tutorials
+        - fuse_variables
+        - fuse_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
@@ -2263,15 +2263,15 @@ repositories:
       version: rolling
     release:
       packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
-      - gc_spl
-      - gc_spl_2022
-      - gc_spl_interfaces
-      - rcgcd_spl_14
-      - rcgcd_spl_14_conversion
-      - rcgcrd_spl_4
-      - rcgcrd_spl_4_conversion
+        - game_controller_spl
+        - game_controller_spl_interfaces
+        - gc_spl
+        - gc_spl_2022
+        - gc_spl_interfaces
+        - rcgcd_spl_14
+        - rcgcd_spl_14_conversion
+        - rcgcrd_spl_4
+        - rcgcrd_spl_4_conversion
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
@@ -2284,7 +2284,7 @@ repositories:
   gazebo_ros_pkgs:
     release:
       packages:
-      - gazebo_msgs
+        - gazebo_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
@@ -2296,12 +2296,12 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
-      - generate_parameter_library
-      - generate_parameter_library_example
-      - generate_parameter_library_py
-      - generate_parameter_module_example
-      - parameter_traits
+        - cmake_generate_parameter_module_example
+        - generate_parameter_library
+        - generate_parameter_library_example
+        - generate_parameter_library_py
+        - generate_parameter_module_example
+        - parameter_traits
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
@@ -2318,9 +2318,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - geodesy
-      - geographic_info
-      - geographic_msgs
+        - geodesy
+        - geographic_info
+        - geographic_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -2353,20 +2353,20 @@ repositories:
       version: jazzy
     release:
       packages:
-      - examples_tf2_py
-      - geometry2
-      - tf2
-      - tf2_bullet
-      - tf2_eigen
-      - tf2_eigen_kdl
-      - tf2_geometry_msgs
-      - tf2_kdl
-      - tf2_msgs
-      - tf2_py
-      - tf2_ros
-      - tf2_ros_py
-      - tf2_sensor_msgs
-      - tf2_tools
+        - examples_tf2_py
+        - geometry2
+        - tf2
+        - tf2_bullet
+        - tf2_eigen
+        - tf2_eigen_kdl
+        - tf2_geometry_msgs
+        - tf2_kdl
+        - tf2_msgs
+        - tf2_py
+        - tf2_ros
+        - tf2_ros_py
+        - tf2_sensor_msgs
+        - tf2_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
@@ -2384,9 +2384,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - geometry_tutorials
-      - turtle_tf2_cpp
-      - turtle_tf2_py
+        - geometry_tutorials
+        - turtle_tf2_cpp
+        - turtle_tf2_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
@@ -2415,8 +2415,8 @@ repositories:
   googletest:
     release:
       packages:
-      - gmock_vendor
-      - gtest_vendor
+        - gmock_vendor
+        - gtest_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
@@ -2433,10 +2433,10 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - gps_msgs
-      - gps_tools
-      - gps_umd
-      - gpsd_client
+        - gps_msgs
+        - gps_tools
+        - gps_umd
+        - gpsd_client
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
@@ -2514,21 +2514,21 @@ repositories:
       version: jazzy
     release:
       packages:
-      - grid_map
-      - grid_map_cmake_helpers
-      - grid_map_core
-      - grid_map_costmap_2d
-      - grid_map_cv
-      - grid_map_demos
-      - grid_map_filters
-      - grid_map_loader
-      - grid_map_msgs
-      - grid_map_octomap
-      - grid_map_pcl
-      - grid_map_ros
-      - grid_map_rviz_plugin
-      - grid_map_sdf
-      - grid_map_visualization
+        - grid_map
+        - grid_map_cmake_helpers
+        - grid_map_core
+        - grid_map_costmap_2d
+        - grid_map_cv
+        - grid_map_demos
+        - grid_map_filters
+        - grid_map_loader
+        - grid_map_msgs
+        - grid_map_octomap
+        - grid_map_pcl
+        - grid_map_ros
+        - grid_map_rviz_plugin
+        - grid_map_sdf
+        - grid_map_visualization
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/grid_map-release.git
@@ -2766,8 +2766,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - gz_ros2_control
-      - gz_ros2_control_demos
+        - gz_ros2_control
+        - gz_ros2_control_demos
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
@@ -2936,10 +2936,10 @@ repositories:
   iceoryx:
     release:
       packages:
-      - iceoryx_binding_c
-      - iceoryx_hoofs
-      - iceoryx_introspection
-      - iceoryx_posh
+        - iceoryx_binding_c
+        - iceoryx_hoofs
+        - iceoryx_introspection
+        - iceoryx_posh
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
@@ -2963,9 +2963,9 @@ repositories:
       version: main
     release:
       packages:
-      - ign_rviz
-      - ign_rviz_common
-      - ign_rviz_plugins
+        - ign_rviz
+        - ign_rviz_common
+        - ign_rviz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
@@ -2982,11 +2982,11 @@ repositories:
       version: jazzy
     release:
       packages:
-      - camera_calibration_parsers
-      - camera_info_manager
-      - camera_info_manager_py
-      - image_common
-      - image_transport
+        - camera_calibration_parsers
+        - camera_info_manager
+        - camera_info_manager_py
+        - image_common
+        - image_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
@@ -3004,15 +3004,15 @@ repositories:
       version: jazzy
     release:
       packages:
-      - camera_calibration
-      - depth_image_proc
-      - image_pipeline
-      - image_proc
-      - image_publisher
-      - image_rotate
-      - image_view
-      - stereo_image_proc
-      - tracetools_image_pipeline
+        - camera_calibration
+        - depth_image_proc
+        - image_pipeline
+        - image_proc
+        - image_publisher
+        - image_rotate
+        - image_view
+        - stereo_image_proc
+        - tracetools_image_pipeline
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
@@ -3030,11 +3030,11 @@ repositories:
       version: jazzy
     release:
       packages:
-      - compressed_depth_image_transport
-      - compressed_image_transport
-      - image_transport_plugins
-      - theora_image_transport
-      - zstd_image_transport
+        - compressed_depth_image_transport
+        - compressed_image_transport
+        - image_transport_plugins
+        - theora_image_transport
+        - zstd_image_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
@@ -3052,9 +3052,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - imu_pipeline
-      - imu_processors
-      - imu_transformer
+        - imu_pipeline
+        - imu_processors
+        - imu_transformer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
@@ -3071,10 +3071,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - imu_complementary_filter
-      - imu_filter_madgwick
-      - imu_tools
-      - rviz_imu_plugin
+        - imu_complementary_filter
+        - imu_filter_madgwick
+        - imu_tools
+        - rviz_imu_plugin
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
@@ -3145,8 +3145,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - joint_state_publisher
-      - joint_state_publisher_gui
+        - joint_state_publisher
+        - joint_state_publisher_gui
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
@@ -3179,12 +3179,12 @@ repositories:
       version: ros2
     release:
       packages:
-      - joy
-      - joy_linux
-      - sdl2_vendor
-      - spacenav
-      - wiimote
-      - wiimote_msgs
+        - joy
+        - joy_linux
+        - sdl2_vendor
+        - spacenav
+        - wiimote
+        - wiimote_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
@@ -3234,8 +3234,8 @@ repositories:
       version: master
     release:
       packages:
-      - kinematics_interface
-      - kinematics_interface_kdl
+        - kinematics_interface
+        - kinematics_interface_kdl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
@@ -3318,6 +3318,16 @@ repositories:
       url: https://github.com/automatika-robotics/kompass.git
       version: main
     status: developed
+  kompass_interfaces:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   lanelet2:
     doc:
       type: git
@@ -3325,17 +3335,17 @@ repositories:
       version: master
     release:
       packages:
-      - lanelet2
-      - lanelet2_core
-      - lanelet2_examples
-      - lanelet2_io
-      - lanelet2_maps
-      - lanelet2_matching
-      - lanelet2_projection
-      - lanelet2_python
-      - lanelet2_routing
-      - lanelet2_traffic_rules
-      - lanelet2_validation
+        - lanelet2
+        - lanelet2_core
+        - lanelet2_examples
+        - lanelet2_io
+        - lanelet2_maps
+        - lanelet2_matching
+        - lanelet2_projection
+        - lanelet2_python
+        - lanelet2_routing
+        - lanelet2_traffic_rules
+        - lanelet2_validation
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
@@ -3395,12 +3405,12 @@ repositories:
       version: jazzy
     release:
       packages:
-      - launch
-      - launch_pytest
-      - launch_testing
-      - launch_testing_ament_cmake
-      - launch_xml
-      - launch_yaml
+        - launch
+        - launch_pytest
+        - launch_testing
+        - launch_testing_ament_cmake
+        - launch_xml
+        - launch_yaml
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
@@ -3433,9 +3443,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - launch_ros
-      - launch_testing_ros
-      - ros2launch
+        - launch_ros
+        - launch_testing_ros
+        - ros2launch
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
@@ -3453,10 +3463,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - leo
-      - leo_description
-      - leo_msgs
-      - leo_teleop
+        - leo
+        - leo_description
+        - leo_msgs
+        - leo_teleop
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
@@ -3473,8 +3483,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - leo_desktop
-      - leo_viz
+        - leo_desktop
+        - leo_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
@@ -3491,9 +3501,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - leo_bringup
-      - leo_fw
-      - leo_robot
+        - leo_bringup
+        - leo_fw
+        - leo_robot
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
@@ -3510,10 +3520,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - leo_gz_bringup
-      - leo_gz_plugins
-      - leo_gz_worlds
-      - leo_simulator
+        - leo_gz_bringup
+        - leo_gz_plugins
+        - leo_gz_worlds
+        - leo_simulator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
@@ -3734,11 +3744,11 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - mapviz
-      - mapviz_interfaces
-      - mapviz_plugins
-      - multires_image
-      - tile_map
+        - mapviz
+        - mapviz_interfaces
+        - mapviz_plugins
+        - multires_image
+        - tile_map
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
@@ -3756,8 +3766,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - marine_acoustic_msgs
-      - marine_sensor_msgs
+        - marine_acoustic_msgs
+        - marine_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
@@ -3789,18 +3799,18 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - swri_cli_tools
-      - swri_console_util
-      - swri_dbw_interface
-      - swri_geometry_util
-      - swri_image_util
-      - swri_math_util
-      - swri_opencv_util
-      - swri_roscpp
-      - swri_route_util
-      - swri_serial_util
-      - swri_system_util
-      - swri_transform_util
+        - swri_cli_tools
+        - swri_console_util
+        - swri_dbw_interface
+        - swri_geometry_util
+        - swri_image_util
+        - swri_math_util
+        - swri_opencv_util
+        - swri_roscpp
+        - swri_route_util
+        - swri_serial_util
+        - swri_system_util
+        - swri_transform_util
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
@@ -3818,15 +3828,15 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - marti_can_msgs
-      - marti_common_msgs
-      - marti_dbw_msgs
-      - marti_introspection_msgs
-      - marti_nav_msgs
-      - marti_perception_msgs
-      - marti_sensor_msgs
-      - marti_status_msgs
-      - marti_visualization_msgs
+        - marti_can_msgs
+        - marti_common_msgs
+        - marti_dbw_msgs
+        - marti_introspection_msgs
+        - marti_nav_msgs
+        - marti_perception_msgs
+        - marti_sensor_msgs
+        - marti_status_msgs
+        - marti_visualization_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
@@ -3859,10 +3869,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - libmavconn
-      - mavros
-      - mavros_extras
-      - mavros_msgs
+        - libmavconn
+        - mavros
+        - mavros_extras
+        - mavros_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
@@ -3940,8 +3950,8 @@ repositories:
       version: master
     release:
       packages:
-      - micro_ros_diagnostic_bridge
-      - micro_ros_diagnostic_msgs
+        - micro_ros_diagnostic_bridge
+        - micro_ros_diagnostic_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
@@ -3973,11 +3983,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - microstrain_inertial_description
-      - microstrain_inertial_driver
-      - microstrain_inertial_examples
-      - microstrain_inertial_msgs
-      - microstrain_inertial_rqt
+        - microstrain_inertial_description
+        - microstrain_inertial_driver
+        - microstrain_inertial_examples
+        - microstrain_inertial_msgs
+        - microstrain_inertial_rqt
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
@@ -4021,26 +4031,26 @@ repositories:
       version: develop
     release:
       packages:
-      - kitti_metrics_eval
-      - mola
-      - mola_bridge_ros2
-      - mola_demos
-      - mola_input_euroc_dataset
-      - mola_input_kitti360_dataset
-      - mola_input_kitti_dataset
-      - mola_input_mulran_dataset
-      - mola_input_paris_luco_dataset
-      - mola_input_rawlog
-      - mola_input_rosbag2
-      - mola_kernel
-      - mola_launcher
-      - mola_metric_maps
-      - mola_msgs
-      - mola_pose_list
-      - mola_relocalization
-      - mola_traj_tools
-      - mola_viz
-      - mola_yaml
+        - kitti_metrics_eval
+        - mola
+        - mola_bridge_ros2
+        - mola_demos
+        - mola_input_euroc_dataset
+        - mola_input_kitti360_dataset
+        - mola_input_kitti_dataset
+        - mola_input_mulran_dataset
+        - mola_input_paris_luco_dataset
+        - mola_input_rawlog
+        - mola_input_rosbag2
+        - mola_kernel
+        - mola_launcher
+        - mola_metric_maps
+        - mola_msgs
+        - mola_pose_list
+        - mola_relocalization
+        - mola_traj_tools
+        - mola_viz
+        - mola_yaml
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
@@ -4112,8 +4122,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - motion_capture_tracking
-      - motion_capture_tracking_interfaces
+        - motion_capture_tracking
+        - motion_capture_tracking_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
@@ -4130,47 +4140,47 @@ repositories:
       version: main
     release:
       packages:
-      - chomp_motion_planner
-      - moveit
-      - moveit_common
-      - moveit_configs_utils
-      - moveit_core
-      - moveit_hybrid_planning
-      - moveit_kinematics
-      - moveit_planners
-      - moveit_planners_chomp
-      - moveit_planners_ompl
-      - moveit_planners_stomp
-      - moveit_plugins
-      - moveit_py
-      - moveit_resources_prbt_ikfast_manipulator_plugin
-      - moveit_resources_prbt_moveit_config
-      - moveit_resources_prbt_pg70_support
-      - moveit_resources_prbt_support
-      - moveit_ros
-      - moveit_ros_benchmarks
-      - moveit_ros_control_interface
-      - moveit_ros_move_group
-      - moveit_ros_occupancy_map_monitor
-      - moveit_ros_perception
-      - moveit_ros_planning
-      - moveit_ros_planning_interface
-      - moveit_ros_robot_interaction
-      - moveit_ros_tests
-      - moveit_ros_trajectory_cache
-      - moveit_ros_visualization
-      - moveit_ros_warehouse
-      - moveit_runtime
-      - moveit_servo
-      - moveit_setup_app_plugins
-      - moveit_setup_assistant
-      - moveit_setup_controllers
-      - moveit_setup_core_plugins
-      - moveit_setup_framework
-      - moveit_setup_srdf_plugins
-      - moveit_simple_controller_manager
-      - pilz_industrial_motion_planner
-      - pilz_industrial_motion_planner_testutils
+        - chomp_motion_planner
+        - moveit
+        - moveit_common
+        - moveit_configs_utils
+        - moveit_core
+        - moveit_hybrid_planning
+        - moveit_kinematics
+        - moveit_planners
+        - moveit_planners_chomp
+        - moveit_planners_ompl
+        - moveit_planners_stomp
+        - moveit_plugins
+        - moveit_py
+        - moveit_resources_prbt_ikfast_manipulator_plugin
+        - moveit_resources_prbt_moveit_config
+        - moveit_resources_prbt_pg70_support
+        - moveit_resources_prbt_support
+        - moveit_ros
+        - moveit_ros_benchmarks
+        - moveit_ros_control_interface
+        - moveit_ros_move_group
+        - moveit_ros_occupancy_map_monitor
+        - moveit_ros_perception
+        - moveit_ros_planning
+        - moveit_ros_planning_interface
+        - moveit_ros_robot_interaction
+        - moveit_ros_tests
+        - moveit_ros_trajectory_cache
+        - moveit_ros_visualization
+        - moveit_ros_warehouse
+        - moveit_runtime
+        - moveit_servo
+        - moveit_setup_app_plugins
+        - moveit_setup_assistant
+        - moveit_setup_controllers
+        - moveit_setup_core_plugins
+        - moveit_setup_framework
+        - moveit_setup_srdf_plugins
+        - moveit_simple_controller_manager
+        - pilz_industrial_motion_planner
+        - pilz_industrial_motion_planner_testutils
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
@@ -4204,13 +4214,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - dual_arm_panda_moveit_config
-      - moveit_resources
-      - moveit_resources_fanuc_description
-      - moveit_resources_fanuc_moveit_config
-      - moveit_resources_panda_description
-      - moveit_resources_panda_moveit_config
-      - moveit_resources_pr2_description
+        - dual_arm_panda_moveit_config
+        - moveit_resources
+        - moveit_resources_fanuc_description
+        - moveit_resources_fanuc_moveit_config
+        - moveit_resources_panda_description
+        - moveit_resources_panda_moveit_config
+        - moveit_resources_pr2_description
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -4257,8 +4267,8 @@ repositories:
       version: main
     release:
       packages:
-      - mqtt_client
-      - mqtt_client_interfaces
+        - mqtt_client
+        - mqtt_client_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
@@ -4290,16 +4300,16 @@ repositories:
       version: ros2
     release:
       packages:
-      - mrpt_map_server
-      - mrpt_msgs_bridge
-      - mrpt_nav_interfaces
-      - mrpt_navigation
-      - mrpt_pf_localization
-      - mrpt_pointcloud_pipeline
-      - mrpt_rawlog
-      - mrpt_reactivenav2d
-      - mrpt_tps_astar_planner
-      - mrpt_tutorials
+        - mrpt_map_server
+        - mrpt_msgs_bridge
+        - mrpt_nav_interfaces
+        - mrpt_navigation
+        - mrpt_pf_localization
+        - mrpt_pointcloud_pipeline
+        - mrpt_rawlog
+        - mrpt_reactivenav2d
+        - mrpt_tps_astar_planner
+        - mrpt_tutorials
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
@@ -4331,20 +4341,20 @@ repositories:
       version: main
     release:
       packages:
-      - mrpt_apps
-      - mrpt_libapps
-      - mrpt_libbase
-      - mrpt_libgui
-      - mrpt_libhwdrivers
-      - mrpt_libmaps
-      - mrpt_libmath
-      - mrpt_libnav
-      - mrpt_libobs
-      - mrpt_libopengl
-      - mrpt_libposes
-      - mrpt_libros_bridge
-      - mrpt_libslam
-      - mrpt_libtclap
+        - mrpt_apps
+        - mrpt_libapps
+        - mrpt_libbase
+        - mrpt_libgui
+        - mrpt_libhwdrivers
+        - mrpt_libmaps
+        - mrpt_libmath
+        - mrpt_libnav
+        - mrpt_libobs
+        - mrpt_libopengl
+        - mrpt_libposes
+        - mrpt_libros_bridge
+        - mrpt_libslam
+        - mrpt_libtclap
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
@@ -4361,13 +4371,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - mrpt_generic_sensor
-      - mrpt_sensor_bumblebee_stereo
-      - mrpt_sensor_gnss_nmea
-      - mrpt_sensor_gnss_novatel
-      - mrpt_sensor_imu_taobotics
-      - mrpt_sensorlib
-      - mrpt_sensors
+        - mrpt_generic_sensor
+        - mrpt_sensor_bumblebee_stereo
+        - mrpt_sensor_gnss_nmea
+        - mrpt_sensor_gnss_novatel
+        - mrpt_sensor_imu_taobotics
+        - mrpt_sensorlib
+        - mrpt_sensors
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
@@ -4429,8 +4439,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - nao_command_msgs
-      - nao_sensor_msgs
+        - nao_command_msgs
+        - nao_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
@@ -4447,10 +4457,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - nao_lola
-      - nao_lola_client
-      - nao_lola_command_msgs
-      - nao_lola_sensor_msgs
+        - nao_lola
+        - nao_lola_client
+        - nao_lola_command_msgs
+        - nao_lola_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
@@ -4463,9 +4473,9 @@ repositories:
   nav2_minimal_turtlebot_simulation:
     release:
       packages:
-      - nav2_minimal_tb3_sim
-      - nav2_minimal_tb4_description
-      - nav2_minimal_tb4_sim
+        - nav2_minimal_tb3_sim
+        - nav2_minimal_tb4_description
+        - nav2_minimal_tb4_sim
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
@@ -4482,49 +4492,49 @@ repositories:
       version: jazzy
     release:
       packages:
-      - costmap_queue
-      - dwb_core
-      - dwb_critics
-      - dwb_msgs
-      - dwb_plugins
-      - nav2_amcl
-      - nav2_behavior_tree
-      - nav2_behaviors
-      - nav2_bringup
-      - nav2_bt_navigator
-      - nav2_collision_monitor
-      - nav2_common
-      - nav2_constrained_smoother
-      - nav2_controller
-      - nav2_core
-      - nav2_costmap_2d
-      - nav2_dwb_controller
-      - nav2_graceful_controller
-      - nav2_lifecycle_manager
-      - nav2_loopback_sim
-      - nav2_map_server
-      - nav2_mppi_controller
-      - nav2_msgs
-      - nav2_navfn_planner
-      - nav2_planner
-      - nav2_regulated_pure_pursuit_controller
-      - nav2_rotation_shim_controller
-      - nav2_rviz_plugins
-      - nav2_simple_commander
-      - nav2_smac_planner
-      - nav2_smoother
-      - nav2_system_tests
-      - nav2_theta_star_planner
-      - nav2_util
-      - nav2_velocity_smoother
-      - nav2_voxel_grid
-      - nav2_waypoint_follower
-      - nav_2d_msgs
-      - nav_2d_utils
-      - navigation2
-      - opennav_docking
-      - opennav_docking_bt
-      - opennav_docking_core
+        - costmap_queue
+        - dwb_core
+        - dwb_critics
+        - dwb_msgs
+        - dwb_plugins
+        - nav2_amcl
+        - nav2_behavior_tree
+        - nav2_behaviors
+        - nav2_bringup
+        - nav2_bt_navigator
+        - nav2_collision_monitor
+        - nav2_common
+        - nav2_constrained_smoother
+        - nav2_controller
+        - nav2_core
+        - nav2_costmap_2d
+        - nav2_dwb_controller
+        - nav2_graceful_controller
+        - nav2_lifecycle_manager
+        - nav2_loopback_sim
+        - nav2_map_server
+        - nav2_mppi_controller
+        - nav2_msgs
+        - nav2_navfn_planner
+        - nav2_planner
+        - nav2_regulated_pure_pursuit_controller
+        - nav2_rotation_shim_controller
+        - nav2_rviz_plugins
+        - nav2_simple_commander
+        - nav2_smac_planner
+        - nav2_smoother
+        - nav2_system_tests
+        - nav2_theta_star_planner
+        - nav2_util
+        - nav2_velocity_smoother
+        - nav2_voxel_grid
+        - nav2_waypoint_follower
+        - nav_2d_msgs
+        - nav_2d_utils
+        - navigation2
+        - opennav_docking
+        - opennav_docking_bt
+        - opennav_docking_core
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
@@ -4541,7 +4551,7 @@ repositories:
       version: jazzy
     release:
       packages:
-      - map_msgs
+        - map_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -4678,8 +4688,8 @@ repositories:
       version: master
     release:
       packages:
-      - nodl_python
-      - ros2nodl
+        - nodl_python
+        - ros2nodl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
@@ -4712,8 +4722,8 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - novatel_gps_driver
-      - novatel_gps_msgs
+        - novatel_gps_driver
+        - novatel_gps_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
@@ -4772,9 +4782,9 @@ repositories:
       version: devel
     release:
       packages:
-      - dynamic_edt_3d
-      - octomap
-      - octovis
+        - dynamic_edt_3d
+        - octomap
+        - octovis
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/octomap-release.git
@@ -4791,8 +4801,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - octomap_mapping
-      - octomap_server
+        - octomap_mapping
+        - octomap_server
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
@@ -4869,7 +4879,7 @@ repositories:
       version: main
     release:
       packages:
-      - odri_master_board_sdk
+        - odri_master_board_sdk
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
@@ -4947,8 +4957,8 @@ repositories:
   orocos_kdl_vendor:
     release:
       packages:
-      - orocos_kdl_vendor
-      - python_orocos_kdl_vendor
+        - orocos_kdl_vendor
+        - python_orocos_kdl_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
@@ -5018,8 +5028,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-      - ouster_ros
-      - ouster_sensor_msgs
+        - ouster_ros
+        - ouster_sensor_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
@@ -5037,8 +5047,8 @@ repositories:
       version: master
     release:
       packages:
-      - ouxt_common
-      - ouxt_lint_common
+        - ouxt_common
+        - ouxt_lint_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
@@ -5055,8 +5065,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_statistics
-      - pal_statistics_msgs
+        - pal_statistics
+        - pal_statistics_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
@@ -5091,7 +5101,7 @@ repositories:
   perception_open3d:
     release:
       packages:
-      - open3d_conversions
+        - open3d_conversions
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
@@ -5109,9 +5119,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - pcl_conversions
-      - pcl_ros
-      - perception_pcl
+        - pcl_conversions
+        - pcl_ros
+        - perception_pcl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
@@ -5156,22 +5166,22 @@ repositories:
       version: rolling
     release:
       packages:
-      - libphidget22
-      - phidgets_accelerometer
-      - phidgets_analog_inputs
-      - phidgets_analog_outputs
-      - phidgets_api
-      - phidgets_digital_inputs
-      - phidgets_digital_outputs
-      - phidgets_drivers
-      - phidgets_gyroscope
-      - phidgets_high_speed_encoder
-      - phidgets_ik
-      - phidgets_magnetometer
-      - phidgets_motors
-      - phidgets_msgs
-      - phidgets_spatial
-      - phidgets_temperature
+        - libphidget22
+        - phidgets_accelerometer
+        - phidgets_analog_inputs
+        - phidgets_analog_outputs
+        - phidgets_api
+        - phidgets_digital_inputs
+        - phidgets_digital_outputs
+        - phidgets_drivers
+        - phidgets_gyroscope
+        - phidgets_high_speed_encoder
+        - phidgets_ik
+        - phidgets_magnetometer
+        - phidgets_motors
+        - phidgets_msgs
+        - phidgets_spatial
+        - phidgets_temperature
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
@@ -5210,8 +5220,8 @@ repositories:
       version: main
     release:
       packages:
-      - picknik_reset_fault_controller
-      - picknik_twist_controller
+        - picknik_reset_fault_controller
+        - picknik_twist_controller
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
@@ -5319,8 +5329,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - point_cloud_transport
-      - point_cloud_transport_py
+        - point_cloud_transport
+        - point_cloud_transport_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -5338,11 +5348,11 @@ repositories:
       version: jazzy
     release:
       packages:
-      - draco_point_cloud_transport
-      - point_cloud_interfaces
-      - point_cloud_transport_plugins
-      - zlib_point_cloud_transport
-      - zstd_point_cloud_transport
+        - draco_point_cloud_transport
+        - point_cloud_interfaces
+        - point_cloud_transport_plugins
+        - zlib_point_cloud_transport
+        - zstd_point_cloud_transport
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
@@ -5392,10 +5402,10 @@ repositories:
       version: main
     release:
       packages:
-      - polygon_demos
-      - polygon_msgs
-      - polygon_rviz_plugins
-      - polygon_utils
+        - polygon_demos
+        - polygon_msgs
+        - polygon_rviz_plugins
+        - polygon_utils
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
@@ -5458,7 +5468,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - ptz_action_server_msgs
+        - ptz_action_server_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/ptz_action_server-release.git
@@ -5596,7 +5606,7 @@ repositories:
       version: main
     release:
       packages:
-      - python_mrpt
+        - python_mrpt
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
@@ -5655,12 +5665,12 @@ repositories:
       version: jazzy
     release:
       packages:
-      - qt_dotgraph
-      - qt_gui
-      - qt_gui_app
-      - qt_gui_core
-      - qt_gui_cpp
-      - qt_gui_py_common
+        - qt_dotgraph
+        - qt_gui
+        - qt_gui_app
+        - qt_gui_core
+        - qt_gui_cpp
+        - qt_gui_py_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
@@ -5693,9 +5703,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - r2r_spl_7
-      - splsm_7
-      - splsm_7_conversion
+        - r2r_spl_7
+        - splsm_7
+        - splsm_7_conversion
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
@@ -5734,8 +5744,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - raspimouse
-      - raspimouse_msgs
+        - raspimouse
+        - raspimouse_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
@@ -5785,9 +5795,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - raspimouse_fake
-      - raspimouse_gazebo
-      - raspimouse_sim
+        - raspimouse_fake
+        - raspimouse_gazebo
+        - raspimouse_sim
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_sim-release.git
@@ -5805,9 +5815,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - raspimouse_navigation
-      - raspimouse_slam
-      - raspimouse_slam_navigation
+        - raspimouse_navigation
+        - raspimouse_slam
+        - raspimouse_slam_navigation
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse_slam_navigation_ros2-release.git
@@ -5889,8 +5899,8 @@ repositories:
       version: master
     release:
       packages:
-      - rc_reason_clients
-      - rc_reason_msgs
+        - rc_reason_clients
+        - rc_reason_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
@@ -5924,10 +5934,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rcl
-      - rcl_action
-      - rcl_lifecycle
-      - rcl_yaml_param_parser
+        - rcl
+        - rcl_action
+        - rcl_lifecycle
+        - rcl_yaml_param_parser
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
@@ -5945,16 +5955,16 @@ repositories:
       version: jazzy
     release:
       packages:
-      - action_msgs
-      - builtin_interfaces
-      - composition_interfaces
-      - lifecycle_msgs
-      - rcl_interfaces
-      - rosgraph_msgs
-      - service_msgs
-      - statistics_msgs
-      - test_msgs
-      - type_description_interfaces
+        - action_msgs
+        - builtin_interfaces
+        - composition_interfaces
+        - lifecycle_msgs
+        - rcl_interfaces
+        - rosgraph_msgs
+        - service_msgs
+        - statistics_msgs
+        - test_msgs
+        - type_description_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
@@ -5972,9 +5982,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rcl_logging_interface
-      - rcl_logging_noop
-      - rcl_logging_spdlog
+        - rcl_logging_interface
+        - rcl_logging_noop
+        - rcl_logging_spdlog
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
@@ -6003,10 +6013,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - rclc
-      - rclc_examples
-      - rclc_lifecycle
-      - rclc_parameter
+        - rclc
+        - rclc_examples
+        - rclc_lifecycle
+        - rclc_parameter
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
@@ -6024,10 +6034,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rclcpp
-      - rclcpp_action
-      - rclcpp_components
-      - rclcpp_lifecycle
+        - rclcpp
+        - rclcpp_action
+        - rclcpp_components
+        - rclcpp_lifecycle
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
@@ -6077,10 +6087,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - rcss3d_agent
-      - rcss3d_agent_basic
-      - rcss3d_agent_msgs
-      - rcss3d_agent_msgs_to_soccer_interfaces
+        - rcss3d_agent
+        - rcss3d_agent_basic
+        - rcss3d_agent_msgs
+        - rcss3d_agent_msgs_to_soccer_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
@@ -6138,9 +6148,9 @@ repositories:
       version: ros2-master
     release:
       packages:
-      - realsense2_camera
-      - realsense2_camera_msgs
-      - realsense2_description
+        - realsense2_camera
+        - realsense2_camera_msgs
+        - realsense2_description
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
@@ -6158,8 +6168,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rttest
-      - tlsf_cpp
+        - rttest
+        - tlsf_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
@@ -6192,8 +6202,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - libcurl_vendor
-      - resource_retriever
+        - libcurl_vendor
+        - resource_retriever
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
@@ -6278,18 +6288,18 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_charger_msgs
-      - rmf_dispenser_msgs
-      - rmf_door_msgs
-      - rmf_fleet_msgs
-      - rmf_ingestor_msgs
-      - rmf_lift_msgs
-      - rmf_obstacle_msgs
-      - rmf_scheduler_msgs
-      - rmf_site_map_msgs
-      - rmf_task_msgs
-      - rmf_traffic_msgs
-      - rmf_workcell_msgs
+        - rmf_charger_msgs
+        - rmf_dispenser_msgs
+        - rmf_door_msgs
+        - rmf_fleet_msgs
+        - rmf_ingestor_msgs
+        - rmf_lift_msgs
+        - rmf_obstacle_msgs
+        - rmf_scheduler_msgs
+        - rmf_site_map_msgs
+        - rmf_task_msgs
+        - rmf_traffic_msgs
+        - rmf_workcell_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
@@ -6306,12 +6316,12 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_charging_schedule
-      - rmf_fleet_adapter
-      - rmf_fleet_adapter_python
-      - rmf_task_ros2
-      - rmf_traffic_ros2
-      - rmf_websocket
+        - rmf_charging_schedule
+        - rmf_fleet_adapter
+        - rmf_fleet_adapter_python
+        - rmf_task_ros2
+        - rmf_traffic_ros2
+        - rmf_websocket
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
@@ -6328,9 +6338,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_building_sim_gz_plugins
-      - rmf_robot_sim_common
-      - rmf_robot_sim_gz_plugins
+        - rmf_building_sim_gz_plugins
+        - rmf_robot_sim_common
+        - rmf_robot_sim_gz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
@@ -6347,8 +6357,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_task
-      - rmf_task_sequence
+        - rmf_task
+        - rmf_task_sequence
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
@@ -6365,8 +6375,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_traffic
-      - rmf_traffic_examples
+        - rmf_traffic
+        - rmf_traffic_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
@@ -6383,10 +6393,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_building_map_tools
-      - rmf_traffic_editor
-      - rmf_traffic_editor_assets
-      - rmf_traffic_editor_test_maps
+        - rmf_building_map_tools
+        - rmf_traffic_editor
+        - rmf_traffic_editor_assets
+        - rmf_traffic_editor_test_maps
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
@@ -6418,7 +6428,7 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_dev
+        - rmf_dev
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
@@ -6435,14 +6445,14 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmf_visualization
-      - rmf_visualization_building_systems
-      - rmf_visualization_fleet_states
-      - rmf_visualization_floorplans
-      - rmf_visualization_navgraphs
-      - rmf_visualization_obstacles
-      - rmf_visualization_rviz2_plugins
-      - rmf_visualization_schedule
+        - rmf_visualization
+        - rmf_visualization_building_systems
+        - rmf_visualization_fleet_states
+        - rmf_visualization_floorplans
+        - rmf_visualization_navgraphs
+        - rmf_visualization_obstacles
+        - rmf_visualization_rviz2_plugins
+        - rmf_visualization_schedule
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
@@ -6474,8 +6484,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmw
-      - rmw_implementation_cmake
+        - rmw
+        - rmw_implementation_cmake
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
@@ -6493,9 +6503,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmw_connextdds
-      - rmw_connextdds_common
-      - rti_connext_dds_cmake_module
+        - rmw_connextdds
+        - rmw_connextdds_common
+        - rti_connext_dds_cmake_module
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
@@ -6512,7 +6522,7 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmw_cyclonedds_cpp
+        - rmw_cyclonedds_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
@@ -6546,9 +6556,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmw_fastrtps_cpp
-      - rmw_fastrtps_dynamic_cpp
-      - rmw_fastrtps_shared_cpp
+        - rmw_fastrtps_cpp
+        - rmw_fastrtps_dynamic_cpp
+        - rmw_fastrtps_shared_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
@@ -6566,8 +6576,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - gurumdds_cmake_module
-      - rmw_gurumdds_cpp
+        - gurumdds_cmake_module
+        - rmw_gurumdds_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
@@ -6600,8 +6610,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rmw_zenoh_cpp
-      - zenoh_cpp_vendor
+        - rmw_zenoh_cpp
+        - zenoh_cpp_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
@@ -6628,8 +6638,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - robot_calibration
-      - robot_calibration_msgs
+        - robot_calibration
+        - robot_calibration_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
@@ -6699,7 +6709,8 @@ repositories:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master
-    status_description: Maintained in source form only since no ROS 1 packages available
+    status_description:
+      Maintained in source form only since no ROS 1 packages available
       in Rolling
   ros2_canopen:
     doc:
@@ -6708,19 +6719,19 @@ repositories:
       version: master
     release:
       packages:
-      - canopen
-      - canopen_402_driver
-      - canopen_base_driver
-      - canopen_core
-      - canopen_fake_slaves
-      - canopen_interfaces
-      - canopen_master_driver
-      - canopen_proxy_driver
-      - canopen_ros2_control
-      - canopen_ros2_controllers
-      - canopen_tests
-      - canopen_utils
-      - lely_core_libraries
+        - canopen
+        - canopen_402_driver
+        - canopen_base_driver
+        - canopen_core
+        - canopen_fake_slaves
+        - canopen_interfaces
+        - canopen_master_driver
+        - canopen_proxy_driver
+        - canopen_ros2_control
+        - canopen_ros2_controllers
+        - canopen_tests
+        - canopen_utils
+        - lely_core_libraries
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
@@ -6737,17 +6748,17 @@ repositories:
       version: master
     release:
       packages:
-      - controller_interface
-      - controller_manager
-      - controller_manager_msgs
-      - hardware_interface
-      - hardware_interface_testing
-      - joint_limits
-      - ros2_control
-      - ros2_control_test_assets
-      - ros2controlcli
-      - rqt_controller_manager
-      - transmission_interface
+        - controller_interface
+        - controller_manager
+        - controller_manager_msgs
+        - hardware_interface
+        - hardware_interface_testing
+        - joint_limits
+        - ros2_control
+        - ros2_control_test_assets
+        - ros2controlcli
+        - rqt_controller_manager
+        - transmission_interface
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
@@ -6764,31 +6775,31 @@ repositories:
       version: master
     release:
       packages:
-      - ackermann_steering_controller
-      - admittance_controller
-      - bicycle_steering_controller
-      - diff_drive_controller
-      - effort_controllers
-      - force_torque_sensor_broadcaster
-      - forward_command_controller
-      - gpio_controllers
-      - gripper_controllers
-      - imu_sensor_broadcaster
-      - joint_state_broadcaster
-      - joint_trajectory_controller
-      - mecanum_drive_controller
-      - parallel_gripper_controller
-      - pid_controller
-      - pose_broadcaster
-      - position_controllers
-      - range_sensor_broadcaster
-      - ros2_controllers
-      - ros2_controllers_test_nodes
-      - rqt_joint_trajectory_controller
-      - steering_controllers_library
-      - tricycle_controller
-      - tricycle_steering_controller
-      - velocity_controllers
+        - ackermann_steering_controller
+        - admittance_controller
+        - bicycle_steering_controller
+        - diff_drive_controller
+        - effort_controllers
+        - force_torque_sensor_broadcaster
+        - forward_command_controller
+        - gpio_controllers
+        - gripper_controllers
+        - imu_sensor_broadcaster
+        - joint_state_broadcaster
+        - joint_trajectory_controller
+        - mecanum_drive_controller
+        - parallel_gripper_controller
+        - pid_controller
+        - pose_broadcaster
+        - position_controllers
+        - range_sensor_broadcaster
+        - ros2_controllers
+        - ros2_controllers_test_nodes
+        - rqt_joint_trajectory_controller
+        - steering_controllers_library
+        - tricycle_controller
+        - tricycle_steering_controller
+        - velocity_controllers
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
@@ -6805,12 +6816,12 @@ repositories:
       version: main
     release:
       packages:
-      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-      - kortex_api
-      - kortex_bringup
-      - kortex_description
-      - kortex_driver
+        - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+        - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+        - kortex_api
+        - kortex_bringup
+        - kortex_description
+        - kortex_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
@@ -6837,21 +6848,21 @@ repositories:
       version: jazzy-devel
     release:
       packages:
-      - plansys2_bringup
-      - plansys2_bt_actions
-      - plansys2_core
-      - plansys2_domain_expert
-      - plansys2_executor
-      - plansys2_lifecycle_manager
-      - plansys2_msgs
-      - plansys2_pddl_parser
-      - plansys2_planner
-      - plansys2_popf_plan_solver
-      - plansys2_problem_expert
-      - plansys2_support_py
-      - plansys2_terminal
-      - plansys2_tests
-      - plansys2_tools
+        - plansys2_bringup
+        - plansys2_bt_actions
+        - plansys2_core
+        - plansys2_domain_expert
+        - plansys2_executor
+        - plansys2_lifecycle_manager
+        - plansys2_msgs
+        - plansys2_pddl_parser
+        - plansys2_planner
+        - plansys2_popf_plan_solver
+        - plansys2_problem_expert
+        - plansys2_support_py
+        - plansys2_terminal
+        - plansys2_tests
+        - plansys2_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_planning_system-release.git
@@ -6868,8 +6879,8 @@ repositories:
       version: main
     release:
       packages:
-      - robotiq_controllers
-      - robotiq_description
+        - robotiq_controllers
+        - robotiq_description
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
@@ -6886,8 +6897,8 @@ repositories:
       version: main
     release:
       packages:
-      - ros2_socketcan
-      - ros2_socketcan_msgs
+        - ros2_socketcan
+        - ros2_socketcan_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
@@ -6904,13 +6915,13 @@ repositories:
       version: jazzy
     release:
       packages:
-      - lttngpy
-      - ros2trace
-      - tracetools
-      - tracetools_launch
-      - tracetools_read
-      - tracetools_test
-      - tracetools_trace
+        - lttngpy
+        - ros2trace
+        - tracetools
+        - tracetools_launch
+        - tracetools_read
+        - tracetools_test
+        - tracetools_trace
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
@@ -6944,21 +6955,21 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ros2action
-      - ros2cli
-      - ros2cli_test_interfaces
-      - ros2component
-      - ros2doctor
-      - ros2interface
-      - ros2lifecycle
-      - ros2lifecycle_test_fixtures
-      - ros2multicast
-      - ros2node
-      - ros2param
-      - ros2pkg
-      - ros2run
-      - ros2service
-      - ros2topic
+        - ros2action
+        - ros2cli
+        - ros2cli_test_interfaces
+        - ros2component
+        - ros2doctor
+        - ros2interface
+        - ros2lifecycle
+        - ros2lifecycle_test_fixtures
+        - ros2multicast
+        - ros2node
+        - ros2param
+        - ros2pkg
+        - ros2run
+        - ros2service
+        - ros2topic
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
@@ -6991,8 +7002,8 @@ repositories:
       version: main
     release:
       packages:
-      - ros2launch_security
-      - ros2launch_security_examples
+        - ros2launch_security
+        - ros2launch_security_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
@@ -7010,8 +7021,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ros_babel_fish
-      - ros_babel_fish_test_msgs
+        - ros_babel_fish
+        - ros_babel_fish_test_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
@@ -7038,8 +7049,8 @@ repositories:
       version: main
     release:
       packages:
-      - battery_state_broadcaster
-      - battery_state_rviz_overlay
+        - battery_state_broadcaster
+        - battery_state_rviz_overlay
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
@@ -7053,7 +7064,7 @@ repositories:
   ros_canopen:
     release:
       packages:
-      - can_msgs
+        - can_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
@@ -7086,13 +7097,13 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ros_gz
-      - ros_gz_bridge
-      - ros_gz_image
-      - ros_gz_interfaces
-      - ros_gz_sim
-      - ros_gz_sim_demos
-      - test_ros_gz_bridge
+        - ros_gz
+        - ros_gz_bridge
+        - ros_gz_image
+        - ros_gz_interfaces
+        - ros_gz_sim
+        - ros_gz_sim_demos
+        - test_ros_gz_bridge
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
@@ -7131,8 +7142,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ros2test
-      - ros_testing
+        - ros2test
+        - ros_testing
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
@@ -7150,7 +7161,7 @@ repositories:
       version: jazzy
     release:
       packages:
-      - turtlesim
+        - turtlesim
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
@@ -7179,30 +7190,30 @@ repositories:
       version: jazzy
     release:
       packages:
-      - liblz4_vendor
-      - mcap_vendor
-      - ros2bag
-      - rosbag2
-      - rosbag2_compression
-      - rosbag2_compression_zstd
-      - rosbag2_cpp
-      - rosbag2_examples_cpp
-      - rosbag2_examples_py
-      - rosbag2_interfaces
-      - rosbag2_performance_benchmarking
-      - rosbag2_performance_benchmarking_msgs
-      - rosbag2_py
-      - rosbag2_storage
-      - rosbag2_storage_default_plugins
-      - rosbag2_storage_mcap
-      - rosbag2_storage_sqlite3
-      - rosbag2_test_common
-      - rosbag2_test_msgdefs
-      - rosbag2_tests
-      - rosbag2_transport
-      - shared_queues_vendor
-      - sqlite3_vendor
-      - zstd_vendor
+        - liblz4_vendor
+        - mcap_vendor
+        - ros2bag
+        - rosbag2
+        - rosbag2_compression
+        - rosbag2_compression_zstd
+        - rosbag2_cpp
+        - rosbag2_examples_cpp
+        - rosbag2_examples_py
+        - rosbag2_interfaces
+        - rosbag2_performance_benchmarking
+        - rosbag2_performance_benchmarking_msgs
+        - rosbag2_py
+        - rosbag2_storage
+        - rosbag2_storage_default_plugins
+        - rosbag2_storage_mcap
+        - rosbag2_storage_sqlite3
+        - rosbag2_test_common
+        - rosbag2_test_msgdefs
+        - rosbag2_tests
+        - rosbag2_transport
+        - shared_queues_vendor
+        - sqlite3_vendor
+        - zstd_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
@@ -7219,7 +7230,8 @@ repositories:
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
-    status_description: Maintained in source form only since no ROS 1 packages available
+    status_description:
+      Maintained in source form only since no ROS 1 packages available
       in Rolling
   rosbag2_to_video:
     doc:
@@ -7243,13 +7255,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - rosapi
-      - rosapi_msgs
-      - rosbridge_library
-      - rosbridge_msgs
-      - rosbridge_server
-      - rosbridge_suite
-      - rosbridge_test_msgs
+        - rosapi
+        - rosapi_msgs
+        - rosbridge_library
+        - rosbridge_msgs
+        - rosbridge_server
+        - rosbridge_suite
+        - rosbridge_test_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
@@ -7266,19 +7278,19 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rosidl_adapter
-      - rosidl_cli
-      - rosidl_cmake
-      - rosidl_generator_c
-      - rosidl_generator_cpp
-      - rosidl_generator_type_description
-      - rosidl_parser
-      - rosidl_pycommon
-      - rosidl_runtime_c
-      - rosidl_runtime_cpp
-      - rosidl_typesupport_interface
-      - rosidl_typesupport_introspection_c
-      - rosidl_typesupport_introspection_cpp
+        - rosidl_adapter
+        - rosidl_cli
+        - rosidl_cmake
+        - rosidl_generator_c
+        - rosidl_generator_cpp
+        - rosidl_generator_type_description
+        - rosidl_parser
+        - rosidl_pycommon
+        - rosidl_runtime_c
+        - rosidl_runtime_cpp
+        - rosidl_typesupport_interface
+        - rosidl_typesupport_introspection_c
+        - rosidl_typesupport_introspection_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
@@ -7296,8 +7308,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rosidl_core_generators
-      - rosidl_core_runtime
+        - rosidl_core_generators
+        - rosidl_core_runtime
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
@@ -7315,7 +7327,7 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rosidl_generator_dds_idl
+        - rosidl_generator_dds_idl
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
@@ -7333,8 +7345,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rosidl_default_generators
-      - rosidl_default_runtime
+        - rosidl_default_generators
+        - rosidl_default_runtime
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
@@ -7384,7 +7396,7 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rosidl_generator_py
+        - rosidl_generator_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
@@ -7418,8 +7430,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rosidl_typesupport_c
-      - rosidl_typesupport_cpp
+        - rosidl_typesupport_c
+        - rosidl_typesupport_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
@@ -7437,9 +7449,9 @@ repositories:
       version: jazzy
     release:
       packages:
-      - fastrtps_cmake_module
-      - rosidl_typesupport_fastrtps_c
-      - rosidl_typesupport_fastrtps_cpp
+        - fastrtps_cmake_module
+        - rosidl_typesupport_fastrtps_c
+        - rosidl_typesupport_fastrtps_cpp
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
@@ -7457,8 +7469,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rclpy_message_converter
-      - rclpy_message_converter_msgs
+        - rclpy_message_converter
+        - rclpy_message_converter_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
@@ -7487,7 +7499,7 @@ repositories:
   rot_conv_lib:
     release:
       packages:
-      - rot_conv
+        - rot_conv
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
@@ -7532,11 +7544,11 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rqt
-      - rqt_gui
-      - rqt_gui_cpp
-      - rqt_gui_py
-      - rqt_py_common
+        - rqt
+        - rqt_gui
+        - rqt_gui_cpp
+        - rqt_gui_py
+        - rqt_py_common
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
@@ -7569,8 +7581,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rqt_bag
-      - rqt_bag_plugins
+        - rqt_bag
+        - rqt_bag_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
@@ -7663,8 +7675,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rqt_image_overlay
-      - rqt_image_overlay_layer
+        - rqt_image_overlay
+        - rqt_image_overlay_layer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
@@ -7969,8 +7981,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - rt_manipulators_cpp
-      - rt_manipulators_examples
+        - rt_manipulators_cpp
+        - rt_manipulators_examples
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
@@ -8018,19 +8030,19 @@ repositories:
       version: jazzy-devel
     release:
       packages:
-      - rtabmap_conversions
-      - rtabmap_demos
-      - rtabmap_examples
-      - rtabmap_launch
-      - rtabmap_msgs
-      - rtabmap_odom
-      - rtabmap_python
-      - rtabmap_ros
-      - rtabmap_rviz_plugins
-      - rtabmap_slam
-      - rtabmap_sync
-      - rtabmap_util
-      - rtabmap_viz
+        - rtabmap_conversions
+        - rtabmap_demos
+        - rtabmap_examples
+        - rtabmap_launch
+        - rtabmap_msgs
+        - rtabmap_odom
+        - rtabmap_python
+        - rtabmap_ros
+        - rtabmap_rviz_plugins
+        - rtabmap_slam
+        - rtabmap_sync
+        - rtabmap_util
+        - rtabmap_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
@@ -8073,14 +8085,14 @@ repositories:
       version: jazzy
     release:
       packages:
-      - rviz2
-      - rviz_assimp_vendor
-      - rviz_common
-      - rviz_default_plugins
-      - rviz_ogre_vendor
-      - rviz_rendering
-      - rviz_rendering_tests
-      - rviz_visual_testing_framework
+        - rviz2
+        - rviz_assimp_vendor
+        - rviz_common
+        - rviz_default_plugins
+        - rviz_ogre_vendor
+        - rviz_rendering
+        - rviz_rendering_tests
+        - rviz_visual_testing_framework
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
@@ -8098,8 +8110,8 @@ repositories:
       version: main
     release:
       packages:
-      - rviz_2d_overlay_msgs
-      - rviz_2d_overlay_plugins
+        - rviz_2d_overlay_msgs
+        - rviz_2d_overlay_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
@@ -8162,17 +8174,17 @@ repositories:
       version: jazzy
     release:
       packages:
-      - scenario_execution
-      - scenario_execution_control
-      - scenario_execution_coverage
-      - scenario_execution_gazebo
-      - scenario_execution_interfaces
-      - scenario_execution_nav2
-      - scenario_execution_os
-      - scenario_execution_py_trees_ros
-      - scenario_execution_ros
-      - scenario_execution_rviz
-      - scenario_execution_x11
+        - scenario_execution
+        - scenario_execution_control
+        - scenario_execution_coverage
+        - scenario_execution_gazebo
+        - scenario_execution_interfaces
+        - scenario_execution_nav2
+        - scenario_execution_os
+        - scenario_execution_py_trees_ros
+        - scenario_execution_ros
+        - scenario_execution_rviz
+        - scenario_execution_x11
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
@@ -8189,8 +8201,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - sdformat_test_files
-      - sdformat_urdf
+        - sdformat_test_files
+        - sdformat_urdf
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
@@ -8300,9 +8312,9 @@ repositories:
       version: main
     release:
       packages:
-      - sick_safevisionary_driver
-      - sick_safevisionary_interfaces
-      - sick_safevisionary_tests
+        - sick_safevisionary_driver
+        - sick_safevisionary_interfaces
+        - sick_safevisionary_tests
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
@@ -8426,10 +8438,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - executive_smach
-      - smach
-      - smach_msgs
-      - smach_ros
+        - executive_smach
+        - smach
+        - smach_msgs
+        - smach_ros
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
@@ -8468,12 +8480,12 @@ repositories:
       version: rolling
     release:
       packages:
-      - soccer_geometry_msgs
-      - soccer_interfaces
-      - soccer_model_msgs
-      - soccer_vision_2d_msgs
-      - soccer_vision_3d_msgs
-      - soccer_vision_attribute_msgs
+        - soccer_geometry_msgs
+        - soccer_interfaces
+        - soccer_model_msgs
+        - soccer_vision_2d_msgs
+        - soccer_vision_3d_msgs
+        - soccer_vision_attribute_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
@@ -8535,8 +8547,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - openvdb_vendor
-      - spatio_temporal_voxel_layer
+        - openvdb_vendor
+        - spatio_temporal_voxel_layer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
@@ -8580,8 +8592,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - sros2
-      - sros2_cmake
+        - sros2
+        - sros2_cmake
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
@@ -8660,10 +8672,10 @@ repositories:
       version: master
     release:
       packages:
-      - launch_system_modes
-      - system_modes
-      - system_modes_examples
-      - system_modes_msgs
+        - launch_system_modes
+        - system_modes
+        - system_modes_examples
+        - system_modes_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
@@ -8699,11 +8711,11 @@ repositories:
       version: master
     release:
       packages:
-      - joy_teleop
-      - key_teleop
-      - mouse_teleop
-      - teleop_tools
-      - teleop_tools_msgs
+        - joy_teleop
+        - key_teleop
+        - mouse_teleop
+        - teleop_tools
+        - teleop_tools_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
@@ -8880,8 +8892,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - topic_tools
-      - topic_tools_interfaces
+        - topic_tools
+        - topic_tools_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
@@ -8898,9 +8910,9 @@ repositories:
       version: rolling-devel
     release:
       packages:
-      - trac_ik
-      - trac_ik_kinematics_plugin
-      - trac_ik_lib
+        - trac_ik
+        - trac_ik_kinematics_plugin
+        - trac_ik_lib
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
@@ -8933,8 +8945,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - ros2trace_analysis
-      - tracetools_analysis
+        - ros2trace_analysis
+        - tracetools_analysis
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
@@ -8952,10 +8964,10 @@ repositories:
       version: main
     release:
       packages:
-      - asio_cmake_module
-      - io_context
-      - serial_driver
-      - udp_driver
+        - asio_cmake_module
+        - io_context
+        - serial_driver
+        - udp_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
@@ -9017,9 +9029,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - turtlebot3_fake_node
-      - turtlebot3_gazebo
-      - turtlebot3_simulations
+        - turtlebot3_fake_node
+        - turtlebot3_gazebo
+        - turtlebot3_simulations
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
@@ -9036,10 +9048,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - turtlebot4_description
-      - turtlebot4_msgs
-      - turtlebot4_navigation
-      - turtlebot4_node
+        - turtlebot4_description
+        - turtlebot4_msgs
+        - turtlebot4_navigation
+        - turtlebot4_node
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
@@ -9056,8 +9068,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - turtlebot4_desktop
-      - turtlebot4_viz
+        - turtlebot4_desktop
+        - turtlebot4_viz
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_desktop-release.git
@@ -9074,11 +9086,11 @@ repositories:
       version: jazzy
     release:
       packages:
-      - turtlebot4_base
-      - turtlebot4_bringup
-      - turtlebot4_diagnostics
-      - turtlebot4_robot
-      - turtlebot4_tests
+        - turtlebot4_base
+        - turtlebot4_bringup
+        - turtlebot4_diagnostics
+        - turtlebot4_robot
+        - turtlebot4_tests
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_robot-release.git
@@ -9110,10 +9122,10 @@ repositories:
       version: jazzy
     release:
       packages:
-      - turtlebot4_gz_bringup
-      - turtlebot4_gz_gui_plugins
-      - turtlebot4_gz_toolbox
-      - turtlebot4_simulator
+        - turtlebot4_gz_bringup
+        - turtlebot4_gz_gui_plugins
+        - turtlebot4_gz_toolbox
+        - turtlebot4_simulator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_simulator-release.git
@@ -9145,16 +9157,16 @@ repositories:
       version: ros2
     release:
       packages:
-      - tuw_airskin_msgs
-      - tuw_geo_msgs
-      - tuw_geometry_msgs
-      - tuw_graph_msgs
-      - tuw_msgs
-      - tuw_multi_robot_msgs
-      - tuw_nav_msgs
-      - tuw_object_map_msgs
-      - tuw_object_msgs
-      - tuw_std_msgs
+        - tuw_airskin_msgs
+        - tuw_geo_msgs
+        - tuw_geometry_msgs
+        - tuw_graph_msgs
+        - tuw_msgs
+        - tuw_multi_robot_msgs
+        - tuw_nav_msgs
+        - tuw_object_map_msgs
+        - tuw_object_msgs
+        - tuw_std_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_msgs-release.git
@@ -9241,10 +9253,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - ublox
-      - ublox_gps
-      - ublox_msgs
-      - ublox_serialization
+        - ublox
+        - ublox_gps
+        - ublox_msgs
+        - ublox_serialization
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
@@ -9262,12 +9274,12 @@ repositories:
       version: main
     release:
       packages:
-      - ntrip_client_node
-      - ublox_dgnss
-      - ublox_dgnss_node
-      - ublox_nav_sat_fix_hp_node
-      - ublox_ubx_interfaces
-      - ublox_ubx_msgs
+        - ntrip_client_node
+        - ublox_dgnss
+        - ublox_dgnss_node
+        - ublox_nav_sat_fix_hp_node
+        - ublox_ubx_interfaces
+        - ublox_ubx_msgs
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
@@ -9371,12 +9383,12 @@ repositories:
       version: main
     release:
       packages:
-      - ur
-      - ur_calibration
-      - ur_controllers
-      - ur_dashboard_msgs
-      - ur_moveit_config
-      - ur_robot_driver
+        - ur
+        - ur_calibration
+        - ur_controllers
+        - ur_dashboard_msgs
+        - ur_moveit_config
+        - ur_robot_driver
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
@@ -9404,8 +9416,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - urdf
-      - urdf_parser_plugin
+        - urdf
+        - urdf_parser_plugin
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
@@ -9439,7 +9451,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - urdfdom_py
+        - urdfdom_py
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
@@ -9581,12 +9593,12 @@ repositories:
       version: jazzy
     release:
       packages:
-      - desktop
-      - desktop_full
-      - perception
-      - ros_base
-      - ros_core
-      - simulation
+        - desktop
+        - desktop_full
+        - perception
+        - ros_base
+        - ros_core
+        - simulation
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
@@ -9604,11 +9616,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - velodyne
-      - velodyne_driver
-      - velodyne_laserscan
-      - velodyne_msgs
-      - velodyne_pointcloud
+        - velodyne
+        - velodyne_driver
+        - velodyne_laserscan
+        - velodyne_msgs
+        - velodyne_pointcloud
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
@@ -9625,9 +9637,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-      - velodyne_description
-      - velodyne_gazebo_plugins
-      - velodyne_simulator
+        - velodyne_description
+        - velodyne_gazebo_plugins
+        - velodyne_simulator
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
@@ -9644,8 +9656,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - vision_msgs
-      - vision_msgs_rviz_plugins
+        - vision_msgs
+        - vision_msgs_rviz_plugins
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
@@ -9678,9 +9690,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - cv_bridge
-      - image_geometry
-      - vision_opencv
+        - cv_bridge
+        - image_geometry
+        - vision_opencv
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -9817,18 +9829,18 @@ repositories:
       version: master
     release:
       packages:
-      - webots_ros2
-      - webots_ros2_control
-      - webots_ros2_driver
-      - webots_ros2_epuck
-      - webots_ros2_importer
-      - webots_ros2_mavic
-      - webots_ros2_msgs
-      - webots_ros2_tesla
-      - webots_ros2_tests
-      - webots_ros2_tiago
-      - webots_ros2_turtlebot
-      - webots_ros2_universal_robot
+        - webots_ros2
+        - webots_ros2_control
+        - webots_ros2_driver
+        - webots_ros2_epuck
+        - webots_ros2_importer
+        - webots_ros2_mavic
+        - webots_ros2_msgs
+        - webots_ros2_tesla
+        - webots_ros2_tests
+        - webots_ros2_tiago
+        - webots_ros2_turtlebot
+        - webots_ros2_universal_robot
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
@@ -9846,8 +9858,8 @@ repositories:
       version: humble
     release:
       packages:
-      - wireless_msgs
-      - wireless_watcher
+        - wireless_msgs
+        - wireless_watcher
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
@@ -9906,11 +9918,11 @@ repositories:
       version: main
     release:
       packages:
-      - yasmin
-      - yasmin_demos
-      - yasmin_msgs
-      - yasmin_ros
-      - yasmin_viewer
+        - yasmin
+        - yasmin_demos
+        - yasmin_msgs
+        - yasmin_ros
+        - yasmin_viewer
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
@@ -9927,8 +9939,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - zbar_ros
-      - zbar_ros_interfaces
+        - zbar_ros
+        - zbar_ros_interfaces
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4,11 +4,11 @@
 ---
 release_platforms:
   debian:
-    - bookworm
+  - bookworm
   rhel:
-    - "9"
+  - '9'
   ubuntu:
-    - noble
+  - noble
 repositories:
   SMACC2:
     doc:
@@ -17,8 +17,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - smacc2
-        - smacc2_msgs
+      - smacc2
+      - smacc2_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
@@ -99,8 +99,8 @@ repositories:
   ament_black:
     release:
       packages:
-        - ament_black
-        - ament_cmake_black
+      - ament_black
+      - ament_cmake_black
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
@@ -117,28 +117,28 @@ repositories:
       version: rolling
     release:
       packages:
-        - ament_cmake
-        - ament_cmake_auto
-        - ament_cmake_core
-        - ament_cmake_export_definitions
-        - ament_cmake_export_dependencies
-        - ament_cmake_export_include_directories
-        - ament_cmake_export_interfaces
-        - ament_cmake_export_libraries
-        - ament_cmake_export_link_flags
-        - ament_cmake_export_targets
-        - ament_cmake_gen_version_h
-        - ament_cmake_gmock
-        - ament_cmake_google_benchmark
-        - ament_cmake_gtest
-        - ament_cmake_include_directories
-        - ament_cmake_libraries
-        - ament_cmake_pytest
-        - ament_cmake_python
-        - ament_cmake_target_dependencies
-        - ament_cmake_test
-        - ament_cmake_vendor_package
-        - ament_cmake_version
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_export_targets
+      - ament_cmake_gen_version_h
+      - ament_cmake_gmock
+      - ament_cmake_google_benchmark
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_vendor_package
+      - ament_cmake_version
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
@@ -171,8 +171,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - ament_cmake_ros
-        - domain_coordinator
+      - ament_cmake_ros
+      - domain_coordinator
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
@@ -205,8 +205,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - ament_index_cpp
-        - ament_index_python
+      - ament_index_cpp
+      - ament_index_python
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
@@ -224,37 +224,37 @@ repositories:
       version: rolling
     release:
       packages:
-        - ament_clang_format
-        - ament_clang_tidy
-        - ament_cmake_clang_format
-        - ament_cmake_clang_tidy
-        - ament_cmake_copyright
-        - ament_cmake_cppcheck
-        - ament_cmake_cpplint
-        - ament_cmake_flake8
-        - ament_cmake_lint_cmake
-        - ament_cmake_mypy
-        - ament_cmake_pclint
-        - ament_cmake_pep257
-        - ament_cmake_pycodestyle
-        - ament_cmake_pyflakes
-        - ament_cmake_uncrustify
-        - ament_cmake_xmllint
-        - ament_copyright
-        - ament_cppcheck
-        - ament_cpplint
-        - ament_flake8
-        - ament_lint
-        - ament_lint_auto
-        - ament_lint_cmake
-        - ament_lint_common
-        - ament_mypy
-        - ament_pclint
-        - ament_pep257
-        - ament_pycodestyle
-        - ament_pyflakes
-        - ament_uncrustify
-        - ament_xmllint
+      - ament_clang_format
+      - ament_clang_tidy
+      - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_mypy
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pycodestyle
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_mypy
+      - ament_pclint
+      - ament_pep257
+      - ament_pycodestyle
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
@@ -331,8 +331,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - apex_test_tools
-        - test_apex_test_tools
+      - apex_test_tools
+      - test_apex_test_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
@@ -364,10 +364,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - apriltag_detector
-        - apriltag_detector_mit
-        - apriltag_detector_umich
-        - apriltag_draw
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
@@ -421,8 +421,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - aruco_opencv
-        - aruco_opencv_msgs
+      - aruco_opencv
+      - aruco_opencv_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
@@ -439,9 +439,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - aruco
-        - aruco_msgs
-        - aruco_ros
+      - aruco
+      - aruco_msgs
+      - aruco_ros
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
@@ -458,14 +458,14 @@ repositories:
       version: master
     release:
       packages:
-        - delphi_esr_msgs
-        - delphi_mrr_msgs
-        - delphi_srr_msgs
-        - derived_object_msgs
-        - ibeo_msgs
-        - kartech_linear_actuator_msgs
-        - mobileye_560_660_msgs
-        - neobotix_usboard_msgs
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
@@ -522,9 +522,9 @@ repositories:
       version: master
     release:
       packages:
-        - automotive_autonomy_msgs
-        - automotive_navigation_msgs
-        - automotive_platform_msgs
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
@@ -537,8 +537,8 @@ repositories:
   autoware_adapi_msgs:
     release:
       packages:
-        - autoware_adapi_v1_msgs
-        - autoware_adapi_version_msgs
+      - autoware_adapi_v1_msgs
+      - autoware_adapi_version_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
@@ -566,8 +566,8 @@ repositories:
   autoware_cmake:
     release:
       packages:
-        - autoware_cmake
-        - autoware_lint_common
+      - autoware_cmake
+      - autoware_lint_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
@@ -580,9 +580,9 @@ repositories:
   autoware_internal_msgs:
     release:
       packages:
-        - autoware_internal_debug_msgs
-        - autoware_internal_msgs
-        - autoware_internal_perception_msgs
+      - autoware_internal_debug_msgs
+      - autoware_internal_msgs
+      - autoware_internal_perception_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
@@ -595,8 +595,8 @@ repositories:
   autoware_lanelet2_extension:
     release:
       packages:
-        - autoware_lanelet2_extension
-        - autoware_lanelet2_extension_python
+      - autoware_lanelet2_extension
+      - autoware_lanelet2_extension_python
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
@@ -609,16 +609,16 @@ repositories:
   autoware_msgs:
     release:
       packages:
-        - autoware_common_msgs
-        - autoware_control_msgs
-        - autoware_localization_msgs
-        - autoware_map_msgs
-        - autoware_perception_msgs
-        - autoware_planning_msgs
-        - autoware_sensing_msgs
-        - autoware_system_msgs
-        - autoware_v2x_msgs
-        - autoware_vehicle_msgs
+      - autoware_common_msgs
+      - autoware_control_msgs
+      - autoware_localization_msgs
+      - autoware_map_msgs
+      - autoware_perception_msgs
+      - autoware_planning_msgs
+      - autoware_sensing_msgs
+      - autoware_system_msgs
+      - autoware_v2x_msgs
+      - autoware_vehicle_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
@@ -661,7 +661,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - aws_robomaker_small_warehouse_world
+      - aws_robomaker_small_warehouse_world
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
@@ -752,7 +752,7 @@ repositories:
       version: master
     release:
       packages:
-        - behaviortree_cpp
+      - behaviortree_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
@@ -784,11 +784,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - bond
-        - bond_core
-        - bondcpp
-        - bondpy
-        - smclib
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
@@ -857,9 +857,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - cartographer_ros
-        - cartographer_ros_msgs
-        - cartographer_rviz
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
@@ -877,8 +877,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-        - cascade_lifecycle_msgs
-        - rclcpp_cascade_lifecycle
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
@@ -985,19 +985,19 @@ repositories:
       version: rolling
     release:
       packages:
-        - actionlib_msgs
-        - common_interfaces
-        - diagnostic_msgs
-        - geometry_msgs
-        - nav_msgs
-        - sensor_msgs
-        - sensor_msgs_py
-        - shape_msgs
-        - std_msgs
-        - std_srvs
-        - stereo_msgs
-        - trajectory_msgs
-        - visualization_msgs
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - sensor_msgs_py
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
@@ -1073,8 +1073,8 @@ repositories:
   cpp_polyfills:
     release:
       packages:
-        - tcb_span
-        - tl_expected
+      - tcb_span
+      - tl_expected
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
@@ -1117,8 +1117,8 @@ repositories:
       version: main
     release:
       packages:
-        - data_tamer_cpp
-        - data_tamer_msgs
+      - data_tamer_cpp
+      - data_tamer_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
@@ -1136,26 +1136,26 @@ repositories:
       version: rolling
     release:
       packages:
-        - action_tutorials_cpp
-        - action_tutorials_py
-        - composition
-        - demo_nodes_cpp
-        - demo_nodes_cpp_native
-        - demo_nodes_py
-        - dummy_map_server
-        - dummy_robot_bringup
-        - dummy_sensors
-        - image_tools
-        - intra_process_demo
-        - lifecycle
-        - lifecycle_py
-        - logging_demo
-        - pendulum_control
-        - pendulum_msgs
-        - quality_of_service_demo_cpp
-        - quality_of_service_demo_py
-        - topic_monitor
-        - topic_statistics_demo
+      - action_tutorials_cpp
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - lifecycle_py
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      - topic_statistics_demo
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
@@ -1189,11 +1189,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - diagnostic_aggregator
-        - diagnostic_common_diagnostics
-        - diagnostic_updater
-        - diagnostics
-        - self_test
+      - diagnostic_aggregator
+      - diagnostic_common_diagnostics
+      - diagnostic_updater
+      - diagnostics
+      - self_test
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
@@ -1211,10 +1211,10 @@ repositories:
       version: galactic
     release:
       packages:
-        - dolly
-        - dolly_follow
-        - dolly_gazebo
-        - dolly_ignition
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
@@ -1278,9 +1278,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - dynamixel_sdk
-        - dynamixel_sdk_custom_interfaces
-        - dynamixel_sdk_examples
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
@@ -1297,8 +1297,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - dynamixel_workbench
-        - dynamixel_workbench_toolbox
+      - dynamixel_workbench
+      - dynamixel_workbench_toolbox
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
@@ -1345,31 +1345,31 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-        - ecl_command_line
-        - ecl_concepts
-        - ecl_containers
-        - ecl_converters
-        - ecl_core
-        - ecl_core_apps
-        - ecl_devices
-        - ecl_eigen
-        - ecl_exceptions
-        - ecl_filesystem
-        - ecl_formatters
-        - ecl_geometry
-        - ecl_ipc
-        - ecl_linear_algebra
-        - ecl_manipulators
-        - ecl_math
-        - ecl_mobile_robot
-        - ecl_mpl
-        - ecl_sigslots
-        - ecl_statistics
-        - ecl_streams
-        - ecl_threads
-        - ecl_time
-        - ecl_type_traits
-        - ecl_utilities
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
@@ -1387,14 +1387,14 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-        - ecl_config
-        - ecl_console
-        - ecl_converters_lite
-        - ecl_errors
-        - ecl_io
-        - ecl_lite
-        - ecl_sigslots_lite
-        - ecl_time_lite
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
@@ -1412,9 +1412,9 @@ repositories:
       version: release/1.0.x
     release:
       packages:
-        - ecl_build
-        - ecl_license
-        - ecl_tools
+      - ecl_build
+      - ecl_license
+      - ecl_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
@@ -1569,28 +1569,28 @@ repositories:
       version: rolling
     release:
       packages:
-        - examples_rclcpp_async_client
-        - examples_rclcpp_cbg_executor
-        - examples_rclcpp_minimal_action_client
-        - examples_rclcpp_minimal_action_server
-        - examples_rclcpp_minimal_client
-        - examples_rclcpp_minimal_composition
-        - examples_rclcpp_minimal_publisher
-        - examples_rclcpp_minimal_service
-        - examples_rclcpp_minimal_subscriber
-        - examples_rclcpp_minimal_timer
-        - examples_rclcpp_multithreaded_executor
-        - examples_rclcpp_wait_set
-        - examples_rclpy_executors
-        - examples_rclpy_guard_conditions
-        - examples_rclpy_minimal_action_client
-        - examples_rclpy_minimal_action_server
-        - examples_rclpy_minimal_client
-        - examples_rclpy_minimal_publisher
-        - examples_rclpy_minimal_service
-        - examples_rclpy_minimal_subscriber
-        - examples_rclpy_pointcloud_publisher
-        - launch_testing_examples
+      - examples_rclcpp_async_client
+      - examples_rclcpp_cbg_executor
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
+      - examples_rclcpp_wait_set
+      - examples_rclpy_executors
+      - examples_rclpy_guard_conditions
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      - examples_rclpy_pointcloud_publisher
+      - launch_testing_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
@@ -1770,15 +1770,15 @@ repositories:
       version: rolling
     release:
       packages:
-        - flexbe_behavior_engine
-        - flexbe_core
-        - flexbe_input
-        - flexbe_mirror
-        - flexbe_msgs
-        - flexbe_onboard
-        - flexbe_states
-        - flexbe_testing
-        - flexbe_widget
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
@@ -1795,10 +1795,10 @@ repositories:
       version: ros2-release
     release:
       packages:
-        - flir_camera_description
-        - flir_camera_msgs
-        - spinnaker_camera_driver
-        - spinnaker_synchronized_camera_driver
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
@@ -1830,8 +1830,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - fmi_adapter
-        - fmi_adapter_examples
+      - fmi_adapter
+      - fmi_adapter_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
@@ -1926,19 +1926,19 @@ repositories:
       version: rolling
     release:
       packages:
-        - fuse
-        - fuse_constraints
-        - fuse_core
-        - fuse_doc
-        - fuse_graphs
-        - fuse_loss
-        - fuse_models
-        - fuse_msgs
-        - fuse_optimizers
-        - fuse_publishers
-        - fuse_tutorials
-        - fuse_variables
-        - fuse_viz
+      - fuse
+      - fuse_constraints
+      - fuse_core
+      - fuse_doc
+      - fuse_graphs
+      - fuse_loss
+      - fuse_models
+      - fuse_msgs
+      - fuse_optimizers
+      - fuse_publishers
+      - fuse_tutorials
+      - fuse_variables
+      - fuse_viz
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
@@ -1956,8 +1956,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - game_controller_spl
-        - game_controller_spl_interfaces
+      - game_controller_spl
+      - game_controller_spl_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
@@ -1974,12 +1974,12 @@ repositories:
       version: main
     release:
       packages:
-        - cmake_generate_parameter_module_example
-        - generate_parameter_library
-        - generate_parameter_library_example
-        - generate_parameter_library_py
-        - generate_parameter_module_example
-        - parameter_traits
+      - cmake_generate_parameter_module_example
+      - generate_parameter_library
+      - generate_parameter_library_example
+      - generate_parameter_library_py
+      - generate_parameter_module_example
+      - parameter_traits
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
@@ -1996,9 +1996,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - geodesy
-        - geographic_info
-        - geographic_msgs
+      - geodesy
+      - geographic_info
+      - geographic_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -2031,20 +2031,20 @@ repositories:
       version: rolling
     release:
       packages:
-        - examples_tf2_py
-        - geometry2
-        - tf2
-        - tf2_bullet
-        - tf2_eigen
-        - tf2_eigen_kdl
-        - tf2_geometry_msgs
-        - tf2_kdl
-        - tf2_msgs
-        - tf2_py
-        - tf2_ros
-        - tf2_ros_py
-        - tf2_sensor_msgs
-        - tf2_tools
+      - examples_tf2_py
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_eigen_kdl
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_ros_py
+      - tf2_sensor_msgs
+      - tf2_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
@@ -2062,9 +2062,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - geometry_tutorials
-        - turtle_tf2_cpp
-        - turtle_tf2_py
+      - geometry_tutorials
+      - turtle_tf2_cpp
+      - turtle_tf2_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
@@ -2093,8 +2093,8 @@ repositories:
   googletest:
     release:
       packages:
-        - gmock_vendor
-        - gtest_vendor
+      - gmock_vendor
+      - gtest_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
@@ -2111,10 +2111,10 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - gps_msgs
-        - gps_tools
-        - gps_umd
-        - gpsd_client
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
@@ -2414,8 +2414,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - gz_ros2_control
-        - gz_ros2_control_demos
+      - gz_ros2_control
+      - gz_ros2_control_demos
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
@@ -2583,10 +2583,10 @@ repositories:
   iceoryx:
     release:
       packages:
-        - iceoryx_binding_c
-        - iceoryx_hoofs
-        - iceoryx_introspection
-        - iceoryx_posh
+      - iceoryx_binding_c
+      - iceoryx_hoofs
+      - iceoryx_introspection
+      - iceoryx_posh
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
@@ -2610,9 +2610,9 @@ repositories:
       version: main
     release:
       packages:
-        - ign_rviz
-        - ign_rviz_common
-        - ign_rviz_plugins
+      - ign_rviz
+      - ign_rviz_common
+      - ign_rviz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
@@ -2629,12 +2629,12 @@ repositories:
       version: rolling
     release:
       packages:
-        - camera_calibration_parsers
-        - camera_info_manager
-        - camera_info_manager_py
-        - image_common
-        - image_transport
-        - image_transport_py
+      - camera_calibration_parsers
+      - camera_info_manager
+      - camera_info_manager_py
+      - image_common
+      - image_transport
+      - image_transport_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
@@ -2652,15 +2652,15 @@ repositories:
       version: rolling
     release:
       packages:
-        - camera_calibration
-        - depth_image_proc
-        - image_pipeline
-        - image_proc
-        - image_publisher
-        - image_rotate
-        - image_view
-        - stereo_image_proc
-        - tracetools_image_pipeline
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      - tracetools_image_pipeline
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
@@ -2678,11 +2678,11 @@ repositories:
       version: rolling
     release:
       packages:
-        - compressed_depth_image_transport
-        - compressed_image_transport
-        - image_transport_plugins
-        - theora_image_transport
-        - zstd_image_transport
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      - zstd_image_transport
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
@@ -2700,9 +2700,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - imu_pipeline
-        - imu_processors
-        - imu_transformer
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
@@ -2719,10 +2719,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - imu_complementary_filter
-        - imu_filter_madgwick
-        - imu_tools
-        - rviz_imu_plugin
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
@@ -2793,8 +2793,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - joint_state_publisher
-        - joint_state_publisher_gui
+      - joint_state_publisher
+      - joint_state_publisher_gui
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
@@ -2827,12 +2827,12 @@ repositories:
       version: ros2
     release:
       packages:
-        - joy
-        - joy_linux
-        - sdl2_vendor
-        - spacenav
-        - wiimote
-        - wiimote_msgs
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      - spacenav
+      - wiimote
+      - wiimote_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
@@ -2882,8 +2882,8 @@ repositories:
       version: master
     release:
       packages:
-        - kinematics_interface
-        - kinematics_interface_kdl
+      - kinematics_interface
+      - kinematics_interface_kdl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
@@ -2983,17 +2983,17 @@ repositories:
       version: master
     release:
       packages:
-        - lanelet2
-        - lanelet2_core
-        - lanelet2_examples
-        - lanelet2_io
-        - lanelet2_maps
-        - lanelet2_matching
-        - lanelet2_projection
-        - lanelet2_python
-        - lanelet2_routing
-        - lanelet2_traffic_rules
-        - lanelet2_validation
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_matching
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
@@ -3068,12 +3068,12 @@ repositories:
       version: rolling
     release:
       packages:
-        - launch
-        - launch_pytest
-        - launch_testing
-        - launch_testing_ament_cmake
-        - launch_xml
-        - launch_yaml
+      - launch
+      - launch_pytest
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
@@ -3106,9 +3106,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - launch_ros
-        - launch_testing_ros
-        - ros2launch
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
@@ -3126,10 +3126,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - leo
-        - leo_description
-        - leo_msgs
-        - leo_teleop
+      - leo
+      - leo_description
+      - leo_msgs
+      - leo_teleop
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
@@ -3146,8 +3146,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - leo_desktop
-        - leo_viz
+      - leo_desktop
+      - leo_viz
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
@@ -3164,9 +3164,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - leo_bringup
-        - leo_fw
-        - leo_robot
+      - leo_bringup
+      - leo_fw
+      - leo_robot
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
@@ -3183,10 +3183,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - leo_gz_bringup
-        - leo_gz_plugins
-        - leo_gz_worlds
-        - leo_simulator
+      - leo_gz_bringup
+      - leo_gz_plugins
+      - leo_gz_worlds
+      - leo_simulator
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
@@ -3382,11 +3382,11 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - mapviz
-        - mapviz_interfaces
-        - mapviz_plugins
-        - multires_image
-        - tile_map
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
@@ -3403,8 +3403,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - marine_acoustic_msgs
-        - marine_sensor_msgs
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
@@ -3436,18 +3436,18 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - swri_cli_tools
-        - swri_console_util
-        - swri_dbw_interface
-        - swri_geometry_util
-        - swri_image_util
-        - swri_math_util
-        - swri_opencv_util
-        - swri_roscpp
-        - swri_route_util
-        - swri_serial_util
-        - swri_system_util
-        - swri_transform_util
+      - swri_cli_tools
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
@@ -3465,15 +3465,15 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - marti_can_msgs
-        - marti_common_msgs
-        - marti_dbw_msgs
-        - marti_introspection_msgs
-        - marti_nav_msgs
-        - marti_perception_msgs
-        - marti_sensor_msgs
-        - marti_status_msgs
-        - marti_visualization_msgs
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_introspection_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
@@ -3506,10 +3506,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - libmavconn
-        - mavros
-        - mavros_extras
-        - mavros_msgs
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
@@ -3587,8 +3587,8 @@ repositories:
       version: master
     release:
       packages:
-        - micro_ros_diagnostic_bridge
-        - micro_ros_diagnostic_msgs
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
@@ -3620,11 +3620,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - microstrain_inertial_description
-        - microstrain_inertial_driver
-        - microstrain_inertial_examples
-        - microstrain_inertial_msgs
-        - microstrain_inertial_rqt
+      - microstrain_inertial_description
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
@@ -3680,26 +3680,26 @@ repositories:
       version: develop
     release:
       packages:
-        - kitti_metrics_eval
-        - mola
-        - mola_bridge_ros2
-        - mola_demos
-        - mola_input_euroc_dataset
-        - mola_input_kitti360_dataset
-        - mola_input_kitti_dataset
-        - mola_input_mulran_dataset
-        - mola_input_paris_luco_dataset
-        - mola_input_rawlog
-        - mola_input_rosbag2
-        - mola_kernel
-        - mola_launcher
-        - mola_metric_maps
-        - mola_msgs
-        - mola_pose_list
-        - mola_relocalization
-        - mola_traj_tools
-        - mola_viz
-        - mola_yaml
+      - kitti_metrics_eval
+      - mola
+      - mola_bridge_ros2
+      - mola_demos
+      - mola_input_euroc_dataset
+      - mola_input_kitti360_dataset
+      - mola_input_kitti_dataset
+      - mola_input_mulran_dataset
+      - mola_input_paris_luco_dataset
+      - mola_input_rawlog
+      - mola_input_rosbag2
+      - mola_kernel
+      - mola_launcher
+      - mola_metric_maps
+      - mola_msgs
+      - mola_pose_list
+      - mola_relocalization
+      - mola_traj_tools
+      - mola_viz
+      - mola_yaml
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
@@ -3771,8 +3771,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - motion_capture_tracking
-        - motion_capture_tracking_interfaces
+      - motion_capture_tracking
+      - motion_capture_tracking_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
@@ -3789,47 +3789,47 @@ repositories:
       version: main
     release:
       packages:
-        - chomp_motion_planner
-        - moveit
-        - moveit_common
-        - moveit_configs_utils
-        - moveit_core
-        - moveit_hybrid_planning
-        - moveit_kinematics
-        - moveit_planners
-        - moveit_planners_chomp
-        - moveit_planners_ompl
-        - moveit_planners_stomp
-        - moveit_plugins
-        - moveit_py
-        - moveit_resources_prbt_ikfast_manipulator_plugin
-        - moveit_resources_prbt_moveit_config
-        - moveit_resources_prbt_pg70_support
-        - moveit_resources_prbt_support
-        - moveit_ros
-        - moveit_ros_benchmarks
-        - moveit_ros_control_interface
-        - moveit_ros_move_group
-        - moveit_ros_occupancy_map_monitor
-        - moveit_ros_perception
-        - moveit_ros_planning
-        - moveit_ros_planning_interface
-        - moveit_ros_robot_interaction
-        - moveit_ros_tests
-        - moveit_ros_trajectory_cache
-        - moveit_ros_visualization
-        - moveit_ros_warehouse
-        - moveit_runtime
-        - moveit_servo
-        - moveit_setup_app_plugins
-        - moveit_setup_assistant
-        - moveit_setup_controllers
-        - moveit_setup_core_plugins
-        - moveit_setup_framework
-        - moveit_setup_srdf_plugins
-        - moveit_simple_controller_manager
-        - pilz_industrial_motion_planner
-        - pilz_industrial_motion_planner_testutils
+      - chomp_motion_planner
+      - moveit
+      - moveit_common
+      - moveit_configs_utils
+      - moveit_core
+      - moveit_hybrid_planning
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_planners_stomp
+      - moveit_plugins
+      - moveit_py
+      - moveit_resources_prbt_ikfast_manipulator_plugin
+      - moveit_resources_prbt_moveit_config
+      - moveit_resources_prbt_pg70_support
+      - moveit_resources_prbt_support
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_tests
+      - moveit_ros_trajectory_cache
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_setup_app_plugins
+      - moveit_setup_assistant
+      - moveit_setup_controllers
+      - moveit_setup_core_plugins
+      - moveit_setup_framework
+      - moveit_setup_srdf_plugins
+      - moveit_simple_controller_manager
+      - pilz_industrial_motion_planner
+      - pilz_industrial_motion_planner_testutils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
@@ -3863,13 +3863,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - dual_arm_panda_moveit_config
-        - moveit_resources
-        - moveit_resources_fanuc_description
-        - moveit_resources_fanuc_moveit_config
-        - moveit_resources_panda_description
-        - moveit_resources_panda_moveit_config
-        - moveit_resources_pr2_description
+      - dual_arm_panda_moveit_config
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -3916,8 +3916,8 @@ repositories:
       version: main
     release:
       packages:
-        - mqtt_client
-        - mqtt_client_interfaces
+      - mqtt_client
+      - mqtt_client_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
@@ -3949,16 +3949,16 @@ repositories:
       version: ros2
     release:
       packages:
-        - mrpt_map_server
-        - mrpt_msgs_bridge
-        - mrpt_nav_interfaces
-        - mrpt_navigation
-        - mrpt_pf_localization
-        - mrpt_pointcloud_pipeline
-        - mrpt_rawlog
-        - mrpt_reactivenav2d
-        - mrpt_tps_astar_planner
-        - mrpt_tutorials
+      - mrpt_map_server
+      - mrpt_msgs_bridge
+      - mrpt_nav_interfaces
+      - mrpt_navigation
+      - mrpt_pf_localization
+      - mrpt_pointcloud_pipeline
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tps_astar_planner
+      - mrpt_tutorials
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
@@ -3990,20 +3990,20 @@ repositories:
       version: main
     release:
       packages:
-        - mrpt_apps
-        - mrpt_libapps
-        - mrpt_libbase
-        - mrpt_libgui
-        - mrpt_libhwdrivers
-        - mrpt_libmaps
-        - mrpt_libmath
-        - mrpt_libnav
-        - mrpt_libobs
-        - mrpt_libopengl
-        - mrpt_libposes
-        - mrpt_libros_bridge
-        - mrpt_libslam
-        - mrpt_libtclap
+      - mrpt_apps
+      - mrpt_libapps
+      - mrpt_libbase
+      - mrpt_libgui
+      - mrpt_libhwdrivers
+      - mrpt_libmaps
+      - mrpt_libmath
+      - mrpt_libnav
+      - mrpt_libobs
+      - mrpt_libopengl
+      - mrpt_libposes
+      - mrpt_libros_bridge
+      - mrpt_libslam
+      - mrpt_libtclap
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
@@ -4020,13 +4020,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - mrpt_generic_sensor
-        - mrpt_sensor_bumblebee_stereo
-        - mrpt_sensor_gnss_nmea
-        - mrpt_sensor_gnss_novatel
-        - mrpt_sensor_imu_taobotics
-        - mrpt_sensorlib
-        - mrpt_sensors
+      - mrpt_generic_sensor
+      - mrpt_sensor_bumblebee_stereo
+      - mrpt_sensor_gnss_nmea
+      - mrpt_sensor_gnss_novatel
+      - mrpt_sensor_imu_taobotics
+      - mrpt_sensorlib
+      - mrpt_sensors
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
@@ -4089,8 +4089,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - nao_command_msgs
-        - nao_sensor_msgs
+      - nao_command_msgs
+      - nao_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
@@ -4107,10 +4107,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - nao_lola
-        - nao_lola_client
-        - nao_lola_command_msgs
-        - nao_lola_sensor_msgs
+      - nao_lola
+      - nao_lola_client
+      - nao_lola_command_msgs
+      - nao_lola_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
@@ -4123,9 +4123,9 @@ repositories:
   nav2_minimal_turtlebot_simulation:
     release:
       packages:
-        - nav2_minimal_tb3_sim
-        - nav2_minimal_tb4_description
-        - nav2_minimal_tb4_sim
+      - nav2_minimal_tb3_sim
+      - nav2_minimal_tb4_description
+      - nav2_minimal_tb4_sim
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
@@ -4142,7 +4142,7 @@ repositories:
       version: rolling
     release:
       packages:
-        - map_msgs
+      - map_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -4237,8 +4237,8 @@ repositories:
       version: master
     release:
       packages:
-        - nodl_python
-        - ros2nodl
+      - nodl_python
+      - ros2nodl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
@@ -4271,8 +4271,8 @@ repositories:
       version: ros2-devel
     release:
       packages:
-        - novatel_gps_driver
-        - novatel_gps_msgs
+      - novatel_gps_driver
+      - novatel_gps_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
@@ -4331,8 +4331,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - octomap_mapping
-        - octomap_server
+      - octomap_mapping
+      - octomap_server
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
@@ -4409,7 +4409,7 @@ repositories:
       version: main
     release:
       packages:
-        - odri_master_board_sdk
+      - odri_master_board_sdk
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
@@ -4487,8 +4487,8 @@ repositories:
   orocos_kdl_vendor:
     release:
       packages:
-        - orocos_kdl_vendor
-        - python_orocos_kdl_vendor
+      - orocos_kdl_vendor
+      - python_orocos_kdl_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
@@ -4558,8 +4558,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-        - ouster_ros
-        - ouster_sensor_msgs
+      - ouster_ros
+      - ouster_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
@@ -4577,8 +4577,8 @@ repositories:
       version: master
     release:
       packages:
-        - ouxt_common
-        - ouxt_lint_common
+      - ouxt_common
+      - ouxt_lint_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
@@ -4595,8 +4595,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-        - pal_statistics
-        - pal_statistics_msgs
+      - pal_statistics
+      - pal_statistics_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
@@ -4631,7 +4631,7 @@ repositories:
   perception_open3d:
     release:
       packages:
-        - open3d_conversions
+      - open3d_conversions
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
@@ -4649,9 +4649,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - pcl_conversions
-        - pcl_ros
-        - perception_pcl
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
@@ -4696,22 +4696,22 @@ repositories:
       version: rolling
     release:
       packages:
-        - libphidget22
-        - phidgets_accelerometer
-        - phidgets_analog_inputs
-        - phidgets_analog_outputs
-        - phidgets_api
-        - phidgets_digital_inputs
-        - phidgets_digital_outputs
-        - phidgets_drivers
-        - phidgets_gyroscope
-        - phidgets_high_speed_encoder
-        - phidgets_ik
-        - phidgets_magnetometer
-        - phidgets_motors
-        - phidgets_msgs
-        - phidgets_spatial
-        - phidgets_temperature
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_analog_outputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
@@ -4750,8 +4750,8 @@ repositories:
       version: main
     release:
       packages:
-        - picknik_reset_fault_controller
-        - picknik_twist_controller
+      - picknik_reset_fault_controller
+      - picknik_twist_controller
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
@@ -4859,8 +4859,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - point_cloud_transport
-        - point_cloud_transport_py
+      - point_cloud_transport
+      - point_cloud_transport_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -4878,11 +4878,11 @@ repositories:
       version: rolling
     release:
       packages:
-        - draco_point_cloud_transport
-        - point_cloud_interfaces
-        - point_cloud_transport_plugins
-        - zlib_point_cloud_transport
-        - zstd_point_cloud_transport
+      - draco_point_cloud_transport
+      - point_cloud_interfaces
+      - point_cloud_transport_plugins
+      - zlib_point_cloud_transport
+      - zstd_point_cloud_transport
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
@@ -4932,10 +4932,10 @@ repositories:
       version: main
     release:
       packages:
-        - polygon_demos
-        - polygon_msgs
-        - polygon_rviz_plugins
-        - polygon_utils
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
@@ -5104,7 +5104,7 @@ repositories:
       version: main
     release:
       packages:
-        - python_mrpt
+      - python_mrpt
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
@@ -5163,12 +5163,12 @@ repositories:
       version: rolling
     release:
       packages:
-        - qt_dotgraph
-        - qt_gui
-        - qt_gui_app
-        - qt_gui_core
-        - qt_gui_cpp
-        - qt_gui_py_common
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
@@ -5201,9 +5201,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - r2r_spl_7
-        - splsm_7
-        - splsm_7_conversion
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
@@ -5242,8 +5242,8 @@ repositories:
       version: jazzy
     release:
       packages:
-        - raspimouse
-        - raspimouse_msgs
+      - raspimouse
+      - raspimouse_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
@@ -5325,8 +5325,8 @@ repositories:
       version: master
     release:
       packages:
-        - rc_reason_clients
-        - rc_reason_msgs
+      - rc_reason_clients
+      - rc_reason_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
@@ -5360,10 +5360,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - rcl
-        - rcl_action
-        - rcl_lifecycle
-        - rcl_yaml_param_parser
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
@@ -5381,16 +5381,16 @@ repositories:
       version: rolling
     release:
       packages:
-        - action_msgs
-        - builtin_interfaces
-        - composition_interfaces
-        - lifecycle_msgs
-        - rcl_interfaces
-        - rosgraph_msgs
-        - service_msgs
-        - statistics_msgs
-        - test_msgs
-        - type_description_interfaces
+      - action_msgs
+      - builtin_interfaces
+      - composition_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - service_msgs
+      - statistics_msgs
+      - test_msgs
+      - type_description_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
@@ -5408,9 +5408,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - rcl_logging_interface
-        - rcl_logging_noop
-        - rcl_logging_spdlog
+      - rcl_logging_interface
+      - rcl_logging_noop
+      - rcl_logging_spdlog
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
@@ -5439,10 +5439,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - rclc
-        - rclc_examples
-        - rclc_lifecycle
-        - rclc_parameter
+      - rclc
+      - rclc_examples
+      - rclc_lifecycle
+      - rclc_parameter
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
@@ -5460,10 +5460,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - rclcpp
-        - rclcpp_action
-        - rclcpp_components
-        - rclcpp_lifecycle
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
@@ -5513,10 +5513,10 @@ repositories:
       version: rolling
     release:
       packages:
-        - rcss3d_agent
-        - rcss3d_agent_basic
-        - rcss3d_agent_msgs
-        - rcss3d_agent_msgs_to_soccer_interfaces
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
+      - rcss3d_agent_msgs_to_soccer_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
@@ -5574,8 +5574,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rttest
-        - tlsf_cpp
+      - rttest
+      - tlsf_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
@@ -5608,8 +5608,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - libcurl_vendor
-        - resource_retriever
+      - libcurl_vendor
+      - resource_retriever
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
@@ -5699,13 +5699,13 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_demos
-        - rmf_demos_assets
-        - rmf_demos_bridges
-        - rmf_demos_fleet_adapter
-        - rmf_demos_gz
-        - rmf_demos_maps
-        - rmf_demos_tasks
+      - rmf_demos
+      - rmf_demos_assets
+      - rmf_demos_bridges
+      - rmf_demos_fleet_adapter
+      - rmf_demos_gz
+      - rmf_demos_maps
+      - rmf_demos_tasks
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
@@ -5722,19 +5722,19 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_charger_msgs
-        - rmf_dispenser_msgs
-        - rmf_door_msgs
-        - rmf_fleet_msgs
-        - rmf_ingestor_msgs
-        - rmf_lift_msgs
-        - rmf_obstacle_msgs
-        - rmf_reservation_msgs
-        - rmf_scheduler_msgs
-        - rmf_site_map_msgs
-        - rmf_task_msgs
-        - rmf_traffic_msgs
-        - rmf_workcell_msgs
+      - rmf_charger_msgs
+      - rmf_dispenser_msgs
+      - rmf_door_msgs
+      - rmf_fleet_msgs
+      - rmf_ingestor_msgs
+      - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_reservation_msgs
+      - rmf_scheduler_msgs
+      - rmf_site_map_msgs
+      - rmf_task_msgs
+      - rmf_traffic_msgs
+      - rmf_workcell_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
@@ -5751,13 +5751,13 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_charging_schedule
-        - rmf_fleet_adapter
-        - rmf_fleet_adapter_python
-        - rmf_reservation_node
-        - rmf_task_ros2
-        - rmf_traffic_ros2
-        - rmf_websocket
+      - rmf_charging_schedule
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_reservation_node
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      - rmf_websocket
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
@@ -5774,9 +5774,9 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_building_sim_gz_plugins
-        - rmf_robot_sim_common
-        - rmf_robot_sim_gz_plugins
+      - rmf_building_sim_gz_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
@@ -5793,8 +5793,8 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_task
-        - rmf_task_sequence
+      - rmf_task
+      - rmf_task_sequence
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
@@ -5811,8 +5811,8 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_traffic
-        - rmf_traffic_examples
+      - rmf_traffic
+      - rmf_traffic_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
@@ -5829,10 +5829,10 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_building_map_tools
-        - rmf_traffic_editor
-        - rmf_traffic_editor_assets
-        - rmf_traffic_editor_test_maps
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - rmf_traffic_editor_test_maps
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
@@ -5864,7 +5864,7 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_dev
+      - rmf_dev
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
@@ -5881,14 +5881,14 @@ repositories:
       version: main
     release:
       packages:
-        - rmf_visualization
-        - rmf_visualization_building_systems
-        - rmf_visualization_fleet_states
-        - rmf_visualization_floorplans
-        - rmf_visualization_navgraphs
-        - rmf_visualization_obstacles
-        - rmf_visualization_rviz2_plugins
-        - rmf_visualization_schedule
+      - rmf_visualization
+      - rmf_visualization_building_systems
+      - rmf_visualization_fleet_states
+      - rmf_visualization_floorplans
+      - rmf_visualization_navgraphs
+      - rmf_visualization_obstacles
+      - rmf_visualization_rviz2_plugins
+      - rmf_visualization_schedule
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
@@ -5920,8 +5920,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rmw
-        - rmw_implementation_cmake
+      - rmw
+      - rmw_implementation_cmake
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
@@ -5939,9 +5939,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - rmw_connextdds
-        - rmw_connextdds_common
-        - rti_connext_dds_cmake_module
+      - rmw_connextdds
+      - rmw_connextdds_common
+      - rti_connext_dds_cmake_module
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
@@ -5958,7 +5958,7 @@ repositories:
       version: rolling
     release:
       packages:
-        - rmw_cyclonedds_cpp
+      - rmw_cyclonedds_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
@@ -5992,9 +5992,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - rmw_fastrtps_cpp
-        - rmw_fastrtps_dynamic_cpp
-        - rmw_fastrtps_shared_cpp
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
@@ -6012,8 +6012,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - gurumdds_cmake_module
-        - rmw_gurumdds_cpp
+      - gurumdds_cmake_module
+      - rmw_gurumdds_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
@@ -6046,8 +6046,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rmw_zenoh_cpp
-        - zenoh_cpp_vendor
+      - rmw_zenoh_cpp
+      - zenoh_cpp_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
@@ -6064,8 +6064,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - robot_calibration
-        - robot_calibration_msgs
+      - robot_calibration
+      - robot_calibration_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
@@ -6120,8 +6120,7 @@ repositories:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master
-    status_description:
-      Maintained in source form only since no ROS 1 packages available
+    status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
   ros2_canopen:
     doc:
@@ -6130,19 +6129,19 @@ repositories:
       version: master
     release:
       packages:
-        - canopen
-        - canopen_402_driver
-        - canopen_base_driver
-        - canopen_core
-        - canopen_fake_slaves
-        - canopen_interfaces
-        - canopen_master_driver
-        - canopen_proxy_driver
-        - canopen_ros2_control
-        - canopen_ros2_controllers
-        - canopen_tests
-        - canopen_utils
-        - lely_core_libraries
+      - canopen
+      - canopen_402_driver
+      - canopen_base_driver
+      - canopen_core
+      - canopen_fake_slaves
+      - canopen_interfaces
+      - canopen_master_driver
+      - canopen_proxy_driver
+      - canopen_ros2_control
+      - canopen_ros2_controllers
+      - canopen_tests
+      - canopen_utils
+      - lely_core_libraries
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
@@ -6159,17 +6158,17 @@ repositories:
       version: master
     release:
       packages:
-        - controller_interface
-        - controller_manager
-        - controller_manager_msgs
-        - hardware_interface
-        - hardware_interface_testing
-        - joint_limits
-        - ros2_control
-        - ros2_control_test_assets
-        - ros2controlcli
-        - rqt_controller_manager
-        - transmission_interface
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - hardware_interface_testing
+      - joint_limits
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - rqt_controller_manager
+      - transmission_interface
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
@@ -6186,31 +6185,31 @@ repositories:
       version: master
     release:
       packages:
-        - ackermann_steering_controller
-        - admittance_controller
-        - bicycle_steering_controller
-        - diff_drive_controller
-        - effort_controllers
-        - force_torque_sensor_broadcaster
-        - forward_command_controller
-        - gpio_controllers
-        - gripper_controllers
-        - imu_sensor_broadcaster
-        - joint_state_broadcaster
-        - joint_trajectory_controller
-        - mecanum_drive_controller
-        - parallel_gripper_controller
-        - pid_controller
-        - pose_broadcaster
-        - position_controllers
-        - range_sensor_broadcaster
-        - ros2_controllers
-        - ros2_controllers_test_nodes
-        - rqt_joint_trajectory_controller
-        - steering_controllers_library
-        - tricycle_controller
-        - tricycle_steering_controller
-        - velocity_controllers
+      - ackermann_steering_controller
+      - admittance_controller
+      - bicycle_steering_controller
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_broadcaster
+      - forward_command_controller
+      - gpio_controllers
+      - gripper_controllers
+      - imu_sensor_broadcaster
+      - joint_state_broadcaster
+      - joint_trajectory_controller
+      - mecanum_drive_controller
+      - parallel_gripper_controller
+      - pid_controller
+      - pose_broadcaster
+      - position_controllers
+      - range_sensor_broadcaster
+      - ros2_controllers
+      - ros2_controllers_test_nodes
+      - rqt_joint_trajectory_controller
+      - steering_controllers_library
+      - tricycle_controller
+      - tricycle_steering_controller
+      - velocity_controllers
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
@@ -6237,12 +6236,12 @@ repositories:
       version: main
     release:
       packages:
-        - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-        - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-        - kortex_api
-        - kortex_bringup
-        - kortex_description
-        - kortex_driver
+      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kortex_api
+      - kortex_bringup
+      - kortex_description
+      - kortex_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
@@ -6259,8 +6258,8 @@ repositories:
       version: main
     release:
       packages:
-        - robotiq_controllers
-        - robotiq_description
+      - robotiq_controllers
+      - robotiq_description
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
@@ -6277,8 +6276,8 @@ repositories:
       version: main
     release:
       packages:
-        - ros2_socketcan
-        - ros2_socketcan_msgs
+      - ros2_socketcan
+      - ros2_socketcan_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
@@ -6295,13 +6294,13 @@ repositories:
       version: rolling
     release:
       packages:
-        - lttngpy
-        - ros2trace
-        - tracetools
-        - tracetools_launch
-        - tracetools_read
-        - tracetools_test
-        - tracetools_trace
+      - lttngpy
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
@@ -6335,21 +6334,21 @@ repositories:
       version: rolling
     release:
       packages:
-        - ros2action
-        - ros2cli
-        - ros2cli_test_interfaces
-        - ros2component
-        - ros2doctor
-        - ros2interface
-        - ros2lifecycle
-        - ros2lifecycle_test_fixtures
-        - ros2multicast
-        - ros2node
-        - ros2param
-        - ros2pkg
-        - ros2run
-        - ros2service
-        - ros2topic
+      - ros2action
+      - ros2cli
+      - ros2cli_test_interfaces
+      - ros2component
+      - ros2doctor
+      - ros2interface
+      - ros2lifecycle
+      - ros2lifecycle_test_fixtures
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2topic
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
@@ -6382,8 +6381,8 @@ repositories:
       version: main
     release:
       packages:
-        - ros2launch_security
-        - ros2launch_security_examples
+      - ros2launch_security
+      - ros2launch_security_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
@@ -6401,8 +6400,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - ros_babel_fish
-        - ros_babel_fish_test_msgs
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
@@ -6419,8 +6418,8 @@ repositories:
       version: main
     release:
       packages:
-        - battery_state_broadcaster
-        - battery_state_rviz_overlay
+      - battery_state_broadcaster
+      - battery_state_rviz_overlay
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
@@ -6434,7 +6433,7 @@ repositories:
   ros_canopen:
     release:
       packages:
-        - can_msgs
+      - can_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
@@ -6467,13 +6466,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - ros_gz
-        - ros_gz_bridge
-        - ros_gz_image
-        - ros_gz_interfaces
-        - ros_gz_sim
-        - ros_gz_sim_demos
-        - test_ros_gz_bridge
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      - test_ros_gz_bridge
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
@@ -6512,8 +6511,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - ros2test
-        - ros_testing
+      - ros2test
+      - ros_testing
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
@@ -6531,8 +6530,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - turtlesim
-        - turtlesim_msgs
+      - turtlesim
+      - turtlesim_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
@@ -6561,30 +6560,30 @@ repositories:
       version: rolling
     release:
       packages:
-        - liblz4_vendor
-        - mcap_vendor
-        - ros2bag
-        - rosbag2
-        - rosbag2_compression
-        - rosbag2_compression_zstd
-        - rosbag2_cpp
-        - rosbag2_examples_cpp
-        - rosbag2_examples_py
-        - rosbag2_interfaces
-        - rosbag2_performance_benchmarking
-        - rosbag2_performance_benchmarking_msgs
-        - rosbag2_py
-        - rosbag2_storage
-        - rosbag2_storage_default_plugins
-        - rosbag2_storage_mcap
-        - rosbag2_storage_sqlite3
-        - rosbag2_test_common
-        - rosbag2_test_msgdefs
-        - rosbag2_tests
-        - rosbag2_transport
-        - shared_queues_vendor
-        - sqlite3_vendor
-        - zstd_vendor
+      - liblz4_vendor
+      - mcap_vendor
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_compression_zstd
+      - rosbag2_cpp
+      - rosbag2_examples_cpp
+      - rosbag2_examples_py
+      - rosbag2_interfaces
+      - rosbag2_performance_benchmarking
+      - rosbag2_performance_benchmarking_msgs
+      - rosbag2_py
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_sqlite3
+      - rosbag2_test_common
+      - rosbag2_test_msgdefs
+      - rosbag2_tests
+      - rosbag2_transport
+      - shared_queues_vendor
+      - sqlite3_vendor
+      - zstd_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
@@ -6601,8 +6600,7 @@ repositories:
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
-    status_description:
-      Maintained in source form only since no ROS 1 packages available
+    status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
   rosbag2_to_video:
     doc:
@@ -6626,13 +6624,13 @@ repositories:
       version: ros2
     release:
       packages:
-        - rosapi
-        - rosapi_msgs
-        - rosbridge_library
-        - rosbridge_msgs
-        - rosbridge_server
-        - rosbridge_suite
-        - rosbridge_test_msgs
+      - rosapi
+      - rosapi_msgs
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      - rosbridge_test_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
@@ -6649,19 +6647,19 @@ repositories:
       version: rolling
     release:
       packages:
-        - rosidl_adapter
-        - rosidl_cli
-        - rosidl_cmake
-        - rosidl_generator_c
-        - rosidl_generator_cpp
-        - rosidl_generator_type_description
-        - rosidl_parser
-        - rosidl_pycommon
-        - rosidl_runtime_c
-        - rosidl_runtime_cpp
-        - rosidl_typesupport_interface
-        - rosidl_typesupport_introspection_c
-        - rosidl_typesupport_introspection_cpp
+      - rosidl_adapter
+      - rosidl_cli
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_generator_type_description
+      - rosidl_parser
+      - rosidl_pycommon
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
@@ -6679,8 +6677,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rosidl_core_generators
-        - rosidl_core_runtime
+      - rosidl_core_generators
+      - rosidl_core_runtime
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
@@ -6698,7 +6696,7 @@ repositories:
       version: rolling
     release:
       packages:
-        - rosidl_generator_dds_idl
+      - rosidl_generator_dds_idl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
@@ -6716,8 +6714,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rosidl_default_generators
-        - rosidl_default_runtime
+      - rosidl_default_generators
+      - rosidl_default_runtime
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
@@ -6767,7 +6765,7 @@ repositories:
       version: rolling
     release:
       packages:
-        - rosidl_generator_py
+      - rosidl_generator_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
@@ -6801,8 +6799,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rosidl_typesupport_c
-        - rosidl_typesupport_cpp
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
@@ -6820,9 +6818,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - fastrtps_cmake_module
-        - rosidl_typesupport_fastrtps_c
-        - rosidl_typesupport_fastrtps_cpp
+      - fastrtps_cmake_module
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
@@ -6840,8 +6838,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rclpy_message_converter
-        - rclpy_message_converter_msgs
+      - rclpy_message_converter
+      - rclpy_message_converter_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
@@ -6870,7 +6868,7 @@ repositories:
   rot_conv_lib:
     release:
       packages:
-        - rot_conv
+      - rot_conv
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
@@ -6915,11 +6913,11 @@ repositories:
       version: rolling
     release:
       packages:
-        - rqt
-        - rqt_gui
-        - rqt_gui_cpp
-        - rqt_gui_py
-        - rqt_py_common
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
@@ -6952,8 +6950,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rqt_bag
-        - rqt_bag_plugins
+      - rqt_bag
+      - rqt_bag_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
@@ -7046,8 +7044,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - rqt_image_overlay
-        - rqt_image_overlay_layer
+      - rqt_image_overlay
+      - rqt_image_overlay_layer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
@@ -7322,8 +7320,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - rt_manipulators_cpp
-        - rt_manipulators_examples
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
@@ -7397,14 +7395,14 @@ repositories:
       version: rolling
     release:
       packages:
-        - rviz2
-        - rviz_assimp_vendor
-        - rviz_common
-        - rviz_default_plugins
-        - rviz_ogre_vendor
-        - rviz_rendering
-        - rviz_rendering_tests
-        - rviz_visual_testing_framework
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
@@ -7422,8 +7420,8 @@ repositories:
       version: main
     release:
       packages:
-        - rviz_2d_overlay_msgs
-        - rviz_2d_overlay_plugins
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
@@ -7455,8 +7453,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - sdformat_test_files
-        - sdformat_urdf
+      - sdformat_test_files
+      - sdformat_urdf
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
@@ -7581,9 +7579,9 @@ repositories:
       version: main
     release:
       packages:
-        - sick_safevisionary_driver
-        - sick_safevisionary_interfaces
-        - sick_safevisionary_tests
+      - sick_safevisionary_driver
+      - sick_safevisionary_interfaces
+      - sick_safevisionary_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
@@ -7676,10 +7674,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - executive_smach
-        - smach
-        - smach_msgs
-        - smach_ros
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
@@ -7718,12 +7716,12 @@ repositories:
       version: rolling
     release:
       packages:
-        - soccer_geometry_msgs
-        - soccer_interfaces
-        - soccer_model_msgs
-        - soccer_vision_2d_msgs
-        - soccer_vision_3d_msgs
-        - soccer_vision_attribute_msgs
+      - soccer_geometry_msgs
+      - soccer_interfaces
+      - soccer_model_msgs
+      - soccer_vision_2d_msgs
+      - soccer_vision_3d_msgs
+      - soccer_vision_attribute_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
@@ -7812,8 +7810,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - sros2
-        - sros2_cmake
+      - sros2
+      - sros2_cmake
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
@@ -7892,10 +7890,10 @@ repositories:
       version: master
     release:
       packages:
-        - launch_system_modes
-        - system_modes
-        - system_modes_examples
-        - system_modes_msgs
+      - launch_system_modes
+      - system_modes
+      - system_modes_examples
+      - system_modes_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
@@ -7931,11 +7929,11 @@ repositories:
       version: master
     release:
       packages:
-        - joy_teleop
-        - key_teleop
-        - mouse_teleop
-        - teleop_tools
-        - teleop_tools_msgs
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
@@ -8112,8 +8110,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - topic_tools
-        - topic_tools_interfaces
+      - topic_tools
+      - topic_tools_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
@@ -8130,9 +8128,9 @@ repositories:
       version: rolling-devel
     release:
       packages:
-        - trac_ik
-        - trac_ik_kinematics_plugin
-        - trac_ik_lib
+      - trac_ik
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
@@ -8165,8 +8163,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - ros2trace_analysis
-        - tracetools_analysis
+      - ros2trace_analysis
+      - tracetools_analysis
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
@@ -8184,10 +8182,10 @@ repositories:
       version: main
     release:
       packages:
-        - asio_cmake_module
-        - io_context
-        - serial_driver
-        - udp_driver
+      - asio_cmake_module
+      - io_context
+      - serial_driver
+      - udp_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
@@ -8249,9 +8247,9 @@ repositories:
       version: ros2
     release:
       packages:
-        - turtlebot3_fake_node
-        - turtlebot3_gazebo
-        - turtlebot3_simulations
+      - turtlebot3_fake_node
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
@@ -8283,16 +8281,16 @@ repositories:
       version: ros2
     release:
       packages:
-        - tuw_airskin_msgs
-        - tuw_geo_msgs
-        - tuw_geometry_msgs
-        - tuw_graph_msgs
-        - tuw_msgs
-        - tuw_multi_robot_msgs
-        - tuw_nav_msgs
-        - tuw_object_map_msgs
-        - tuw_object_msgs
-        - tuw_std_msgs
+      - tuw_airskin_msgs
+      - tuw_geo_msgs
+      - tuw_geometry_msgs
+      - tuw_graph_msgs
+      - tuw_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_map_msgs
+      - tuw_object_msgs
+      - tuw_std_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_msgs-release.git
@@ -8369,10 +8367,10 @@ repositories:
       version: ros2
     release:
       packages:
-        - ublox
-        - ublox_gps
-        - ublox_msgs
-        - ublox_serialization
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
@@ -8390,12 +8388,12 @@ repositories:
       version: main
     release:
       packages:
-        - ntrip_client_node
-        - ublox_dgnss
-        - ublox_dgnss_node
-        - ublox_nav_sat_fix_hp_node
-        - ublox_ubx_interfaces
-        - ublox_ubx_msgs
+      - ntrip_client_node
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_nav_sat_fix_hp_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
@@ -8499,12 +8497,12 @@ repositories:
       version: main
     release:
       packages:
-        - ur
-        - ur_calibration
-        - ur_controllers
-        - ur_dashboard_msgs
-        - ur_moveit_config
-        - ur_robot_driver
+      - ur
+      - ur_calibration
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_moveit_config
+      - ur_robot_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
@@ -8532,8 +8530,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - urdf
-        - urdf_parser_plugin
+      - urdf
+      - urdf_parser_plugin
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
@@ -8567,7 +8565,7 @@ repositories:
       version: ros2
     release:
       packages:
-        - urdfdom_py
+      - urdfdom_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
@@ -8709,12 +8707,12 @@ repositories:
       version: rolling
     release:
       packages:
-        - desktop
-        - desktop_full
-        - perception
-        - ros_base
-        - ros_core
-        - simulation
+      - desktop
+      - desktop_full
+      - perception
+      - ros_base
+      - ros_core
+      - simulation
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
@@ -8732,11 +8730,11 @@ repositories:
       version: ros2
     release:
       packages:
-        - velodyne
-        - velodyne_driver
-        - velodyne_laserscan
-        - velodyne_msgs
-        - velodyne_pointcloud
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
@@ -8753,9 +8751,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-        - velodyne_description
-        - velodyne_gazebo_plugins
-        - velodyne_simulator
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
@@ -8772,8 +8770,8 @@ repositories:
       version: ros2
     release:
       packages:
-        - vision_msgs
-        - vision_msgs_rviz_plugins
+      - vision_msgs
+      - vision_msgs_rviz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
@@ -8806,9 +8804,9 @@ repositories:
       version: rolling
     release:
       packages:
-        - cv_bridge
-        - image_geometry
-        - vision_opencv
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -8935,18 +8933,18 @@ repositories:
       version: master
     release:
       packages:
-        - webots_ros2
-        - webots_ros2_control
-        - webots_ros2_driver
-        - webots_ros2_epuck
-        - webots_ros2_importer
-        - webots_ros2_mavic
-        - webots_ros2_msgs
-        - webots_ros2_tesla
-        - webots_ros2_tests
-        - webots_ros2_tiago
-        - webots_ros2_turtlebot
-        - webots_ros2_universal_robot
+      - webots_ros2
+      - webots_ros2_control
+      - webots_ros2_driver
+      - webots_ros2_epuck
+      - webots_ros2_importer
+      - webots_ros2_mavic
+      - webots_ros2_msgs
+      - webots_ros2_tesla
+      - webots_ros2_tests
+      - webots_ros2_tiago
+      - webots_ros2_turtlebot
+      - webots_ros2_universal_robot
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
@@ -8991,11 +8989,11 @@ repositories:
       version: main
     release:
       packages:
-        - yasmin
-        - yasmin_demos
-        - yasmin_msgs
-        - yasmin_ros
-        - yasmin_viewer
+      - yasmin
+      - yasmin_demos
+      - yasmin_msgs
+      - yasmin_ros
+      - yasmin_viewer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
@@ -9012,8 +9010,8 @@ repositories:
       version: rolling
     release:
       packages:
-        - zbar_ros
-        - zbar_ros_interfaces
+      - zbar_ros
+      - zbar_ros_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4,11 +4,11 @@
 ---
 release_platforms:
   debian:
-  - bookworm
+    - bookworm
   rhel:
-  - '9'
+    - "9"
   ubuntu:
-  - noble
+    - noble
 repositories:
   SMACC2:
     doc:
@@ -17,8 +17,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - smacc2
-      - smacc2_msgs
+        - smacc2
+        - smacc2_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
@@ -99,8 +99,8 @@ repositories:
   ament_black:
     release:
       packages:
-      - ament_black
-      - ament_cmake_black
+        - ament_black
+        - ament_cmake_black
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
@@ -117,28 +117,28 @@ repositories:
       version: rolling
     release:
       packages:
-      - ament_cmake
-      - ament_cmake_auto
-      - ament_cmake_core
-      - ament_cmake_export_definitions
-      - ament_cmake_export_dependencies
-      - ament_cmake_export_include_directories
-      - ament_cmake_export_interfaces
-      - ament_cmake_export_libraries
-      - ament_cmake_export_link_flags
-      - ament_cmake_export_targets
-      - ament_cmake_gen_version_h
-      - ament_cmake_gmock
-      - ament_cmake_google_benchmark
-      - ament_cmake_gtest
-      - ament_cmake_include_directories
-      - ament_cmake_libraries
-      - ament_cmake_pytest
-      - ament_cmake_python
-      - ament_cmake_target_dependencies
-      - ament_cmake_test
-      - ament_cmake_vendor_package
-      - ament_cmake_version
+        - ament_cmake
+        - ament_cmake_auto
+        - ament_cmake_core
+        - ament_cmake_export_definitions
+        - ament_cmake_export_dependencies
+        - ament_cmake_export_include_directories
+        - ament_cmake_export_interfaces
+        - ament_cmake_export_libraries
+        - ament_cmake_export_link_flags
+        - ament_cmake_export_targets
+        - ament_cmake_gen_version_h
+        - ament_cmake_gmock
+        - ament_cmake_google_benchmark
+        - ament_cmake_gtest
+        - ament_cmake_include_directories
+        - ament_cmake_libraries
+        - ament_cmake_pytest
+        - ament_cmake_python
+        - ament_cmake_target_dependencies
+        - ament_cmake_test
+        - ament_cmake_vendor_package
+        - ament_cmake_version
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
@@ -171,8 +171,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - ament_cmake_ros
-      - domain_coordinator
+        - ament_cmake_ros
+        - domain_coordinator
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
@@ -205,8 +205,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - ament_index_cpp
-      - ament_index_python
+        - ament_index_cpp
+        - ament_index_python
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
@@ -224,37 +224,37 @@ repositories:
       version: rolling
     release:
       packages:
-      - ament_clang_format
-      - ament_clang_tidy
-      - ament_cmake_clang_format
-      - ament_cmake_clang_tidy
-      - ament_cmake_copyright
-      - ament_cmake_cppcheck
-      - ament_cmake_cpplint
-      - ament_cmake_flake8
-      - ament_cmake_lint_cmake
-      - ament_cmake_mypy
-      - ament_cmake_pclint
-      - ament_cmake_pep257
-      - ament_cmake_pycodestyle
-      - ament_cmake_pyflakes
-      - ament_cmake_uncrustify
-      - ament_cmake_xmllint
-      - ament_copyright
-      - ament_cppcheck
-      - ament_cpplint
-      - ament_flake8
-      - ament_lint
-      - ament_lint_auto
-      - ament_lint_cmake
-      - ament_lint_common
-      - ament_mypy
-      - ament_pclint
-      - ament_pep257
-      - ament_pycodestyle
-      - ament_pyflakes
-      - ament_uncrustify
-      - ament_xmllint
+        - ament_clang_format
+        - ament_clang_tidy
+        - ament_cmake_clang_format
+        - ament_cmake_clang_tidy
+        - ament_cmake_copyright
+        - ament_cmake_cppcheck
+        - ament_cmake_cpplint
+        - ament_cmake_flake8
+        - ament_cmake_lint_cmake
+        - ament_cmake_mypy
+        - ament_cmake_pclint
+        - ament_cmake_pep257
+        - ament_cmake_pycodestyle
+        - ament_cmake_pyflakes
+        - ament_cmake_uncrustify
+        - ament_cmake_xmllint
+        - ament_copyright
+        - ament_cppcheck
+        - ament_cpplint
+        - ament_flake8
+        - ament_lint
+        - ament_lint_auto
+        - ament_lint_cmake
+        - ament_lint_common
+        - ament_mypy
+        - ament_pclint
+        - ament_pep257
+        - ament_pycodestyle
+        - ament_pyflakes
+        - ament_uncrustify
+        - ament_xmllint
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
@@ -331,8 +331,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - apex_test_tools
-      - test_apex_test_tools
+        - apex_test_tools
+        - test_apex_test_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
@@ -364,10 +364,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - apriltag_detector
-      - apriltag_detector_mit
-      - apriltag_detector_umich
-      - apriltag_draw
+        - apriltag_detector
+        - apriltag_detector_mit
+        - apriltag_detector_umich
+        - apriltag_draw
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
@@ -421,8 +421,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - aruco_opencv
-      - aruco_opencv_msgs
+        - aruco_opencv
+        - aruco_opencv_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
@@ -439,9 +439,9 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - aruco
-      - aruco_msgs
-      - aruco_ros
+        - aruco
+        - aruco_msgs
+        - aruco_ros
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
@@ -458,14 +458,14 @@ repositories:
       version: master
     release:
       packages:
-      - delphi_esr_msgs
-      - delphi_mrr_msgs
-      - delphi_srr_msgs
-      - derived_object_msgs
-      - ibeo_msgs
-      - kartech_linear_actuator_msgs
-      - mobileye_560_660_msgs
-      - neobotix_usboard_msgs
+        - delphi_esr_msgs
+        - delphi_mrr_msgs
+        - delphi_srr_msgs
+        - derived_object_msgs
+        - ibeo_msgs
+        - kartech_linear_actuator_msgs
+        - mobileye_560_660_msgs
+        - neobotix_usboard_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
@@ -522,9 +522,9 @@ repositories:
       version: master
     release:
       packages:
-      - automotive_autonomy_msgs
-      - automotive_navigation_msgs
-      - automotive_platform_msgs
+        - automotive_autonomy_msgs
+        - automotive_navigation_msgs
+        - automotive_platform_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
@@ -537,8 +537,8 @@ repositories:
   autoware_adapi_msgs:
     release:
       packages:
-      - autoware_adapi_v1_msgs
-      - autoware_adapi_version_msgs
+        - autoware_adapi_v1_msgs
+        - autoware_adapi_version_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
@@ -566,8 +566,8 @@ repositories:
   autoware_cmake:
     release:
       packages:
-      - autoware_cmake
-      - autoware_lint_common
+        - autoware_cmake
+        - autoware_lint_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
@@ -580,9 +580,9 @@ repositories:
   autoware_internal_msgs:
     release:
       packages:
-      - autoware_internal_debug_msgs
-      - autoware_internal_msgs
-      - autoware_internal_perception_msgs
+        - autoware_internal_debug_msgs
+        - autoware_internal_msgs
+        - autoware_internal_perception_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
@@ -595,8 +595,8 @@ repositories:
   autoware_lanelet2_extension:
     release:
       packages:
-      - autoware_lanelet2_extension
-      - autoware_lanelet2_extension_python
+        - autoware_lanelet2_extension
+        - autoware_lanelet2_extension_python
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
@@ -609,16 +609,16 @@ repositories:
   autoware_msgs:
     release:
       packages:
-      - autoware_common_msgs
-      - autoware_control_msgs
-      - autoware_localization_msgs
-      - autoware_map_msgs
-      - autoware_perception_msgs
-      - autoware_planning_msgs
-      - autoware_sensing_msgs
-      - autoware_system_msgs
-      - autoware_v2x_msgs
-      - autoware_vehicle_msgs
+        - autoware_common_msgs
+        - autoware_control_msgs
+        - autoware_localization_msgs
+        - autoware_map_msgs
+        - autoware_perception_msgs
+        - autoware_planning_msgs
+        - autoware_sensing_msgs
+        - autoware_system_msgs
+        - autoware_v2x_msgs
+        - autoware_vehicle_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
@@ -661,7 +661,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - aws_robomaker_small_warehouse_world
+        - aws_robomaker_small_warehouse_world
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
@@ -752,7 +752,7 @@ repositories:
       version: master
     release:
       packages:
-      - behaviortree_cpp
+        - behaviortree_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
@@ -784,11 +784,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - bond
-      - bond_core
-      - bondcpp
-      - bondpy
-      - smclib
+        - bond
+        - bond_core
+        - bondcpp
+        - bondpy
+        - smclib
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
@@ -857,9 +857,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - cartographer_ros
-      - cartographer_ros_msgs
-      - cartographer_rviz
+        - cartographer_ros
+        - cartographer_ros_msgs
+        - cartographer_rviz
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
@@ -877,8 +877,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-      - cascade_lifecycle_msgs
-      - rclcpp_cascade_lifecycle
+        - cascade_lifecycle_msgs
+        - rclcpp_cascade_lifecycle
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
@@ -985,19 +985,19 @@ repositories:
       version: rolling
     release:
       packages:
-      - actionlib_msgs
-      - common_interfaces
-      - diagnostic_msgs
-      - geometry_msgs
-      - nav_msgs
-      - sensor_msgs
-      - sensor_msgs_py
-      - shape_msgs
-      - std_msgs
-      - std_srvs
-      - stereo_msgs
-      - trajectory_msgs
-      - visualization_msgs
+        - actionlib_msgs
+        - common_interfaces
+        - diagnostic_msgs
+        - geometry_msgs
+        - nav_msgs
+        - sensor_msgs
+        - sensor_msgs_py
+        - shape_msgs
+        - std_msgs
+        - std_srvs
+        - stereo_msgs
+        - trajectory_msgs
+        - visualization_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
@@ -1073,8 +1073,8 @@ repositories:
   cpp_polyfills:
     release:
       packages:
-      - tcb_span
-      - tl_expected
+        - tcb_span
+        - tl_expected
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
@@ -1117,8 +1117,8 @@ repositories:
       version: main
     release:
       packages:
-      - data_tamer_cpp
-      - data_tamer_msgs
+        - data_tamer_cpp
+        - data_tamer_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
@@ -1136,26 +1136,26 @@ repositories:
       version: rolling
     release:
       packages:
-      - action_tutorials_cpp
-      - action_tutorials_py
-      - composition
-      - demo_nodes_cpp
-      - demo_nodes_cpp_native
-      - demo_nodes_py
-      - dummy_map_server
-      - dummy_robot_bringup
-      - dummy_sensors
-      - image_tools
-      - intra_process_demo
-      - lifecycle
-      - lifecycle_py
-      - logging_demo
-      - pendulum_control
-      - pendulum_msgs
-      - quality_of_service_demo_cpp
-      - quality_of_service_demo_py
-      - topic_monitor
-      - topic_statistics_demo
+        - action_tutorials_cpp
+        - action_tutorials_py
+        - composition
+        - demo_nodes_cpp
+        - demo_nodes_cpp_native
+        - demo_nodes_py
+        - dummy_map_server
+        - dummy_robot_bringup
+        - dummy_sensors
+        - image_tools
+        - intra_process_demo
+        - lifecycle
+        - lifecycle_py
+        - logging_demo
+        - pendulum_control
+        - pendulum_msgs
+        - quality_of_service_demo_cpp
+        - quality_of_service_demo_py
+        - topic_monitor
+        - topic_statistics_demo
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
@@ -1189,11 +1189,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - diagnostic_aggregator
-      - diagnostic_common_diagnostics
-      - diagnostic_updater
-      - diagnostics
-      - self_test
+        - diagnostic_aggregator
+        - diagnostic_common_diagnostics
+        - diagnostic_updater
+        - diagnostics
+        - self_test
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
@@ -1211,10 +1211,10 @@ repositories:
       version: galactic
     release:
       packages:
-      - dolly
-      - dolly_follow
-      - dolly_gazebo
-      - dolly_ignition
+        - dolly
+        - dolly_follow
+        - dolly_gazebo
+        - dolly_ignition
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
@@ -1278,9 +1278,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - dynamixel_sdk
-      - dynamixel_sdk_custom_interfaces
-      - dynamixel_sdk_examples
+        - dynamixel_sdk
+        - dynamixel_sdk_custom_interfaces
+        - dynamixel_sdk_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
@@ -1297,8 +1297,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - dynamixel_workbench
-      - dynamixel_workbench_toolbox
+        - dynamixel_workbench
+        - dynamixel_workbench_toolbox
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
@@ -1345,31 +1345,31 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-      - ecl_command_line
-      - ecl_concepts
-      - ecl_containers
-      - ecl_converters
-      - ecl_core
-      - ecl_core_apps
-      - ecl_devices
-      - ecl_eigen
-      - ecl_exceptions
-      - ecl_filesystem
-      - ecl_formatters
-      - ecl_geometry
-      - ecl_ipc
-      - ecl_linear_algebra
-      - ecl_manipulators
-      - ecl_math
-      - ecl_mobile_robot
-      - ecl_mpl
-      - ecl_sigslots
-      - ecl_statistics
-      - ecl_streams
-      - ecl_threads
-      - ecl_time
-      - ecl_type_traits
-      - ecl_utilities
+        - ecl_command_line
+        - ecl_concepts
+        - ecl_containers
+        - ecl_converters
+        - ecl_core
+        - ecl_core_apps
+        - ecl_devices
+        - ecl_eigen
+        - ecl_exceptions
+        - ecl_filesystem
+        - ecl_formatters
+        - ecl_geometry
+        - ecl_ipc
+        - ecl_linear_algebra
+        - ecl_manipulators
+        - ecl_math
+        - ecl_mobile_robot
+        - ecl_mpl
+        - ecl_sigslots
+        - ecl_statistics
+        - ecl_streams
+        - ecl_threads
+        - ecl_time
+        - ecl_type_traits
+        - ecl_utilities
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
@@ -1387,14 +1387,14 @@ repositories:
       version: release/1.2.x
     release:
       packages:
-      - ecl_config
-      - ecl_console
-      - ecl_converters_lite
-      - ecl_errors
-      - ecl_io
-      - ecl_lite
-      - ecl_sigslots_lite
-      - ecl_time_lite
+        - ecl_config
+        - ecl_console
+        - ecl_converters_lite
+        - ecl_errors
+        - ecl_io
+        - ecl_lite
+        - ecl_sigslots_lite
+        - ecl_time_lite
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
@@ -1412,9 +1412,9 @@ repositories:
       version: release/1.0.x
     release:
       packages:
-      - ecl_build
-      - ecl_license
-      - ecl_tools
+        - ecl_build
+        - ecl_license
+        - ecl_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
@@ -1569,28 +1569,28 @@ repositories:
       version: rolling
     release:
       packages:
-      - examples_rclcpp_async_client
-      - examples_rclcpp_cbg_executor
-      - examples_rclcpp_minimal_action_client
-      - examples_rclcpp_minimal_action_server
-      - examples_rclcpp_minimal_client
-      - examples_rclcpp_minimal_composition
-      - examples_rclcpp_minimal_publisher
-      - examples_rclcpp_minimal_service
-      - examples_rclcpp_minimal_subscriber
-      - examples_rclcpp_minimal_timer
-      - examples_rclcpp_multithreaded_executor
-      - examples_rclcpp_wait_set
-      - examples_rclpy_executors
-      - examples_rclpy_guard_conditions
-      - examples_rclpy_minimal_action_client
-      - examples_rclpy_minimal_action_server
-      - examples_rclpy_minimal_client
-      - examples_rclpy_minimal_publisher
-      - examples_rclpy_minimal_service
-      - examples_rclpy_minimal_subscriber
-      - examples_rclpy_pointcloud_publisher
-      - launch_testing_examples
+        - examples_rclcpp_async_client
+        - examples_rclcpp_cbg_executor
+        - examples_rclcpp_minimal_action_client
+        - examples_rclcpp_minimal_action_server
+        - examples_rclcpp_minimal_client
+        - examples_rclcpp_minimal_composition
+        - examples_rclcpp_minimal_publisher
+        - examples_rclcpp_minimal_service
+        - examples_rclcpp_minimal_subscriber
+        - examples_rclcpp_minimal_timer
+        - examples_rclcpp_multithreaded_executor
+        - examples_rclcpp_wait_set
+        - examples_rclpy_executors
+        - examples_rclpy_guard_conditions
+        - examples_rclpy_minimal_action_client
+        - examples_rclpy_minimal_action_server
+        - examples_rclpy_minimal_client
+        - examples_rclpy_minimal_publisher
+        - examples_rclpy_minimal_service
+        - examples_rclpy_minimal_subscriber
+        - examples_rclpy_pointcloud_publisher
+        - launch_testing_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
@@ -1770,15 +1770,15 @@ repositories:
       version: rolling
     release:
       packages:
-      - flexbe_behavior_engine
-      - flexbe_core
-      - flexbe_input
-      - flexbe_mirror
-      - flexbe_msgs
-      - flexbe_onboard
-      - flexbe_states
-      - flexbe_testing
-      - flexbe_widget
+        - flexbe_behavior_engine
+        - flexbe_core
+        - flexbe_input
+        - flexbe_mirror
+        - flexbe_msgs
+        - flexbe_onboard
+        - flexbe_states
+        - flexbe_testing
+        - flexbe_widget
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
@@ -1795,10 +1795,10 @@ repositories:
       version: ros2-release
     release:
       packages:
-      - flir_camera_description
-      - flir_camera_msgs
-      - spinnaker_camera_driver
-      - spinnaker_synchronized_camera_driver
+        - flir_camera_description
+        - flir_camera_msgs
+        - spinnaker_camera_driver
+        - spinnaker_synchronized_camera_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
@@ -1830,8 +1830,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - fmi_adapter
-      - fmi_adapter_examples
+        - fmi_adapter
+        - fmi_adapter_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
@@ -1926,19 +1926,19 @@ repositories:
       version: rolling
     release:
       packages:
-      - fuse
-      - fuse_constraints
-      - fuse_core
-      - fuse_doc
-      - fuse_graphs
-      - fuse_loss
-      - fuse_models
-      - fuse_msgs
-      - fuse_optimizers
-      - fuse_publishers
-      - fuse_tutorials
-      - fuse_variables
-      - fuse_viz
+        - fuse
+        - fuse_constraints
+        - fuse_core
+        - fuse_doc
+        - fuse_graphs
+        - fuse_loss
+        - fuse_models
+        - fuse_msgs
+        - fuse_optimizers
+        - fuse_publishers
+        - fuse_tutorials
+        - fuse_variables
+        - fuse_viz
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
@@ -1956,8 +1956,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - game_controller_spl
-      - game_controller_spl_interfaces
+        - game_controller_spl
+        - game_controller_spl_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
@@ -1974,12 +1974,12 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
-      - generate_parameter_library
-      - generate_parameter_library_example
-      - generate_parameter_library_py
-      - generate_parameter_module_example
-      - parameter_traits
+        - cmake_generate_parameter_module_example
+        - generate_parameter_library
+        - generate_parameter_library_example
+        - generate_parameter_library_py
+        - generate_parameter_module_example
+        - parameter_traits
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
@@ -1996,9 +1996,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - geodesy
-      - geographic_info
-      - geographic_msgs
+        - geodesy
+        - geographic_info
+        - geographic_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
@@ -2031,20 +2031,20 @@ repositories:
       version: rolling
     release:
       packages:
-      - examples_tf2_py
-      - geometry2
-      - tf2
-      - tf2_bullet
-      - tf2_eigen
-      - tf2_eigen_kdl
-      - tf2_geometry_msgs
-      - tf2_kdl
-      - tf2_msgs
-      - tf2_py
-      - tf2_ros
-      - tf2_ros_py
-      - tf2_sensor_msgs
-      - tf2_tools
+        - examples_tf2_py
+        - geometry2
+        - tf2
+        - tf2_bullet
+        - tf2_eigen
+        - tf2_eigen_kdl
+        - tf2_geometry_msgs
+        - tf2_kdl
+        - tf2_msgs
+        - tf2_py
+        - tf2_ros
+        - tf2_ros_py
+        - tf2_sensor_msgs
+        - tf2_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
@@ -2062,9 +2062,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - geometry_tutorials
-      - turtle_tf2_cpp
-      - turtle_tf2_py
+        - geometry_tutorials
+        - turtle_tf2_cpp
+        - turtle_tf2_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
@@ -2093,8 +2093,8 @@ repositories:
   googletest:
     release:
       packages:
-      - gmock_vendor
-      - gtest_vendor
+        - gmock_vendor
+        - gtest_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
@@ -2111,10 +2111,10 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - gps_msgs
-      - gps_tools
-      - gps_umd
-      - gpsd_client
+        - gps_msgs
+        - gps_tools
+        - gps_umd
+        - gpsd_client
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
@@ -2414,8 +2414,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - gz_ros2_control
-      - gz_ros2_control_demos
+        - gz_ros2_control
+        - gz_ros2_control_demos
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
@@ -2583,10 +2583,10 @@ repositories:
   iceoryx:
     release:
       packages:
-      - iceoryx_binding_c
-      - iceoryx_hoofs
-      - iceoryx_introspection
-      - iceoryx_posh
+        - iceoryx_binding_c
+        - iceoryx_hoofs
+        - iceoryx_introspection
+        - iceoryx_posh
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
@@ -2610,9 +2610,9 @@ repositories:
       version: main
     release:
       packages:
-      - ign_rviz
-      - ign_rviz_common
-      - ign_rviz_plugins
+        - ign_rviz
+        - ign_rviz_common
+        - ign_rviz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
@@ -2629,12 +2629,12 @@ repositories:
       version: rolling
     release:
       packages:
-      - camera_calibration_parsers
-      - camera_info_manager
-      - camera_info_manager_py
-      - image_common
-      - image_transport
-      - image_transport_py
+        - camera_calibration_parsers
+        - camera_info_manager
+        - camera_info_manager_py
+        - image_common
+        - image_transport
+        - image_transport_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
@@ -2652,15 +2652,15 @@ repositories:
       version: rolling
     release:
       packages:
-      - camera_calibration
-      - depth_image_proc
-      - image_pipeline
-      - image_proc
-      - image_publisher
-      - image_rotate
-      - image_view
-      - stereo_image_proc
-      - tracetools_image_pipeline
+        - camera_calibration
+        - depth_image_proc
+        - image_pipeline
+        - image_proc
+        - image_publisher
+        - image_rotate
+        - image_view
+        - stereo_image_proc
+        - tracetools_image_pipeline
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
@@ -2678,11 +2678,11 @@ repositories:
       version: rolling
     release:
       packages:
-      - compressed_depth_image_transport
-      - compressed_image_transport
-      - image_transport_plugins
-      - theora_image_transport
-      - zstd_image_transport
+        - compressed_depth_image_transport
+        - compressed_image_transport
+        - image_transport_plugins
+        - theora_image_transport
+        - zstd_image_transport
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
@@ -2700,9 +2700,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - imu_pipeline
-      - imu_processors
-      - imu_transformer
+        - imu_pipeline
+        - imu_processors
+        - imu_transformer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
@@ -2719,10 +2719,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - imu_complementary_filter
-      - imu_filter_madgwick
-      - imu_tools
-      - rviz_imu_plugin
+        - imu_complementary_filter
+        - imu_filter_madgwick
+        - imu_tools
+        - rviz_imu_plugin
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
@@ -2793,8 +2793,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - joint_state_publisher
-      - joint_state_publisher_gui
+        - joint_state_publisher
+        - joint_state_publisher_gui
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
@@ -2827,12 +2827,12 @@ repositories:
       version: ros2
     release:
       packages:
-      - joy
-      - joy_linux
-      - sdl2_vendor
-      - spacenav
-      - wiimote
-      - wiimote_msgs
+        - joy
+        - joy_linux
+        - sdl2_vendor
+        - spacenav
+        - wiimote
+        - wiimote_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
@@ -2882,8 +2882,8 @@ repositories:
       version: master
     release:
       packages:
-      - kinematics_interface
-      - kinematics_interface_kdl
+        - kinematics_interface
+        - kinematics_interface_kdl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
@@ -2966,6 +2966,16 @@ repositories:
       url: https://github.com/automatika-robotics/kompass.git
       version: main
     status: developed
+  kompass_interfaces:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
   lanelet2:
     doc:
       type: git
@@ -2973,17 +2983,17 @@ repositories:
       version: master
     release:
       packages:
-      - lanelet2
-      - lanelet2_core
-      - lanelet2_examples
-      - lanelet2_io
-      - lanelet2_maps
-      - lanelet2_matching
-      - lanelet2_projection
-      - lanelet2_python
-      - lanelet2_routing
-      - lanelet2_traffic_rules
-      - lanelet2_validation
+        - lanelet2
+        - lanelet2_core
+        - lanelet2_examples
+        - lanelet2_io
+        - lanelet2_maps
+        - lanelet2_matching
+        - lanelet2_projection
+        - lanelet2_python
+        - lanelet2_routing
+        - lanelet2_traffic_rules
+        - lanelet2_validation
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
@@ -3058,12 +3068,12 @@ repositories:
       version: rolling
     release:
       packages:
-      - launch
-      - launch_pytest
-      - launch_testing
-      - launch_testing_ament_cmake
-      - launch_xml
-      - launch_yaml
+        - launch
+        - launch_pytest
+        - launch_testing
+        - launch_testing_ament_cmake
+        - launch_xml
+        - launch_yaml
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
@@ -3096,9 +3106,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - launch_ros
-      - launch_testing_ros
-      - ros2launch
+        - launch_ros
+        - launch_testing_ros
+        - ros2launch
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
@@ -3116,10 +3126,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - leo
-      - leo_description
-      - leo_msgs
-      - leo_teleop
+        - leo
+        - leo_description
+        - leo_msgs
+        - leo_teleop
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
@@ -3136,8 +3146,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - leo_desktop
-      - leo_viz
+        - leo_desktop
+        - leo_viz
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
@@ -3154,9 +3164,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - leo_bringup
-      - leo_fw
-      - leo_robot
+        - leo_bringup
+        - leo_fw
+        - leo_robot
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
@@ -3173,10 +3183,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - leo_gz_bringup
-      - leo_gz_plugins
-      - leo_gz_worlds
-      - leo_simulator
+        - leo_gz_bringup
+        - leo_gz_plugins
+        - leo_gz_worlds
+        - leo_simulator
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
@@ -3372,11 +3382,11 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - mapviz
-      - mapviz_interfaces
-      - mapviz_plugins
-      - multires_image
-      - tile_map
+        - mapviz
+        - mapviz_interfaces
+        - mapviz_plugins
+        - multires_image
+        - tile_map
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
@@ -3393,8 +3403,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - marine_acoustic_msgs
-      - marine_sensor_msgs
+        - marine_acoustic_msgs
+        - marine_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
@@ -3426,18 +3436,18 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - swri_cli_tools
-      - swri_console_util
-      - swri_dbw_interface
-      - swri_geometry_util
-      - swri_image_util
-      - swri_math_util
-      - swri_opencv_util
-      - swri_roscpp
-      - swri_route_util
-      - swri_serial_util
-      - swri_system_util
-      - swri_transform_util
+        - swri_cli_tools
+        - swri_console_util
+        - swri_dbw_interface
+        - swri_geometry_util
+        - swri_image_util
+        - swri_math_util
+        - swri_opencv_util
+        - swri_roscpp
+        - swri_route_util
+        - swri_serial_util
+        - swri_system_util
+        - swri_transform_util
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
@@ -3455,15 +3465,15 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - marti_can_msgs
-      - marti_common_msgs
-      - marti_dbw_msgs
-      - marti_introspection_msgs
-      - marti_nav_msgs
-      - marti_perception_msgs
-      - marti_sensor_msgs
-      - marti_status_msgs
-      - marti_visualization_msgs
+        - marti_can_msgs
+        - marti_common_msgs
+        - marti_dbw_msgs
+        - marti_introspection_msgs
+        - marti_nav_msgs
+        - marti_perception_msgs
+        - marti_sensor_msgs
+        - marti_status_msgs
+        - marti_visualization_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
@@ -3496,10 +3506,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - libmavconn
-      - mavros
-      - mavros_extras
-      - mavros_msgs
+        - libmavconn
+        - mavros
+        - mavros_extras
+        - mavros_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
@@ -3577,8 +3587,8 @@ repositories:
       version: master
     release:
       packages:
-      - micro_ros_diagnostic_bridge
-      - micro_ros_diagnostic_msgs
+        - micro_ros_diagnostic_bridge
+        - micro_ros_diagnostic_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
@@ -3610,11 +3620,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - microstrain_inertial_description
-      - microstrain_inertial_driver
-      - microstrain_inertial_examples
-      - microstrain_inertial_msgs
-      - microstrain_inertial_rqt
+        - microstrain_inertial_description
+        - microstrain_inertial_driver
+        - microstrain_inertial_examples
+        - microstrain_inertial_msgs
+        - microstrain_inertial_rqt
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
@@ -3670,26 +3680,26 @@ repositories:
       version: develop
     release:
       packages:
-      - kitti_metrics_eval
-      - mola
-      - mola_bridge_ros2
-      - mola_demos
-      - mola_input_euroc_dataset
-      - mola_input_kitti360_dataset
-      - mola_input_kitti_dataset
-      - mola_input_mulran_dataset
-      - mola_input_paris_luco_dataset
-      - mola_input_rawlog
-      - mola_input_rosbag2
-      - mola_kernel
-      - mola_launcher
-      - mola_metric_maps
-      - mola_msgs
-      - mola_pose_list
-      - mola_relocalization
-      - mola_traj_tools
-      - mola_viz
-      - mola_yaml
+        - kitti_metrics_eval
+        - mola
+        - mola_bridge_ros2
+        - mola_demos
+        - mola_input_euroc_dataset
+        - mola_input_kitti360_dataset
+        - mola_input_kitti_dataset
+        - mola_input_mulran_dataset
+        - mola_input_paris_luco_dataset
+        - mola_input_rawlog
+        - mola_input_rosbag2
+        - mola_kernel
+        - mola_launcher
+        - mola_metric_maps
+        - mola_msgs
+        - mola_pose_list
+        - mola_relocalization
+        - mola_traj_tools
+        - mola_viz
+        - mola_yaml
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
@@ -3761,8 +3771,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - motion_capture_tracking
-      - motion_capture_tracking_interfaces
+        - motion_capture_tracking
+        - motion_capture_tracking_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
@@ -3779,47 +3789,47 @@ repositories:
       version: main
     release:
       packages:
-      - chomp_motion_planner
-      - moveit
-      - moveit_common
-      - moveit_configs_utils
-      - moveit_core
-      - moveit_hybrid_planning
-      - moveit_kinematics
-      - moveit_planners
-      - moveit_planners_chomp
-      - moveit_planners_ompl
-      - moveit_planners_stomp
-      - moveit_plugins
-      - moveit_py
-      - moveit_resources_prbt_ikfast_manipulator_plugin
-      - moveit_resources_prbt_moveit_config
-      - moveit_resources_prbt_pg70_support
-      - moveit_resources_prbt_support
-      - moveit_ros
-      - moveit_ros_benchmarks
-      - moveit_ros_control_interface
-      - moveit_ros_move_group
-      - moveit_ros_occupancy_map_monitor
-      - moveit_ros_perception
-      - moveit_ros_planning
-      - moveit_ros_planning_interface
-      - moveit_ros_robot_interaction
-      - moveit_ros_tests
-      - moveit_ros_trajectory_cache
-      - moveit_ros_visualization
-      - moveit_ros_warehouse
-      - moveit_runtime
-      - moveit_servo
-      - moveit_setup_app_plugins
-      - moveit_setup_assistant
-      - moveit_setup_controllers
-      - moveit_setup_core_plugins
-      - moveit_setup_framework
-      - moveit_setup_srdf_plugins
-      - moveit_simple_controller_manager
-      - pilz_industrial_motion_planner
-      - pilz_industrial_motion_planner_testutils
+        - chomp_motion_planner
+        - moveit
+        - moveit_common
+        - moveit_configs_utils
+        - moveit_core
+        - moveit_hybrid_planning
+        - moveit_kinematics
+        - moveit_planners
+        - moveit_planners_chomp
+        - moveit_planners_ompl
+        - moveit_planners_stomp
+        - moveit_plugins
+        - moveit_py
+        - moveit_resources_prbt_ikfast_manipulator_plugin
+        - moveit_resources_prbt_moveit_config
+        - moveit_resources_prbt_pg70_support
+        - moveit_resources_prbt_support
+        - moveit_ros
+        - moveit_ros_benchmarks
+        - moveit_ros_control_interface
+        - moveit_ros_move_group
+        - moveit_ros_occupancy_map_monitor
+        - moveit_ros_perception
+        - moveit_ros_planning
+        - moveit_ros_planning_interface
+        - moveit_ros_robot_interaction
+        - moveit_ros_tests
+        - moveit_ros_trajectory_cache
+        - moveit_ros_visualization
+        - moveit_ros_warehouse
+        - moveit_runtime
+        - moveit_servo
+        - moveit_setup_app_plugins
+        - moveit_setup_assistant
+        - moveit_setup_controllers
+        - moveit_setup_core_plugins
+        - moveit_setup_framework
+        - moveit_setup_srdf_plugins
+        - moveit_simple_controller_manager
+        - pilz_industrial_motion_planner
+        - pilz_industrial_motion_planner_testutils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
@@ -3853,13 +3863,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - dual_arm_panda_moveit_config
-      - moveit_resources
-      - moveit_resources_fanuc_description
-      - moveit_resources_fanuc_moveit_config
-      - moveit_resources_panda_description
-      - moveit_resources_panda_moveit_config
-      - moveit_resources_pr2_description
+        - dual_arm_panda_moveit_config
+        - moveit_resources
+        - moveit_resources_fanuc_description
+        - moveit_resources_fanuc_moveit_config
+        - moveit_resources_panda_description
+        - moveit_resources_panda_moveit_config
+        - moveit_resources_pr2_description
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
@@ -3906,8 +3916,8 @@ repositories:
       version: main
     release:
       packages:
-      - mqtt_client
-      - mqtt_client_interfaces
+        - mqtt_client
+        - mqtt_client_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
@@ -3939,16 +3949,16 @@ repositories:
       version: ros2
     release:
       packages:
-      - mrpt_map_server
-      - mrpt_msgs_bridge
-      - mrpt_nav_interfaces
-      - mrpt_navigation
-      - mrpt_pf_localization
-      - mrpt_pointcloud_pipeline
-      - mrpt_rawlog
-      - mrpt_reactivenav2d
-      - mrpt_tps_astar_planner
-      - mrpt_tutorials
+        - mrpt_map_server
+        - mrpt_msgs_bridge
+        - mrpt_nav_interfaces
+        - mrpt_navigation
+        - mrpt_pf_localization
+        - mrpt_pointcloud_pipeline
+        - mrpt_rawlog
+        - mrpt_reactivenav2d
+        - mrpt_tps_astar_planner
+        - mrpt_tutorials
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
@@ -3980,20 +3990,20 @@ repositories:
       version: main
     release:
       packages:
-      - mrpt_apps
-      - mrpt_libapps
-      - mrpt_libbase
-      - mrpt_libgui
-      - mrpt_libhwdrivers
-      - mrpt_libmaps
-      - mrpt_libmath
-      - mrpt_libnav
-      - mrpt_libobs
-      - mrpt_libopengl
-      - mrpt_libposes
-      - mrpt_libros_bridge
-      - mrpt_libslam
-      - mrpt_libtclap
+        - mrpt_apps
+        - mrpt_libapps
+        - mrpt_libbase
+        - mrpt_libgui
+        - mrpt_libhwdrivers
+        - mrpt_libmaps
+        - mrpt_libmath
+        - mrpt_libnav
+        - mrpt_libobs
+        - mrpt_libopengl
+        - mrpt_libposes
+        - mrpt_libros_bridge
+        - mrpt_libslam
+        - mrpt_libtclap
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
@@ -4010,13 +4020,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - mrpt_generic_sensor
-      - mrpt_sensor_bumblebee_stereo
-      - mrpt_sensor_gnss_nmea
-      - mrpt_sensor_gnss_novatel
-      - mrpt_sensor_imu_taobotics
-      - mrpt_sensorlib
-      - mrpt_sensors
+        - mrpt_generic_sensor
+        - mrpt_sensor_bumblebee_stereo
+        - mrpt_sensor_gnss_nmea
+        - mrpt_sensor_gnss_novatel
+        - mrpt_sensor_imu_taobotics
+        - mrpt_sensorlib
+        - mrpt_sensors
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
@@ -4079,8 +4089,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - nao_command_msgs
-      - nao_sensor_msgs
+        - nao_command_msgs
+        - nao_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
@@ -4097,10 +4107,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - nao_lola
-      - nao_lola_client
-      - nao_lola_command_msgs
-      - nao_lola_sensor_msgs
+        - nao_lola
+        - nao_lola_client
+        - nao_lola_command_msgs
+        - nao_lola_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
@@ -4113,9 +4123,9 @@ repositories:
   nav2_minimal_turtlebot_simulation:
     release:
       packages:
-      - nav2_minimal_tb3_sim
-      - nav2_minimal_tb4_description
-      - nav2_minimal_tb4_sim
+        - nav2_minimal_tb3_sim
+        - nav2_minimal_tb4_description
+        - nav2_minimal_tb4_sim
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation-release.git
@@ -4132,7 +4142,7 @@ repositories:
       version: rolling
     release:
       packages:
-      - map_msgs
+        - map_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
@@ -4227,8 +4237,8 @@ repositories:
       version: master
     release:
       packages:
-      - nodl_python
-      - ros2nodl
+        - nodl_python
+        - ros2nodl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
@@ -4261,8 +4271,8 @@ repositories:
       version: ros2-devel
     release:
       packages:
-      - novatel_gps_driver
-      - novatel_gps_msgs
+        - novatel_gps_driver
+        - novatel_gps_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
@@ -4321,8 +4331,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - octomap_mapping
-      - octomap_server
+        - octomap_mapping
+        - octomap_server
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
@@ -4399,7 +4409,7 @@ repositories:
       version: main
     release:
       packages:
-      - odri_master_board_sdk
+        - odri_master_board_sdk
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
@@ -4477,8 +4487,8 @@ repositories:
   orocos_kdl_vendor:
     release:
       packages:
-      - orocos_kdl_vendor
-      - python_orocos_kdl_vendor
+        - orocos_kdl_vendor
+        - python_orocos_kdl_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
@@ -4548,8 +4558,8 @@ repositories:
       version: rolling-devel
     release:
       packages:
-      - ouster_ros
-      - ouster_sensor_msgs
+        - ouster_ros
+        - ouster_sensor_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
@@ -4567,8 +4577,8 @@ repositories:
       version: master
     release:
       packages:
-      - ouxt_common
-      - ouxt_lint_common
+        - ouxt_common
+        - ouxt_lint_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
@@ -4585,8 +4595,8 @@ repositories:
       version: humble-devel
     release:
       packages:
-      - pal_statistics
-      - pal_statistics_msgs
+        - pal_statistics
+        - pal_statistics_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
@@ -4621,7 +4631,7 @@ repositories:
   perception_open3d:
     release:
       packages:
-      - open3d_conversions
+        - open3d_conversions
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
@@ -4639,9 +4649,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - pcl_conversions
-      - pcl_ros
-      - perception_pcl
+        - pcl_conversions
+        - pcl_ros
+        - perception_pcl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
@@ -4686,22 +4696,22 @@ repositories:
       version: rolling
     release:
       packages:
-      - libphidget22
-      - phidgets_accelerometer
-      - phidgets_analog_inputs
-      - phidgets_analog_outputs
-      - phidgets_api
-      - phidgets_digital_inputs
-      - phidgets_digital_outputs
-      - phidgets_drivers
-      - phidgets_gyroscope
-      - phidgets_high_speed_encoder
-      - phidgets_ik
-      - phidgets_magnetometer
-      - phidgets_motors
-      - phidgets_msgs
-      - phidgets_spatial
-      - phidgets_temperature
+        - libphidget22
+        - phidgets_accelerometer
+        - phidgets_analog_inputs
+        - phidgets_analog_outputs
+        - phidgets_api
+        - phidgets_digital_inputs
+        - phidgets_digital_outputs
+        - phidgets_drivers
+        - phidgets_gyroscope
+        - phidgets_high_speed_encoder
+        - phidgets_ik
+        - phidgets_magnetometer
+        - phidgets_motors
+        - phidgets_msgs
+        - phidgets_spatial
+        - phidgets_temperature
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
@@ -4740,8 +4750,8 @@ repositories:
       version: main
     release:
       packages:
-      - picknik_reset_fault_controller
-      - picknik_twist_controller
+        - picknik_reset_fault_controller
+        - picknik_twist_controller
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
@@ -4849,8 +4859,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - point_cloud_transport
-      - point_cloud_transport_py
+        - point_cloud_transport
+        - point_cloud_transport_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
@@ -4868,11 +4878,11 @@ repositories:
       version: rolling
     release:
       packages:
-      - draco_point_cloud_transport
-      - point_cloud_interfaces
-      - point_cloud_transport_plugins
-      - zlib_point_cloud_transport
-      - zstd_point_cloud_transport
+        - draco_point_cloud_transport
+        - point_cloud_interfaces
+        - point_cloud_transport_plugins
+        - zlib_point_cloud_transport
+        - zstd_point_cloud_transport
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
@@ -4922,10 +4932,10 @@ repositories:
       version: main
     release:
       packages:
-      - polygon_demos
-      - polygon_msgs
-      - polygon_rviz_plugins
-      - polygon_utils
+        - polygon_demos
+        - polygon_msgs
+        - polygon_rviz_plugins
+        - polygon_utils
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
@@ -5094,7 +5104,7 @@ repositories:
       version: main
     release:
       packages:
-      - python_mrpt
+        - python_mrpt
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
@@ -5153,12 +5163,12 @@ repositories:
       version: rolling
     release:
       packages:
-      - qt_dotgraph
-      - qt_gui
-      - qt_gui_app
-      - qt_gui_core
-      - qt_gui_cpp
-      - qt_gui_py_common
+        - qt_dotgraph
+        - qt_gui
+        - qt_gui_app
+        - qt_gui_core
+        - qt_gui_cpp
+        - qt_gui_py_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
@@ -5191,9 +5201,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - r2r_spl_7
-      - splsm_7
-      - splsm_7_conversion
+        - r2r_spl_7
+        - splsm_7
+        - splsm_7_conversion
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
@@ -5232,8 +5242,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - raspimouse
-      - raspimouse_msgs
+        - raspimouse
+        - raspimouse_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
@@ -5315,8 +5325,8 @@ repositories:
       version: master
     release:
       packages:
-      - rc_reason_clients
-      - rc_reason_msgs
+        - rc_reason_clients
+        - rc_reason_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
@@ -5350,10 +5360,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - rcl
-      - rcl_action
-      - rcl_lifecycle
-      - rcl_yaml_param_parser
+        - rcl
+        - rcl_action
+        - rcl_lifecycle
+        - rcl_yaml_param_parser
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
@@ -5371,16 +5381,16 @@ repositories:
       version: rolling
     release:
       packages:
-      - action_msgs
-      - builtin_interfaces
-      - composition_interfaces
-      - lifecycle_msgs
-      - rcl_interfaces
-      - rosgraph_msgs
-      - service_msgs
-      - statistics_msgs
-      - test_msgs
-      - type_description_interfaces
+        - action_msgs
+        - builtin_interfaces
+        - composition_interfaces
+        - lifecycle_msgs
+        - rcl_interfaces
+        - rosgraph_msgs
+        - service_msgs
+        - statistics_msgs
+        - test_msgs
+        - type_description_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
@@ -5398,9 +5408,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - rcl_logging_interface
-      - rcl_logging_noop
-      - rcl_logging_spdlog
+        - rcl_logging_interface
+        - rcl_logging_noop
+        - rcl_logging_spdlog
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
@@ -5429,10 +5439,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - rclc
-      - rclc_examples
-      - rclc_lifecycle
-      - rclc_parameter
+        - rclc
+        - rclc_examples
+        - rclc_lifecycle
+        - rclc_parameter
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
@@ -5450,10 +5460,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - rclcpp
-      - rclcpp_action
-      - rclcpp_components
-      - rclcpp_lifecycle
+        - rclcpp
+        - rclcpp_action
+        - rclcpp_components
+        - rclcpp_lifecycle
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
@@ -5503,10 +5513,10 @@ repositories:
       version: rolling
     release:
       packages:
-      - rcss3d_agent
-      - rcss3d_agent_basic
-      - rcss3d_agent_msgs
-      - rcss3d_agent_msgs_to_soccer_interfaces
+        - rcss3d_agent
+        - rcss3d_agent_basic
+        - rcss3d_agent_msgs
+        - rcss3d_agent_msgs_to_soccer_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
@@ -5564,8 +5574,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rttest
-      - tlsf_cpp
+        - rttest
+        - tlsf_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
@@ -5598,8 +5608,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - libcurl_vendor
-      - resource_retriever
+        - libcurl_vendor
+        - resource_retriever
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
@@ -5689,13 +5699,13 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_demos
-      - rmf_demos_assets
-      - rmf_demos_bridges
-      - rmf_demos_fleet_adapter
-      - rmf_demos_gz
-      - rmf_demos_maps
-      - rmf_demos_tasks
+        - rmf_demos
+        - rmf_demos_assets
+        - rmf_demos_bridges
+        - rmf_demos_fleet_adapter
+        - rmf_demos_gz
+        - rmf_demos_maps
+        - rmf_demos_tasks
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
@@ -5712,19 +5722,19 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_charger_msgs
-      - rmf_dispenser_msgs
-      - rmf_door_msgs
-      - rmf_fleet_msgs
-      - rmf_ingestor_msgs
-      - rmf_lift_msgs
-      - rmf_obstacle_msgs
-      - rmf_reservation_msgs
-      - rmf_scheduler_msgs
-      - rmf_site_map_msgs
-      - rmf_task_msgs
-      - rmf_traffic_msgs
-      - rmf_workcell_msgs
+        - rmf_charger_msgs
+        - rmf_dispenser_msgs
+        - rmf_door_msgs
+        - rmf_fleet_msgs
+        - rmf_ingestor_msgs
+        - rmf_lift_msgs
+        - rmf_obstacle_msgs
+        - rmf_reservation_msgs
+        - rmf_scheduler_msgs
+        - rmf_site_map_msgs
+        - rmf_task_msgs
+        - rmf_traffic_msgs
+        - rmf_workcell_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
@@ -5741,13 +5751,13 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_charging_schedule
-      - rmf_fleet_adapter
-      - rmf_fleet_adapter_python
-      - rmf_reservation_node
-      - rmf_task_ros2
-      - rmf_traffic_ros2
-      - rmf_websocket
+        - rmf_charging_schedule
+        - rmf_fleet_adapter
+        - rmf_fleet_adapter_python
+        - rmf_reservation_node
+        - rmf_task_ros2
+        - rmf_traffic_ros2
+        - rmf_websocket
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
@@ -5764,9 +5774,9 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_building_sim_gz_plugins
-      - rmf_robot_sim_common
-      - rmf_robot_sim_gz_plugins
+        - rmf_building_sim_gz_plugins
+        - rmf_robot_sim_common
+        - rmf_robot_sim_gz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
@@ -5783,8 +5793,8 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_task
-      - rmf_task_sequence
+        - rmf_task
+        - rmf_task_sequence
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
@@ -5801,8 +5811,8 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_traffic
-      - rmf_traffic_examples
+        - rmf_traffic
+        - rmf_traffic_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
@@ -5819,10 +5829,10 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_building_map_tools
-      - rmf_traffic_editor
-      - rmf_traffic_editor_assets
-      - rmf_traffic_editor_test_maps
+        - rmf_building_map_tools
+        - rmf_traffic_editor
+        - rmf_traffic_editor_assets
+        - rmf_traffic_editor_test_maps
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
@@ -5854,7 +5864,7 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_dev
+        - rmf_dev
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
@@ -5871,14 +5881,14 @@ repositories:
       version: main
     release:
       packages:
-      - rmf_visualization
-      - rmf_visualization_building_systems
-      - rmf_visualization_fleet_states
-      - rmf_visualization_floorplans
-      - rmf_visualization_navgraphs
-      - rmf_visualization_obstacles
-      - rmf_visualization_rviz2_plugins
-      - rmf_visualization_schedule
+        - rmf_visualization
+        - rmf_visualization_building_systems
+        - rmf_visualization_fleet_states
+        - rmf_visualization_floorplans
+        - rmf_visualization_navgraphs
+        - rmf_visualization_obstacles
+        - rmf_visualization_rviz2_plugins
+        - rmf_visualization_schedule
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
@@ -5910,8 +5920,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rmw
-      - rmw_implementation_cmake
+        - rmw
+        - rmw_implementation_cmake
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
@@ -5929,9 +5939,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - rmw_connextdds
-      - rmw_connextdds_common
-      - rti_connext_dds_cmake_module
+        - rmw_connextdds
+        - rmw_connextdds_common
+        - rti_connext_dds_cmake_module
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
@@ -5948,7 +5958,7 @@ repositories:
       version: rolling
     release:
       packages:
-      - rmw_cyclonedds_cpp
+        - rmw_cyclonedds_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
@@ -5982,9 +5992,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - rmw_fastrtps_cpp
-      - rmw_fastrtps_dynamic_cpp
-      - rmw_fastrtps_shared_cpp
+        - rmw_fastrtps_cpp
+        - rmw_fastrtps_dynamic_cpp
+        - rmw_fastrtps_shared_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
@@ -6002,8 +6012,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - gurumdds_cmake_module
-      - rmw_gurumdds_cpp
+        - gurumdds_cmake_module
+        - rmw_gurumdds_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
@@ -6036,8 +6046,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rmw_zenoh_cpp
-      - zenoh_cpp_vendor
+        - rmw_zenoh_cpp
+        - zenoh_cpp_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
@@ -6054,8 +6064,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - robot_calibration
-      - robot_calibration_msgs
+        - robot_calibration
+        - robot_calibration_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
@@ -6110,7 +6120,8 @@ repositories:
       type: git
       url: https://github.com/ros2/ros1_bridge.git
       version: master
-    status_description: Maintained in source form only since no ROS 1 packages available
+    status_description:
+      Maintained in source form only since no ROS 1 packages available
       in Rolling
   ros2_canopen:
     doc:
@@ -6119,19 +6130,19 @@ repositories:
       version: master
     release:
       packages:
-      - canopen
-      - canopen_402_driver
-      - canopen_base_driver
-      - canopen_core
-      - canopen_fake_slaves
-      - canopen_interfaces
-      - canopen_master_driver
-      - canopen_proxy_driver
-      - canopen_ros2_control
-      - canopen_ros2_controllers
-      - canopen_tests
-      - canopen_utils
-      - lely_core_libraries
+        - canopen
+        - canopen_402_driver
+        - canopen_base_driver
+        - canopen_core
+        - canopen_fake_slaves
+        - canopen_interfaces
+        - canopen_master_driver
+        - canopen_proxy_driver
+        - canopen_ros2_control
+        - canopen_ros2_controllers
+        - canopen_tests
+        - canopen_utils
+        - lely_core_libraries
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
@@ -6148,17 +6159,17 @@ repositories:
       version: master
     release:
       packages:
-      - controller_interface
-      - controller_manager
-      - controller_manager_msgs
-      - hardware_interface
-      - hardware_interface_testing
-      - joint_limits
-      - ros2_control
-      - ros2_control_test_assets
-      - ros2controlcli
-      - rqt_controller_manager
-      - transmission_interface
+        - controller_interface
+        - controller_manager
+        - controller_manager_msgs
+        - hardware_interface
+        - hardware_interface_testing
+        - joint_limits
+        - ros2_control
+        - ros2_control_test_assets
+        - ros2controlcli
+        - rqt_controller_manager
+        - transmission_interface
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
@@ -6175,31 +6186,31 @@ repositories:
       version: master
     release:
       packages:
-      - ackermann_steering_controller
-      - admittance_controller
-      - bicycle_steering_controller
-      - diff_drive_controller
-      - effort_controllers
-      - force_torque_sensor_broadcaster
-      - forward_command_controller
-      - gpio_controllers
-      - gripper_controllers
-      - imu_sensor_broadcaster
-      - joint_state_broadcaster
-      - joint_trajectory_controller
-      - mecanum_drive_controller
-      - parallel_gripper_controller
-      - pid_controller
-      - pose_broadcaster
-      - position_controllers
-      - range_sensor_broadcaster
-      - ros2_controllers
-      - ros2_controllers_test_nodes
-      - rqt_joint_trajectory_controller
-      - steering_controllers_library
-      - tricycle_controller
-      - tricycle_steering_controller
-      - velocity_controllers
+        - ackermann_steering_controller
+        - admittance_controller
+        - bicycle_steering_controller
+        - diff_drive_controller
+        - effort_controllers
+        - force_torque_sensor_broadcaster
+        - forward_command_controller
+        - gpio_controllers
+        - gripper_controllers
+        - imu_sensor_broadcaster
+        - joint_state_broadcaster
+        - joint_trajectory_controller
+        - mecanum_drive_controller
+        - parallel_gripper_controller
+        - pid_controller
+        - pose_broadcaster
+        - position_controllers
+        - range_sensor_broadcaster
+        - ros2_controllers
+        - ros2_controllers_test_nodes
+        - rqt_joint_trajectory_controller
+        - steering_controllers_library
+        - tricycle_controller
+        - tricycle_steering_controller
+        - velocity_controllers
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
@@ -6226,12 +6237,12 @@ repositories:
       version: main
     release:
       packages:
-      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-      - kortex_api
-      - kortex_bringup
-      - kortex_description
-      - kortex_driver
+        - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+        - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+        - kortex_api
+        - kortex_bringup
+        - kortex_description
+        - kortex_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
@@ -6248,8 +6259,8 @@ repositories:
       version: main
     release:
       packages:
-      - robotiq_controllers
-      - robotiq_description
+        - robotiq_controllers
+        - robotiq_description
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
@@ -6266,8 +6277,8 @@ repositories:
       version: main
     release:
       packages:
-      - ros2_socketcan
-      - ros2_socketcan_msgs
+        - ros2_socketcan
+        - ros2_socketcan_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
@@ -6284,13 +6295,13 @@ repositories:
       version: rolling
     release:
       packages:
-      - lttngpy
-      - ros2trace
-      - tracetools
-      - tracetools_launch
-      - tracetools_read
-      - tracetools_test
-      - tracetools_trace
+        - lttngpy
+        - ros2trace
+        - tracetools
+        - tracetools_launch
+        - tracetools_read
+        - tracetools_test
+        - tracetools_trace
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
@@ -6324,21 +6335,21 @@ repositories:
       version: rolling
     release:
       packages:
-      - ros2action
-      - ros2cli
-      - ros2cli_test_interfaces
-      - ros2component
-      - ros2doctor
-      - ros2interface
-      - ros2lifecycle
-      - ros2lifecycle_test_fixtures
-      - ros2multicast
-      - ros2node
-      - ros2param
-      - ros2pkg
-      - ros2run
-      - ros2service
-      - ros2topic
+        - ros2action
+        - ros2cli
+        - ros2cli_test_interfaces
+        - ros2component
+        - ros2doctor
+        - ros2interface
+        - ros2lifecycle
+        - ros2lifecycle_test_fixtures
+        - ros2multicast
+        - ros2node
+        - ros2param
+        - ros2pkg
+        - ros2run
+        - ros2service
+        - ros2topic
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
@@ -6371,8 +6382,8 @@ repositories:
       version: main
     release:
       packages:
-      - ros2launch_security
-      - ros2launch_security_examples
+        - ros2launch_security
+        - ros2launch_security_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
@@ -6390,8 +6401,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - ros_babel_fish
-      - ros_babel_fish_test_msgs
+        - ros_babel_fish
+        - ros_babel_fish_test_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
@@ -6408,8 +6419,8 @@ repositories:
       version: main
     release:
       packages:
-      - battery_state_broadcaster
-      - battery_state_rviz_overlay
+        - battery_state_broadcaster
+        - battery_state_rviz_overlay
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
@@ -6423,7 +6434,7 @@ repositories:
   ros_canopen:
     release:
       packages:
-      - can_msgs
+        - can_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
@@ -6456,13 +6467,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - ros_gz
-      - ros_gz_bridge
-      - ros_gz_image
-      - ros_gz_interfaces
-      - ros_gz_sim
-      - ros_gz_sim_demos
-      - test_ros_gz_bridge
+        - ros_gz
+        - ros_gz_bridge
+        - ros_gz_image
+        - ros_gz_interfaces
+        - ros_gz_sim
+        - ros_gz_sim_demos
+        - test_ros_gz_bridge
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
@@ -6501,8 +6512,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - ros2test
-      - ros_testing
+        - ros2test
+        - ros_testing
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
@@ -6520,8 +6531,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - turtlesim
-      - turtlesim_msgs
+        - turtlesim
+        - turtlesim_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
@@ -6550,30 +6561,30 @@ repositories:
       version: rolling
     release:
       packages:
-      - liblz4_vendor
-      - mcap_vendor
-      - ros2bag
-      - rosbag2
-      - rosbag2_compression
-      - rosbag2_compression_zstd
-      - rosbag2_cpp
-      - rosbag2_examples_cpp
-      - rosbag2_examples_py
-      - rosbag2_interfaces
-      - rosbag2_performance_benchmarking
-      - rosbag2_performance_benchmarking_msgs
-      - rosbag2_py
-      - rosbag2_storage
-      - rosbag2_storage_default_plugins
-      - rosbag2_storage_mcap
-      - rosbag2_storage_sqlite3
-      - rosbag2_test_common
-      - rosbag2_test_msgdefs
-      - rosbag2_tests
-      - rosbag2_transport
-      - shared_queues_vendor
-      - sqlite3_vendor
-      - zstd_vendor
+        - liblz4_vendor
+        - mcap_vendor
+        - ros2bag
+        - rosbag2
+        - rosbag2_compression
+        - rosbag2_compression_zstd
+        - rosbag2_cpp
+        - rosbag2_examples_cpp
+        - rosbag2_examples_py
+        - rosbag2_interfaces
+        - rosbag2_performance_benchmarking
+        - rosbag2_performance_benchmarking_msgs
+        - rosbag2_py
+        - rosbag2_storage
+        - rosbag2_storage_default_plugins
+        - rosbag2_storage_mcap
+        - rosbag2_storage_sqlite3
+        - rosbag2_test_common
+        - rosbag2_test_msgdefs
+        - rosbag2_tests
+        - rosbag2_transport
+        - shared_queues_vendor
+        - sqlite3_vendor
+        - zstd_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
@@ -6590,7 +6601,8 @@ repositories:
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
-    status_description: Maintained in source form only since no ROS 1 packages available
+    status_description:
+      Maintained in source form only since no ROS 1 packages available
       in Rolling
   rosbag2_to_video:
     doc:
@@ -6614,13 +6626,13 @@ repositories:
       version: ros2
     release:
       packages:
-      - rosapi
-      - rosapi_msgs
-      - rosbridge_library
-      - rosbridge_msgs
-      - rosbridge_server
-      - rosbridge_suite
-      - rosbridge_test_msgs
+        - rosapi
+        - rosapi_msgs
+        - rosbridge_library
+        - rosbridge_msgs
+        - rosbridge_server
+        - rosbridge_suite
+        - rosbridge_test_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
@@ -6637,19 +6649,19 @@ repositories:
       version: rolling
     release:
       packages:
-      - rosidl_adapter
-      - rosidl_cli
-      - rosidl_cmake
-      - rosidl_generator_c
-      - rosidl_generator_cpp
-      - rosidl_generator_type_description
-      - rosidl_parser
-      - rosidl_pycommon
-      - rosidl_runtime_c
-      - rosidl_runtime_cpp
-      - rosidl_typesupport_interface
-      - rosidl_typesupport_introspection_c
-      - rosidl_typesupport_introspection_cpp
+        - rosidl_adapter
+        - rosidl_cli
+        - rosidl_cmake
+        - rosidl_generator_c
+        - rosidl_generator_cpp
+        - rosidl_generator_type_description
+        - rosidl_parser
+        - rosidl_pycommon
+        - rosidl_runtime_c
+        - rosidl_runtime_cpp
+        - rosidl_typesupport_interface
+        - rosidl_typesupport_introspection_c
+        - rosidl_typesupport_introspection_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
@@ -6667,8 +6679,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rosidl_core_generators
-      - rosidl_core_runtime
+        - rosidl_core_generators
+        - rosidl_core_runtime
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
@@ -6686,7 +6698,7 @@ repositories:
       version: rolling
     release:
       packages:
-      - rosidl_generator_dds_idl
+        - rosidl_generator_dds_idl
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
@@ -6704,8 +6716,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rosidl_default_generators
-      - rosidl_default_runtime
+        - rosidl_default_generators
+        - rosidl_default_runtime
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
@@ -6755,7 +6767,7 @@ repositories:
       version: rolling
     release:
       packages:
-      - rosidl_generator_py
+        - rosidl_generator_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
@@ -6789,8 +6801,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rosidl_typesupport_c
-      - rosidl_typesupport_cpp
+        - rosidl_typesupport_c
+        - rosidl_typesupport_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
@@ -6808,9 +6820,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - fastrtps_cmake_module
-      - rosidl_typesupport_fastrtps_c
-      - rosidl_typesupport_fastrtps_cpp
+        - fastrtps_cmake_module
+        - rosidl_typesupport_fastrtps_c
+        - rosidl_typesupport_fastrtps_cpp
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
@@ -6828,8 +6840,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rclpy_message_converter
-      - rclpy_message_converter_msgs
+        - rclpy_message_converter
+        - rclpy_message_converter_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
@@ -6858,7 +6870,7 @@ repositories:
   rot_conv_lib:
     release:
       packages:
-      - rot_conv
+        - rot_conv
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
@@ -6903,11 +6915,11 @@ repositories:
       version: rolling
     release:
       packages:
-      - rqt
-      - rqt_gui
-      - rqt_gui_cpp
-      - rqt_gui_py
-      - rqt_py_common
+        - rqt
+        - rqt_gui
+        - rqt_gui_cpp
+        - rqt_gui_py
+        - rqt_py_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
@@ -6940,8 +6952,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rqt_bag
-      - rqt_bag_plugins
+        - rqt_bag
+        - rqt_bag_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
@@ -7034,8 +7046,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - rqt_image_overlay
-      - rqt_image_overlay_layer
+        - rqt_image_overlay
+        - rqt_image_overlay_layer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
@@ -7310,8 +7322,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - rt_manipulators_cpp
-      - rt_manipulators_examples
+        - rt_manipulators_cpp
+        - rt_manipulators_examples
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
@@ -7385,14 +7397,14 @@ repositories:
       version: rolling
     release:
       packages:
-      - rviz2
-      - rviz_assimp_vendor
-      - rviz_common
-      - rviz_default_plugins
-      - rviz_ogre_vendor
-      - rviz_rendering
-      - rviz_rendering_tests
-      - rviz_visual_testing_framework
+        - rviz2
+        - rviz_assimp_vendor
+        - rviz_common
+        - rviz_default_plugins
+        - rviz_ogre_vendor
+        - rviz_rendering
+        - rviz_rendering_tests
+        - rviz_visual_testing_framework
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
@@ -7410,8 +7422,8 @@ repositories:
       version: main
     release:
       packages:
-      - rviz_2d_overlay_msgs
-      - rviz_2d_overlay_plugins
+        - rviz_2d_overlay_msgs
+        - rviz_2d_overlay_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
@@ -7443,8 +7455,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - sdformat_test_files
-      - sdformat_urdf
+        - sdformat_test_files
+        - sdformat_urdf
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
@@ -7569,9 +7581,9 @@ repositories:
       version: main
     release:
       packages:
-      - sick_safevisionary_driver
-      - sick_safevisionary_interfaces
-      - sick_safevisionary_tests
+        - sick_safevisionary_driver
+        - sick_safevisionary_interfaces
+        - sick_safevisionary_tests
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
@@ -7664,10 +7676,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - executive_smach
-      - smach
-      - smach_msgs
-      - smach_ros
+        - executive_smach
+        - smach
+        - smach_msgs
+        - smach_ros
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
@@ -7706,12 +7718,12 @@ repositories:
       version: rolling
     release:
       packages:
-      - soccer_geometry_msgs
-      - soccer_interfaces
-      - soccer_model_msgs
-      - soccer_vision_2d_msgs
-      - soccer_vision_3d_msgs
-      - soccer_vision_attribute_msgs
+        - soccer_geometry_msgs
+        - soccer_interfaces
+        - soccer_model_msgs
+        - soccer_vision_2d_msgs
+        - soccer_vision_3d_msgs
+        - soccer_vision_attribute_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
@@ -7800,8 +7812,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - sros2
-      - sros2_cmake
+        - sros2
+        - sros2_cmake
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
@@ -7880,10 +7892,10 @@ repositories:
       version: master
     release:
       packages:
-      - launch_system_modes
-      - system_modes
-      - system_modes_examples
-      - system_modes_msgs
+        - launch_system_modes
+        - system_modes
+        - system_modes_examples
+        - system_modes_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
@@ -7919,11 +7931,11 @@ repositories:
       version: master
     release:
       packages:
-      - joy_teleop
-      - key_teleop
-      - mouse_teleop
-      - teleop_tools
-      - teleop_tools_msgs
+        - joy_teleop
+        - key_teleop
+        - mouse_teleop
+        - teleop_tools
+        - teleop_tools_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
@@ -8100,8 +8112,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - topic_tools
-      - topic_tools_interfaces
+        - topic_tools
+        - topic_tools_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
@@ -8118,9 +8130,9 @@ repositories:
       version: rolling-devel
     release:
       packages:
-      - trac_ik
-      - trac_ik_kinematics_plugin
-      - trac_ik_lib
+        - trac_ik
+        - trac_ik_kinematics_plugin
+        - trac_ik_lib
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
@@ -8153,8 +8165,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - ros2trace_analysis
-      - tracetools_analysis
+        - ros2trace_analysis
+        - tracetools_analysis
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
@@ -8172,10 +8184,10 @@ repositories:
       version: main
     release:
       packages:
-      - asio_cmake_module
-      - io_context
-      - serial_driver
-      - udp_driver
+        - asio_cmake_module
+        - io_context
+        - serial_driver
+        - udp_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
@@ -8237,9 +8249,9 @@ repositories:
       version: ros2
     release:
       packages:
-      - turtlebot3_fake_node
-      - turtlebot3_gazebo
-      - turtlebot3_simulations
+        - turtlebot3_fake_node
+        - turtlebot3_gazebo
+        - turtlebot3_simulations
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
@@ -8271,16 +8283,16 @@ repositories:
       version: ros2
     release:
       packages:
-      - tuw_airskin_msgs
-      - tuw_geo_msgs
-      - tuw_geometry_msgs
-      - tuw_graph_msgs
-      - tuw_msgs
-      - tuw_multi_robot_msgs
-      - tuw_nav_msgs
-      - tuw_object_map_msgs
-      - tuw_object_msgs
-      - tuw_std_msgs
+        - tuw_airskin_msgs
+        - tuw_geo_msgs
+        - tuw_geometry_msgs
+        - tuw_graph_msgs
+        - tuw_msgs
+        - tuw_multi_robot_msgs
+        - tuw_nav_msgs
+        - tuw_object_map_msgs
+        - tuw_object_msgs
+        - tuw_std_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_msgs-release.git
@@ -8357,10 +8369,10 @@ repositories:
       version: ros2
     release:
       packages:
-      - ublox
-      - ublox_gps
-      - ublox_msgs
-      - ublox_serialization
+        - ublox
+        - ublox_gps
+        - ublox_msgs
+        - ublox_serialization
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
@@ -8378,12 +8390,12 @@ repositories:
       version: main
     release:
       packages:
-      - ntrip_client_node
-      - ublox_dgnss
-      - ublox_dgnss_node
-      - ublox_nav_sat_fix_hp_node
-      - ublox_ubx_interfaces
-      - ublox_ubx_msgs
+        - ntrip_client_node
+        - ublox_dgnss
+        - ublox_dgnss_node
+        - ublox_nav_sat_fix_hp_node
+        - ublox_ubx_interfaces
+        - ublox_ubx_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
@@ -8487,12 +8499,12 @@ repositories:
       version: main
     release:
       packages:
-      - ur
-      - ur_calibration
-      - ur_controllers
-      - ur_dashboard_msgs
-      - ur_moveit_config
-      - ur_robot_driver
+        - ur
+        - ur_calibration
+        - ur_controllers
+        - ur_dashboard_msgs
+        - ur_moveit_config
+        - ur_robot_driver
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
@@ -8520,8 +8532,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - urdf
-      - urdf_parser_plugin
+        - urdf
+        - urdf_parser_plugin
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
@@ -8555,7 +8567,7 @@ repositories:
       version: ros2
     release:
       packages:
-      - urdfdom_py
+        - urdfdom_py
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
@@ -8697,12 +8709,12 @@ repositories:
       version: rolling
     release:
       packages:
-      - desktop
-      - desktop_full
-      - perception
-      - ros_base
-      - ros_core
-      - simulation
+        - desktop
+        - desktop_full
+        - perception
+        - ros_base
+        - ros_core
+        - simulation
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
@@ -8720,11 +8732,11 @@ repositories:
       version: ros2
     release:
       packages:
-      - velodyne
-      - velodyne_driver
-      - velodyne_laserscan
-      - velodyne_msgs
-      - velodyne_pointcloud
+        - velodyne
+        - velodyne_driver
+        - velodyne_laserscan
+        - velodyne_msgs
+        - velodyne_pointcloud
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
@@ -8741,9 +8753,9 @@ repositories:
       version: foxy-devel
     release:
       packages:
-      - velodyne_description
-      - velodyne_gazebo_plugins
-      - velodyne_simulator
+        - velodyne_description
+        - velodyne_gazebo_plugins
+        - velodyne_simulator
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne_simulator-release.git
@@ -8760,8 +8772,8 @@ repositories:
       version: ros2
     release:
       packages:
-      - vision_msgs
-      - vision_msgs_rviz_plugins
+        - vision_msgs
+        - vision_msgs_rviz_plugins
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
@@ -8794,9 +8806,9 @@ repositories:
       version: rolling
     release:
       packages:
-      - cv_bridge
-      - image_geometry
-      - vision_opencv
+        - cv_bridge
+        - image_geometry
+        - vision_opencv
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
@@ -8923,18 +8935,18 @@ repositories:
       version: master
     release:
       packages:
-      - webots_ros2
-      - webots_ros2_control
-      - webots_ros2_driver
-      - webots_ros2_epuck
-      - webots_ros2_importer
-      - webots_ros2_mavic
-      - webots_ros2_msgs
-      - webots_ros2_tesla
-      - webots_ros2_tests
-      - webots_ros2_tiago
-      - webots_ros2_turtlebot
-      - webots_ros2_universal_robot
+        - webots_ros2
+        - webots_ros2_control
+        - webots_ros2_driver
+        - webots_ros2_epuck
+        - webots_ros2_importer
+        - webots_ros2_mavic
+        - webots_ros2_msgs
+        - webots_ros2_tesla
+        - webots_ros2_tests
+        - webots_ros2_tiago
+        - webots_ros2_turtlebot
+        - webots_ros2_universal_robot
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
@@ -8979,11 +8991,11 @@ repositories:
       version: main
     release:
       packages:
-      - yasmin
-      - yasmin_demos
-      - yasmin_msgs
-      - yasmin_ros
-      - yasmin_viewer
+        - yasmin
+        - yasmin_demos
+        - yasmin_msgs
+        - yasmin_ros
+        - yasmin_viewer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
@@ -9000,8 +9012,8 @@ repositories:
       version: rolling
     release:
       packages:
-      - zbar_ros
-      - zbar_ros_interfaces
+        - zbar_ros
+        - zbar_ros_interfaces
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git


### PR DESCRIPTION
# Please add kompass_interfaces to be indexed in the rosdistro

## Package name:

`kompass_interfaces`

## Package Upstream Source:

https://github.com/automatika-robotics/kompass.git

## Purpose of using this:

`kompass_interfaces` contains the ROS2 interfaces (msg/srv/action) for `kompass` package


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
