### PR TITLE
ros_battery_monitoring: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7267,7 +7267,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_battery_monitoring` to `1.0.1-1`:

- upstream repository: https://github.com/ipa320/ros_battery_monitoring.git
- release repository: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## battery_state_broadcaster

```
* fix realtime_tools include
* Contributors: Jonas Otto
```

## battery_state_rviz_overlay

- No changes
