### PR TITLE
mola_lidar_odometry: 0.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3788,7 +3788,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.6.2-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.1-1`

## mola_lidar_odometry

```
* ros2 launch: add .mm and .simplemap optional initial map arguments
* All exhaustive docs on ros2-related mola launch YAML files with the meaning of all BridgeROS2 parameter
* Delegate publishing georeference info to BridgeROS2
* Contributors: Jose Luis Blanco-Claraco
```
