### PR TITLE
gz_ros2_control: 1.2.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2926,7 +2926,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.10-1
+      version: 1.2.11-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.11-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.10-1`

## gz_ros2_control

```
* Add remap option to controller manager (#442 <https://github.com/ros-controls/gz_ros2_control/issues/442>)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: Tatsuro Sakaguchi
```

## gz_ros2_control_demos

```
* Update diff_drive_controller.yaml (#494 <https://github.com/ros-controls/gz_ros2_control/issues/494>) (#496 <https://github.com/ros-controls/gz_ros2_control/issues/496>)
  (cherry picked from commit 135332632bd340f17eeb0930b0d46b30fb956ebb)
  Co-authored-by: Aarav Gupta <mailto:amronos275@gmail.com>
* Update cart demos to use joint_trajectory_controller (#486 <https://github.com/ros-controls/gz_ros2_control/issues/486>) (#489 <https://github.com/ros-controls/gz_ros2_control/issues/489>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 11fc5ddce5bd8fd80a6792d15edd73179f1a8105)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Use files from demos for testing (#485 <https://github.com/ros-controls/gz_ros2_control/issues/485>) (#487 <https://github.com/ros-controls/gz_ros2_control/issues/487>)
  (cherry picked from commit a12ef5a67a18522a618f2848625103d33df73fb8)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```
