### PR TITLE
Update python.yaml to include tactigon-gear pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10069,6 +10069,10 @@ python3-tabulate:
   nixos: [python3Packages.tabulate]
   rhel: [python3-tabulate]
   ubuntu: [python3-tabulate]
+python3-tactigon-gear-pip:
+  ubuntu:
+    pip:
+      packages: [tactigon-gear]
 python3-tcr-roboclaw-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10070,7 +10070,7 @@ python3-tabulate:
   rhel: [python3-tabulate]
   ubuntu: [python3-tabulate]
 python3-tactigon-gear-pip:
-  ubuntu:
+  '*':
     pip:
       packages: [tactigon-gear]
 python3-tcr-roboclaw-pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

tactigon-gear

## Package Upstream Source:

https://pypi.org/project/tactigon-gear/

## Purpose of using this:

The tactigon-gear package provides a Python SDK that enables connection to the Tactigon Skin wearable device via Bluetooth Low Energy. It is part of the Tactigon Gear environment, which includes:

-     Collecting raw motion/gesture data from the wearable device.

-     Sending data to a cloud-based server maintained by Next Industries s.r.l.

-     Requesting training of gesture recognition models and downloading these models for real-time use.

    Offering a command line interface for data collection, labeling, and upload.

This package is valuable for integrating natural user interfaces (gesture-based control) into Python projects, especially in robotics and IoT applications.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

Note: tactigon-gear is a PyPI only package at the moment.
- Debian: Not available
  - REQUIRED
- Ubuntu: Not available
  - REQUIRED
- Fedora: Not available
  - IF AVAILABLE
- Arch: Not available
  - IF AVAILABLE
- Gentoo: Not available
  - IF AVAILABLE
- macOS: Not available
  - IF AVAILABLE
- Alpine: Not available
  - IF AVAILABLE
- NixOS/nixpkgs: Not available
  - OPTIONAL
- openSUSE: Not available
  - IF AVAILABLE
- rhel: Not available
  - IF AVAILABLE

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here:

https://github.com/TactigonTeam/Tactigon-ROS

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
