### PR TITLE
Update gazebo_ros_pkgs status to EOL

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2947,7 +2947,8 @@ repositories:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: ros2
-    status: maintained
+    status: end-of-life
+    status_description: Deprecated. Use ros_gz instead.
   gazebo_set_joint_positions_plugin:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3371,7 +3371,8 @@ repositories:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
       version: noetic-devel
-    status: maintained
+    status: end-of-life
+    status_description: Deprecated. Use ros_gz instead.
   gazebo_set_joint_positions_plugin:
     doc:
       type: git


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1252

gazebo_ros_pkgs is deprecated with Gazebo Classic 11 reaching end of life.