### PR TITLE
cras_ros_utils: 2.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1813,7 +1813,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
-      version: 2.5.0-1
+      version: 2.5.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `2.5.1-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/ros-utils.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## cras_bag_tools

```
* Fixed running on Jetsons.
* Contributors: Martin Pecka
```

## cras_cpp_common

- No changes

## cras_docs_common

- No changes

## cras_py_common

- No changes

## cras_topic_tools

- No changes

## image_transport_codecs

- No changes
