### PR TITLE
movie_publisher: 2.0.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6339,7 +6339,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `2.0.1-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## camera_info_manager_lib

- No changes

## camera_info_manager_metadata_extractor

- No changes

## exiftool_metadata_extractor

- No changes

## exiv2_metadata_extractor

- No changes

## lensfun_metadata_extractor

- No changes

## libexif_metadata_extractor

- No changes

## movie_publisher

```
* Try fixing build on buildfarm
* Contributors: Martin Pecka
```

## movie_publisher_plugins

- No changes

## movie_publisher_plugins_copyleft

- No changes

## movie_publisher_plugins_nonfree

- No changes

## movie_publisher_plugins_permissive

- No changes

