### PR TITLE
ros_gz: 1.0.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7327,7 +7327,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.7-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.9-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.7-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Minor optimization to avoid dynamic casting in Gazebo callbacks (#692 <https://github.com/gazebosim/ros_gz/issues/692>) (#693 <https://github.com/gazebosim/ros_gz/issues/693>)
  (cherry picked from commit f646d5cade730166f8cb408d483c24b6d382ca0e)
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Fix spelling in entity creation (#688 <https://github.com/gazebosim/ros_gz/issues/688>) (#689 <https://github.com/gazebosim/ros_gz/issues/689>)
  (cherry picked from commit 5e3b0730359a4f3f23cb26f6083ae5620b9a5ea1)
  Co-authored-by: Leander Stephen D'Souza <mailto:leanderdsouza1234@gmail.com>
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
