### PR TITLE
mola_lidar_odometry: 0.5.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4105,7 +4105,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.5.2-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## mola_lidar_odometry

```
* Merge pull request #11 from MOLAorg/10-bad-first-icp-re-starting-from-scratch-with-a-new-local-map
  Fix NaN pointcloud radius in doInitializeEstimatedMaxSensorRange()
* Unit tests: add test run against MulRan dataset fragment (Lidar+IMU)
* cli: fix name of example pipeline file when --help invoked
* unit tests: fix wrong usage of state estimator yaml file
* mola-lo-gui-mulran: show IMU & GPS data in GUI
* Define a sensible value for maxRange
* Fix cmake warning when built w/o mola_state_estimation_simple sourced in the env
* Contributors: Jose Luis Blanco-Claraco
```
