### PR TITLE
mola_lidar_odometry: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3775,7 +3775,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.6.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.6.0-1`

## mola_lidar_odometry

```
* Do not re-publish the map if it does not change, e.g. in localization-only mode
* ros2 launch file: two new arguments 'mola_lo_pipeline' and 'generate_simplemap'
* Default 3D-LO pipeline: Add new env var 'MOLA_LOCALMAP_LAYER_NAME', useful when localizing with prebuilt maps
* Merge pull request #12 from r-aguilera/develop
  fix launch file params
* fix launch file params
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera
```
