### PR TITLE
Add heightmap_spawner package

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3283,6 +3283,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
     status: maintained
+  heightmap_spawner:
+    source:
+      type: git
+      url: https://github.com/damanikjosh/heightmap_spawner.git
+      version: humble
+    status: developed
   hey5_description:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2928,6 +2928,12 @@ repositories:
       url: https://github.com/tu-darmstadt-ros-pkg/hector_rviz_overlay.git
       version: jazzy
     status: maintained
+  heightmap_spawner:
+    source:
+      type: git
+      url: https://github.com/damanikjosh/heightmap_spawner.git
+      version: jazzy
+    status: developed
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

heightmap_spawner

## Package Upstream Source:

[https://github.com/damanikjosh/heightmap_spawner](https://github.com/damanikjosh/heightmap_spawner)

## Purpose of using this:

A ROS 2 package that converts occupancy grids from `nav2_map_server` into 3D heightmap models for use in Gazebo simulations.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

Currently, only source available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

heightmap_spawner

# The source is here:

https://github.com/damanikjosh/heightmap_spawner

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
