### PR TITLE
foxglove_bridge: 0.8.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3203,7 +3203,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/foxglove/ros_foxglove_bridge-release.git
-      version: 0.8.1-1
+      version: 0.8.3-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_bridge` to `0.8.3-1`:

- upstream repository: https://github.com/foxglove/ros-foxglove-bridge.git
- release repository: https://github.com/foxglove/ros_foxglove_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.1-1`

## foxglove_bridge

```
* add best_effort_qos_topic_whitelist param (#329 <https://github.com/foxglove/ros-foxglove-bridge/issues/329>)
* Add missing functional include in message_definition_cache.cpp (#334 <https://github.com/foxglove/ros-foxglove-bridge/issues/334>)
* Contributors: David Revay, Silvio Traversaro
```
