### PR TITLE
Add insight_gui to Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3110,6 +3110,12 @@ repositories:
       url: https://github.com/CCNYRoboticsLab/imu_tools.git
       version: jazzy
     status: maintained
+  insight_gui:
+    source:
+      type: git
+      url: https://github.com/julianmueller/insight_gui.git
+      version: jazzy
+    status: developed
   interactive_marker_twist_server:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

https://github.com/julianmueller/insight_gui

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
