### PR TITLE
Add source entry for urinterfaces

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11227,6 +11227,12 @@ repositories:
       url: https://github.com/ros-drivers/urg_node_msgs.git
       version: master
     status: maintained
+  urinterfaces:
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/urinterfaces.git
+      version: master
+    status: developed
   usb_cam:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here: 

https://github.com/UniversalRobots/urinterfaces

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro