### PR TITLE
ros2_control: 4.26.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6283,7 +6283,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.25.0-1
+      version: 4.26.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.26.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.25.0-1`

## controller_interface

```
* add a semantic command interface to "semantic_components" (#1945 <https://github.com/ros-controls/ros2_control/issues/1945>)
* Contributors: Thibault Poignonec
```

## controller_manager

```
* Slightly increase timeout of test_spawner_unspawner (#2037 <https://github.com/ros-controls/ros2_control/issues/2037>)
* Contributors: Christoph Fröhlich
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix memory leak in the ros2_control (#2033 <https://github.com/ros-controls/ros2_control/issues/2033>)
* Semantic components docs (#2032 <https://github.com/ros-controls/ros2_control/issues/2032>)
* [Doc] Fix broken link. (#2034 <https://github.com/ros-controls/ros2_control/issues/2034>)
* Contributors: Christoph Fröhlich, Dr. Denis, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Fix memory leak in the ros2_control (#2033 <https://github.com/ros-controls/ros2_control/issues/2033>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
