### PR TITLE
gz_launch_vendor: 0.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2811,7 +2811,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_launch_vendor` to `0.0.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_launch_vendor.git
- release repository: https://github.com/ros2-gbp/gz_launch_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.4-1`

## gz_launch_vendor

```
* Bump version to 7.1.1 (#4 <https://github.com/gazebo-release/gz_launch_vendor/issues/4>)
* Contributors: Addisu Z. Taddese
```
