### PR TITLE
pal_statistics: 2.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6312,7 +6312,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.6.0-1
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.6.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.0-1`

## pal_statistics

```
* Merge branch 'add/sai/maintainer' into 'humble-devel'
  Add Sai to the package maintainers
  See merge request qa/pal_statistics!51
* Add Sai to the package maintainers
* Merge branch 'use/core/libboost' into 'humble-devel'
  Use libboost-dev instead of whole boost libraries
  See merge request qa/pal_statistics!50
* Use libboost-dev instead of whole boost libraries
* Merge branch 'fix/includes/clang' into 'humble-devel'
  use std::optional to initialize properly instead of -1
  See merge request qa/pal_statistics!49
* use std::optional to initialize properly instead of -1
* Contributors: Jordan Palacios, Sai Kishor Kothakota
```

## pal_statistics_msgs

- No changes
