### PR TITLE
franka_ros2: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2801,6 +2801,28 @@ repositories:
       version: main
     status: developed
   franka_ros2:
+    doc:
+      type: git
+      url: https://github.com/frankaemika/franka_ros2.git
+      version: v1.0.0
+    release:
+      packages:
+      - franka_bringup
+      - franka_example_controllers
+      - franka_fr3_moveit_config
+      - franka_gazebo_bringup
+      - franka_gripper
+      - franka_hardware
+      - franka_ign_ros2_control
+      - franka_msgs
+      - franka_robot_state_broadcaster
+      - franka_ros2
+      - franka_semantic_components
+      - integration_launch_testing
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/franka_ros2-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/frankaemika/franka_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros2` to `1.0.0-1`:

- upstream repository: https://github.com/frankaemika/franka_ros2.git
- release repository: https://github.com/ros2-gbp/franka_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## franka_bringup

- No changes

## franka_example_controllers

- No changes

## franka_fr3_moveit_config

- No changes

## franka_gazebo_bringup

- No changes

## franka_gripper

- No changes

## franka_hardware

- No changes

## franka_ign_ros2_control

- No changes

## franka_msgs

- No changes

## franka_robot_state_broadcaster

- No changes

## franka_semantic_components

- No changes

## integration_launch_testing

- No changes
