### PR TITLE
Add python-snap7

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9055,6 +9055,10 @@ python3-pytest-xvfb:
     pip:
       packages: [pytest-xvfb]
   ubuntu: [python3-pytest-xvfb]
+python3-python-snap7-pip:
+  "*":
+    pip:
+      packages: [python-snap7]
 python3-pytorch-pip: *migrate_eol_2025_04_30_python3_pytorch_pip
 python3-pytrinamic-pip:
   debian:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python-snap7`

## Package Upstream Source:

Github repository: https://github.com/gijzelaerr/python-snap7

## Purpose of using this:

The `python-snap7` Python module provides a wrapper for the Snap7 Ethernet communication suite. This allows writing ROS nodes that interface natively with the Siemens S7 PLCs.

Documentation: https://python-snap7.readthedocs.io/en/latest/

## Links to Distribution Packages

PyPI: https://pypi.org/project/python-snap7/

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
