### PR TITLE
Add isaacsim pip with cache pkgs

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6796,6 +6796,22 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
+python3-isaacsim-extscache-kit-pip:
+  '*':
+    pip:
+      packages: [isaacsim-extscache-kit]
+python3-isaacsim-extscache-kit-sdk-pip:
+  '*':
+    pip:
+      packages: [isaacsim-extscache-kit-sdk]
+python3-isaacsim-extscache-physics-pip:
+  '*':
+    pip:
+      packages: [isaacsim-extscache-physics]
+python3-isaacsim-pip:
+  '*':
+    pip:
+      packages: [isaacsim]
 python3-j1939-pip: *migrate_eol_2025_04_30_python3_j1939_pip
 python3-jinja2:
   alpine: [py3-jinja2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6796,22 +6796,26 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
-python3-isaacsim-extscache-kit-pip:
+python3-isaacsim-all-pip:
   '*':
     pip:
-      packages: [isaacsim-extscache-kit]
-python3-isaacsim-extscache-kit-sdk-pip:
+      packages: [isaacsim, isaacsim-app, isaacsim-asset, isaacsim-benchmark, isaacsim-code-editor, isaacsim-core, isaacsim-cortex, isaacsim-example, isaacsim-gui, isaacsim-replicator, isaacsim-rl, isaacsim-robot, isaacsim-robot-motion, isaacsim-robot-setup, isaacsim-ros1, isaacsim-ros2, isaacsim-sensor, isaacsim-storage, isaacsim-template, isaacsim-test, isaacsim-utils]
+python3-isaacsim-extscache-pip:
   '*':
     pip:
-      packages: [isaacsim-extscache-kit-sdk]
-python3-isaacsim-extscache-physics-pip:
+      packages: [isaacsim, isaacsim-extscache-kit, isaacsim-extscache-kit-sdk, isaacsim-extscache-physics]
+python3-isaacsim-rl-pip:
   '*':
     pip:
-      packages: [isaacsim-extscache-physics]
-python3-isaacsim-pip:
+      packages: [isaacsim, isaacsim-rl, isaacsim-replicator, isaacsim-app]
+python3-isaacsim-ros-pip:
   '*':
     pip:
-      packages: [isaacsim]
+      packages: [isaacsim, isaacsim-ros1]
+python3-isaacsim-ros2-pip:
+  '*':
+    pip:
+      packages: [isaacsim, isaacsim-ros2]
 python3-j1939-pip: *migrate_eol_2025_04_30_python3_j1939_pip
 python3-jinja2:
   alpine: [py3-jinja2]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
Edit: In the newly released Isaac Sim 4.5.0, the package structure has changed. Packages are now installed via pip extras, and I propose adding the following extras to rosdep to replace the old ones:

python3-isaacsim-all-pip
python3-isaacsim-rl-pip
python3-isaacsim-ros-pip
python3-isaacsim-ros2-pip
python3-isaacsim-extscache-pip

~~python3-isaacsim-pip~~
~~python3-isaacsim-extscache-physics-pip~~
~~python3-isaacsim-extscache-kit-pip~~
~~python3-isaacsim-extscache-kit-sdk-pip~~

## Package Upstream Source:

NA

## Purpose of using this:

Simulating ROS integrated robots using NVIDIA Omniverse IsaacSim.
~~The main package `isaacsim` can be supplemented by any subset of the other three cache packages to accelerate first time startup.~~

## Links to Distribution Packages
There are no special distribution packages, only pip.
pip:
 - https://pypi.org/project/isaacsim/
 - ~~https://pypi.org/project/isaacsim-extscache-physics/~~
 - ~~https://pypi.org/project/isaacsim-extscache-kit/~~
 - ~~https://pypi.org/project/isaacsim-extscache-kit-sdk/~~

Edit: Available extras can be inspected in the `isaacsim-4.5.0.0.tar.gz` file available on PyPI.

## Additional notes
Installation with rosdep might require the user to set the --as-root pip:false flag, e.g.
`rosdep install -i -y --from-paths src --as-root pip:false`