### PR TITLE
moveit: 2.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3904,7 +3904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.13.0-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.0-1`

## chomp_motion_planner

```
* Use ! in place of not keyword for Pilz and CHOMP planners (#3217 <https://github.com/ros-planning/moveit2/issues/3217>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Sebastian Castro, Silvio Traversaro
```

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* Reverts #2985 <https://github.com/ros-planning/moveit2/issues/2985>, Ports moveit #3388 <https://github.com/ros-planning/moveit2/issues/3388> #3470 <https://github.com/ros-planning/moveit2/issues/3470> #3539 <https://github.com/ros-planning/moveit2/issues/3539> (#3284 <https://github.com/ros-planning/moveit2/issues/3284>)
* Add missing target dependencies to eigen_stl_containers (#3295 <https://github.com/ros-planning/moveit2/issues/3295>)
* Support including the names of other attached objects in touch_link (#3276 <https://github.com/ros-planning/moveit2/issues/3276>)
* Fix: misleading error logs in RobotState::setFromIKSubgroups() (#3263 <https://github.com/ros-planning/moveit2/issues/3263>)
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* Remove plugins from export set (#3227 <https://github.com/ros-planning/moveit2/issues/3227>)
* [Issue-879] Add const specifier to moveit_core (#3202 <https://github.com/ros-planning/moveit2/issues/3202>)
* Don't destroy objects on attach (#3205 <https://github.com/ros-planning/moveit2/issues/3205>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Remove ACM entries when removing collision objects (#3183 <https://github.com/ros-planning/moveit2/issues/3183>)
* handle continuous joints in getLowerAndUpperLimits (#3153 <https://github.com/ros-planning/moveit2/issues/3153>)
* Contributors: Aleksey Nogin, Jafar Uruç, Mario Prats, Mark Johnson, Marq Rasmussen, Michael Görner, Paul Gesel, Sebastian Castro, Robert Haschke, Zhong Jin, gayar
```

## moveit_hybrid_planning

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* Contributors: Sebastian Castro
```

## moveit_kinematics

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* Remove plugins from export set (#3227 <https://github.com/ros-planning/moveit2/issues/3227>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Paul Gesel, Sebastian Castro
```

## moveit_planners

```
* fix chomp inclued, closes #3228 <https://github.com/ros-planning/moveit2/issues/3228> (#3229 <https://github.com/ros-planning/moveit2/issues/3229>)
* Contributors: Michael Ferguson
```

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_planners_stomp

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* Fix passing different types to std::min in cost_functions.hpp (#3244 <https://github.com/ros-planning/moveit2/issues/3244>)
* Contributors: Sebastian Castro, Silvio Traversaro
```

## moveit_plugins

- No changes

## moveit_py

```
* move TrajectoryExecutionManager::clear() to private (#3226 <https://github.com/ros-planning/moveit2/issues/3226>)
* Update CMakeLists.txt (#3218 <https://github.com/ros-planning/moveit2/issues/3218>)
* Contributors: Dongya Jiang, mosfet80
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Sebastian Castro
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* Add logic to Ros2ControlManager to match ros2_control (#3332 <https://github.com/ros-planning/moveit2/issues/3332>)
* Fix Ros2ControlManager chained controller logic (#3301 <https://github.com/ros-planning/moveit2/issues/3301>)
* Parallel gripper controller (#3246 <https://github.com/ros-planning/moveit2/issues/3246>)
* Update controller_manager_plugin.cpp (#3179 <https://github.com/ros-planning/moveit2/issues/3179>)
  Fixing the bug where the namespace is not properly applied when using Ros2ControlMultiManager
* Contributors: Marq Rasmussen, Paul Gesel, Seohyeon Ryu
```

## moveit_ros_move_group

```
* Ports moveit #3676 <https://github.com/ros-planning/moveit2/issues/3676> and #3682 <https://github.com/ros-planning/moveit2/issues/3682> (#3283 <https://github.com/ros-planning/moveit2/issues/3283>)
* Remove plugins from export set (#3227 <https://github.com/ros-planning/moveit2/issues/3227>)
* move TrajectoryExecutionManager::clear() to private (#3226 <https://github.com/ros-planning/moveit2/issues/3226>)
* Contributors: Dongya Jiang, Mark Johnson, Michael Görner, Robert Haschke, Paul Gesel
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* fix: pointcloud_octomap_updater not cleaning objects at max_range (#3294 <https://github.com/ros-planning/moveit2/issues/3294>)
* fix: OctoMap and Filtered_Cloud Not Updating During Movement Execution (#3209 <https://github.com/ros-planning/moveit2/issues/3209>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Marco Magri, Sebastian Castro
```

## moveit_ros_planning

```
* Enable allowed_execution_duration_scaling and allowed_goal_duration_margin for each controller (#3335 <https://github.com/ros-planning/moveit2/issues/3335>)
* Add allowed_start_tolerance_joints parameter (Port moveit`#3287 <https://github.com/ros-planning/moveit2/issues/3287>`_) (#3309 <https://github.com/ros-planning/moveit2/issues/3309>)
* load robot_description from other namespace (#3269 <https://github.com/ros-planning/moveit2/issues/3269>)
* Ports moveit #3676 <https://github.com/ros-planning/moveit2/issues/3676> and #3682 <https://github.com/ros-planning/moveit2/issues/3682> (#3283 <https://github.com/ros-planning/moveit2/issues/3283>)
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* [moveit_ros] fix race condition when stopping trajectory execution (#3198 <https://github.com/ros-planning/moveit2/issues/3198>)
* move TrajectoryExecutionManager::clear() to private (#3226 <https://github.com/ros-planning/moveit2/issues/3226>)
* Don't destroy objects on attach (#3205 <https://github.com/ros-planning/moveit2/issues/3205>)
* Simplify scene update that does not include new robot_state (#3206 <https://github.com/ros-planning/moveit2/issues/3206>)
* Fix planning_scene_monitor sync when passed empty robot state (#3187 <https://github.com/ros-planning/moveit2/issues/3187>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Fix logic in CheckStartStateBounds adapter (#3143 <https://github.com/ros-planning/moveit2/issues/3143>)
* Contributors: Daniel García López, Dongya Jiang, Mark Johnson, Marq Rasmussen, Michael Görner, RLi43, Robert Haschke, Sebastian Castro
```

## moveit_ros_planning_interface

```
* Reverts #2985 <https://github.com/ros-planning/moveit2/issues/2985>, Ports moveit #3388 <https://github.com/ros-planning/moveit2/issues/3388> #3470 <https://github.com/ros-planning/moveit2/issues/3470> #3539 <https://github.com/ros-planning/moveit2/issues/3539> (#3284 <https://github.com/ros-planning/moveit2/issues/3284>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Mark Johnson, Michael Görner, Robert Haschke, Sebastian Castro
```

## moveit_ros_robot_interaction

```
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Sebastian Castro
```

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

```
* Fuzzy-matching Trajectory Cache Injectable Traits refactor 🔥🔥 (#2941 <https://github.com/ros-planning/moveit2/issues/2941>)
* Contributors: methylDragon
```

## moveit_ros_visualization

```
* Use attached object colors as is in Rviz plugin (#3274 <https://github.com/ros-planning/moveit2/issues/3274>)
* Fix MeshShape::clear() for safer mesh removal (#3164 <https://github.com/ros-planning/moveit2/issues/3164>)
* Contributors: Aleksey Nogin, Matt Wang
```

## moveit_ros_warehouse

```
* Address deprecations of StaticSingleThreadedExecutor and realtime_tools/thread_priority.hpp (#3139 <https://github.com/ros-planning/moveit2/issues/3139>)
* Contributors: Sebastian Castro
```

## moveit_runtime

- No changes

## moveit_servo

```
* Update current state even if servo is paused (#3341 <https://github.com/ros-planning/moveit2/issues/3341>)
* Update robot state if time since last command exceeds timeout (#3251 <https://github.com/ros-planning/moveit2/issues/3251>)
* Fix docstring for Servo smoothHalt function (#3298 <https://github.com/ros-planning/moveit2/issues/3298>)
* servo_keyboard_input: Add Windows support (#3290 <https://github.com/ros-planning/moveit2/issues/3290>)
* Servo Node - pause service: check if request is different than current state. (#3265 <https://github.com/ros-planning/moveit2/issues/3265>)
* Reduce mutex scope in Servo thread (#3259 <https://github.com/ros-planning/moveit2/issues/3259>)
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* Address deprecations of StaticSingleThreadedExecutor and realtime_tools/thread_priority.hpp (#3139 <https://github.com/ros-planning/moveit2/issues/3139>)
* Contributors: Henning Kayser, Jelmer de Wolde, Kazuya Oguma, Paul Gesel, Sebastian Castro, Silvio Traversaro
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (#3249 <https://github.com/ros-planning/moveit2/issues/3249>)
* Contributors: Silvio Traversaro
```

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (#3249 <https://github.com/ros-planning/moveit2/issues/3249>)
* Contributors: Silvio Traversaro
```

## moveit_setup_framework

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (#3249 <https://github.com/ros-planning/moveit2/issues/3249>)
* Fix: Conditionally install launch directory if it exists (#3191 <https://github.com/ros-planning/moveit2/issues/3191>)
* Contributors: Filippo Bosi, Silvio Traversaro
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

```
* Parallel gripper controller (#3246 <https://github.com/ros-planning/moveit2/issues/3246>)
* Contributors: Marq Rasmussen
```

## pilz_industrial_motion_planner

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>)
* pilz_industrial_motion_planner: Use tf2::fromMsg instead of tf2::convert (#3219 <https://github.com/ros-planning/moveit2/issues/3219>)
* Use ! in place of not keyword for Pilz and CHOMP planners (#3217 <https://github.com/ros-planning/moveit2/issues/3217>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>)
* Contributors: Sebastian Castro, Silvio Traversaro
```

## pilz_industrial_motion_planner_testutils

- No changes
