### PR TITLE
rviz: 14.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7458,7 +7458,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.0-1
+      version: 14.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.4.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.4.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix preferred tools loading names (#1321 <https://github.com/ros2/rviz/issues/1321>)
* Add RVIZ_COMMON_PUBLIC macro to ToolManager (#1323 <https://github.com/ros2/rviz/issues/1323>)
* Clean visualization_manager.cpp (#1317 <https://github.com/ros2/rviz/issues/1317>)
* Contributors: RaduPopescu, Silvio Traversaro, mosfet80
```

## rviz_default_plugins

```
* Fixed the XY Orbit controller move (#1327 <https://github.com/ros2/rviz/issues/1327>)
  Co-authored-by: Terry Scott <mailto:tscott@seegrid.com>
* Contributors: Terry Scott
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
