### PR TITLE
py_trees_ros: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6841,7 +6841,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros-release.git
-      version: 2.2.2-3
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.3.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros
- release repository: https://github.com/ros2-gbp/py_trees_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.2-3`

## py_trees_ros

```
* [behaviours] Implement Behaviors to Interact with ROS Services (#215 <https://github.com/splintered-reality/py_trees_ros/issues/215>)
* [behaviours] Support setting subscription callback_group (#220 <https://github.com/splintered-reality/py_trees_ros/issues/220>)
* [behaviours] Add keyword arguments to setup
* [vscode] gl capabilities in the devcontainer
* [readme] py-trees-js status for rolling, humble
* [readme] deb install instructions for ros2
* [readme] py-trees-ros build status for rolling, humble
* Contributors: Amal Nanavati, Daniel Stonier, Hervé Audren, fred-labs
```
