### PR TITLE
yasmin: 3.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11804,7 +11804,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 3.0.3-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `3.1.0-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.3-1`

## yasmin

```
* new yasmin logs
* improving c++ logs code
* setting default log level of python yasmin to info
* log levels added to yasmin logs
* fixing license comments
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

```
* set_ros_loggers allows setting node to log
* fixing license comments
* updating changelog files
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* new yasmin logs
* improving ros_logs
* set_ros_loggers allows setting node to log
* fixing format
* fixing license comments
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

```
* updating yasmin viewer dependencies
* new viewer build
* adding package-lock.json to gitignore
* package-lock.json removed
* adding layouts to toolbar
* fixing license comments
* Contributors: Miguel Ángel González Santamarta
```
