### PR TITLE
pangolin: 0.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4713,11 +4713,15 @@ repositories:
       version: humble-devel
     status: maintained
   pangolin:
+    doc:
+      type: git
+      url: https://github.com/stevenlovegrove/Pangolin.git
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Pangolin-release.git
-      version: 0.9.1-2
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/stevenlovegrove/Pangolin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pangolin` to `0.9.3-1`:

- upstream repository: https://github.com/stevenlovegrove/Pangolin.git
- release repository: https://github.com/ros2-gbp/Pangolin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.1-2`
