### PR TITLE
clearpath_config: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1038,7 +1038,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## clearpath_config

```
* Add Zenoh support (#113 <https://github.com/clearpathrobotics/clearpath_config/issues/113>)
  * Add Zenoh to the list of supported RMW implementations
  * Add zenoh_router_config_uri parameter to middleware config
  * Add a sanity check to make sure we aren't trying to use Zenoh on a MicroROS-using platform
  * Allow Zenoh on generic platforms
* Contributors: Chris Iverach-Brereton
```
