### PR TITLE
add synapticon_ros2_control

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10230,6 +10230,12 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: ros2-devel
     status: developed
+  synapticon_ros2_control:
+    source:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: main
+    status: maintained
   sync_parameter_server:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8901,6 +8901,12 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: ros2-devel
     status: developed
+  synapticon_ros2_control:
+    source:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: main
+    status: maintained
   system_fingerprint:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7994,6 +7994,12 @@ repositories:
       url: https://github.com/swri-robotics/swri_console.git
       version: ros2-devel
     status: developed
+  synapticon_ros2_control:
+    source:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: main
+    status: maintained
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

synapticon_ros2_control

# The source is here:

https://github.com/synapticon/synapticon_ros2_control

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
