### PR TITLE
Add `py_trees_ros_tutorials` and `py_trees_ros_viewer` to Rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6864,6 +6864,13 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: release/2.1.x
     status: maintained
+  py_trees_ros_tutorials:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    status: developed
   py_trees_ros_viewer:
     source:
       test_pull_requests: true

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6864,6 +6864,13 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: release/2.1.x
     status: maintained
+  py_trees_ros_viewer:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:

https://github.com/splintered-reality/py_trees_ros_tutorials.git
https://github.com/splintered-reality/py_trees_ros_viewer.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
