### PR TITLE
eigen_stl_containers: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1469,7 +1469,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
-      version: 1.0.0-6
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen_stl_containers` to `1.1.0-1`:

- upstream repository: https://github.com/ros/eigen_stl_containers.git
- release repository: https://github.com/ros2-gbp/eigen_stl_containers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-6`

## eigen_stl_containers

```
* CMakeLists.txt: fixing relocatable package issue (#19 <https://github.com/ros/eigen_stl_containers/issues/19>)
* Contributors: Matthias Schoepfer
```
