### PR TITLE
py_trees_ros_interfaces: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5577,7 +5577,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
-      version: 2.1.0-4
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.1.1-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces
- release repository: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-4`

## py_trees_ros_interfaces

```
* Update minimum CMake version
* [readme] fix alignment in columns
* [readme] update release links
* Contributors: Daniel Stonier, Sebastian Castro
```
