### PR TITLE
generate_parameter_library: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1996,13 +1996,14 @@ repositories:
       - cmake_generate_parameter_module_example
       - generate_parameter_library
       - generate_parameter_library_example
+      - generate_parameter_library_example_external
       - generate_parameter_library_py
       - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.9-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.4.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.9-1`

## cmake_generate_parameter_module_example

- No changes

## generate_parameter_library

```
* Change header install path (#213 <https://github.com/PickNikRobotics/generate_parameter_library/issues/213>)
* Contributors: Auguste Bourgois
```

## generate_parameter_library_example

```
* Change header install path (#213 <https://github.com/PickNikRobotics/generate_parameter_library/issues/213>)
* Contributors: Auguste Bourgois
```

## generate_parameter_library_example_external

```
* Change header install path (#213 <https://github.com/PickNikRobotics/generate_parameter_library/issues/213>)
* Contributors: Auguste Bourgois
```

## generate_parameter_library_py

```
* Unit test friendly folder structure for Python examples (#237 <https://github.com/PickNikRobotics/generate_parameter_library/issues/237>)
* Fix conversion typos (#238 <https://github.com/PickNikRobotics/generate_parameter_library/issues/238>)
* Apply clang-tidy suggestions to std::move certain variables (#228 <https://github.com/PickNikRobotics/generate_parameter_library/issues/228>)
* Contributors: Sebastian Castro
```

## generate_parameter_module_example

```
* Unit test friendly folder structure for Python examples (#237 <https://github.com/PickNikRobotics/generate_parameter_library/issues/237>)
* Fix flake8 error in publisher example (#229 <https://github.com/PickNikRobotics/generate_parameter_library/issues/229>)
* Contributors: Sebastian Castro
```

## parameter_traits

- No changes
