### PR TITLE
Add hyveos_bridge and hyveos_msgs to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2599,6 +2599,18 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hyveos:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros.git
+      version: main
+    status: developed
+  hyveos_msgs:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros_msgs.git
+      version: main
+    status: developed
   iceoryx:
     release:
       packages:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2599,7 +2599,7 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
-  hyveos:
+  hyveos_bridge:
     source:
       type: git
       url: https://github.com/p2p-industries/hyveos_ros.git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:

- https://github.com/p2p-industries/hyveos_ros.git
- https://github.com/p2p-industries/hyveos_ros_msgs.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro, see https://github.com/p2p-industries/hyveos_ros/actions/runs/12740928363 and https://github.com/p2p-industries/hyveos_ros_msgs/actions/runs/12742117089
