### PR TITLE
ros2_kortex: 0.2.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8255,8 +8255,8 @@ repositories:
       - kortex_driver
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.2-1
+      url: git@github.com:aalmrad/ros2_kortex-release.git
+      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.2-2`:

- upstream repository: https://github.com/Kinovarobotics/ros2_kortex.git
- release repository: git@github.com:aalmrad/ros2_kortex-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.2-1`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* specify planning pipelines to use (#157 <https://github.com/Kinovarobotics/ros2_kortex/issues/157>)
* Refactor MoveIt Launch files (#162 <https://github.com/Kinovarobotics/ros2_kortex/issues/162>)
* Contributors: Anthony Baker
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* specify planning pipelines to use (#157 <https://github.com/Kinovarobotics/ros2_kortex/issues/157>)
* Refactor MoveIt Launch files (#162 <https://github.com/Kinovarobotics/ros2_kortex/issues/162>)
* Add use_external_cable parameter to URDF (#155 <https://github.com/Kinovarobotics/ros2_kortex/issues/155>)
* Contributors: Anthony Baker
```

## kortex_api

- No changes

## kortex_bringup

- No changes

## kortex_description

```
* Refactor MoveIt Launch files (#162 <https://github.com/Kinovarobotics/ros2_kortex/issues/162>)
* Add use_external_cable parameter to URDF (#155 <https://github.com/Kinovarobotics/ros2_kortex/issues/155>)
* Contributors: Anthony Baker
```

## kortex_driver

```
* cxx: remove unused-but-set-parameter (#164 <https://github.com/Kinovarobotics/ros2_kortex/issues/164>)
* Contributors: Alex Moriarty
```
