### PR TITLE
Revert "Add python3-pymongo-pip  for debian and ubuntu"

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7304,6 +7304,13 @@ python3-moteus-pip:
   ubuntu:
     pip:
       packages: [moteus]
+python3-motor-pip:
+  debian:
+    pip:
+      packages: [motor]
+  ubuntu:
+    pip:
+      packages: [motor]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7304,13 +7304,6 @@ python3-moteus-pip:
   ubuntu:
     pip:
       packages: [moteus]
-python3-motor-pip:
-  debian:
-    pip:
-      packages: [motor]
-  ubuntu:
-    pip:
-      packages: [motor]
 python3-msgpack:
   debian:
     '*': [python3-msgpack]
@@ -8494,13 +8487,6 @@ python3-pymongo:
   nixos: [python3Packages.pymongo]
   openembedded: [python3-pymongo@meta-python]
   ubuntu: [python3-pymongo]
-python3-pymongo-pip:
-  debian:
-    pip:
-      packages: [pymongo]
-  ubuntu:
-    pip:
-      packages: [pymongo]
 python3-pynmea2:
   debian: [python3-nmea2]
   fedora:


### PR DESCRIPTION
Reverts ros/rosdistro#40564

This breaks our policy and will potentially break any system on which there are packages using the system installed pymongo version (ROS or not ROS package.) 

> Native packages are strongly preferred. If a native package exists for the key in question, then that should always be used over e.g. a pip key.

If you need a newer version and want to override it on your own system you're welcome to do that in your own rosdep sources file, but we cannot maintain those conflicting keys for everyone because the cost of the side effects for the entire community is much higher than the benefit for the few users who want the new feature in the new release. 

python3-pymongo is available on all generations of Ubuntu: https://packages.ubuntu.com/oracular/python3-pymongo