### PR TITLE
image_transport_plugins: 5.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2743,7 +2743,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 5.0.1-1
+      version: 5.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `5.0.2-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.1-1`

## compressed_depth_image_transport

- No changes

## compressed_image_transport

```
* [ADD] flag for jpeg compression of bayer format (#98 <https://github.com/ros-perception/image_transport_plugins/issues/98>)
* Contributors: wodtko
```

## image_transport_plugins

- No changes

## theora_image_transport

- No changes

## zstd_image_transport

```
* Use standard C++ type unsigned int in place of uint (#174 <https://github.com/ros-perception/image_transport_plugins/issues/174>)
* Contributors: Silvio Traversaro
```
