### PR TITLE
clearpath_common: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.0.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* [clearpath_platform_description] Fixed R100 rear cover colour. (#145 <https://github.com/clearpathrobotics/clearpath_common/issues/145>)
* Contributors: Tony Baltovski
```

## clearpath_sensors_description

- No changes
