### PR TITLE
Add pyubx2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10739,7 +10739,7 @@ python3-zmq:
   nixos: [python3Packages.pyzmq]
   rhel: [python3-zmq]
   ubuntu: [python3-zmq]
-pyubx2:
+pyubx2-pip:
   ubuntu:
     pip:
       packages: [pyubx2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10739,6 +10739,10 @@ python3-zmq:
   nixos: [python3Packages.pyzmq]
   rhel: [python3-zmq]
   ubuntu: [python3-zmq]
+pyubx2:
+  ubuntu:
+    pip:
+      packages: [pyubx2]
 qdarkstyle-pip:
   debian:
     pip: [qdarkstyle]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9040,6 +9040,10 @@ python3-pytrinamic-pip:
   ubuntu:
     pip:
       packages: [pytrinamic]
+python3-pyubx2-pip:
+  '*':
+    pip:
+      packages: [pyubx2]
 python3-pyudev:
   debian: [python3-pyudev]
   fedora: [python3-pyudev]
@@ -10739,10 +10743,6 @@ python3-zmq:
   nixos: [python3Packages.pyzmq]
   rhel: [python3-zmq]
   ubuntu: [python3-zmq]
-python3-pyubx2-pip:
-  '*':
-    pip:
-      packages: [pyubx2]
 qdarkstyle-pip:
   debian:
     pip: [qdarkstyle]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10739,8 +10739,8 @@ python3-zmq:
   nixos: [python3Packages.pyzmq]
   rhel: [python3-zmq]
   ubuntu: [python3-zmq]
-pyubx2-pip:
-  ubuntu:
+python3-pyubx2-pip:
+  '*':
     pip:
       packages: [pyubx2]
 qdarkstyle-pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pyubx2

## Package Upstream Source:

https://github.com/semuconsulting/pyubx2

## Purpose of using this:

It's a "Python library for parsing and generating UBX GPS/GNSS protocol messages." 

## Links to Distribution Packages

https://pypi.org/project/pyubx2/

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
