### PR TITLE
rmw: 7.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6023,10 +6023,11 @@ repositories:
       packages:
       - rmw
       - rmw_implementation_cmake
+      - rmw_security_common
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.6.0-1
+      version: 7.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.7.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.6.0-1`

## rmw

```
* get_zero_initialized_xxx functions return zero initialized structure. (#380 <https://github.com/ros2/rmw/issues/380>)
  * get_zero_initialized_xxx functions return zero initialized structure.
  * introduce RMW_EVENT_TYPE_MAX in rmw_event_type_t.
  * add a comment and more tests for rmw_event_type.
  ---------
* Contributors: Tomoya Fujita
```

## rmw_implementation_cmake

- No changes

## rmw_security_common

```
* Added rmw_security_common (#388 <https://github.com/ros2/rmw/issues/388>)
* Contributors: Alejandro Hernández Cordero
```
