### PR TITLE
ros_babel_fish: 3.25.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6516,7 +6516,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.10.2-1
+      version: 3.25.2-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `3.25.2-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.2-1`

## ros_babel_fish

```
* Refactored array size templating and improved compile time checks by moving checks to constexpr.
  Fixes (#11 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/11>).
  This reduces the potential for errors and allows easier compile time checking.
  Many checks are also moved to constexpr and static assertions catching common errors at compile time instead of run time.
* Use no declaration instead of static assert for compilers that evaluate it even when not used.
* Added a method to get the actual underlying message from a compound message.
  Usage:
  using geometry_msgs::msg::Point;
  Point point = compound["position"].as<CompoundMessage>().message<Point>();
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Refactored array size templating and improved compile time checks by moving checks to constexpr.
  Fixes (#11 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/11>).
  This reduces the potential for errors and allows easier compile time checking.
  Many checks are also moved to constexpr and static assertions catching common errors at compile time instead of run time.
* Contributors: Stefan Fabian
```
