### PR TITLE
control_toolbox: 3.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.6.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.0-1`

## control_toolbox

```
* Branch for humble (backport #265 <https://github.com/ros-controls/control_toolbox/issues/265>) (#271 <https://github.com/ros-controls/control_toolbox/issues/271>)
* Update include paths of GPL (#264 <https://github.com/ros-controls/control_toolbox/issues/264>) (#266 <https://github.com/ros-controls/control_toolbox/issues/266>)
* Contributors: mergify[bot]
```
