### PR TITLE
synapticon_ros2_control: 0.1.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10224,6 +10224,21 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: ros2-devel
     status: developed
+  synapticon_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: 0.1.1
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/synapticon/synapticon_ros2_control-release_v1.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: 0.1.1
+    status: maintained
   sync_parameter_server:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `synapticon_ros2_control` to `0.1.1-2`:

- upstream repository: https://github.com/synapticon/synapticon_ros2_control
- release repository: https://github.com/synapticon/synapticon_ros2_control-release_v1.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
