### PR TITLE
crane_plus: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1286,6 +1286,29 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  crane_plus:
+    doc:
+      type: git
+      url: https://github.com/rt-net/crane_plus.git
+      version: master
+    release:
+      packages:
+      - crane_plus
+      - crane_plus_control
+      - crane_plus_description
+      - crane_plus_examples
+      - crane_plus_gazebo
+      - crane_plus_moveit_config
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/crane_plus-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/crane_plus.git
+      version: master
+    status: maintained
   create3_examples:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `crane_plus` to `3.0.0-1`:

- upstream repository: https://github.com/rt-net/crane_plus.git
- release repository: https://github.com/ros2-gbp/crane_plus-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## crane_plus

- No changes

## crane_plus_control

- No changes

## crane_plus_description

```
* Mock components対応 (#86 <https://github.com/rt-net/crane_plus/issues/86>)
* Jazzy対応 (#78 <https://github.com/rt-net/crane_plus/issues/78>)
* Gazebo環境にカメラを追加 (#83 <https://github.com/rt-net/crane_plus/issues/83>)
* テスト実行時はダミーのパラメータファイルを読み込めるようにdescription_loaderを修正 (#73 <https://github.com/rt-net/crane_plus/issues/73>)
* Contributors: Kuwamai, YusukeKato, mizonon
```

## crane_plus_examples

```
* Mock components対応 (#86 <https://github.com/rt-net/crane_plus/issues/86>)
* Jazzy対応 (#78 <https://github.com/rt-net/crane_plus/issues/78>)
* Gazebo環境にカメラを追加 (#83 <https://github.com/rt-net/crane_plus/issues/83>)
* READMEにカメラサンプルデモのGIFを追加 (#70 <https://github.com/rt-net/crane_plus/issues/70>)
* Contributors: Kuwamai, YusukeKato, mizonon
```

## crane_plus_gazebo

```
* Jazzy対応 (#78 <https://github.com/rt-net/crane_plus/issues/78>)
* Gazebo環境にカメラを追加 (#83 <https://github.com/rt-net/crane_plus/issues/83>)
* テスト実行時はダミーのパラメータファイルを読み込めるようにdescription_loaderを修正 (#73 <https://github.com/rt-net/crane_plus/issues/73>)
* Contributors: Kuwamai, YusukeKato, mizonon
```

## crane_plus_moveit_config

```
* Mock components対応 (#86 <https://github.com/rt-net/crane_plus/issues/86>)
* Jazzy対応 (#78 <https://github.com/rt-net/crane_plus/issues/78>)
* Contributors: Kuwamai, YusukeKato, mizonon
```
