### PR TITLE
py_trees_ros_tutorials: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5088,6 +5088,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: devel
     status: developed
+  py_trees_ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    status: developed
   py_trees_ros_viewer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.3.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## py_trees_ros_tutorials

```
* [tutorials] fix: grammar mistake (#51 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/51>)
* [doc] some fresh dot files
* [mock] update for new shutdown handling for humble
* [docs] update intersphinx releases to latest py_trees releases
* [tutorials] refactor for explicit composite arguments
* [mock] bugfix signal type mismatch for charging status
* Contributors: Daniel Stonier, Humaney
```
