### PR TITLE
ros2cli: 0.37.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6463,7 +6463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.36.1-1
+      version: 0.37.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.37.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.36.1-1`

## ros2action

```
* Maintaining consistency of automatically putting time stamps in the service and action calls similiar to publishing in rostopics. (#961 <https://github.com/ros2/ros2cli/issues/961>)
* ros2action: add SIGINT handler to manage cancel request. (#956 <https://github.com/ros2/ros2cli/issues/956>)
* Contributors: Sukhvansh Jain, Tomoya Fujita
```

## ros2cli

```
* Rename the test_{daemon,direct}.py tests. (#959 <https://github.com/ros2/ros2cli/issues/959>)
* Contributors: Chris Lalancette
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* Add ament_xmllint test by default to ament_python packages. (#957 <https://github.com/ros2/ros2cli/issues/957>)
* Contributors: Chris Lalancette
```

## ros2run

- No changes

## ros2service

```
* Maintaining consistency of automatically putting time stamps in the service and action calls similiar to publishing in rostopics. (#961 <https://github.com/ros2/ros2cli/issues/961>)
* Contributors: Sukhvansh Jain, Tomoya Fujita
```

## ros2topic

```
* support multiple fields in ros2topic echo (#964 <https://github.com/ros2/ros2cli/issues/964>)
* Contributors: SangtaekLee
```
