### PR TITLE
bond_core: 4.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -803,7 +803,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.0-1
+      version: 4.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.1.1-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-1`

## bond

```
* Remove empty Doxygen mainpage files (#106 <https://github.com/ros/bond_core/issues/106>)
* Clarify licenses of bond_core and smclib (#105 <https://github.com/ros/bond_core/issues/105>)
* Contributors: Michael Carroll
```

## bond_core

```
* Clarify licenses of bond_core and smclib (#105 <https://github.com/ros/bond_core/issues/105>)
* Contributors: Michael Carroll
```

## bondcpp

```
* Fix copyright/license headers and enable lint (#107 <https://github.com/ros/bond_core/issues/107>)
* Remove empty Doxygen mainpage files (#106 <https://github.com/ros/bond_core/issues/106>)
* Clarify licenses of bond_core and smclib (#105 <https://github.com/ros/bond_core/issues/105>)
* Contributors: Michael Carroll
```

## bondpy

```
* Remove empty Doxygen mainpage files (#106 <https://github.com/ros/bond_core/issues/106>)
* Clarify licenses of bond_core and smclib (#105 <https://github.com/ros/bond_core/issues/105>)
* Contributors: Michael Carroll
```

## smclib

```
* Do not include windows.h in statemap.hpp (#109 <https://github.com/ros/bond_core/issues/109>)
  * Do not include windows.h in statemap.hpp
  * Simplify ifdef structure
* Remove empty Doxygen mainpage files (#106 <https://github.com/ros/bond_core/issues/106>)
* Clarify licenses of bond_core and smclib (#105 <https://github.com/ros/bond_core/issues/105>)
* Contributors: Michael Carroll, Silvio Traversaro
```
