### PR TITLE
qml_ros2_plugin: 1.25.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7088,7 +7088,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
-      version: 1.0.1-2
+      version: 1.25.2-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml_ros2_plugin` to `1.25.2-1`:

- upstream repository: https://github.com/StefanFabian/qml_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-2`

## qml_ros2_plugin

```
* Apply required changes due to change of array template parameters in ros_babel_fish.
* Updated communication test message fields in accordance to renaming in ros_babel_fish_test_msgs.
* Fixed crashes when exiting application due to node still being used.
* Added method to create an empty action goal for a given action with the Ros2 singleton.
* Fixed possible crash if querying services/actions before node is initialized and downgraded error to warning.
  Will just return no results if not initialized yet.
* Added convenience functions to get types for given topic/service/action.
* Added name and type properties to ServiceClient.
* Made image transport test more robust.
* Added graph queries getTopicNamesAndTypes, getServiceNamesAndTypes and getActionNamesAndTypes to Ros2 singleton.
* Small quality refactorings.
* Contributors: Stefan Fabian
```
