### PR TITLE
clearpath_config: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1060,7 +1060,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## clearpath_config

```
* Jazzy Phidgets IMU Filter (#119 <https://github.com/clearpathrobotics/clearpath_config/issues/119>)
  * Add filter to IMU entry
  * Enable mag only for Phidgets
  * Add DATA topic to Phidget
* Add the phidget to default sample (#120 <https://github.com/clearpathrobotics/clearpath_config/issues/120>)
* Change default user to robot (#121 <https://github.com/clearpathrobotics/clearpath_config/issues/121>)
* Feature/diagnostics (#117 <https://github.com/clearpathrobotics/clearpath_config/issues/117>)
  * Switched class (shared) variables to non-muteable types to prevent unexpected behaviour if they were ever changed
  * Remove redundant getters and setters
  * Remove duplicate variable definition
  * Add topic message type and correct rates so they are not shared muteable variables
* Ewellix Lift (#115 <https://github.com/clearpathrobotics/clearpath_config/issues/115>)
  * Added Ewellix Lift (#109 <https://github.com/clearpathrobotics/clearpath_config/issues/109>)
  * Initial add of lifts to config
  * Added ewellix parameters
  * Fix lint
* Removed deprecated parameters
* Contributors: Hilary Luo, Luis Camero
```
