### PR TITLE
py_trees: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6809,7 +6809,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.2.3-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.3.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/ros2-gbp/py_trees-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.3-1`

## py_trees

```
* [code] Fix CI and update to latest Ubuntu/Python versions (#454 <https://github.com/splintered-reality/py_trees/issues/454>)
* [behaviours] Shorten line in docstring (#450 <https://github.com/splintered-reality/py_trees/issues/450>)
* [docs] add ticking tree
* [composites] Reduce circulation when the parallel node policy is SuccessOnOne (#440 <https://github.com/splintered-reality/py_trees/issues/440>)
* [docs] fix make target (#430 <https://github.com/splintered-reality/py_trees/issues/430>)
* [composites] use typing.Sequence for children argument (#436 <https://github.com/splintered-reality/py_trees/issues/436>)
* Improve timing of tick_tock() and allow stopping on terminal state (#444 <https://github.com/splintered-reality/py_trees/issues/444>)
* [vscode] update extensions, set spell checking to UK
* [behaviours] add ProbabilisticBehaviour(Behaviour)
* [readme] consolidate development instructions
* [code] remove unused import
* [vscode] recommend extensions, especially devcontainers
* Contributors: Daniel Stonier, Efe Mert Demir, Nino Walker, Sebastian Castro, gitpushoriginmaster, wanfeng
```
