### PR TITLE
gz_ros2_control: 2.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2464,7 +2464,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.3-1
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.5-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## gz_ros2_control

```
* Add remap option to controller manager (#442 <https://github.com/ros-controls/gz_ros2_control/issues/442>) (#482 <https://github.com/ros-controls/gz_ros2_control/issues/482>)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  (cherry picked from commit 0a44a087734cb7ef69b8cf82db2a38c551164a7b)
  Co-authored-by: Tatsuro Sakaguchi <mailto:tacchan.mello.ioiq@gmail.com>
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Use files from demos for testing (#485 <https://github.com/ros-controls/gz_ros2_control/issues/485>)
* Contributors: Christoph Fröhlich
```
