### PR TITLE
clearpath_common: 1.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.0.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.1.0-2`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_common

```
* Add enable_ekf launch parameter to platform -> localization launch files. Disable the EKF node if enable_ekf is false. (#133 <https://github.com/clearpathrobotics/clearpath_common/issues/133>) (#134 <https://github.com/clearpathrobotics/clearpath_common/issues/134>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_control

```
* Add enable_ekf launch parameter to platform -> localization launch files. Disable the EKF node if enable_ekf is false. (#133 <https://github.com/clearpathrobotics/clearpath_common/issues/133>) (#134 <https://github.com/clearpathrobotics/clearpath_common/issues/134>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Ewellix Lift (#136 <https://github.com/clearpathrobotics/clearpath_common/issues/136>)
  Ewellix Lift
  -  Remove upper_joint
  - Add moveit jpc
  - Add control for joint position controller
  - Add hardware parameters
  - Add lifts to generators
  - Initial add of Ewellix lift description files
* Add enable_ekf launch parameter to platform -> localization launch files. Disable the EKF node if enable_ekf is false. (#133 <https://github.com/clearpathrobotics/clearpath_common/issues/133>) (#134 <https://github.com/clearpathrobotics/clearpath_common/issues/134>)
* Contributors: Chris Iverach-Brereton, luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Ewellix Lift (#136 <https://github.com/clearpathrobotics/clearpath_common/issues/136>)
  Ewellix Lift
  -  Remove upper_joint
  - Add moveit jpc
  - Add control for joint position controller
  - Add hardware parameters
  - Add lifts to generators
  - Initial add of Ewellix lift description files
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Fix color of rear lights
* Add flag to disable platform controllers for manipulation controller manager
* [clearpath_platform_description] Fixed Ridgeback R100 rear light colour. (#127 <https://github.com/clearpathrobotics/clearpath_common/issues/127>)
* Add flag to disable platform controllers for manipulation controller manager
* [clearpath_platform_description] Fixed Ridgeback R100 rear light colour. (#127 <https://github.com/clearpathrobotics/clearpath_common/issues/127>)
* Contributors: Luis Camero, Tony Baltovski
```

## clearpath_sensors_description

- No changes
