### PR TITLE
cras_ros_utils: 2.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1804,6 +1804,7 @@ repositories:
       version: master
     release:
       packages:
+      - cras_bag_tools
       - cras_cpp_common
       - cras_docs_common
       - cras_py_common
@@ -1812,7 +1813,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.4.8-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.5.0-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.8-1`

## cras_bag_tools

```
* filter_bag: Split into a reusable module, added more filters and example configs.
* topic_set: Support iteration over TopicSet.
* extract_images: Support global speedup setting.
* filter_bag: Refactor.
* filter_bag: Rewritten to use image_transport_codecs
* Added extract_images
* Added filter_bag
* Contributors: Martin Pecka
```

## cras_cpp_common

- No changes

## cras_docs_common

- No changes

## cras_py_common

```
* plugin_utils: Fixed Python 2.7 compatibility.
* Added plugin_utils.
* string_utils: Added pretty_file_size()
* message_utils: Added msg_to_raw and raw_to_msg
* Fixed dependencies.
* image_encodings: Added isDepth().
* Added image_encodings.py and distortion_models.py .
* Contributors: Martin Pecka
```

## cras_topic_tools

- No changes

## image_transport_codecs

```
* Fixed RVL decoder incorrectly marking some images as malformed.
  Apparently, the compression ratio can get better that 5:1 (happens mostly in images with large NaN areas).
* Contributors: Martin Pecka
```
