### PR TITLE
rqt_plot: 1.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7220,7 +7220,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.6.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.1-1`

## rqt_plot

```
* Add unit tests for topic name validation & field expansion (#108 <https://github.com/ros-visualization/rqt_plot/issues/108>)
* Fix double slash when plotting all sub-fields with trailing slash (#107 <https://github.com/ros-visualization/rqt_plot/issues/107>)
* Fix listing of nested basic type fields (#101 <https://github.com/ros-visualization/rqt_plot/issues/101>)
* Fix f-string and add single quote around field name (#100 <https://github.com/ros-visualization/rqt_plot/issues/100>)
* Contributors: Christophe Bedard
```
