### PR TITLE
ros_gz: 2.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6587,7 +6587,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.3-2
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.4-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.3-2`

## ros_gz

- No changes

## ros_gz_bridge

```
* Minor optimization to avoid dynamic casting in Gazebo callbacks (#692 <https://github.com/gazebosim/ros_gz/issues/692>)
* Contributors: Addisu Z. Taddese
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Fix spelling in entity creation (#688 <https://github.com/gazebosim/ros_gz/issues/688>)
* Use PIMPL pattern in gzserver (#683 <https://github.com/gazebosim/ros_gz/issues/683>)
* Expose header for GzServer (#681 <https://github.com/gazebosim/ros_gz/issues/681>)
* Contributors: Addisu Z. Taddese, Leander Stephen D'Souza, Patrick Roncagliolo
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
