### PR TITLE
Added hebi_cpp_api to jazzy and rolling distribution.yaml files

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2303,6 +2303,12 @@ repositories:
       url: https://github.com/tier4/heaphook.git
       version: main
     status: maintained
+  hebi_cpp_api:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: ros2
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2303,12 +2303,6 @@ repositories:
       url: https://github.com/tier4/heaphook.git
       version: main
     status: maintained
-  hebi_cpp_api:
-    source:
-      type: git
-      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
-      version: ros2
-    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3037,6 +3037,12 @@ repositories:
       url: https://github.com/tier4/heaphook.git
       version: main
     status: maintained
+  hebi_cpp_api:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: ros2
+    status: maintained
   hector_rviz_overlay:
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2595,6 +2595,12 @@ repositories:
       url: https://github.com/tier4/heaphook.git
       version: main
     status: maintained
+  hebi_cpp_api:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: ros2
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy
rolling

# The source is here:

https://github.com/HebiRobotics/hebi_cpp_api_ros.git

Previously released on Humble

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
