### PR TITLE
py_trees_ros_viewer: 0.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5086,6 +5086,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: devel
     status: developed
+  py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
+      version: 0.2.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: developed
   pybind11_json_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.2.4-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer
- release repository: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## py_trees_ros_viewer

```
* [code] Fixed Namespace switching error (#35 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/35>)
* [code] Update deprecated QoS settings (#34 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/34>)
* [infra] resolve chrome 80+ incompatibility (#32 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/32>)
* Contributors: Daniel Stonier, Sebastian Castro, J Keshav Bhupathy Vignesh
```
