### PR TITLE
mola_state_estimation: 1.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4978,7 +4978,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.6.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.0-1`

## mola_imu_preintegration

```
* Fix package.xml URLs
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation

```
* Fix package.xml URLs
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_simple

```
* Merge pull request #1 <https://github.com/MOLAorg/mola_state_estimation/issues/1> from MOLAorg/9-need-help-on-integrating-imu-for-lidar-odometry
  More stable integration of IMU twist information
* Shorter logger name
* Fix package.xml URLs
* tolerate unsorted sensor inputs without throwing
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Shorter logger name
* Contributors: Jose Luis Blanco-Claraco
```
