### PR TITLE
Update fmi_adapter and fmilibrary_vendor branch names

### DIFF
--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1159,7 +1159,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: master
+      version: galactic
     status: maintained
   foonathan_memory_vendor:
     release:

--- a/galactic/distribution.yaml
+++ b/galactic/distribution.yaml
@@ -1136,7 +1136,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: galactic
     release:
       packages:
       - fmi_adapter
@@ -1148,7 +1148,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: master
+      version: galactic
     status: maintained
   fmilibrary_vendor:
     release:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1782,7 +1782,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: rolling
+      version: iron
     status: maintained
   foonathan_memory_vendor:
     release:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1759,7 +1759,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: rolling
+      version: iron
     release:
       packages:
       - fmi_adapter
@@ -1771,7 +1771,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: rolling
+      version: iron
     status: maintained
   fmilibrary_vendor:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2273,7 +2273,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: rolling
+      version: jazzy
     release:
       packages:
       - fmi_adapter
@@ -2285,7 +2285,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: rolling
+      version: jazzy
     status: maintained
   fmilibrary_vendor:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2296,7 +2296,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   foonathan_memory_vendor:
     release:


### PR DESCRIPTION
Updated branch names in fmi_adapter and fmilibrary_vendor sources where rolling (or formerly master) had been used when creating releases for new distros.