### PR TITLE
mapviz: 2.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3828,7 +3828,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.4-1
+      version: 2.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.5-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.4-1`

## mapviz

- No changes

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Fix topic lists (#833 <https://github.com/swri-robotics/mapviz/issues/833>)
  Fixed problems with topic list display.
* Contributors: nick-alton
```

## multires_image

- No changes

## tile_map

- No changes
