### PR TITLE
eigen_stl_containers: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2173,7 +2173,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
-      version: 1.0.0-4
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `1.1.0-1`:

- upstream repository: https://github.com/ros/eigen_stl_containers.git
- release repository: https://github.com/ros2-gbp/eigen_stl_containers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-4`

## eigen_stl_containers

```
* CMakeLists.txt: fixing relocatable package issue (#19 <https://github.com/ros/eigen_stl_containers/issues/19>)
* Contributors: Matthias Schoepfer
```
