### PR TITLE
novatel_oem7_driver: 20.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5806,7 +5806,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 20.1.0-1
+      version: 20.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `20.6.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `20.1.0-1`

## novatel_oem7_driver

```
Various QoL changes
Modifications:
* Reduced log verbosity of various expected logs to DEBUG
* Updated launch files to include all configurable parameters
* Added BESTGNSSVEL and RAWIMUSX Oem7 Messages
* Expanded oem7_msgs.yaml and std_oem7_raw_msgs.yaml to include all topics matching Oem7Decoder database
* Minor adjustments to std_init_commands.yaml
```

## novatel_oem7_msgs

```
Various QoL changes
* BESTGNSSVEL, INSPVASX Oem7 Messages
```
