### PR TITLE
rmw_zenoh: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6893,7 +6893,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.2-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.1-1`

## rmw_zenoh_cpp

```
* Introduce the advanced publisher and subscriber (#469 <https://github.com/ros2/rmw_zenoh/issues/469>)
* Add tracing instrumentation using tracetools  (#471 <https://github.com/ros2/rmw_zenoh/issues/471>)
* Switch to debug log if topic_name not in topic_map (#464 <https://github.com/ros2/rmw_zenoh/issues/464>)
* Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits) (#461 <https://github.com/ros2/rmw_zenoh/issues/461>)
* Contributors: Alejandro Hernandez Cordero, Christophe Bedard, Julien Enoch, Yadunund, Yuyuan Yuan
```

## zenoh_cpp_vendor

```
* Bump zenoh-c to 261493 and zenoh-cpp to 5dfb68c (#466 <https://github.com/ros2/rmw_zenoh/issues/466>)
* Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits) (#461 <https://github.com/ros2/rmw_zenoh/issues/461>)
* Contributors: Julien Enoch
```
