### PR TITLE
fanuc: 0.6.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2851,6 +2851,43 @@ repositories:
       url: https://github.com/iron-ox/fadecandy_ros.git
       version: master
     status: developed
+  fanuc:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/fanuc.git
+      version: noetic
+    release:
+      packages:
+      - fanuc_cr35ia_support
+      - fanuc_cr7ia_support
+      - fanuc_crx10ia_support
+      - fanuc_driver
+      - fanuc_lrmate200i_support
+      - fanuc_lrmate200ib_support
+      - fanuc_lrmate200ic_support
+      - fanuc_lrmate200id_support
+      - fanuc_m10ia_support
+      - fanuc_m16ib_support
+      - fanuc_m20ia_support
+      - fanuc_m20ib_support
+      - fanuc_m430ia_support
+      - fanuc_m6ib_support
+      - fanuc_m710ic_support
+      - fanuc_m900ia_support
+      - fanuc_m900ib_support
+      - fanuc_r1000ia_support
+      - fanuc_r2000ib_support
+      - fanuc_r2000ic_support
+      - fanuc_resources
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/fanuc-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/fanuc.git
+      version: noetic-devel
+    status: maintained
   fath_pivot_mount_description:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fanuc` to `0.6.0-1`:

- upstream repository: https://github.com/ros-industrial/fanuc.git
- release repository: https://github.com/ros-industrial-release/fanuc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## fanuc_cr35ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_cr7ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_crx10ia_support

```
* first release of this package.
* promote experimental packages for CRX-10iA, LR Mate 200iD, R-2000iB and R-2000iC to main repository.
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
* contributors: Ademola Oridate, gavanderhoorn
```

## fanuc_driver

```
* use ``target_compile_defs`` from ``industrial_core`` (#324 <https://github.com/ros-industrial/fanuc/issues/324>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_lrmate200i_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_lrmate200ib_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_lrmate200ic_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_lrmate200id_support

```
* first release of this package.
* promote experimental packages for CRX-10iA, LR Mate 200iD, R-2000iB and R-2000iC to main repository.
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
* contributors: Jethro Tan, gavanderhoorn
```

## fanuc_m10ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m16ib_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m20ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m20ib_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* add OPW kinematics parameters for M-20iB/25 (#314 <https://github.com/ros-industrial/fanuc/issues/314>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
* contributors: Axel Schroth, gavanderhoorn
```

## fanuc_m430ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m6ib_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m710ic_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m900ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_m900ib_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_r1000ia_support

```
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```

## fanuc_r2000ib_support

```
* first release of this package.
* promote experimental packages for CRX-10iA, LR Mate 200iD, R-2000iB and R-2000iC to main repository.
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
* contributors: Ademola Oridate, gavanderhoorn
```

## fanuc_r2000ic_support

```
* first release of this package.
* promote experimental packages for CRX-10iA, LR Mate 200iD, R-2000iB and R-2000iC to main repository.
* remove ``--inorder`` xacro arg everywhere (#372 <https://github.com/ros-industrial/fanuc/issues/372>).
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
* contributors: Ademola Oridate, Didier Quirin, Michael Ripperger, Simon Schmeisser, gavanderhoorn
```

## fanuc_resources

```
* no changes.
* for a complete list of changes see the commit log for 0.6.0 <https://github.com/ros-industrial/fanuc/compare/0.5.1...0.6.0>.
```
