### PR TITLE
Add black-pip key for debian and ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -113,6 +113,13 @@ black:
   ubuntu:
     '*': [black]
     bionic: null
+black-pip:
+  debian:
+    pip:
+      packages: [black]
+  ubuntu:
+    pip:
+      packages: [black]
 canopen-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

black-pip

## Package Upstream Source:

https://github.com/psf/black

## Purpose of using this:

In apt the current version supported is 21.12b0 and the latest stable version available from black is 24.10.0 which includes bug fixes and feature updates that are desired. Also, 21.12b0 is not supported by the VS Code black extension.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

* pip: https://pypi.org/project/black/
