### PR TITLE
py_trees_ros_tutorials: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6914,6 +6914,15 @@ repositories:
       version: release/2.1.x
     status: maintained
   py_trees_ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.3.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## py_trees_ros_tutorials

```
* [tutorials] fix: grammar mistake (#51 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/51>)
* [doc] some fresh dot files
* [mock] update for new shutdown handling for humble
* [docs] update intersphinx releases to latest py_trees releases
* [tutorials] refactor for explicit composite arguments
* [mock] bugfix signal type mismatch for charging status
* Contributors: Daniel Stonier, Humaney
```
