### PR TITLE
diagnostics: 4.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1241,7 +1241,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.3.1-1
+      version: 4.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.4.2-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.1-1`

## diagnostic_aggregator

```
* Checking licenses in CI (#431 <https://github.com/ros/diagnostics/issues/431>)
  * Checking licenses in ci
* Add Windows support (#426 <https://github.com/ros/diagnostics/issues/426>)
* Support custom rclcpp::NodeOptions (#417 <https://github.com/ros/diagnostics/issues/417>)
* Skipping flaky tests (#413 <https://github.com/ros/diagnostics/issues/413>)
* Skipping flaky ntp test (#409 <https://github.com/ros/diagnostics/issues/409>)
* Contributors: Christian Henkel, Patrick Roncagliolo, Silvio Traversaro
```

## diagnostic_common_diagnostics

```
* common_diagnostics cleaned hostname string (#405 <https://github.com/ros/diagnostics/issues/405>)
  * Hostnames are properly cleaned to only contain alphanumeric characters or underscore.
* Skipping flaky ntp test (#409 <https://github.com/ros/diagnostics/issues/409>)
* Add missing rclpy dependency to common_diagnostics to fix rosdoc2 output (#402 <https://github.com/ros/diagnostics/issues/402>)
* Contributors: Christian Henkel, R Kent James, sjusner
```

## diagnostic_updater

```
* Add Windows support (#426 <https://github.com/ros/diagnostics/issues/426>)
* Skipping flaky tests (#413 <https://github.com/ros/diagnostics/issues/413>)
* Contributors: Christian Henkel, Silvio Traversaro
```

## diagnostics

- No changes

## self_test

- No changes
