### PR TITLE
realtime_tools: 3.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5696,7 +5696,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.1.0-1
+      version: 3.2.0-2
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.2.0-2`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-1`

## realtime_tools

```
* Add Lock-free Queue (#253 <https://github.com/ros-controls/realtime_tools/issues/253>)
* Use humble branch of control_toolbox repo (#258 <https://github.com/ros-controls/realtime_tools/issues/258>)
* Avoid to include windows.h in realtime_helpers.hpp (#255 <https://github.com/ros-controls/realtime_tools/issues/255>)
* Bump version of pre-commit hooks (#251 <https://github.com/ros-controls/realtime_tools/issues/251>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Silvio Traversaro, github-actions[bot]
```
