### PR TITLE
ros2_controllers: 2.41.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8190,7 +8190,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.40.0-1
+      version: 2.41.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.41.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.40.0-1`

## ackermann_steering_controller

```
* Fix typos in steering_controllers_lib (backport #1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>) (#1466 <https://github.com/ros-controls/ros2_controllers/issues/1466>)
* Contributors: mergify[bot]
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Fix typos in steering_controllers_lib (backport #1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>) (#1466 <https://github.com/ros-controls/ros2_controllers/issues/1466>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Check dt in updateFromVelocity (backport #1481 <https://github.com/ros-controls/ros2_controllers/issues/1481>) (#1486 <https://github.com/ros-controls/ros2_controllers/issues/1486>)
* Remove empty on_shutdown() callbacks (backport #1477 <https://github.com/ros-controls/ros2_controllers/issues/1477>) (#1482 <https://github.com/ros-controls/ros2_controllers/issues/1482>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Remove empty on_shutdown() callbacks (backport #1477 <https://github.com/ros-controls/ros2_controllers/issues/1477>) (#1482 <https://github.com/ros-controls/ros2_controllers/issues/1482>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

```
* [pose_broadcaster] Check for valid pose before attempting to publish a tf for it (backport #1479 <https://github.com/ros-controls/ros2_controllers/issues/1479>) (#1483 <https://github.com/ros-controls/ros2_controllers/issues/1483>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Update generate_parameter_library dependency in steering_controllers_library (backport #1465 <https://github.com/ros-controls/ros2_controllers/issues/1465>) (#1468 <https://github.com/ros-controls/ros2_controllers/issues/1468>)
* Fix typos in steering_controllers_lib (backport #1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>) (#1466 <https://github.com/ros-controls/ros2_controllers/issues/1466>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Remove empty on_shutdown() callbacks (backport #1477 <https://github.com/ros-controls/ros2_controllers/issues/1477>) (#1482 <https://github.com/ros-controls/ros2_controllers/issues/1482>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* Fix typos in steering_controllers_lib (backport #1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>) (#1466 <https://github.com/ros-controls/ros2_controllers/issues/1466>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
