### PR TITLE
ros2_controllers: 4.19.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6833,7 +6833,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.18.0-1
+      version: 4.19.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.19.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.18.0-1`

## ackermann_steering_controller

```
* Fix typos in steering_controllers_lib (#1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## admittance_controller

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## bicycle_steering_controller

```
* Fix typos in steering_controllers_lib (#1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## diff_drive_controller

```
* Check dt in updateFromVelocity (#1481 <https://github.com/ros-controls/ros2_controllers/issues/1481>)
* Remove empty on_shutdown() callbacks (#1477 <https://github.com/ros-controls/ros2_controllers/issues/1477>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Julia Jia, Tony Najjar
```

## effort_controllers

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## force_torque_sensor_broadcaster

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## forward_command_controller

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## gpio_controllers

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## gripper_controllers

```
* Remove custom logic to skip configuration of gripper_controllers on Windows or macOS (#1471 <https://github.com/ros-controls/ros2_controllers/issues/1471>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Silvio Traversaro
```

## imu_sensor_broadcaster

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## joint_state_broadcaster

```
* Use urdf/model.hpp for rolling (#1476 <https://github.com/ros-controls/ros2_controllers/issues/1476>)
* Use urdf/model.hpp for rolling (#1473 <https://github.com/ros-controls/ros2_controllers/issues/1473>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, verma nakul
```

## joint_trajectory_controller

```
* Remove empty on_shutdown() callbacks (#1477 <https://github.com/ros-controls/ros2_controllers/issues/1477>)
* Use urdf/model.hpp for rolling (#1473 <https://github.com/ros-controls/ros2_controllers/issues/1473>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Julia Jia, verma nakul
```

## mecanum_drive_controller

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Clean up unused variable EPS in mecanum_drive_controller (#1444 <https://github.com/ros-controls/ros2_controllers/issues/1444>)
* Contributors: Bence Magyar, Shankar-Balajee
```

## parallel_gripper_controller

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## pid_controller

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## pose_broadcaster

```
* [pose_broadcaster] Check for valid pose before attempting to publish a tf for it (#1479 <https://github.com/ros-controls/ros2_controllers/issues/1479>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Felix Exner
```

## position_controllers

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## range_sensor_broadcaster

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Update generate_parameter_library dependency in steering_controllers_library (#1465 <https://github.com/ros-controls/ros2_controllers/issues/1465>)
* Fix typos in steering_controllers_lib (#1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>)
* Fix open-loop odometry in case of ref timeout (#1454 <https://github.com/ros-controls/ros2_controllers/issues/1454>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Christoph Fröhlich, Silvio Traversaro
```

## tricycle_controller

```
* Remove empty on_shutdown() callbacks (#1477 <https://github.com/ros-controls/ros2_controllers/issues/1477>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Julia Jia
```

## tricycle_steering_controller

```
* Fix typos in steering_controllers_lib (#1464 <https://github.com/ros-controls/ros2_controllers/issues/1464>)
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar, Christoph Fröhlich
```

## velocity_controllers

```
* Remove visibility macros (#1451 <https://github.com/ros-controls/ros2_controllers/issues/1451>)
* Contributors: Bence Magyar
```
