### PR TITLE
rmw_zenoh: 0.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6829,7 +6829,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.1-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-1`

## rmw_zenoh_cpp

```
* Bump Zenoh to commit id e4ea6f0 (1.2.0 + few commits) (#448 <https://github.com/ros2/rmw_zenoh/issues/448>)
* Inform users that peers will not discover and communicate with one another until the router is started (#444 <https://github.com/ros2/rmw_zenoh/issues/444>)
* Clear the error after rmw_serialized_message_resize() (#436 <https://github.com/ros2/rmw_zenoh/issues/436>)
* Fix ZENOH_ROUTER_CHECK_ATTEMPTS which was not respected (#428 <https://github.com/ros2/rmw_zenoh/issues/428>)
* fix: use the default destructor to drop the member Payload (#420 <https://github.com/ros2/rmw_zenoh/issues/420>)
* Remove gid_hash_ from AttachmentData (#417 <https://github.com/ros2/rmw_zenoh/issues/417>)
* Sync the config with the default config in Zenoh. (#413 <https://github.com/ros2/rmw_zenoh/issues/413>)
* fix: check the context validity before accessing the session (#406 <https://github.com/ros2/rmw_zenoh/issues/406>)
* Fix wan't typo (#401 <https://github.com/ros2/rmw_zenoh/issues/401>)
* Contributors: ChenYing Kuo (CY), Chris Lalancette, Julien Enoch, Mahmoud Mazouz, Tim Clephas, Yadunund, Yuyuan Yuan
```

## zenoh_cpp_vendor

```
* Bump Zenoh to commit id e4ea6f0 (1.2.0 + few commits) (#448 <https://github.com/ros2/rmw_zenoh/issues/448>)
* Bump zenoh-c and zenoh-cpp to 1.1.1 (#431 <https://github.com/ros2/rmw_zenoh/issues/431>)
* Update Zenoh version (#409 <https://github.com/ros2/rmw_zenoh/issues/409>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Yadunund, Yuyuan Yuan
```
