### PR TITLE
rmf_traffic_editor: 1.9.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6460,7 +6460,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.9.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.9.1-1`

## rmf_building_map_tools

```
* Add flag to skip calculating and setting camera pose (#523 <https://github.com/open-rmf/rmf_traffic_editor//issues/523>)
* Add the ability to customize the base world file (#519 <https://github.com/open-rmf/rmf_traffic_editor//issues/519>)
* Contributors: Aaron Chong, Arjo Chakravarty
```

## rmf_traffic_editor

- No changes

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

- No changes
