### PR TITLE
rqt_plot: 1.4.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7953,7 +7953,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.4.0-2
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.4.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-2`

## rqt_plot

```
* Add single quotes around topic in validation msg for consistency (backport #99 <https://github.com/ros-visualization/rqt_plot/issues/99>) (#102 <https://github.com/ros-visualization/rqt_plot/issues/102>)
  * Add single quotes around topic in validation msg for consistency (#99 <https://github.com/ros-visualization/rqt_plot/issues/99>)
  This is more consistent with the other messages below.
  (cherry picked from commit 2662c21b82a9758af7dd288dfeb0c6caf3b87cf4)
  # Conflicts:
  #     src/rqt_plot/plot_widget.py
  * Fix merge
  ---------
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Remove CODEOWNERS (backport #96 <https://github.com/ros-visualization/rqt_plot/issues/96>) (#97 <https://github.com/ros-visualization/rqt_plot/issues/97>)
  Remove CODEOWNERS (#96 <https://github.com/ros-visualization/rqt_plot/issues/96>)
  (cherry picked from commit 842cd61ba59a5240b730791de567ad489d2e2900)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
