### PR TITLE
ros2_control: 4.24.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6792,7 +6792,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.23.0-1
+      version: 4.24.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.24.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.23.0-1`

## controller_interface

```
* Trigger shutdown transition in destructor (#1979 <https://github.com/ros-controls/ros2_control/issues/1979>)
* Contributors: Christoph Fröhlich
```

## controller_manager

```
* [CM] Remove obsolete ControllerMock from the tests (#1990 <https://github.com/ros-controls/ros2_control/issues/1990>)
* Initialize robot description in ControllerManager (#1983 <https://github.com/ros-controls/ros2_control/issues/1983>)
* Contributors: Dominic Reber, Wiktor Bajor
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add missing link of mock_components to hardware_interface (#1992 <https://github.com/ros-controls/ros2_control/issues/1992>)
* Using urdf/model.hpp for rolling (#1978 <https://github.com/ros-controls/ros2_control/issues/1978>)
* Remove visibility include from docs (#1975 <https://github.com/ros-controls/ros2_control/issues/1975>)
* Contributors: Christoph Fröhlich, Silvio Traversaro, verma nakul
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Return strong type for joint_limits helpers (#1981 <https://github.com/ros-controls/ros2_control/issues/1981>)
* Trigger shutdown transition in destructor (#1979 <https://github.com/ros-controls/ros2_control/issues/1979>)
* Add joint limiter interface plugins to enforce limits defined in the URDF (#1526 <https://github.com/ros-controls/ros2_control/issues/1526>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Wiktor Bajor
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
