### PR TITLE
urinterfaces: 7.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11300,6 +11300,11 @@ repositories:
       version: master
     status: maintained
   urinterfaces:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/urinterfaces-release.git
+      version: 7.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/urinterfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urinterfaces` to `7.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/urinterfaces.git
- release repository: https://github.com/ros2-gbp/urinterfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## urinterfaces

```
* Update msg, srv and action files (#4 <https://github.com/UniversalRobots/ur_interfaces/issues/4>)
* Update metainfo (#5 <https://github.com/UniversalRobots/ur_interfaces/issues/5>)
* Update ci (#3 <https://github.com/UniversalRobots/ur_interfaces/issues/3>)
* Add CI and pre-commit #1 <https://github.com/UniversalRobots/ur_interfaces/issues/1> from UniversalRobots/ci
* Add dependency on action_msgs
* Introducing new Universal Robots urinterfaces repository
* Contributors: Ali Ekber Celik, Felix Exner, Michal Milkowski, Viktor Lukacs
```
