### PR TITLE
mvsim: 0.13.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4125,7 +4125,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.13.0-1
+      version: 0.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.13.1-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.13.0-1`

## mvsim

```
* Merge pull request #65 <https://github.com/MRPT/mvsim/issues/65> from MRPT/fix/no-joystick-crash
  BUGFIX: Crash due to access uninitialized memory when no joystick is …
* BUGFIX: Crash due to access uninitialized memory when no joystick is found
* Merge pull request #64 <https://github.com/MRPT/mvsim/issues/64> from MRPT/feature/new-dem-param
  New offset parameters for DEM XYZRGB files
* New offset parameters for DEM XYZRGB files
* greenhouse demo world: add ROS 1 launch file too
* version.h
* Contributors: Jose Luis Blanco-Claraco
```
