### PR TITLE
moveit_visual_tools: 4.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3953,7 +3953,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_visual_tools` to `4.1.2-1`:

- upstream repository: https://github.com/ros-planning/moveit_visual_tools.git
- release repository: https://github.com/ros2-gbp/moveit_visual_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.1-1`

## moveit_visual_tools

```
* Enhancement/use hpp for headers based on PR https://github.com/moveit/moveit2/pull/3113 (#147 <https://github.com/ros-planning/moveit_visual_tools/issues/147>)
* Contributors: Cihat Kurtuluş Altıparmak
```
