### PR TITLE
Update fmi_adapter and fmilibrary_vendor branch names

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2273,7 +2273,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: rolling
+      version: jazzy
     release:
       packages:
       - fmi_adapter
@@ -2285,7 +2285,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
-      version: rolling
+      version: jazzy
     status: maintained
   fmilibrary_vendor:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2296,7 +2296,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
-      version: rolling
+      version: jazzy
     status: maintained
   foonathan_memory_vendor:
     release:


### PR DESCRIPTION
Updated branch names of fmi_adapter and fmilibrary_vendor sources for Jazzy releases, where branch rolling had been used when creating the first Jazzy releases.