### PR TITLE
image_pipeline: 6.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2721,7 +2721,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.7-1
+      version: 6.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.8-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.7-1`

## camera_calibration

```
* Check repeatedly (backport #1066 <https://github.com/ros-perception/image_pipeline/issues/1066>) (#1070 <https://github.com/ros-perception/image_pipeline/issues/1070>)
  I made it so that it is checked multiple times instead of just once.
  - fix #1052 <https://github.com/ros-perception/image_pipeline/issues/1052>
  Co-authored-by: Tatsuro Sakaguchi <mailto:tacchan.mello.ioiq@gmail.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* improve stereo calibration tutorial (#1065 <https://github.com/ros-perception/image_pipeline/issues/1065>)
  * make topic names consistent by removing the my_ prefix on some
  topics
  * show the output of ros2 service list so that service names are more
  clear
  * explain what left/right/left_camera/right_camera actually mean
* Contributors: Michael Ferguson, mergify[bot]
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

```
* Removed warning (#1063 <https://github.com/ros-perception/image_pipeline/issues/1063>)
* Contributors: Alejandro Hernández Cordero
```

## image_publisher

```
* Fix Windows compilation in image_publisher.cpp (#1061 <https://github.com/ros-perception/image_pipeline/issues/1061>)
  PR https://github.com/ros-perception/image_pipeline/pull/985 added some
  code that used M_PI, but M_PI is not defined in any standard, and
  before including cmath or math.h in Windows it is necessary to
  define _USE_MATH_DEFINES to ensure that M_PI is defined.
* Contributors: Silvio Traversaro
```

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
