### PR TITLE
grpc: 0.0.13-3 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3821,7 +3821,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.12-2
+      version: 0.0.13-3
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.13-3`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.12-2`

## grpc

```
* Support cmake to build grpc library (#51 <https://github.com/CogRob/catkin_grpc/issues/51>)
  * Support cmake to build grpc library
  * Enable BUILD_SHARED_LIBS
* Contributors: Yuki Furuta
```
