### PR TITLE
ros_babel_fish: 2.25.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7239,7 +7239,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.10.3-1
+      version: 2.25.2-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `2.25.2-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.3-1`

## ros_babel_fish

```
* Fixed FixedLengthArray assigns in CompoundMessages (#11 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/11>).
* Use no declaration instead of static assert for compilers that evaluate it even when not used.
* Added a method to get the actual underlying message from a compound message.
  Usage:
  using geometry_msgs::msg::Point;
  Point point = compound["position"].as<CompoundMessage>().message<Point>();
* Replaced action_tutorials_interfaces by example_interfaces.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Fixed FixedLengthArray assigns in CompoundMessages (#11 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/11>).
* Contributors: Stefan Fabian
```
