### PR TITLE
clearpath_msgs: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1042,7 +1042,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_msgs-release.git
-      version: 1.0.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_msgs.git
- release repository: https://github.com/clearpath-gbp/clearpath_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## clearpath_motor_msgs

```
* A300 (#63 <https://github.com/clearpathrobotics/clearpath_msgs/issues/63>)
  * Added Lynx messages and actions
  * Added A300 changes and enums
  * Added temperature message
* Contributors: Luis Camero, Roni Kreinin, Tony Baltovski
```

## clearpath_msgs

```
* A300 (#63 <https://github.com/clearpathrobotics/clearpath_msgs/issues/63>)
  * Added Lynx messages and actions
  * Added A300 changes and enums
  * Added temperature message
* Contributors: Roni Kreinin, Tony Baltovski
```

## clearpath_platform_msgs

```
* Corrected A300 front light indices
* A300 (#63 <https://github.com/clearpathrobotics/clearpath_msgs/issues/63>)
  * Added Lynx messages and actions
  * Added A300 changes and enums
  * Added temperature message
* Contributors: Roni Kreinin, Tony Baltovski
```
