### PR TITLE
bond_core: 4.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -853,7 +853,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.1.2-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.1-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

- No changes

## bondpy

```
* increase buffer size of bond_status callback in bondpy (#96 <https://github.com/ros/bond_core/issues/96>)
* Contributors: sosoeeee
```

## smclib

- No changes
