### PR TITLE
Add python3-typing-extensions for nixos

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10357,6 +10357,7 @@ python3-typing-extensions:
   fedora: [python3-typing-extensions]
   freebsd: [devel/py-typing-extensions]
   gentoo: [dev-python/typing-extensions]
+  nixos: [python3Packages.typing-extensions]
   opensuse: [python3-typing_extensions]
   rhel:
     '*': [python3-typing-extensions]


### PR DESCRIPTION
See the package entry at [search.nixos.org](https://search.nixos.org/packages?channel=unstable&from=0&size=50&buckets=%7B%22package_attr_set%22%3A%5B%22python312Packages%22%5D%2C%22package_license_set%22%3A%5B%5D%2C%22package_maintainers_set%22%3A%5B%5D%2C%22package_platforms%22%3A%5B%5D%7D&sort=relevance&type=packages&query=typing-extensions).
