### PR TITLE
rviz: 11.2.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9428,7 +9428,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.15-1
+      version: 11.2.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.16-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `11.2.15-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Add RVIZ_COMMON_PUBLIC macro to ToolManager (#1323 <https://github.com/ros2/rviz/issues/1323>) (#1326 <https://github.com/ros2/rviz/issues/1326>)
  (cherry picked from commit ad4813f819e09d05096515045f1688989fb00b81)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Add RVIZ_COMMON_PUBLIC macro (#865 <https://github.com/ros2/rviz/issues/865>) (#1324 <https://github.com/ros2/rviz/issues/1324>)
  (cherry picked from commit 3584a2981d9b49a53d03dc243ce7be8dc142b758)
  Co-authored-by: juchajam <mailto:79612680+msjunechang21@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
