### PR TITLE
rqt_graph: 1.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7141,7 +7141,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.6.1-1
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.7.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.1-1`

## rqt_graph

```
* Add in standard tests. (#104 <https://github.com/ros-visualization/rqt_graph/issues/104>)
* Remove CODEOWNERS (#102 <https://github.com/ros-visualization/rqt_graph/issues/102>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
