### PR TITLE
ign_ros2_control: 0.7.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3548,7 +3548,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.9-1
+      version: 0.7.11-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.11-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.9-1`

## ign_ros2_control

- No changes

## ign_ros2_control_demos

```
* Update diff_drive_controller.yaml (#494 <https://github.com/ros-controls/gz_ros2_control/issues/494>) (#497 <https://github.com/ros-controls/gz_ros2_control/issues/497>)
  (cherry picked from commit 135332632bd340f17eeb0930b0d46b30fb956ebb)
  Co-authored-by: Aarav Gupta <mailto:amronos275@gmail.com>
* Contributors: mergify[bot]
```
