### PR TITLE
mola_lidar_odometry: 0.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4979,7 +4979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.4-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.6.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.4-1`

## mola_lidar_odometry

```
* Fix: publish map on first iteration
* Publish georeferencing frames (utm, enu) when loading a metric map with georef. info
* ros2 lidar odometry launch: add ros argument for /tf reference_frame
* ROS2 kitti Lidar-Odometry demo: fixed to publish correct /tf's
* Add new frame parameters to pipeline YAML files
* Two new parameters (publish_reference_frame, publish_vehicle_frame), to have explicit control on frame names published to both, ROS, and the MOLA state_estimator
* ROS2 service call for load_map(): more concise error messages
* Contributors: Jose Luis Blanco-Claraco
```
