### PR TITLE
hebi_cpp_api: 3.12.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3328,7 +3328,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
-      version: 3.12.2-1
+      version: 3.12.3-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api` to `3.12.3-1`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/ros2-gbp/hebi_cpp_api-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.12.2-1`

## hebi_cpp_api

```
* Fixed CMakeLists.txt to include proper C API files
* Contributors: Hariharan Ravichandran
```
