### PR TITLE
automatika_ros_sugar: 0.2.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -524,7 +524,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.6-1
+      version: 0.2.9-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.2.9-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.6-1`

## automatika_ros_sugar

```
* (docs) Updates supported types docs and adds docstrings
* (feature) Adds a script to  make any python script a systemd service
* (fix) Minor fix to check for action server creation before destruction
* (fix) Adds algorithm config from yaml if available
* (fix) Removes setproctitle as a hard dependency
* (fix) Checks for subscription in got_inputs method
* (fix) Fixes type hints for python3.8 compatibility
* Contributors: ahr, mkabtoul
```
