### PR TITLE
automatika_ros_sugar: 0.2.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -519,7 +519,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.2.6-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.5-1`

## automatika_ros_sugar

```
* (fix) Fixes type hint
* (fix) Fixes getting available events
* (feature) checks for components and events duplicate names
* (fix) Changes type of monitor components to activate
* (chore) Fixes OS versions in CI
* (chore) Adds arms builds to debian packaging
* (refactor) Changes the fuction to create events from jsons
* (fix) Fixes events parsing using serialized events as dictionary keys
* (docs) Adds verification tag
* (docs) Adds external links to docs
* (docs) Adds source link to docs
* Contributors: ahr, mkabtoul
```
