### PR TITLE
coal: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1454,7 +1454,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/coal-library/coal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.1-1`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`
