### PR TITLE
sdformat_vendor: 0.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7622,7 +7622,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.2.3-2
+      version: 0.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.2.4-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-2`

## sdformat_vendor

```
* Bump version to 15.2.0 (#12 <https://github.com/gazebo-release/sdformat_vendor/issues/12>)
* Contributors: Carlos Agüero
```
