### PR TITLE
image_pipeline: 5.0.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3174,7 +3174,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.7-1
+      version: 5.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.8-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.7-1`

## camera_calibration

- No changes

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

```
* Fix new opencv aruco api (backport #1072 <https://github.com/ros-perception/image_pipeline/issues/1072>) (#1073 <https://github.com/ros-perception/image_pipeline/issues/1073>)
* Contributors: mergify[bot]
```

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

```
* image_view：set CvtColorForDisplay encoding as bgr8 (backport #1071 <https://github.com/ros-perception/image_pipeline/issues/1071>) (#1075 <https://github.com/ros-perception/image_pipeline/issues/1075>)
  Co-authored-by: Zhaoyuan Cheng <mailto:zycczyby@gmail.com>
* Contributors: mergify[bot]
```

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
