### PR TITLE
clearpath_ros2_socketcan_interface: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1094,7 +1094,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `2.1.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## clearpath_ros2_socketcan_interface

```
* Wait for interface to be up before launching node (#7 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/7>)
  * Wait for interface to be UP before starting node
* Updated CI to Jazzy. (#5 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/5>)
* Contributors: Roni Kreinin, Tony Baltovski
```
