### PR TITLE
README: expand description of packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-This repo maintains the lists of repositories defining ROS distributions.
+The rosdistro repository stores two independent datasets used in ROS:
 
-It is the implementation of [REP 143](http://ros.org/reps/rep-0143.html).
+1. The lists of repositories that curate ROS packages for each ROS distributions,
+   implementing the data structure defined in [REP 143](http://ros.org/reps/rep-0143.html).
+   Any ROS package release will generate pull requests to the distribution files
+   in this repository.
 
-It also the home of the rosdep rules.
+2. The rosdep rules database, which map the package names used in package.xml files to
+   system package names.
 
 Guide to Contributing
 ---------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The rosdistro repository stores two independent datasets used in ROS:
+This repository maintains two independent sets of packaging metadata used in ROS:
 
 1. The lists of repositories that curate ROS packages for each ROS distributions,
    implementing the data structure defined in [REP 143](http://ros.org/reps/rep-0143.html).


### PR DESCRIPTION
This is not a typical pull request; it's just updating the README with an expanded description of the two types of data contained in this repository in a way that I think is more readable. Thanks in advance for helping to correct any inaccuracies in my phrasing.