### PR TITLE
ros_gz: 2.1.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6528,7 +6528,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.2-1
+      version: 2.1.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.3-2`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.2-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Use both ROS package and message name for unique mappings (#656 <https://github.com/gazebosim/ros_gz/issues/656>)
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Merge pull request #664 <https://github.com/gazebosim/ros_gz/issues/664> from azeey/improve_parameter_handling
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Merge pull request #663 <https://github.com/gazebosim/ros_gz/issues/663> from azeey/improve_arg_parsing
  The RosGzBridge and GzServer now support different spellings for
  boolean arguments (True, true). This also simplifies how
  conditionals are used to create composable nodes by evaluating the
  conditionals and using them as regular Python booleans instead of
  relying on PythonExpression. It was actually the PythonExpression
  that was preventing support of boolean arguments spelled true/false.
* Improve parameter handling for RosGzBridge
* Fix linter errors
* Improve argument parsing in Actions
  The RosGzBridge and GzServer now support different spellings for
  boolean arguments (True, true). This also simplifies how
  conditionals are used to create composable nodes by evaluating the
  conditionals and using them as regular Python booleans instead of
  relying on PythonExpression. It was actually the PythonExpression
  that was preventing support of boolean arguments spelled true/false.
* Fix use_respawn argument causing errors (#651 <https://github.com/gazebosim/ros_gz/issues/651>)
* Add a way to pass extra parameters to ros_gz_bridge (#628 <https://github.com/gazebosim/ros_gz/issues/628>)
  * Add bridge_params argument to ros_gz_bridge
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Wiktor Bajor <mailto:69388767+Wiktor-99@users.noreply.github.com>
* Contributors: Aarav Gupta, Addisu Z. Taddese, Alejandro Hernández Cordero, Øystein Sture
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Shutdown explicitly while existing (#623 <https://github.com/gazebosim/ros_gz/issues/623>)
* Merge pull request #663 <https://github.com/gazebosim/ros_gz/issues/663> from azeey/improve_arg_parsing
  The RosGzBridge and GzServer now support different spellings for
  boolean arguments (True, true). This also simplifies how
  conditionals are used to create composable nodes by evaluating the
  conditionals and using them as regular Python booleans instead of
  relying on PythonExpression. It was actually the PythonExpression
  that was preventing support of boolean arguments spelled true/false.
* Fix linter errors
* Improve argument parsing in Actions
  The RosGzBridge and GzServer now support different spellings for
  boolean arguments (True, true). This also simplifies how
  conditionals are used to create composable nodes by evaluating the
  conditionals and using them as regular Python booleans instead of
  relying on PythonExpression. It was actually the PythonExpression
  that was preventing support of boolean arguments spelled true/false.
* Set env path (#659 <https://github.com/gazebosim/ros_gz/issues/659>)
* Use member variables instead. (#653 <https://github.com/gazebosim/ros_gz/issues/653>)
* Move gzserver logic to its action (#646 <https://github.com/gazebosim/ros_gz/issues/646>)
* Add a way to pass extra parameters to ros_gz_bridge (#628 <https://github.com/gazebosim/ros_gz/issues/628>)
  * Add bridge_params argument to ros_gz_bridge
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Wiktor Bajor <mailto:69388767+Wiktor-99@users.noreply.github.com>
* Add remove entity node (#629 <https://github.com/gazebosim/ros_gz/issues/629>)
* Contributors: Aarav Gupta, Addisu Z. Taddese, Alejandro Hernández Cordero, Carlos Agüero, ChenYing Kuo (CY), Tatsuro Sakaguchi, Wiktor Bajor
```

## ros_gz_sim_demos

```
* Refactor triggered_camera demo (#645 <https://github.com/gazebosim/ros_gz/issues/645>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Refactor rgbd_camera_bridge demo (#643 <https://github.com/gazebosim/ros_gz/issues/643>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Refactor diff_drive demo (#635 <https://github.com/gazebosim/ros_gz/issues/635>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Refactor gpu_lidar_bridge demo (#636 <https://github.com/gazebosim/ros_gz/issues/636>)
  * Refactor gpu_lidar_bridge demo
* Refactor camera demo (#634 <https://github.com/gazebosim/ros_gz/issues/634>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Refactor battery demo (#633 <https://github.com/gazebosim/ros_gz/issues/633>)
* Refactor tf_bridge demo (#644 <https://github.com/gazebosim/ros_gz/issues/644>)
* Refactor magnetometer demo (#638 <https://github.com/gazebosim/ros_gz/issues/638>)
* Refactor imu demo (#637 <https://github.com/gazebosim/ros_gz/issues/637>)
  * Refactor imu demo
* Refactor navsat_gpxfix demo (#642 <https://github.com/gazebosim/ros_gz/issues/642>)
  * Refactor navsat_gpxfix demo
* Refactor navsat demo (#639 <https://github.com/gazebosim/ros_gz/issues/639>)
  * Refactor navsat demo
* Refactor air pressure demo (#632 <https://github.com/gazebosim/ros_gz/issues/632>)
  * Refactor air pressure demo
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Carlos Agüero
```

## test_ros_gz_bridge

- No changes
