### PR TITLE
mola: 1.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4216,7 +4216,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.6.1-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Add new option: publish_tf_from_slam; add better docs on the meaning of all parameters
* Publish georef /tf as /tf_static
* ROS2 bridge now publishes georeferenced map metadata as /tf's and as mrpt_nav_interfaces/GeoreferencingMetadata
* Revert "Feature: all MOLA modules got its MRPT logger to ROS console for easier debugging"
  This reverts commit 8a84611d85022f37b80d8bdcb7acaa1910669fc1.
* FIX: wrong variable in former commit
* Merge pull request #75 <https://github.com/MOLAorg/mola/issues/75> from MOLAorg/feature/mrpt-to-ros-console
  Feature: all MOLA modules got its MRPT logger to ROS console for easier debugging
* Feature: all MOLA modules got its MRPT logger to ROS console for easier debugging
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_kernel

```
* mola_kernel: Add Georeferencing structure and add it to map updates
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

- No changes

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

```
* FIX: parser bug; it should not try to parse commented-out env variables
* Contributors: Jose Luis Blanco-Claraco
```
