### PR TITLE
control_toolbox: 4.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1266,7 +1266,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.5.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.0-1`

## control_toolbox

```
* Rework PID class API (#246 <https://github.com/ros-controls/control_toolbox/issues/246>)
* [PID] Add support for saving i-term when PID is reset (#180 <https://github.com/ros-controls/control_toolbox/issues/180>)
* Update codecov badge in README.md (#273 <https://github.com/ros-controls/control_toolbox/issues/273>)
* Update mergify.yml (#270 <https://github.com/ros-controls/control_toolbox/issues/270>)
* Branch for humble (#265 <https://github.com/ros-controls/control_toolbox/issues/265>)
* Update include paths of GPL (#264 <https://github.com/ros-controls/control_toolbox/issues/264>)
* Contributors: Christoph Fröhlich, Dr. Denis
```
