### PR TITLE
pal_statistics: 2.6.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6312,7 +6312,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.6.1-1
+      version: 2.6.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.6.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.6.1-1`

## pal_statistics

```
* Reworked all pubilsher QoS policies
  Specially important was avoiding keeping all messages, this was running
  away with memory. Also, we switch to a best effort reliability instead
  of reliable, no sense in retrying to send old data.
* Contributors: Jordan Palacios
```

## pal_statistics_msgs

- No changes
