### PR TITLE
gz_rendering_vendor: 0.0.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2892,7 +2892,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_rendering_vendor` to `0.0.6-1`:

- upstream repository: https://github.com/gazebo-release/gz_rendering_vendor.git
- release repository: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.5-1`

## gz_rendering_vendor

```
* Bump version to 8.2.2 (#6 <https://github.com/gazebo-release/gz_rendering_vendor/issues/6>)
* Contributors: Addisu Z. Taddese
```
