### PR TITLE
diagnostics: 4.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1585,7 +1585,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.2.1-1
+      version: 4.2.2-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1574,7 +1574,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2
+      version: ros2-jazzy
     release:
       packages:
       - diagnostic_aggregator
@@ -1590,7 +1590,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/diagnostics.git
-      version: ros2
+      version: ros2-jazzy
     status: maintained
   dolly:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.2.2-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.1-1`

## diagnostic_aggregator

```
* Checking licenses in CI (#431 <https://github.com/ros/diagnostics/issues/431>) (#434 <https://github.com/ros/diagnostics/issues/434>)
  * Checking licenses in ci
* Add Windows support (#426 <https://github.com/ros/diagnostics/issues/426>) (#430 <https://github.com/ros/diagnostics/issues/430>)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Support custom rclcpp::NodeOptions (#417 <https://github.com/ros/diagnostics/issues/417>) (#424 <https://github.com/ros/diagnostics/issues/424>)
  Co-authored-by: Patrick Roncagliolo <mailto:ronca.pat@gmail.com>
* Skipping flaky tests (#413 <https://github.com/ros/diagnostics/issues/413>) (#416 <https://github.com/ros/diagnostics/issues/416>)
* Contributors: Christian Henkel
```

## diagnostic_common_diagnostics

```
* common_diagnostics cleaned hostname string (#405 <https://github.com/ros/diagnostics/issues/405>) (#421 <https://github.com/ros/diagnostics/issues/421>)
  * Hostnames are properly cleaned to only contain alphanumeric characters or underscore.
  Co-authored-by: sjusner <mailto:simon.jusner@knapp.com>
* Add missing rclpy dependency to common_diagnostics to fix rosdoc2 output (#402 <https://github.com/ros/diagnostics/issues/402>) (#408 <https://github.com/ros/diagnostics/issues/408>)
  Co-authored-by: R Kent James <mailto:kent@caspia.com>
* Contributors: Christian Henkel
```

## diagnostic_updater

```
* Add Windows support (#426 <https://github.com/ros/diagnostics/issues/426>) (#430 <https://github.com/ros/diagnostics/issues/430>)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Skipping flaky tests (#413 <https://github.com/ros/diagnostics/issues/413>) (#416 <https://github.com/ros/diagnostics/issues/416>)
  * skipping flaky ntp test
* Contributors: Christian Henkel
```

## diagnostics

- No changes

## self_test

- No changes
