### PR TITLE
rosbag2: 0.31.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6692,13 +6692,12 @@ repositories:
       - rosbag2_test_msgdefs
       - rosbag2_tests
       - rosbag2_transport
-      - shared_queues_vendor
       - sqlite3_vendor
       - zstd_vendor
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.29.0-1
+      version: 0.31.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.31.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.29.0-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* Add test_xmllint.py to python packages. (#1879 <https://github.com/ros2/rosbag2/issues/1879>)
* Add support for replaying based on publication timestamp (#1876 <https://github.com/ros2/rosbag2/issues/1876>)
* Publish clock after delay is over and disable delay on next loops (#1861 <https://github.com/ros2/rosbag2/issues/1861>)
* Support replaying multiple bags (#1848 <https://github.com/ros2/rosbag2/issues/1848>)
* Contributors: Chris Lalancette, Christophe Bedard, Nicola Loi
```

## rosbag2

```
* Support replaying multiple bags (#1848 <https://github.com/ros2/rosbag2/issues/1848>)
* Contributors: Christophe Bedard
```

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Add more logging info to storage and reader/writer open operations (#1881 <https://github.com/ros2/rosbag2/issues/1881>)
* Add PlayerClock::wakeup() to interrupt sleeping (#1869 <https://github.com/ros2/rosbag2/issues/1869>)
* Support replaying multiple bags (#1848 <https://github.com/ros2/rosbag2/issues/1848>)
* Contributors: Christophe Bedard, Michael Orlov
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

```
* avoid using internal modules for examples. (#1905 <https://github.com/ros2/rosbag2/issues/1905>)
* Add test_xmllint.py to python packages. (#1879 <https://github.com/ros2/rosbag2/issues/1879>)
* Contributors: Chris Lalancette, Tomoya Fujita
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Add support for replaying based on publication timestamp (#1876 <https://github.com/ros2/rosbag2/issues/1876>)
* Support replaying multiple bags (#1848 <https://github.com/ros2/rosbag2/issues/1848>)
* Contributors: Christophe Bedard
```

## rosbag2_storage

```
* Add more logging info to storage and reader/writer open operations (#1881 <https://github.com/ros2/rosbag2/issues/1881>)
* Contributors: Michael Orlov
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

```
* Use tmpfs in rosbag2 temporary_directory_fixture (#1901 <https://github.com/ros2/rosbag2/issues/1901>)
* Add debug information for flaky can_record_again_after_stop test (#1871 <https://github.com/ros2/rosbag2/issues/1871>)
* Contributors: Michael Orlov
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Increase timeout to 180s for test_rosbag2_record_end_to_end (#1889 <https://github.com/ros2/rosbag2/issues/1889>)
* Contributors: yadunund
```

## rosbag2_transport

```
* Use tmpfs in rosbag2 temporary_directory_fixture (#1901 <https://github.com/ros2/rosbag2/issues/1901>)
* Bugfix: Recorder discovery does not restart after being stopped (#1894 <https://github.com/ros2/rosbag2/issues/1894>)
* Bugfix. Event publisher not starting for second run after stop (#1888 <https://github.com/ros2/rosbag2/issues/1888>)
* Add support for replaying based on publication timestamp (#1876 <https://github.com/ros2/rosbag2/issues/1876>)
* Publish clock after delay is over and disable delay on next loops (#1861 <https://github.com/ros2/rosbag2/issues/1861>)
* Add PlayerClock::wakeup() to interrupt sleeping (#1869 <https://github.com/ros2/rosbag2/issues/1869>)
* Add debug information for flaky can_record_again_after_stop test (#1871 <https://github.com/ros2/rosbag2/issues/1871>)
* Support replaying multiple bags (#1848 <https://github.com/ros2/rosbag2/issues/1848>)
* Contributors: Christophe Bedard, Michael Orlov, Nicola Loi, Øystein Sture
```

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
