### PR TITLE
ur_description: 2.1.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11038,7 +11038,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.9-1
+      version: 2.1.10-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.10-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.9-1`

## ur_description

```
* Fix ur20 upperarm texture (backport #244 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/244>) (#246 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/246>)
* Removing Blender Lighting and Camera information from visual DAE files (backport #243 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/243>) (#245 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/245>)
* Auto-update pre-commit hooks (backport of #241 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/241>)
* Update package maintainers (backport of #238 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/238>)
* Remove Iron workflows and from README (backport of #230 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/230>)
* Contributors: Felix Exner, Shaurya Kumar
```
