### PR TITLE
realtime_tools: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5733,7 +5733,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.1.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.0-1`

## realtime_tools

```
* [RTPublisher] Use NON_POLLING as default for the realtime pubisher  (#280 <https://github.com/ros-controls/realtime_tools/issues/280>)
* Bump version of pre-commit hooks (#276 <https://github.com/ros-controls/realtime_tools/issues/276>)
* Contributors: Sai Kishor Kothakota, github-actions[bot]
```
