### PR TITLE
Adds msgpack-numpy to rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7325,9 +7325,6 @@ python3-msgpack-numpy:
   fedora:
     pip:
       packages: [msgpack-numpy]
-  gentoo:
-    pip:
-      packages: [msgpack-numpy]
   opensuse: [python3-msgpack-numpy]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6622,18 +6622,6 @@ python3-httplib2:
   fedora: [python3-httplib2]
   gentoo: [dev-python/httplib2]
   ubuntu: [python3-httplib2]
-python3-httpx:
-  debian: [python3-httpx]
-  fedora: [python3-httpx]
-  gentoo: [dev-python/httpx]
-  osx:
-    pip:
-      packages: [httpx]
-  ubuntu:
-    '*': [python3-httpx]
-    focal:
-      pip:
-        packages: [httpx]
 python3-hypothesis:
   debian: [python3-hypothesis]
   fedora: [python3-hypothesis]
@@ -8058,18 +8046,6 @@ python3-pkg-resources:
   opensuse: [python3-setuptools]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
-python3-platformdirs:
-  debian: [python3-platformdirs]
-  fedora: [python3-platformdirs]
-  gentoo: [dev-python/platformdirs]
-  osx:
-    pip:
-      packages: [platformdirs]
-  ubuntu:
-    '*': [python3-platformdirs]
-    focal:
-      pip:
-        packages: [platformdirs]
 python3-playsound-pip:
   alpine:
     pip:
@@ -9620,14 +9596,6 @@ python3-serial:
     '*': ['python%{python3_pkgversion}-pyserial']
     '7': null
   ubuntu: [python3-serial]
-python3-setproctitle:
-  debian: [python3-setproctitle]
-  fedora: [python3-setproctitle]
-  gentoo: [dev-python/setproctitle]
-  osx:
-    pip:
-      packages: [setproctitle]
-  ubuntu: [python3-setproctitle]
 python3-setuptools:
   alpine: [py3-setuptools]
   arch: [python-setuptools]
@@ -9862,18 +9830,6 @@ python3-sounddevice-pip:
   ubuntu:
     pip:
       packages: [sounddevice]
-python3-soundfile:
-  debian: [python3-soundfile]
-  fedora:
-    pip:
-      packages: [soundfile]
-  gentoo:
-    pip:
-      packages: [soundfile]
-  osx:
-    pip:
-      packages: [soundfile]
-  ubuntu: [python3-soundfile]
 python3-sparkfun-ublox-gps-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6631,7 +6631,9 @@ python3-httpx:
       packages: [httpx]
   ubuntu:
     '*': [python3-httpx]
-    focal: null
+    focal:
+      pip:
+        packages: [httpx]
 python3-hypothesis:
   debian: [python3-hypothesis]
   fedora: [python3-hypothesis]
@@ -8064,10 +8066,10 @@ python3-platformdirs:
     pip:
       packages: [platformdirs]
   ubuntu:
-      '*': [python3-platformdirs]
-      focal:
-        pip:
-          packages: [platformdirs]
+    '*': [python3-platformdirs]
+    focal:
+      pip:
+        packages: [platformdirs]
 python3-playsound-pip:
   alpine:
     pip:
@@ -8241,11 +8243,6 @@ python3-pyads-pip:
   ubuntu:
     pip:
       packages: [pyads]
