### PR TITLE
gz_ros2_control: 2.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2476,7 +2476,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.6-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.5-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Update diff_drive_controller.yaml (#494 <https://github.com/ros-controls/gz_ros2_control/issues/494>)
* Update cart demos to use joint_trajectory_controller (#486 <https://github.com/ros-controls/gz_ros2_control/issues/486>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Aarav Gupta, Christoph Fröhlich
```
