### PR TITLE
Add `rmw_desert` to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6008,6 +6008,16 @@ repositories:
       url: https://github.com/ros2/rmw_dds_common.git
       version: rolling
     status: maintained
+  rmw_desert:
+    doc:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.wiki.git
+      version: 1.0
+    source:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: 1.0
+    status: maintained
   rmw_fastrtps:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6041,11 +6041,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.wiki.git
-      version: 1.0
+      version: master
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
-      version: 1.0
+      version: main
     status: maintained
   rmw_fastrtps:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6040,8 +6040,8 @@ repositories:
   rmw_desert:
     doc:
       type: git
-      url: https://github.com/signetlabdei/rmw_desert.wiki.git
-      version: master
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: main
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Rolling

# The source is here:

[https://github.com/signetlabdei/rmw_desert](https://github.com/signetlabdei/rmw_desert)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
