### PR TITLE
ur_robot_driver: 3.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9502,7 +9502,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.0.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Remove all build warnings (#1233 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1233>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Check quaternions for equal dot_product instead of comparing their components individually (#1238 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1238>)
* fix sphinx doc link in ur_robot_driver (#1240 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1240>)
* Disable pose broadcaster on mock hardware (#1229 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1229>)
* Add information about which driver features dont work with mock hardware (#1227 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1227>)
* Add instructions for enabling necessary services and remote control (#1224 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1224>)
* Contributors: Felix Exner, Rune Søe-Knudsen, URJala
```
