### PR TITLE
Adds setproctitle to rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9614,6 +9614,18 @@ python3-serial:
     '*': ['python%{python3_pkgversion}-pyserial']
     '7': null
   ubuntu: [python3-serial]
+python3-setproctitle:
+  alpine: [py3-setproctitle]
+  arch: [python-setproctitle]
+  debian: [python3-setproctitle]
+  fedora: [python3-setproctitle]
+  gentoo: [dev-python/setproctitle]
+  opensuse: [python3-setproctitle]
+  osx:
+    pip:
+      packages: [setproctitle]
+  rhel: [python3-setproctitle]
+  ubuntu: [python3-setproctitle]
 python3-setuptools:
   alpine: [py3-setuptools]
   arch: [python-setuptools]


### PR DESCRIPTION
# Please add the following dependency to the rosdep database.

## Package name:

`python3-setproctitle`

## Package Upstream Source:

[source repository](https://github.com/dvarrazzo/py-setproctitle)

## Purpose of using this:

Python module to customize the process title. Used to write syntactic sugar for ROS2 launch.


## Links to Distribution Packages


- Debian: [python3-setproctitle](https://packages.debian.org/bookworm/python3-setproctitle)
- Ubuntu: [python3-setproctitle](https://packages.ubuntu.com/noble/python3-setproctitle)
- Fedora: [python3-setproctitle](https://packages.fedoraproject.org/pkgs/python-setproctitle/python3-setproctitle/)
- Arch: [python-setproctitle](https://archlinux.org/packages/extra/x86_64/python-setproctitle/)
- Gentoo: [dev-python/setproctitle](https://packages.gentoo.org/packages/dev-python/setproctitle)
- macOS: Not available
  - [pip](https://pypi.org/project/setproctitle/)
- Alpine: [py3-setproctitle](https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-setproctitle)
- NixOS/nixpkgs: Not available
- openSUSE: [python3-setproctitle](https://software.opensuse.org/package/python3-setproctitle)
- rhel: [python3-setproctitle](https://pkgs.org/search/?q=setproctitle)