### PR TITLE
gazebo_ros_pkgs: 3.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2936,7 +2936,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.7.0-1
+      version: 3.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `3.9.0-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs
- release repository: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.0-1`

## gazebo_dev

```
* Update Gazebo web links (#1548 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1548>)
* Contributors: Alejandro Hernández Cordero
```

## gazebo_msgs

```
* Update Gazebo web links (#1548 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1548>)
* Contributors: Alejandro Hernández Cordero
```

## gazebo_plugins

```
* Update Gazebo web links (#1548 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1548>)
* Contributors: Alejandro Hernández Cordero
```

## gazebo_ros

```
* Add Gazebo Classic EOL notice (#1562 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1562>)
* Fix: Fixed uninitialized warning (#1560 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1560>)
* Update Gazebo web links (#1548 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1548>)
* Add support to parse the parameters file directly (#1546 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1546>)
* Contributors: Addisu Z. Taddese, Alejandro Hernández Cordero, Sai Kishor Kothakota, Janosch Machowinski
```

## gazebo_ros_pkgs

```
* Update Gazebo web links (#1548 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1548>)
* Contributors: Alejandro Hernández Cordero
```
