### PR TITLE
Add nobleo_socketcan_bridge to humble & jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5743,6 +5743,12 @@ repositories:
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
       version: ros2
     status: maintained
+  nobleo_socketcan_bridge:
+    source:
+      type: git
+      url: https://github.com/nobleo/nobleo_socketcan_bridge.git
+      version: main
+    status: maintained
   nodl:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4853,6 +4853,12 @@ repositories:
       version: ros2
     status: developed
     status_description: ROS2 support is work-in-progress. Help wanted!
+  nobleo_socketcan_bridge:
+    source:
+      type: git
+      url: https://github.com/nobleo/nobleo_socketcan_bridge.git
+      version: main
+    status: maintained
   nodl:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

humble & jazzy

# The source is here:

https://github.com/nobleo/nobleo_socketcan_bridge

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

See also the previous submission for iron: https://github.com/ros/rosdistro/pull/41512
