### PR TITLE
libfranka: 0.15.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4308,11 +4308,15 @@ repositories:
       version: master
     status: maintained
   libfranka:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/libfranka.git
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.13.6-1
+      version: 0.15.0-1
     source:
       type: git
       url: https://github.com/frankaemika/libfranka.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.15.0-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.13.6-1`
