### PR TITLE
py_trees_ros_viewer: 0.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5096,7 +5096,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Unfortunately, the last version's build was bad...

Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.2.5-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer
- release repository: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.4-1`

## py_trees_ros_viewer

```
* [readme] Small tweaks (#41 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/41>)
* [infra] Fix repo URL in package.xml
* [infra] Add dummy test to make buildfarm happy (#40 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/40>)
* Contributors: Sebastian Castro
```