-python3-pyaudio:
-  debian: [python3-pyaudio]
-  fedora: [python3-pyaudio]
-  gentoo: [dev-python/pyaudio]
-  ubuntu: [python3-pyaudio]
 python3-pyassimp:
   debian:
     '*': [python3-pyassimp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6629,7 +6629,9 @@ python3-httpx:
   osx:
     pip:
       packages: [httpx]
-  ubuntu: [python3-httpx]
+  ubuntu:
+    '*': [python3-httpx]
+    focal: null
 python3-hypothesis:
   debian: [python3-hypothesis]
   fedora: [python3-hypothesis]
@@ -8061,7 +8063,11 @@ python3-platformdirs:
   osx:
     pip:
       packages: [platformdirs]
-  ubuntu: [python3-platformdirs]
+  ubuntu:
+      '*': [python3-platformdirs]
+      focal:
+        pip:
+          packages: [platformdirs]
 python3-playsound-pip:
   alpine:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7328,6 +7328,7 @@ python3-msgpack-numpy:
   gentoo:
     pip:
       packages: [msgpack-numpy]
+  opensuse: [python3-msgpack-numpy]
   osx:
     pip:
       packages: [msgpack-numpy]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6622,6 +6622,14 @@ python3-httplib2:
   fedora: [python3-httplib2]
   gentoo: [dev-python/httplib2]
   ubuntu: [python3-httplib2]
+python3-httpx:
+  debian: [python3-httpx]
+  fedora: [python3-httpx]
+  gentoo: [dev-python/httpx]
+  osx:
+    pip:
+      packages: [httpx]
+  ubuntu: [python3-httpx]
 python3-hypothesis:
   debian: [python3-hypothesis]
   fedora: [python3-hypothesis]
@@ -7320,6 +7328,18 @@ python3-msgpack:
   openembedded: [python3-msgpack@meta-python]
   rhel: ['python%{python3_pkgversion}-msgpack']
   ubuntu: [python3-msgpack]
+python3-msgpack-numpy:
+  debian: [python3-msgpack-numpy]
+  fedora:
+    pip:
+      packages: [msgpack-numpy]
+  gentoo:
+    pip:
+      packages: [msgpack-numpy]
+  osx:
+    pip:
+      packages: [msgpack-numpy]
+  ubuntu: [python3-msgpack-numpy]
 python3-msk-pip:
   debian:
     pip:
@@ -8034,6 +8054,14 @@ python3-pkg-resources:
   opensuse: [python3-setuptools]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-platformdirs:
+  debian: [python3-platformdirs]
+  fedora: [python3-platformdirs]
+  gentoo: [dev-python/platformdirs]
+  osx:
+    pip:
+      packages: [platformdirs]
+  ubuntu: [python3-platformdirs]
 python3-playsound-pip:
   alpine:
     pip:
@@ -8207,6 +8235,11 @@ python3-pyads-pip:
   ubuntu:
     pip:
       packages: [pyads]
+python3-pyaudio:
+  debian: [python3-pyaudio]
+  fedora: [python3-pyaudio]
+  gentoo: [dev-python/pyaudio]
+  ubuntu: [python3-pyaudio]
 python3-pyassimp:
   debian:
     '*': [python3-pyassimp]
@@ -9584,6 +9617,14 @@ python3-serial:
     '*': ['python%{python3_pkgversion}-pyserial']
     '7': null
   ubuntu: [python3-serial]
+python3-setproctitle:
+  debian: [python3-setproctitle]
+  fedora: [python3-setproctitle]
+  gentoo: [dev-python/setproctitle]
+  osx:
+    pip:
+      packages: [setproctitle]
+  ubuntu: [python3-setproctitle]
 python3-setuptools:
   alpine: [py3-setuptools]
   arch: [python-setuptools]
@@ -9818,6 +9859,18 @@ python3-sounddevice-pip:
   ubuntu:
     pip:
       packages: [sounddevice]
+python3-soundfile:
+  debian: [python3-soundfile]
+  fedora:
+    pip:
+      packages: [soundfile]
+  gentoo:
+    pip:
+      packages: [soundfile]
+  osx:
+    pip:
+      packages: [soundfile]
+  ubuntu: [python3-soundfile]
 python3-sparkfun-ublox-gps-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7329,6 +7329,9 @@ python3-msgpack-numpy:
   osx:
     pip:
       packages: [msgpack-numpy]
+  rhel:
+    pip:
+      packages: [msgpack-numpy]
   ubuntu: [python3-msgpack-numpy]
 python3-msk-pip:
   debian:


### PR DESCRIPTION
# Please add the following dependency to the rosdep database

## Package name:

`python3-msgpack-numpy`

## Package Upstream Source:

[source repository](https://github.com/lebedov/msgpack-numpy)

## Purpose of using this:

Provides encoding and decoding routines that enable the serialization and deserialization of numerical and array data types provided by 'numpy' using the highly efficient 'msgpack' format. It is currently being used to provide syntactic sugar to ROS2 launch and enable running subscriber/publisher data post/pre processor functions using a pythonic API (msgpack-numpy is used in this case for serialization and deserialization in inter-process data exchange)


## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: [python3-msgpack-numpy](https://packages.debian.org/bookworm/python3-msgpack-numpy)
- Ubuntu: [python3-msgpack-numpy](https://packages.ubuntu.com/oracular/python3-msgpack-numpy)
- Fedora: not available
      pip: [msgpack-numpy](https://pypi.org/project/msgpack-numpy/)
- Arch: not available
- Gentoo: not available
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: available for python3.11 and python 3.12 [msgpack-numpy](https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=msgpack-numpy)
- openSUSE: [python3-msgpack-numpy](https://software.opensuse.org/package/python3-msgpack-numpy)
- rhel: [python3-msgpack-numpy](https://pkgs.org/search/?q=msgpack-numpy)
  