### PR TITLE
moveit: 2.5.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5134,7 +5134,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.5.7-1
+      version: 2.5.8-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.8-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.7-1`

## chomp_motion_planner

```
* Use ! in place of not keyword for Pilz and CHOMP planners (#3217 <https://github.com/ros-planning/moveit2/issues/3217>) (#3221 <https://github.com/ros-planning/moveit2/issues/3221>)
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, Silvio Traversaro, mergify[bot]
```

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* Switch to get for Dict lookup to prevent KeyError (#3043 <https://github.com/ros-planning/moveit2/issues/3043>) (#3193 <https://github.com/ros-planning/moveit2/issues/3193>)
* Contributors: Brendan Burns, mergify[bot]
```

## moveit_core

```
* Reverts #2985 <https://github.com/ros-planning/moveit2/issues/2985>, Ports moveit #3388 <https://github.com/ros-planning/moveit2/issues/3388> #3470 <https://github.com/ros-planning/moveit2/issues/3470> #3539 <https://github.com/ros-planning/moveit2/issues/3539> (backport #3284 <https://github.com/ros-planning/moveit2/issues/3284>) (#3319 <https://github.com/ros-planning/moveit2/issues/3319>)
* Add missing target dependencies to eigen_stl_containers (backport #3295 <https://github.com/ros-planning/moveit2/issues/3295>) (#3296 <https://github.com/ros-planning/moveit2/issues/3296>)
* Support including the names of other attached objects in touch_link (backport #3276 <https://github.com/ros-planning/moveit2/issues/3276>) (#3287 <https://github.com/ros-planning/moveit2/issues/3287>)
* Fix: misleading error logs in RobotState::setFromIKSubgroups() (backport #3263 <https://github.com/ros-planning/moveit2/issues/3263>) (#3267 <https://github.com/ros-planning/moveit2/issues/3267>)
* Fixed include path for moveit_butterworth_parameters.hpp (#3264 <https://github.com/ros-planning/moveit2/issues/3264>)
* Don't destroy objects on attach (backport #3205 <https://github.com/ros-planning/moveit2/issues/3205>) (#3213 <https://github.com/ros-planning/moveit2/issues/3213>)
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Remove ACM entries when removing collision objects (#3183 <https://github.com/ros-planning/moveit2/issues/3183>) (#3184 <https://github.com/ros-planning/moveit2/issues/3184>)
* Contributors: Sebastian Castro, Michael Görner, Robert Haschke, Zhong Jin, Mark Johnson, Aleksey Nogin, Jacob Odle, Jafar Uruç, mergify[bot]
```

## moveit_hybrid_planning

```
* Fix clang-tidy warnings in hybrid planning package (#3305 <https://github.com/ros-planning/moveit2/issues/3305>)
* Contributors: Sebastian Castro
```

## moveit_kinematics

```
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, mergify[bot]
```

## moveit_planners

```
* fix chomp depend, closes #3228 <https://github.com/ros-planning/moveit2/issues/3228> (backport #3229 <https://github.com/ros-planning/moveit2/issues/3229>) (#3230 <https://github.com/ros-planning/moveit2/issues/3230>)
* Contributors: Michael Ferguson, mergify[bot]
```

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, mergify[bot]
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_control_interface

```
* Fix Ros2ControlManager chained controller logic (#3301 <https://github.com/ros-planning/moveit2/issues/3301>) (#3306 <https://github.com/ros-planning/moveit2/issues/3306>)
* Update controller_manager_plugin.cpp (backport #3179 <https://github.com/ros-planning/moveit2/issues/3179>) (#3235 <https://github.com/ros-planning/moveit2/issues/3235>)
  * Fixing the bug where the namespace is not properly applied when using Ros2ControlMultiManager
* Contributors: Paul Gesel, Seohyeon Ryu, mergify[bot]
```

## moveit_ros_move_group

```
* Ports moveit #3676 <https://github.com/ros-planning/moveit2/issues/3676> and #3682 <https://github.com/ros-planning/moveit2/issues/3682> (backport #3283 <https://github.com/ros-planning/moveit2/issues/3283>) (#3317 <https://github.com/ros-planning/moveit2/issues/3317>)
* move TrajectoryExecutionManager::clear() to private (backport #3226 <https://github.com/ros-planning/moveit2/issues/3226>) (#3237 <https://github.com/ros-planning/moveit2/issues/3237>)
* Contributors: Michael Görner, Robert Haschke, Dongya Jiang, Mark Johnson, mergify[bot]
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* fix: pointcloud_octomap_updater not cleaning objects at max_range (backport #3294 <https://github.com/ros-planning/moveit2/issues/3294>) (#3303 <https://github.com/ros-planning/moveit2/issues/3303>)
* fix: OctoMap and Filtered_Cloud Not Updating During Movement Execution (backport #3209 <https://github.com/ros-planning/moveit2/issues/3209>) (#3211 <https://github.com/ros-planning/moveit2/issues/3211>)
* Use sensor data QOS profile for sensor_msgs::Image and sensor_msgs::PointCloud (backport #664 <https://github.com/ros-planning/moveit2/issues/664>) (#3220 <https://github.com/ros-planning/moveit2/issues/3220>)
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Nathan Brooks, Sebastian Castro, Marco Magri, mergify[bot]
```

## moveit_ros_planning

```
* load robot_description from other namespace (backport #3269 <https://github.com/ros-planning/moveit2/issues/3269>) (#3324 <https://github.com/ros-planning/moveit2/issues/3324>)
* Ports moveit #3676 <https://github.com/ros-planning/moveit2/issues/3676> and #3682 <https://github.com/ros-planning/moveit2/issues/3682> (backport #3283 <https://github.com/ros-planning/moveit2/issues/3283>) (#3317 <https://github.com/ros-planning/moveit2/issues/3317>)
* [moveit_ros] fix race condition when stopping trajectory execution (backport #3198 <https://github.com/ros-planning/moveit2/issues/3198>) (#3239 <https://github.com/ros-planning/moveit2/issues/3239>)
* move TrajectoryExecutionManager::clear() to private (backport #3226 <https://github.com/ros-planning/moveit2/issues/3226>) (#3237 <https://github.com/ros-planning/moveit2/issues/3237>)
* Don't destroy objects on attach (backport #3205 <https://github.com/ros-planning/moveit2/issues/3205>) (#3213 <https://github.com/ros-planning/moveit2/issues/3213>)
* Simplify scene update that does not include new robot_state (#3206 <https://github.com/ros-planning/moveit2/issues/3206>) (#3207 <https://github.com/ros-planning/moveit2/issues/3207>)
* Fix planning_scene_monitor sync when passed empty robot state (#3187 <https://github.com/ros-planning/moveit2/issues/3187>) (#3203 <https://github.com/ros-planning/moveit2/issues/3203>)
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, Michael Görner, Robert Haschke, Dongya Jiang, Mark Johnson, Marq Rasmussen, RLi43, mergify[bot]
```

## moveit_ros_planning_interface

```
* Reverts #2985 <https://github.com/ros-planning/moveit2/issues/2985>, Ports moveit #3388 <https://github.com/ros-planning/moveit2/issues/3388> #3470 <https://github.com/ros-planning/moveit2/issues/3470> #3539 <https://github.com/ros-planning/moveit2/issues/3539> (backport #3284 <https://github.com/ros-planning/moveit2/issues/3284>) (#3319 <https://github.com/ros-planning/moveit2/issues/3319>)
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, Michael Görner, Robert Haschke, Mark Johnson, mergify[bot]
```

## moveit_ros_robot_interaction

```
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, mergify[bot]
```

## moveit_ros_visualization

```
* Use attached object colors as is in Rviz plugin (#3274 <https://github.com/ros-planning/moveit2/issues/3274>) (#3277 <https://github.com/ros-planning/moveit2/issues/3277>)
* Contributors: Aleksey Nogin, mergify[bot]
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (backport #3249 <https://github.com/ros-planning/moveit2/issues/3249>) (#3253 <https://github.com/ros-planning/moveit2/issues/3253>)
* Contributors: Silvio Traversaro, mergify[bot]
```

## moveit_setup_controllers

```
* Fix key duplication in moveit_setup_assistant for FollowJointTrajectory (#2959 <https://github.com/ros-planning/moveit2/issues/2959>) (#3316 <https://github.com/ros-planning/moveit2/issues/3316>)
* Contributors: Chris Schindlbeck, mergify[bot]
```

## moveit_setup_core_plugins

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (backport #3249 <https://github.com/ros-planning/moveit2/issues/3249>) (#3253 <https://github.com/ros-planning/moveit2/issues/3253>)
* Contributors: Silvio Traversaro, mergify[bot]
```

## moveit_setup_framework

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (backport #3249 <https://github.com/ros-planning/moveit2/issues/3249>) (#3253 <https://github.com/ros-planning/moveit2/issues/3253>)
* Fix: Conditionally install launch directory in generated MoveIt config package (backport #3191 <https://github.com/ros-planning/moveit2/issues/3191>) (#3194 <https://github.com/ros-planning/moveit2/issues/3194>)
* Contributors: Filippo Bosi, Silvio Traversaro, mergify[bot]
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Use ! in place of not keyword for Pilz and CHOMP planners (#3217 <https://github.com/ros-planning/moveit2/issues/3217>) (#3221 <https://github.com/ros-planning/moveit2/issues/3221>)
* pilz_industrial_motion_planner: Use tf2::fromMsg instead of tf2::convert (#3219 <https://github.com/ros-planning/moveit2/issues/3219>) (#3223 <https://github.com/ros-planning/moveit2/issues/3223>)
* Update deprecated tf2 imports from .h to .hpp (backport #3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3199 <https://github.com/ros-planning/moveit2/issues/3199>)
* Contributors: Sebastian Castro, Silvio Traversaro, mergify[bot]
```

## pilz_industrial_motion_planner_testutils

- No changes
