### PR TITLE
rmw_zenoh: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6162,7 +6162,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## rmw_zenoh_cpp

```
* Bump Zenoh to commit id e4ea6f0 (1.2.0 + few commits) (#446 <https://github.com/ros2/rmw_zenoh/issues/446>)
* Inform users that peers will not discover and communicate with one another until the router is started (#440 <https://github.com/ros2/rmw_zenoh/issues/440>)
* Clear the error after rmw_serialized_message_resize() (#435 <https://github.com/ros2/rmw_zenoh/issues/435>)
* Fix ZENOH_ROUTER_CHECK_ATTEMPTS which was not respected (#427 <https://github.com/ros2/rmw_zenoh/issues/427>)
* fix: use the default destructor to drop the member Payload (#419 <https://github.com/ros2/rmw_zenoh/issues/419>)
* Remove gid_hash_ from AttachmentData (#416 <https://github.com/ros2/rmw_zenoh/issues/416>)
* Sync the config with the default config in Zenoh. (#396 <https://github.com/ros2/rmw_zenoh/issues/396>)
* fix: check the context validity before accessing the session (#403 <https://github.com/ros2/rmw_zenoh/issues/403>)
* Fix wan't typo (#400 <https://github.com/ros2/rmw_zenoh/issues/400>)
* Contributors: ChenYing Kuo (CY), Chris Lalancette, Julien Enoch, Mahmoud Mazouz, Tim Clephas, Yuyuan Yuan, Yadunund
```

## zenoh_cpp_vendor

```
* Bump Zenoh to commit id e4ea6f0 (1.2.0 + few commits) (#446 <https://github.com/ros2/rmw_zenoh/issues/446>)
* Bump zenoh-c and zenoh-cpp to 1.1.1 (#424 <https://github.com/ros2/rmw_zenoh/issues/424>)
* Update Zenoh version (#405 <https://github.com/ros2/rmw_zenoh/issues/405>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Yuyuan Yuan, Yadunund
```
