### PR TITLE
tensorrt_cmake_module: 0.0.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7997,7 +7997,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
-      version: 0.0.3-3
+      version: 0.0.4-2
     source:
       type: git
       url: https://github.com/tier4/tensorrt_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tensorrt_cmake_module` to `0.0.4-2`:

- upstream repository: https://github.com/tier4/tensorrt_cmake_module.git
- release repository: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-3`

## tensorrt_cmake_module

```
* feat: not including deprecated lib for TRT 9+ (#1 <https://github.com/tier4/tensorrt_cmake_module//issues/1>)
* Contributors: Amadeusz Szymko
```
