### PR TITLE
ros_babel_fish: 0.25.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8533,7 +8533,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.9.4-1
+      version: 0.25.2-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.25.2-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.4-1`

## ros_babel_fish

```
* Updated docs on template call array bounded / fixed length.
* Fixed FixedLengthArray assigns in CompoundMessages (#11 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/11>).
* Use no declaration instead of static assert for compilers that evaluate it even when not used.
* Added a method to get the actual underlying message from a compound message.
  Usage:
  using geometry_msgs::msg::Point;
  Point point = compound["position"].as<CompoundMessage>().message<Point>();
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Fixed FixedLengthArray assigns in CompoundMessages (#11 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/11>).
* Contributors: Stefan Fabian
```
