### PR TITLE
xacro: 2.0.12-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8977,7 +8977,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.11-1
+      version: 2.0.12-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.12-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.11-1`

## xacro

```
* Python 3.13 introduced new attr argument to _write_data (#353 <https://github.com/ros/xacro/issues/353>)
* pyproject.toml: Automatically determine version from git
* Add function python.vars() (#348 <https://github.com/ros/xacro/issues/348>)
* Contributors: Robert Haschke
```
