### PR TITLE
Add python3-ubjson entry for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10385,6 +10385,7 @@ python3-tz:
   ubuntu: [python3-tz]
 python3-ubjson:
   debian: [python3-ubjson]
+  nixos: [python3Packages.py-ubjson]
   ubuntu:
     '*': [python3-ubjson]
 python3-ujson:


### PR DESCRIPTION

Link to nix-search Results

[py-ubjson](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=ubjson)
