### PR TITLE
image_pipeline: 5.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3174,7 +3174,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.6-1
+      version: 5.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.7-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.6-1`

## camera_calibration

```
* Check repeatedly (#1066 <https://github.com/ros-perception/image_pipeline/issues/1066>)
* improve stereo calibration tutorial (backport #1065 <https://github.com/ros-perception/image_pipeline/issues/1065>) (#1067 <https://github.com/ros-perception/image_pipeline/issues/1067>)
  Co-authored-by: Michael Ferguson <mailto:mfergs7@gmail.com>
* Contributors: Tatsuro Sakaguchi, mergify[bot]
```

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

```
* Fix Windows compilation in image_publisher.cpp (backport #1061 <https://github.com/ros-perception/image_pipeline/issues/1061>) (#1062 <https://github.com/ros-perception/image_pipeline/issues/1062>)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Contributors: mergify[bot]
```

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
