### PR TITLE
rmw_zenoh: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6200,7 +6200,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## rmw_zenoh_cpp

```
* Introduce the advanced publisher and subscriber (#368 <https://github.com/ros2/rmw_zenoh/issues/368>)
* Switch to debug log if topic_name not in topic_map (#454 <https://github.com/ros2/rmw_zenoh/issues/454>)
* Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits) (#456 <https://github.com/ros2/rmw_zenoh/issues/456>)
* Contributors: Julien Enoch, Yuyuan Yuan, Yadunund
```

## zenoh_cpp_vendor

```
* Bump zenoh-c to 261493 and zenoh-cpp to 5dfb68c (#463 <https://github.com/ros2/rmw_zenoh/issues/463>)
* Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits) (#456 <https://github.com/ros2/rmw_zenoh/issues/456>)
* Contributors: Julien Enoch
```
