### PR TITLE
Revert "ros_babel_fish: 0.9.6-2 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8477,7 +8477,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.9.6-2
+      version: 0.9.4-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Reverts ros/rosdistro#44077

This seems to have caused a regression in `qml_ros2_plugin`:
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__qml_ros2_plugin__ubuntu_jammy_amd64__binary/33/

FYI, @StefanFabian.