### PR TITLE
backward_ros: 1.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -969,7 +969,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.6-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.7-1`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/ros2-gbp/backward_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.0.6-1`

## backward_ros

```
* Merge pull request #22 from Tobias-Fischer/patch-5
  Add dylib suffix on MacOS
* Merge branch 'foxy-devel' into patch-5
* Install missing package.xml for the ros debian packages (#24)
  Co-authored-by: Talha Gulbudak <mailto:talha.gulbudak@nxp.com>
* Make backward_rosConfig.cmake file relocatable (#23)
* Add dylib suffix on MacOS
* Contributors: Jordan Palacios, Sai Kishor Kothakota, Silvio Traversaro, Tobias Fischer, talhagulbudak
```
