### PR TITLE
rqt_plot: 1.4.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7960,7 +7960,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.4.1-1
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.4.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.1-1`

## rqt_plot

```
* Add unit tests for topic name validation & field expansion (backport #108 <https://github.com/ros-visualization/rqt_plot/issues/108>) (#110 <https://github.com/ros-visualization/rqt_plot/issues/110>)
* Fix double slash when plotting all sub-fields with trailing slash (backport #107 <https://github.com/ros-visualization/rqt_plot/issues/107>) (#109 <https://github.com/ros-visualization/rqt_plot/issues/109>)
* Fix f-string and add single quote around field name (backport #100 <https://github.com/ros-visualization/rqt_plot/issues/100>) (#104 <https://github.com/ros-visualization/rqt_plot/issues/104>)
* Fix listing of nested basic type fields (backport #101 <https://github.com/ros-visualization/rqt_plot/issues/101>) (#106 <https://github.com/ros-visualization/rqt_plot/issues/106>)
* Contributors: mergify[bot]
```
