### PR TITLE
kompass: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3013,6 +3013,14 @@ repositories:
       type: git
       url: https://github.com/automatika-robotics/kompass.git
       version: main
+    release:
+      packages:
+      - kompass
+      - kompass_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kompass-release.git
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.2.1-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## kompass

```
* (fix) Adds controller custom on activate method
* (fix) Updates controller activation method
* (fix) Adds ompl exception catch and log
* (fix) Recreates all subscribers at mode change
* (feature) Fixes set_algorithm for online mode switch
* (feature) Adds TwistStamped to supported types
* (fix) Fixes imports and error in webots_ros2 implementation
* (docs) Updates vision tracking tutorial
* (fix) Adds a list of input/output topics containing None defaults
* (feature) Adds support for 'None' default values of inputs/outputs
* (docs) Adds VisionFollower docs and updates docstrings
* (feature) Adds wait to vision target following callback
* (feature) Adds Detections callback
* (feature) Adds support for lists in topics dictionary and adds doc-strings
* (feature) Adds wait time to get vision tracking in callback loop
* (fix) Sets control callback rate to control time step
* (feature) Updates control classes and supported types
* (feature) Add wait time for vision tracking input in action callback
* (feature) Adds component for visualization
* (feature) Adds Detections to supported types
* (feature) Adds vision object tracking to controller
* (feature) Adds control publishing options to Controller (#32 <https://github.com/automatika-robotics/kompass-ros/issues/32>)
  Adds parallel and array publish options to Controller and updates docs
* (docs) Adds default parameters for each control algorithm
* (fix) Exposes max_num_threads parameter for DWA controller in turtlebot example
* (fix) Updates path last cost in Planner and testing params
* (feature) Adds command execution in closed loop to DriveManager
* (feature) Adds option to select controller commands publishing type
  Select to publish the control commands in a new thread or to publish a TwistArray
* Contributors: ahr, mkabtoul
```

## kompass_interfaces

```
* (fix) Adds action_msgs dependency for kompass_interfaces
* (feature) Adds support for 'None' default values of inputs/outputs
* (feature) Updates control classes and supported types
* (feature) Adds vision tracking action/srv and updates interfaces
* (feature) Adds control publishing options to Controller (#32 <https://github.com/automatika-robotics/kompass-ros/issues/32>)
  Adds parallel and array publish options to Controller and updates docs
* (feature) Adds time_step to TwistArray msg
* Contributors: ahr, mkabtoul
```
