### PR TITLE
add fast-float to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1041,6 +1041,12 @@ fakeroot:
   nixos: [fakeroot]
   rhel: [fakeroot]
   ubuntu: [fakeroot]
+fast-float:
+  debian: [libfast-float-dev]
+  fedora: [fast_float]
+  gentoo: [dev-cpp/fast_float]
+  nixos: [fast-float]
+  ubuntu: [libfast-float-dev]
 fcgi:
   arch: [fcgi, mod_fcgid, spawn-fcgi]
   debian: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1042,10 +1042,15 @@ fakeroot:
   rhel: [fakeroot]
   ubuntu: [fakeroot]
 fast-float:
+  arch: [fast_float]
   debian: [libfast-float-dev]
-  fedora: [fast_float]
+  fedora: [fast_float-devel]
   gentoo: [dev-cpp/fast_float]
   nixos: [fast-float]
+  osx:
+    homebrew:
+      packages: [fast_float]
+  opensuse: [fast_float]
   ubuntu: [libfast-float-dev]
 fcgi:
   arch: [fcgi, mod_fcgid, spawn-fcgi]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

fast_float

## Package Upstream Source:

[TODO link to source repository](https://github.com/fastfloat/fast_float)

## Purpose of using this:

Used as a dependency in c++ libraries such as folly

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/bookworm/libfast-float-dev
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/noble/libfast-float-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/fast_float/fast_float-devel/
  - IF AVAILABLE
- Arch: https://archlinux.org/packages/extra/any/fast_float/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/packages/dev-cpp/fast_float
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/formula/fast_float#default
  - IF AVAILABLE
- Alpine: not available
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.11&show=fast-float&from=0&size=50&sort=relevance&type=packages&query=fast-float
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/fast_float
  - IF AVAILABLE
- rhel: not available
  - IF AVAILABLE
