### PR TITLE
gz_ros2_control: 1.2.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2812,7 +2812,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.9-1
+      version: 1.2.10-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.10-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.9-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Fix ackermann demo (#470 <https://github.com/ros-controls/gz_ros2_control/issues/470>) (#475 <https://github.com/ros-controls/gz_ros2_control/issues/475>)
* Add a namespaced example (#457 <https://github.com/ros-controls/gz_ros2_control/issues/457>) (#460 <https://github.com/ros-controls/gz_ros2_control/issues/460>)
* Update diff_drive controller parameters (#462 <https://github.com/ros-controls/gz_ros2_control/issues/462>) (#464 <https://github.com/ros-controls/gz_ros2_control/issues/464>)
* Add Demos for SDF (#427 <https://github.com/ros-controls/gz_ros2_control/issues/427>) (#465 <https://github.com/ros-controls/gz_ros2_control/issues/465>)
* Contributors: mergify[bot]
```
