### PR TITLE
rmw_cyclonedds: 3.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6080,7 +6080,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `3.2.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.0-1`

## rmw_cyclonedds_cpp

```
* use rmw_security_common (#529 <https://github.com/ros2/rmw_cyclonedds/issues/529>)
* introduce RMW_EVENT_TYPE_MAX in rmw_event_type_t. (#518 <https://github.com/ros2/rmw_cyclonedds/issues/518>)
* Reset the error before setting a new one. (#526 <https://github.com/ros2/rmw_cyclonedds/issues/526>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Tomoya Fujita
```
