### PR TITLE
add 'python3-wheel'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10681,6 +10681,14 @@ python3-wgconfig-pip:
   ubuntu:
     pip:
       packages: [wgconfig]
+python3-wheel:
+  arch: [python-wheel]
+  debian: [python3-wheel]
+  fedora: [python3-wheel]
+  gentoo: [dev-python/wheel]
+  opensuse: [python3-wheel]
+  rhel: [python3-wheel]
+  ubuntu: [python3-wheel]
 python3-whichcraft:
   arch: [python-whichcraft]
   debian: [python3-whichcraft]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Purpose of using this:

Create wheel files.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-wheel
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-wheel
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-wheel/python3-wheel/
- Arch: https://www.archlinux.org/packages/
  - [IF AVAILABLE](https://archlinux.org/packages/extra/any/python-wheel/)
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/wheel
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - [IF AVAILABLE](https://rockylinux.pkgs.org/9/rockylinux-crb-x86_64/python3-wheel-0.36.2-8.el9.noarch.rpm.html)
