### PR TITLE
ublox_dgnss: 0.5.5-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8507,7 +8507,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.5.4-3
+      version: 0.5.5-4
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.5-4`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.4-3`

## ntrip_client_node

```
* added log_level param and CURLOPT_MAXAGE_CONN
* Contributors: Nick Hortovanyi
```

## ublox_dgnss

```
* Merge pull request #33 <https://github.com/aussierobots/ublox_dgnss/issues/33> from bvsam/base-rtcm-support
  Base rtcm support
* Fixed ublox_fb+r_rover.launch.py and ublox_fb+r_base.launch.py
* updated ublox_fb+r_rover.launch.py and ublox_fb+r_base.launch.py
* updated ublox_fb+r_rover.launch.py and ublox_fb+r_base.launch.py
* updated ublox_fb+r_rover.launch.py and ublox_fb+r_base.launch.py
* Changed ublox_fb+r_base.launch.py
* Changed ublox_fb+r_rover.launch.py
* Merge branch 'main' into base-rtcm-support
* Merge pull request #32 <https://github.com/aussierobots/ublox_dgnss/issues/32> from bvsam/mb+r_fix
  Updating mb+r_base launch file and adding missing parameters
* Updating launch file description comments
* Updating mb+r_base launch file and adding missing parameters
* Adding 2 launch files for fixed base use case
* Improving ublox_rover_hpposllh_navsatfix launch file
* Cleaning up and improving launch files
* added ubx_rxm_cor usb output
* ubx_sec_sig msg ver 2 changes
* added log-level for debug
* added log_level param and CURLOPT_MAXAGE_CONN
* Contributors: Benjamin Sam, Nick Hortovanyi, Xiran Zhou, ryan
```

## ublox_dgnss_node

```
* Merge pull request #33 <https://github.com/aussierobots/ublox_dgnss/issues/33> from bvsam/base-rtcm-support
  Base rtcm support
* fixed style
* Merge branch 'main' into base-rtcm-support
* Merge pull request #32 <https://github.com/aussierobots/ublox_dgnss/issues/32> from bvsam/mb+r_fix
  Updating mb+r_base launch file and adding missing parameters
* Fixing formatting to allow for tests to pass
* Fixing formatting to enable tests to pass
* Fixing errors in code to ensure successful builds
* Adding more CONFIG_TMODE parameters
* Updating mb+r_base launch file and adding missing parameters
* Adding initial code for fixed base use case
* uncrustify formatting fixes
* Merge branch 'main' of github.com:aussierobots/ublox_dgnss
* uncrustify formatting changes
* Merge pull request #30 <https://github.com/aussierobots/ublox_dgnss/issues/30> from bvsam/base-station-rtcm
  Add base station rtcm message publishing support
* Updating rtcm publisher QOS for subscription compatibility
* Minor: fixing error in code
* Changing rtcm publisher topic name
* Adding payload logging for rtcm publishing
* Making subscription topics absolute for backwards compatbility
* Updating subscription topic names to be non-absolute
* Fixing errors in code
* Adding basic rtcm receival and publishing functionality
* Added Subcription Options Qos Override on subscriptions
* Add Publisher Option with QOS Overriding for all publishers
* uncrustify formatting changes
* parameter pub for ubx_mon_ver ubx_sec_uniqid
* ubx_sec_sig msg ver 2 changes
* added CFG_SIGNAL for GPS, SBAS, GAL, BDS, QZSS and GLO
* updated cfg items
* Contributors: Benjamin Sam, Nick Hortovanyi, Xiran Zhou, ryan
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

```
* Merge pull request #33 <https://github.com/aussierobots/ublox_dgnss/issues/33> from bvsam/base-rtcm-support
  Base rtcm support
* Adding initial code for fixed base use case
* Update UBXSecSig with 1.5 firmware cent freq jamming state
* Contributors: Benjamin Sam, Nick Hortovanyi
```
