### PR TITLE
synapticon_ros2_control: 0.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10224,6 +10224,21 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: ros2-devel
     status: developed
+  synapticon_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: 0.1.0
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/synapticon/synapticon_ros2_control-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: 0.1.0
+    status: developed
   sync_parameter_server:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10237,7 +10237,7 @@ repositories:
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: 0.1.0
+      version: v0.1.0
     status: developed
   sync_parameter_server:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10228,7 +10228,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: 0.1.0
+      version: v0.1.0
     release:
       tags:
         release: release/humble/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `synapticon_ros2_control` to `0.0.0-1`:

- upstream repository: https://github.com/synapticon/synapticon_ros2_control.git
- release repository: https://github.com/synapticon/synapticon_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
