### PR TITLE
ament_lint: 0.19.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -258,7 +258,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.19.0-1
+      version: 0.19.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.19.1-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.19.0-1`

## ament_clang_format

- No changes

## ament_clang_tidy

- No changes

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

- No changes

## ament_cmake_cppcheck

- No changes

## ament_cmake_cpplint

- No changes

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

- No changes

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

- No changes

## ament_cmake_xmllint

- No changes

## ament_copyright

```
* Improve ament_copyright performance drastically. (#515 <https://github.com/ament/ament_lint/issues/515>)
* Contributors: Chris Lalancette
```

## ament_cppcheck

- No changes

## ament_cpplint

- No changes

## ament_flake8

- No changes

## ament_lint

- No changes

## ament_lint_auto

- No changes

## ament_lint_cmake

- No changes

## ament_lint_common

- No changes

## ament_mypy

```
* Add support for type stubs (#516 <https://github.com/ament/ament_lint/issues/516>)
* Contributors: Michael Carlstrom
```

## ament_pclint

- No changes

## ament_pep257

- No changes

## ament_pycodestyle

- No changes

## ament_pyflakes

- No changes

## ament_uncrustify

- No changes

## ament_xmllint

- No changes
