### PR TITLE
automatika_ros_sugar: 0.2.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -750,7 +750,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.6-1
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.2.7-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.6-1`

## automatika_ros_sugar

```
* (fix) Fixes ChildComponent class in tests
* (fix) Minor fix in component execution_step
* (feature) Adds pytests to package.xml and CMakeLists
* (feature) Adds tests for Actios and ComponentRunType
* (fix) Fixes health_status publishing for non timed components
* (feature) Adds pytest for all event classes and fixes existing errors
* (feature) Adds support for std_msgs MultiArray messages
* (fix) Fixes Event trigger value check and OnGreater event serialization
* Contributors: Maria Kabtoul, mkabtoul
```
