### PR TITLE
Adding aruco_markers to index for distro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -580,6 +580,12 @@ repositories:
       url: https://github.com/christianrauch/apriltag_ros.git
       version: master
     status: developed
+  aruco_markers:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_markers.git
+      version: humble
+    status: developed
   aruco_opencv:
     doc:
       type: git
@@ -616,12 +622,6 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
-    status: developed
-  aruco_markers:
-    source:
-      type: git
-      url: https://github.com/namo-robotics/aruco_markers.git
-      version: humble
     status: developed
   as2_platform_crazyflie:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -601,6 +601,12 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: developed
+  aruco_ros2:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_ros2.git
+      version: humble
+    status: developed
   as2_platform_crazyflie:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -617,10 +617,10 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: developed
-  aruco_ros2:
+  aruco_markers:
     source:
       type: git
-      url: https://github.com/namo-robotics/aruco_ros2.git
+      url: https://github.com/namo-robotics/aruco_markers.git
       version: humble
     status: developed
   as2_platform_crazyflie:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -430,6 +430,12 @@ repositories:
       type: git
       url: https://github.com/ycheng517/ar4_ros_driver.git
       version: main
+  aruco_markers:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_markers.git
+      version: jazzy
+    status: developed
   aruco_opencv:
     doc:
       type: git
@@ -467,12 +473,6 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: maintained
-  aruco_markers:
-    source:
-      type: git
-      url: https://github.com/namo-robotics/aruco_markers.git
-      version: jazzy
-    status: developed
   astuff_sensor_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -461,6 +461,12 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: maintained
+  aruco_ros2:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_ros2.git
+      version: jazzy
+    status: developed
   astuff_sensor_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -467,10 +467,10 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: maintained
-  aruco_ros2:
+  aruco_markers:
     source:
       type: git
-      url: https://github.com/namo-robotics/aruco_ros2.git
+      url: https://github.com/namo-robotics/aruco_markers.git
       version: jazzy
     status: developed
   astuff_sensor_msgs:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -453,10 +453,10 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: maintained
-  aruco_ros2:
+  aruco_markers:
     source:
       type: git
-      url: https://github.com/namo-robotics/aruco_ros2.git
+      url: https://github.com/namo-robotics/aruco_markers.git
       version: rolling
     status: developed
   astuff_sensor_msgs:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -416,6 +416,12 @@ repositories:
       url: https://github.com/christianrauch/apriltag_ros.git
       version: master
     status: developed
+  aruco_markers:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_markers.git
+      version: rolling
+    status: developed
   aruco_opencv:
     doc:
       type: git
@@ -453,12 +459,6 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: maintained
-  aruco_markers:
-    source:
-      type: git
-      url: https://github.com/namo-robotics/aruco_markers.git
-      version: rolling
-    status: developed
   astuff_sensor_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -451,6 +451,12 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: humble-devel
     status: maintained
+  aruco_ros2:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_ros2.git
+      version: rolling
+    status: developed
   astuff_sensor_msgs:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions. 
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

Note: It's my first time trying to release a ros2 package. Apologies in advance for any mistakes on my part. I am following [these instructions](https://docs.ros.org/en/jazzy/How-To-Guides/Releasing/Releasing-a-Package.html).

# Please Add This Package to be indexed in the rosdistro.

humble
jazzy
rolling

# The source is here:

https://github.com/namo-robotics/aruco_markers

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
