### PR TITLE
realtime_tools: 3.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6457,7 +6457,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.4.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.0-1`

## realtime_tools

```
* [RTPublisher] use NON_POLLING as default for the realtime pubisher  (backport #280 <https://github.com/ros-controls/realtime_tools/issues/280>) (#282 <https://github.com/ros-controls/realtime_tools/issues/282>)
* Bump version of pre-commit hooks (backport #276 <https://github.com/ros-controls/realtime_tools/issues/276>) (#278 <https://github.com/ros-controls/realtime_tools/issues/278>)
* Install boost on jazzy as well (backport #273 <https://github.com/ros-controls/realtime_tools/issues/273>) (#275 <https://github.com/ros-controls/realtime_tools/issues/275>)
* Contributors: mergify[bot]
```
