### PR TITLE
Rename fastrtps to fastdds on Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1700,7 +1700,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 2.14.x
+      version: 3.1.x
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1711,7 +1711,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 2.14.x
+      version: 3.1.x
     status: maintained
   feetech_ros2_driver:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1705,7 +1705,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastdds-release.git
-      version: 2.14.4-1
+      version: 3.1.2-1
     source:
       test_commits: true
       test_pull_requests: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1696,10 +1696,10 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: 2.2.x
     status: maintained
-  fastrtps:
+  fastdds:
     doc:
       type: git
-      url: https://github.com/eProsima/Fast-RTPS.git
+      url: https://github.com/eProsima/Fast-DDS.git
       version: 2.14.x
     release:
       tags:


### PR DESCRIPTION
Leaving this as draft until https://github.com/ros2-gbp/fastrtps-release is renamed to `fastdds-release`.