### PR TITLE
dbw_ros: 2.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1471,7 +1471,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.2-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.1-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2025/02/18 release package
* Add drive mode command and report messages
* Add AEB precharge control to brake command and joystick demo
* Fix message function return type and update SAE J1850 CRC header
* Add date/time to EcuInfo message
* Add PropulsionInfo message
* Add RBA, CTA, and auto brake hold statuses to DriverAssist message
* Print model year (calculated from VIN)
* Add signals to apply brakes for gear calibration
* Add gear stuck in neutral diagnostics
* Add support for Polaris RANGER XD 1500 platform
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```

## ds_dbw_joystick_demo

```
* Add AEB precharge control to brake command and joystick demo
* Contributors: Kevin Hallenbeck
```

## ds_dbw_msgs

```
* Add drive mode command and report messages
* Add AEB precharge control to brake command and joystick demo
* Add date/time to EcuInfo message
* Add PropulsionInfo message
* Add RBA, CTA, and auto brake hold statuses to DriverAssist message
* Add signals to apply brakes for gear calibration
* Add gear stuck in neutral diagnostics
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```
