### PR TITLE
ros2_control: 2.48.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8251,7 +8251,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.47.0-1
+      version: 2.48.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.48.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.47.0-1`

## controller_interface

- No changes

## controller_manager

```
* Handle SIGINT properly in the controller manager (backport #2014 <https://github.com/ros-controls/ros2_control/issues/2014>) (#2040 <https://github.com/ros-controls/ros2_control/issues/2040>)
* [CM] Remove obsolete ControllerMock from the tests (#1990 <https://github.com/ros-controls/ros2_control/issues/1990>) (#1991 <https://github.com/ros-controls/ros2_control/issues/1991>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Handle SIGINT properly in the controller manager (backport #2014 <https://github.com/ros-controls/ros2_control/issues/2014>) (#2040 <https://github.com/ros-controls/ros2_control/issues/2040>)
* [Doc] Fix broken link (backport #2034 <https://github.com/ros-controls/ros2_control/issues/2034>) (#2035 <https://github.com/ros-controls/ros2_control/issues/2035>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
