### PR TITLE
ur_simulation_gz: 0.1.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11115,7 +11115,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
-      version: 0.1.0-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `0.1.1-2`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## ur_simulation_gz

```
* Allow using the scaled jtc with GZ Sim (#82 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/82>)
* Reverted string format of gz_args (#77 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/77>)
* Update package maintainers (backport of #74 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/74>)
* Contributors: Felix Exner, LJ Azzalini, mergify[bot]
```
