### PR TITLE
py_trees_js: 0.6.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5545,7 +5545,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.5-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/ros2-gbp/py_trees_js-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.4-1`

## py_trees_js

```
* [formatter] reformat auto-generated resources.py
* [linter] 2 lines between methods
* [readme] fix preview instructions, elucidate non-nvidia alternatives
* [vscode] devcontainer DISPLAY fix
* Contributors: Daniel Stonier
```
