### PR TITLE
ur_description: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8521,7 +8521,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.0.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## ur_description

```
* Fix ur20 upperarm texture (#244 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/244>)
* Removing Blender Lighting and Camera information from visual DAE files (#243 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/243>)
* Auto-update pre-commit hooks (#241 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/241>)
* Update package maintainers (#238 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/238>)
* Contributors: Felix Exner, Shaurya Kumar
```
