### PR TITLE
ros2_control: 4.25.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6283,7 +6283,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.24.0-1
+      version: 4.25.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.25.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.24.0-1`

## controller_interface

```
* Use target_compile_definitions instead of installing test files (#2009 <https://github.com/ros-controls/ros2_control/issues/2009>)
* Add GPS semantic component (#2000 <https://github.com/ros-controls/ros2_control/issues/2000>)
* Contributors: Sai Kishor Kothakota, Wiktor Bajor
```

## controller_manager

```
* Handle SIGINT properly in the controller manager (#2014 <https://github.com/ros-controls/ros2_control/issues/2014>)
* Fix the initial wrong periodicity reported by controller_manager (#2018 <https://github.com/ros-controls/ros2_control/issues/2018>)
* Use target_compile_definitions instead of installing test files (#2009 <https://github.com/ros-controls/ros2_control/issues/2009>)
* Fix a heading level (#2007 <https://github.com/ros-controls/ros2_control/issues/2007>)
* Update path of GPL (#1994 <https://github.com/ros-controls/ros2_control/issues/1994>)
* Fix: on_shutdown callback of controllers never get executed (#1995 <https://github.com/ros-controls/ros2_control/issues/1995>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Wiktor Bajor
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Handle SIGINT properly in the controller manager (#2014 <https://github.com/ros-controls/ros2_control/issues/2014>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Define _USE_MATH_DEFINES in joint_soft_limiter.cpp to ensure that M_PI is defined (#2001 <https://github.com/ros-controls/ros2_control/issues/2001>)
* Use actual position when limiting desired position (#1988 <https://github.com/ros-controls/ros2_control/issues/1988>)
* Contributors: Sai Kishor Kothakota, Silvio Traversaro
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
