### PR TITLE
srdfdom: 2.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10105,7 +10105,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.5-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.7-1`:

- upstream repository: https://github.com/ros-planning/srdfdom.git
- release repository: https://github.com/ros2-gbp/srdfdom-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.5-1`

## srdfdom

```
* Fix installing headers
* Contributors: Robert Haschke
```
