### PR TITLE
launch_pal: 0.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4104,7 +4104,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.7.0-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.10.0-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-1`

## launch_pal

```
* Update wrong return value
* Apply suggestion after review
* Apply 1 suggestion(s) to 1 file(s)
* Add jinja2 dependency
* Add master calibration implementation
* Contributors: David ter Kuile, antoniobrandi
```
