### PR TITLE
autoware_internal_msgs: 1.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -593,10 +593,11 @@ repositories:
       - autoware_internal_debug_msgs
       - autoware_internal_msgs
       - autoware_internal_perception_msgs
+      - autoware_internal_planning_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.3.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.5.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## autoware_internal_debug_msgs

- No changes

## autoware_internal_msgs

- No changes

## autoware_internal_perception_msgs

- No changes

## autoware_internal_planning_msgs

```
* feat(autoware_internal_planning_msgs): adaption to autoware_motion_utils (#45 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/45>)
  * feat(autoware_internal_planning_msgs): add msg required by autoware_motion_utils
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* fix(autoware_internal_planning_msgs): fix PathPoint type error cause by duplicate definition in repo autoware_msgs and autoware_internal_msgs (#46 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/46>)
  * fix(autoware_internal_planning_msgs): fix PathPoint type error cause by duplicate definition in repo autoware_msgs and autoware_internal_msgs
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: NorahXiong
```
