### PR TITLE
Revert "ros_battery_monitoring: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7331,7 +7331,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
-      version: 1.0.1-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#44393

It seems this update (which updated realtime_tools header names) is not actually compatible with jazzy, which we only noticed now. Does rosdistro accept downgrades or should i create a new release on the (now created) jazzy branch?