### PR TITLE
ros2_kortex: 0.2.3-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8249,14 +8249,15 @@ repositories:
       packages:
       - kinova_gen3_6dof_robotiq_2f_85_moveit_config
       - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_lite_moveit_config
       - kortex_api
       - kortex_bringup
       - kortex_description
       - kortex_driver
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.2-1
+      url: git@github.com:aalmrad/ros2_kortex-release.git
+      version: 0.2.3-3
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.3-3`:

- upstream repository: https://github.com/Kinovarobotics/ros2_kortex.git
- release repository: git@github.com:aalmrad/ros2_kortex-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.2-1`
