### PR TITLE
simple_launch: 1.11.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8631,7 +8631,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.10.1-1
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.11.0-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.10.1-1`

## simple_launch

```
* handle gz world export to SDF after some delay
* make gz_launch compatible with substitutions
* Contributors: Olivier Kermorgant
```
