### PR TITLE
movie_publisher: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6324,10 +6324,22 @@ repositories:
       url: https://github.com/peci1/movie_publisher.git
       version: melodic-devel
     release:
+      packages:
+      - camera_info_manager_lib
+      - camera_info_manager_metadata_extractor
+      - exiftool_metadata_extractor
+      - exiv2_metadata_extractor
+      - lensfun_metadata_extractor
+      - libexif_metadata_extractor
+      - movie_publisher
+      - movie_publisher_plugins
+      - movie_publisher_plugins_copyleft
+      - movie_publisher_plugins_nonfree
+      - movie_publisher_plugins_permissive
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 1.4.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `2.0.0-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-1`

## camera_info_manager_lib

```
* Package added.
* Contributors: Martin Pecka
```

## camera_info_manager_metadata_extractor

```
* Package added.
* Contributors: Martin Pecka
```

## exiftool_metadata_extractor

```
* Package added.
* Contributors: Martin Pecka
```

## exiv2_metadata_extractor

```
* Package added.
* Contributors: Martin Pecka
```

## lensfun_metadata_extractor

```
* Package added.
* Contributors: Martin Pecka
```

## libexif_metadata_extractor

```
* Package added.
* Contributors: Martin Pecka
```

## movie_publisher

```
* Cleaned up dependencies.
* Refactor out MovieProcessorBase.
* CI: Add license linting.
* Compatibility with Melodic.
* Improved documentation, rewritten movie_to_bag to C++, added tests.
* Added support for ImgGPSDirection and GPSTrack expressed towards magnetic North.
* Big rewrite. Moved movie_publisher to a subfolder. Added C++/libav implementation and metadata extraction plugins.
* Contributors: Martin Pecka
```

## movie_publisher_plugins

```
* Package added.
* Contributors: Martin Pecka
```

## movie_publisher_plugins_copyleft

```
* Package added.
* Contributors: Martin Pecka
```

## movie_publisher_plugins_nonfree

```
* Package added.
* Contributors: Martin Pecka
```

## movie_publisher_plugins_permissive

```
* Package added.
* Contributors: Martin Pecka
```
