### PR TITLE
Adds ubuntu/osx/arch as targets for pip installation of attrs

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -653,19 +653,7 @@ python-attrs:
     bionic: [python-attr]
     focal: [python-attr]
 python-attrs-pip:
-  arch:
-    pip:
-      packages: [attrs]
-  debian:
-    pip:
-      packages: [attrs]
-  fedora:
-    pip:
-      packages: [attrs]
-  osx:
-    pip:
-      packages: [attrs]
-  ubuntu:
+  '*':
     pip:
       packages: [attrs]
 python-autobahn:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -653,10 +653,19 @@ python-attrs:
     bionic: [python-attr]
     focal: [python-attr]
 python-attrs-pip:
+  arch:
+    pip:
+      packages: [attrs]
   debian:
     pip:
       packages: [attrs]
   fedora:
+    pip:
+      packages: [attrs]
+  osx:
+    pip:
+      packages: [attrs]
+  ubuntu:
     pip:
       packages: [attrs]
 python-autobahn:


### PR DESCRIPTION

## Modified tag

python-attrs-pip

## Package name:

attrs

## Package Upstream Source:

[link to source repository](https://github.com/python-attrs/attrs)

## Purpose of change:

This pull request adds ubuntu/osx/arch as targets for installation with the python-attrs-pip tag. The reason for adding these targets is twofold:

- On **Ubuntu 22.04** (humble and iron), the latest version of attrs available with the tag python3-attrs (in rosdep) is **21.2**.  Whereas, version 21.3 had a massive update to the API, which significantly changed the usage structure. This can be verified from the change log [here](https://www.attrs.org/en/stable/changelog.html#id25).

- The release cycle for this project is very fast and Ubuntu packaging is unlikely to get the latest updates in the future as well.  Therefore, it makes sense to keep the pip installation target (python-attrs-pip) separate from deb installation target (python3-attrs), so that latest updates can be utilized. 


