### PR TITLE
rviz: 14.1.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8154,7 +8154,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.6-1
+      version: 14.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.7-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Add RVIZ_COMMON_PUBLIC macro to ToolManager (#1323 <https://github.com/ros2/rviz/issues/1323>) (#1325 <https://github.com/ros2/rviz/issues/1325>)
  (cherry picked from commit ad4813f819e09d05096515045f1688989fb00b81)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
