### PR TITLE
rmw: 7.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6026,7 +6026,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.5.1-1
+      version: 7.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.6.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.5.1-1`

## rmw

```
* move qos_profile_rosout_default from rcl. (#381 <https://github.com/ros2/rmw/issues/381>)
* Fix ugly overwritten warning messages on error paths. (#387 <https://github.com/ros2/rmw/issues/387>)
  This mostly has to do with calling rmw_reset_error() in
  the proper time in the tests, but we also change one
  test for an allocator to properly check for a valid allocator.
* Fix rmw_validate_namespace{_with_size} error handling. (#386 <https://github.com/ros2/rmw/issues/386>)
  * Fix rmw_validate_namespace{_with_size} error handling.
  It should always set an error, even on invalid arguments.
* Contributors: Chris Lalancette, Tomoya Fujita
```

## rmw_implementation_cmake

- No changes
