### PR TITLE
rviz: 14.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7517,7 +7517,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.1-1
+      version: 14.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.4.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.4.1-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Add basic support for type adaptation (REP 2007) in rviz_common for displays (#1331 <https://github.com/ros2/rviz/issues/1331>)
* Contributors: Patrick Roncagliolo
```

## rviz_default_plugins

```
* Initialize lookup table only once at compile time (#1330 <https://github.com/ros2/rviz/issues/1330>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Patrick Roncagliolo
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
