### PR TITLE
dynamixel_interfaces: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1322,6 +1322,11 @@ repositories:
       version: main
     status: developed
   dynamixel_interfaces:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_interfaces-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
- release repository: https://github.com/ros2-gbp/dynamixel_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## dynamixel_interfaces

```
* First release of dynamixel_interfaces package
* Contributors: Hye-Jong KIM, Sungho Woo
```
