### PR TITLE
Switch bond_core on humble to use the ros2 branch.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1072,7 +1072,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: galactic
+      version: ros2
     release:
       packages:
       - bond
@@ -1087,7 +1087,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: galactic
+      version: ros2
     status: maintained
   boost_geometry_util:
     doc:


### PR DESCRIPTION
That way we can release newer code into Humble.