### PR TITLE
rqt_py_console: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7251,7 +7251,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `1.4.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros2-gbp/rqt_py_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## rqt_py_console

```
* Add the standard tests to rqt_py_console. (#19 <https://github.com/ros-visualization/rqt_py_console/issues/19>)
* Remove CODEOWNERS (#17 <https://github.com/ros-visualization/rqt_py_console/issues/17>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
