### PR TITLE
novatel_oem7_driver: 24.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4963,6 +4963,14 @@ repositories:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git
       version: jazzy
+    release:
+      packages:
+      - novatel_oem7_driver
+      - novatel_oem7_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      version: 24.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `24.0.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## novatel_oem7_driver

```
Formal support for Jazzy
Modifications:
* Upgraded oem7_receiver_if.hpp to remove Boost dependency
* Upgraded port and net receiver connections to ensure that they are non-blocking
* Removed Boost dependency from the port and net receiver connections. This removes the ability to build with Windows. These files have been left but labelled as sync (to indicate they are blocking), these files are deprecated and will be removed in a future release
* Updates to address various deprecation warnings by third party libraries
```

## novatel_oem7_msgs

```
Formal support for Jazzy
```
