### PR TITLE
ros2_controllers: 4.20.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6958,7 +6958,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.19.0-1
+      version: 4.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.20.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.19.0-1`

## ackermann_steering_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

```
* Remove empty callbacks (#1488 <https://github.com/ros-controls/ros2_controllers/issues/1488>)
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich, Julia Jia
```

## bicycle_steering_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* Make diff_drive_controller a ChainableControllerInterface (#1485 <https://github.com/ros-controls/ros2_controllers/issues/1485>)
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Fix SpeedLimiter Constructor regression (#1478 <https://github.com/ros-controls/ros2_controllers/issues/1478>)
* Contributors: Arthur Lovekin, Christoph Fröhlich, Sai Kishor Kothakota
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* Remove empty callbacks (#1488 <https://github.com/ros-controls/ros2_controllers/issues/1488>)
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich, Julia Jia
```

## mecanum_drive_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## parallel_gripper_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## pid_controller

```
* Improve antiwindup description (#1502 <https://github.com/ros-controls/ros2_controllers/issues/1502>)
* Remove empty callbacks (#1488 <https://github.com/ros-controls/ros2_controllers/issues/1488>)
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich, Julia Jia, Victor Coutinho Vieira Santos
```

## pose_broadcaster

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

```
* Update paths of GPL includes (#1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>)
* Contributors: Christoph Fröhlich
```

## velocity_controllers

- No changes
