### PR TITLE
moveit: 2.12.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4372,7 +4372,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.12.1-1
+      version: 2.12.2-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.12.2-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.1-1`

## chomp_motion_planner

```
* Use ! in place of not keyword for Pilz and CHOMP planners (#3217 <https://github.com/ros-planning/moveit2/issues/3217>) (#3222 <https://github.com/ros-planning/moveit2/issues/3222>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Sebastian Castro, Silvio Traversaro, mergify[bot]
```

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* Reverts #2985 <https://github.com/ros-planning/moveit2/issues/2985>, Ports moveit #3388 <https://github.com/ros-planning/moveit2/issues/3388> #3470 <https://github.com/ros-planning/moveit2/issues/3470> #3539 <https://github.com/ros-planning/moveit2/issues/3539> (#3284 <https://github.com/ros-planning/moveit2/issues/3284>) (#3320 <https://github.com/ros-planning/moveit2/issues/3320>)
* Add missing target dependencies to eigen_stl_containers (#3295 <https://github.com/ros-planning/moveit2/issues/3295>) (#3297 <https://github.com/ros-planning/moveit2/issues/3297>)
* Support including the names of other attached objects in touch_link (#3276 <https://github.com/ros-planning/moveit2/issues/3276>) (#3288 <https://github.com/ros-planning/moveit2/issues/3288>)
* Fix: misleading error logs in RobotState::setFromIKSubgroups() (#3263 <https://github.com/ros-planning/moveit2/issues/3263>) (#3266 <https://github.com/ros-planning/moveit2/issues/3266>)
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* Remove plugins from export set (#3227 <https://github.com/ros-planning/moveit2/issues/3227>) (#3242 <https://github.com/ros-planning/moveit2/issues/3242>)
* Don't destroy objects on attach (#3205 <https://github.com/ros-planning/moveit2/issues/3205>) (#3214 <https://github.com/ros-planning/moveit2/issues/3214>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Remove ACM entries when removing collision objects (#3183 <https://github.com/ros-planning/moveit2/issues/3183>) (#3185 <https://github.com/ros-planning/moveit2/issues/3185>)
* Contributors: Aleksey Nogin, Jafar Uruç, Mark Johnson, Marq Rasmussen, Michael Görner, Paul Gesel, Robert Haschke, Sebastian Castro, Zhong Jin, mergify[bot]
```

## moveit_hybrid_planning

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* Contributors: Sebastian Castro, mergify[bot]
```

## moveit_kinematics

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* Remove plugins from export set (#3227 <https://github.com/ros-planning/moveit2/issues/3227>) (#3242 <https://github.com/ros-planning/moveit2/issues/3242>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Paul Gesel, Sebastian Castro, mergify[bot]
```

## moveit_planners

```
* fix chomp inclued, closes #3228 <https://github.com/ros-planning/moveit2/issues/3228> (#3229 <https://github.com/ros-planning/moveit2/issues/3229>) (#3231 <https://github.com/ros-planning/moveit2/issues/3231>)
* Contributors: Michael Ferguson, mergify[bot]
```

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_planners_stomp

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* Fix passing different types to std::min in cost_functions.hpp (#3244 <https://github.com/ros-planning/moveit2/issues/3244>) (#3245 <https://github.com/ros-planning/moveit2/issues/3245>)
* Contributors: Sebastian Castro, Silvio Traversaro, mergify[bot]
```

## moveit_plugins

- No changes

## moveit_py

```
* move TrajectoryExecutionManager::clear() to private (#3226 <https://github.com/ros-planning/moveit2/issues/3226>) (#3238 <https://github.com/ros-planning/moveit2/issues/3238>)
* Contributors: Dongya Jiang, mergify[bot]
```

## moveit_resources_prbt_ikfast_manipulator_plugin

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Sebastian Castro, mergify[bot]
```

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* Add logic to Ros2ControlManager to match ros2_control (#3332 <https://github.com/ros-planning/moveit2/issues/3332>) (#3343 <https://github.com/ros-planning/moveit2/issues/3343>)
* Fix Ros2ControlManager chained controller logic (#3301 <https://github.com/ros-planning/moveit2/issues/3301>) (#3307 <https://github.com/ros-planning/moveit2/issues/3307>)
* Parallel gripper controller (#3246 <https://github.com/ros-planning/moveit2/issues/3246>) (#3260 <https://github.com/ros-planning/moveit2/issues/3260>)
* Update controller_manager_plugin.cpp (#3179 <https://github.com/ros-planning/moveit2/issues/3179>) (#3236 <https://github.com/ros-planning/moveit2/issues/3236>)
* Contributors: Paul Gesel, Marq Rasmussen, Seohyeon Ryu, mergify[bot]
```

## moveit_ros_move_group

```
* Ports moveit #3676 <https://github.com/ros-planning/moveit2/issues/3676> and #3682 <https://github.com/ros-planning/moveit2/issues/3682> (#3283 <https://github.com/ros-planning/moveit2/issues/3283>) (#3318 <https://github.com/ros-planning/moveit2/issues/3318>)
* Remove plugins from export set (#3227 <https://github.com/ros-planning/moveit2/issues/3227>) (#3242 <https://github.com/ros-planning/moveit2/issues/3242>)
* move TrajectoryExecutionManager::clear() to private (#3226 <https://github.com/ros-planning/moveit2/issues/3226>) (#3238 <https://github.com/ros-planning/moveit2/issues/3238>)
* Contributors: Dongya Jiang, Mark Johnson, Michael Görner, Paul Gesel, Robert Haschke, mergify[bot]
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

```
* fix: pointcloud_octomap_updater not cleaning objects at max_range (#3294 <https://github.com/ros-planning/moveit2/issues/3294>) (#3304 <https://github.com/ros-planning/moveit2/issues/3304>)
* fix: OctoMap and Filtered_Cloud Not Updating During Movement Execution (#3209 <https://github.com/ros-planning/moveit2/issues/3209>) (#3212 <https://github.com/ros-planning/moveit2/issues/3212>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Marco Magri, Sebastian Castro, mergify[bot]
```

## moveit_ros_planning

```
* Enable allowed_execution_duration_scaling and allowed_goal_duration_margin for each controller (#3335 <https://github.com/ros-planning/moveit2/issues/3335>) (#3338 <https://github.com/ros-planning/moveit2/issues/3338>)
* Add allowed_start_tolerance_joints parameter (Port moveit`#3287 <https://github.com/ros-planning/moveit2/issues/3287>`_) (#3309 <https://github.com/ros-planning/moveit2/issues/3309>) (#3328 <https://github.com/ros-planning/moveit2/issues/3328>)
* load robot_description from other namespace (#3269 <https://github.com/ros-planning/moveit2/issues/3269>) (#3325 <https://github.com/ros-planning/moveit2/issues/3325>)
* Ports moveit #3676 <https://github.com/ros-planning/moveit2/issues/3676> and #3682 <https://github.com/ros-planning/moveit2/issues/3682> (#3283 <https://github.com/ros-planning/moveit2/issues/3283>) (#3318 <https://github.com/ros-planning/moveit2/issues/3318>)
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* [moveit_ros] fix race condition when stopping trajectory execution (#3198 <https://github.com/ros-planning/moveit2/issues/3198>) (#3240 <https://github.com/ros-planning/moveit2/issues/3240>)
* move TrajectoryExecutionManager::clear() to private (#3226 <https://github.com/ros-planning/moveit2/issues/3226>) (#3238 <https://github.com/ros-planning/moveit2/issues/3238>)
* Don't destroy objects on attach (#3205 <https://github.com/ros-planning/moveit2/issues/3205>) (#3214 <https://github.com/ros-planning/moveit2/issues/3214>)
* Simplify scene update that does not include new robot_state (#3206 <https://github.com/ros-planning/moveit2/issues/3206>) (#3208 <https://github.com/ros-planning/moveit2/issues/3208>)
* Fix planning_scene_monitor sync when passed empty robot state (#3187 <https://github.com/ros-planning/moveit2/issues/3187>) (#3204 <https://github.com/ros-planning/moveit2/issues/3204>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Daniel García López, Dongya Jiang, Mark Johnson, Marq Rasmussen, Michael Görner, RLi43, Robert Haschke, Sebastian Castro, mergify[bot]
```

## moveit_ros_planning_interface

```
* Reverts #2985 <https://github.com/ros-planning/moveit2/issues/2985>, Ports moveit #3388 <https://github.com/ros-planning/moveit2/issues/3388> #3470 <https://github.com/ros-planning/moveit2/issues/3470> #3539 <https://github.com/ros-planning/moveit2/issues/3539> (#3284 <https://github.com/ros-planning/moveit2/issues/3284>) (#3320 <https://github.com/ros-planning/moveit2/issues/3320>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Mark Johnson, Michael Görner, Robert Haschke, Sebastian Castro, mergify[bot]
```

## moveit_ros_robot_interaction

```
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Sebastian Castro, mergify[bot]
```

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

- No changes

## moveit_ros_visualization

```
* Use attached object colors as is in Rviz plugin (#3274 <https://github.com/ros-planning/moveit2/issues/3274>) (#3278 <https://github.com/ros-planning/moveit2/issues/3278>)
* Contributors: Aleksey Nogin, mergify[bot]
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Update current state even if servo is paused (#3341 <https://github.com/ros-planning/moveit2/issues/3341>) (#3347 <https://github.com/ros-planning/moveit2/issues/3347>)
* Servo Node - pause service: check if request is different than current state. (#3265 <https://github.com/ros-planning/moveit2/issues/3265>) (#3348 <https://github.com/ros-planning/moveit2/issues/3348>)
* Update robot state if time since last command exceeds timeout (#3251 <https://github.com/ros-planning/moveit2/issues/3251>) (#3334 <https://github.com/ros-planning/moveit2/issues/3334>)
* Fix docstring for Servo smoothHalt function (#3298 <https://github.com/ros-planning/moveit2/issues/3298>) (#3308 <https://github.com/ros-planning/moveit2/issues/3308>)
* servo_keyboard_input: Add Windows support (#3290 <https://github.com/ros-planning/moveit2/issues/3290>) (#3291 <https://github.com/ros-planning/moveit2/issues/3291>)
* Reduce mutex scope in Servo thread (#3259 <https://github.com/ros-planning/moveit2/issues/3259>) (#3262 <https://github.com/ros-planning/moveit2/issues/3262>)
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* Contributors: Henning Kayser, Jelmer de Wolde, Kazuya Oguma, Paul Gesel, Sebastian Castro, Silvio Traversaro, mergify[bot]
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (#3249 <https://github.com/ros-planning/moveit2/issues/3249>) (#3254 <https://github.com/ros-planning/moveit2/issues/3254>)
* Contributors: Silvio Traversaro, mergify[bot]
```

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (#3249 <https://github.com/ros-planning/moveit2/issues/3249>) (#3254 <https://github.com/ros-planning/moveit2/issues/3254>)
* Contributors: Silvio Traversaro, mergify[bot]
```

## moveit_setup_framework

```
* Explicit convert from std::filesystem::path to std::string for Windows compatibility (#3249 <https://github.com/ros-planning/moveit2/issues/3249>) (#3254 <https://github.com/ros-planning/moveit2/issues/3254>)
* Fix: Conditionally install launch directory if it exists (#3191 <https://github.com/ros-planning/moveit2/issues/3191>) (#3195 <https://github.com/ros-planning/moveit2/issues/3195>)
* Contributors: Filippo Bosi, Silvio Traversaro, mergify[bot]
```

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

```
* Parallel gripper controller (#3246 <https://github.com/ros-planning/moveit2/issues/3246>) (#3260 <https://github.com/ros-planning/moveit2/issues/3260>)
* Contributors: Marq Rasmussen, mergify[bot]
```

## pilz_industrial_motion_planner

```
* Update includes for generate_parameter_library 0.4.0 (#3255 <https://github.com/ros-planning/moveit2/issues/3255>) (#3258 <https://github.com/ros-planning/moveit2/issues/3258>)
* pilz_industrial_motion_planner: Use tf2::fromMsg instead of tf2::convert (#3219 <https://github.com/ros-planning/moveit2/issues/3219>) (#3224 <https://github.com/ros-planning/moveit2/issues/3224>)
* Use ! in place of not keyword for Pilz and CHOMP planners (#3217 <https://github.com/ros-planning/moveit2/issues/3217>) (#3222 <https://github.com/ros-planning/moveit2/issues/3222>)
* Update deprecated tf2 imports from .h to .hpp (#3197 <https://github.com/ros-planning/moveit2/issues/3197>) (#3200 <https://github.com/ros-planning/moveit2/issues/3200>)
* Contributors: Sebastian Castro, Silvio Traversaro, mergify[bot]
```

## pilz_industrial_motion_planner_testutils

- No changes
