### PR TITLE
gz_physics_vendor: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2425,7 +2425,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_physics_vendor` to `0.2.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_physics_vendor.git
- release repository: https://github.com/ros2-gbp/gz_physics_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.0-1`

## gz_physics_vendor

```
* Bump version to 8.1.0 (#7 <https://github.com/gazebo-release/gz_physics_vendor/issues/7>)
* Contributors: Carlos Agüero
```
