### PR TITLE
turtlebot4_setup: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10768,7 +10768,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_setup-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_setup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_setup` to `1.0.5-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_setup.git
- release repository: https://github.com/ros2-gbp/turtlebot4_setup-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.4-1`

## turtlebot4_setup

```
* Remove dhcp true because it was causing eth0 to lose the static IP (#17 <https://github.com/turtlebot/turtlebot4_setup/issues/17>)
* Change the post-install chrony file command from mv to cp. Only copy if the file actually exists.
* Contributors: Chris Iverach-Brereton, Hilary Luo
```
