### PR TITLE
topic_tools: 1.3.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9149,7 +9149,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.3.3-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.2-1`

## topic_tools

```
* Removed manual namespace resolution (#123 <https://github.com/ros-tooling/topic_tools/issues/123>) (#124 <https://github.com/ros-tooling/topic_tools/issues/124>)
* Contributors: Martin Oehler
```

## topic_tools_interfaces

- No changes
