### PR TITLE
fix branch names for kinematics_interface_pinocchio

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3796,7 +3796,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: main
+      version: ros-humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3805,7 +3805,7 @@ repositories:
     source:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: main
+      version: ros-humble
     status: maintained
   kobuki_core:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3249,7 +3249,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: main
+      version: ros-jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -3258,7 +3258,7 @@ repositories:
     source:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: main
+      version: ros-jazzy
     status: maintained
   kobuki_core:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2897,7 +2897,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: main
+      version: ros-rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -2906,7 +2906,7 @@ repositories:
     source:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: main
+      version: ros-rolling
     status: maintained
   kobuki_core:
     doc:


### PR DESCRIPTION
I had accidentally pointed the kinematics_interface_pinocchio package branches to the default branches for both rolling and jazzy versions (https://github.com/ros/rosdistro/pull/44058 and https://github.com/ros/rosdistro/pull/44057) resulting in buildfarm errors (apologies).
This PR fixes this by using the right branches. Affects mainly jazzy and rolling (humble branch is now made explicit to avoid confusion, but is identical to the previous version). 
