### PR TITLE
rcutils: 6.9.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5651,7 +5651,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.3-1
+      version: 6.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.4-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.9.3-1`

## rcutils

```
* Cleanup error handling in rcutils. (#485 <https://github.com/ros2/rcutils/issues/485>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#483 <https://github.com/ros2/rcutils/issues/483>)
* Contributors: Chris Lalancette
```
