### PR TITLE
gz_gui_vendor: 0.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2781,7 +2781,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_gui_vendor` to `0.0.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_gui_vendor.git
- release repository: https://github.com/ros2-gbp/gz_gui_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-1`

## gz_gui_vendor

```
* Bump version to 8.4.0 (#4 <https://github.com/gazebo-release/gz_gui_vendor/issues/4>)
* Contributors: Addisu Z. Taddese
```
