### PR TITLE
gz_fuel_tools_vendor: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2329,7 +2329,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_fuel_tools_vendor` to `0.2.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-1`

## gz_fuel_tools_vendor

```
* Bump version to 10.0.1 (#7 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/7>)
* Contributors: Carlos Agüero
```
