### PR TITLE
realtime_tools: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5696,7 +5696,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.1.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.0.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-1`

## realtime_tools

```
* Remove deprecated code (#262 <https://github.com/ros-controls/realtime_tools/issues/262>)
* Remove RealtimeClock (#261 <https://github.com/ros-controls/realtime_tools/issues/261>)
* Install boost on jazzy as well (#273 <https://github.com/ros-controls/realtime_tools/issues/273>)
* Use ABI workflow from ros2_control_ci (#264 <https://github.com/ros-controls/realtime_tools/issues/264>)
* Improve has_realtime_kernel method (#260 <https://github.com/ros-controls/realtime_tools/issues/260>)
* Branch for jazzy (#263 <https://github.com/ros-controls/realtime_tools/issues/263>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
