### PR TITLE
mola: 1.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4130,7 +4130,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.5.1-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.6.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.5.1-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Publish gridmaps too
* ros2 bridge: rep105 only for map->base_link tfs
* BridgeROS2: support forwarding more than one localization message per timer call
* Fix published /tf's: those from LocalizationSources now can explicitly define their parent and child frames
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_kernel

```
* Fix published /tf's: those from LocalizationSources now can explicitly define their parent and child frames
* LocalizationSources now can explicitly define both, their reference and child frames for each estimated pose
* docs: add state estimation images
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

- No changes

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
