### PR TITLE
control_toolbox: 3.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1083,7 +1083,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.5.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-1`

## control_toolbox

```
* Update plugin lib exception handling (#263 <https://github.com/ros-controls/control_toolbox/issues/263>)
* Fix control_filters tests (#261 <https://github.com/ros-controls/control_toolbox/issues/261>)
* Fix lifecycle warning in test (#262 <https://github.com/ros-controls/control_toolbox/issues/262>)
* Add missing exponential filter tests and export (#260 <https://github.com/ros-controls/control_toolbox/issues/260>)
* Remove visibility boilerplate code (#258 <https://github.com/ros-controls/control_toolbox/issues/258>)
* Add filter plugin for exponential filter (#231 <https://github.com/ros-controls/control_toolbox/issues/231>)
* Bump version of pre-commit hooks (#255 <https://github.com/ros-controls/control_toolbox/issues/255>)
* change the realtime_tools header extensions (#247 <https://github.com/ros-controls/control_toolbox/issues/247>)
* Contributors: Christoph Fröhlich, Julia Jia, Sai Kishor Kothakota, github-actions[bot]
```
