### PR TITLE
resource_retriever: 1.12.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9072,7 +9072,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.7-1
+      version: 1.12.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.8-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.7-1`

## resource_retriever

```
* Allow spaces (#85 <https://github.com/ros/resource_retriever/issues/85>)
* Drop old C++ standard (#73 <https://github.com/ros/resource_retriever/issues/73>)
* On Windows install .dll libraries in <prefix>/bin (#91 <https://github.com/ros/resource_retriever/issues/91>)
* Make importing the library fast (#87 <https://github.com/ros/resource_retriever/issues/87>)
* Contributors: Jochen Sprickerhof, Silvio Traversaro, Simon Schmeisser, Yuki Furuta
```
