### PR TITLE
Add RHEL package for libzip-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7019,6 +7019,7 @@ libzip-dev:
   gentoo: [dev-libs/libzip]
   nixos: [libzip]
   openembedded: [libzip@meta-oe]
+  rhel: [libzip-devel]
   ubuntu: [libzip-dev]
 libzmq3-dev:
   arch: [zeromq]


### PR DESCRIPTION
I don't have a RHEL system to test on; I only tested this on AlmaLinux with the CodeReadyBuilder repo enabled.  
https://pkgs.org/search/?q=libzip-devel also shows that the package is avaiilable for EPEL from unofficial sources.