### PR TITLE
ros2_controllers: 2.42.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8304,7 +8304,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.41.0-1
+      version: 2.42.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.42.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.41.0-1`

## ackermann_steering_controller

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

```
* [Admittance] multiple state/command interfaces (backport #547 <https://github.com/ros-controls/ros2_controllers/issues/547>, #1196 <https://github.com/ros-controls/ros2_controllers/issues/1196>) (#1548 <https://github.com/ros-controls/ros2_controllers/issues/1548>)
* Remove dependency of admittance controller on JTC (backport #1532 <https://github.com/ros-controls/ros2_controllers/issues/1532>) (#1537 <https://github.com/ros-controls/ros2_controllers/issues/1537>)
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich, Marco Magri, Sai Kishor Kothakota
```

## bicycle_steering_controller

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

```
* Bump version of pre-commit hooks (backport #1514 <https://github.com/ros-controls/ros2_controllers/issues/1514>) (#1515 <https://github.com/ros-controls/ros2_controllers/issues/1515>)
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* [JTC]: Abort goal on deactivate (backport #1517 <https://github.com/ros-controls/ros2_controllers/issues/1517>) (#1521 <https://github.com/ros-controls/ros2_controllers/issues/1521>)
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## pid_controller

```
* [pid_controller] Update tests (backport #1538 <https://github.com/ros-controls/ros2_controllers/issues/1538>) (#1545 <https://github.com/ros-controls/ros2_controllers/issues/1545>)
* [pid_controller] Fix logic for feedforward_mode with single reference interface (backport #1520 <https://github.com/ros-controls/ros2_controllers/issues/1520>) (#1539 <https://github.com/ros-controls/ros2_controllers/issues/1539>)
* Improve antiwindup description (backport #1502 <https://github.com/ros-controls/ros2_controllers/issues/1502>) (#1503 <https://github.com/ros-controls/ros2_controllers/issues/1503>)
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich, Victor Coutinho Vieira Santos
```

## pose_broadcaster

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

```
* Update paths of GPL includes (backport #1487 <https://github.com/ros-controls/ros2_controllers/issues/1487>) (#1493 <https://github.com/ros-controls/ros2_controllers/issues/1493>)
* Contributors: Christoph Fröhlich
```

## velocity_controllers

- No changes
