### PR TITLE
ur_client_library: 1.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9616,7 +9616,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 1.6.0-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.7.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-1`

## ur_client_library

```
* Make UrDriver tests run without ctest (#270 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/270>)
* UrDriver: Send program in headless mode after creating trajectory and script_command servers (#271 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/271>)
* Improve limit check (#256 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/256>)
* Use colored log output and timestamps in default log handler (#267 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/267>)
* Parametrize reconnection time for UrDriver (#266 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/266>)
  Co-authored-by: Dominic Reber <mailto:71256590+domire8@users.noreply.github.com>
* Fix DashboardClient load program from subdir (#269 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/269>)
* Increase dashboard timeout in ExampleRobotWrapper to 10s
* Disable internal deprecation warning
* Use a config struct for initializing UrDriver (#264 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/264>)
* Use ExampleRobotWrapper for initialization in all examples (#265 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/265>)
* Enable nightly CI jobs (#263 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/263>)
* Expose diagnostic error codes (#225 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/225>)
* RTDEClient: pause and stop in destructor only if running (#257 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/257>)
* Use coverage flags to distinguish between runs (#261 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/261>)
* Fix branch name for integration tests run on push (#262 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/262>)
* Add codecov/test-results-action (#260 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/260>)
* Fix GH edit URL for trajectory_point_interface example (#259 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/259>)
* Update URL check
* Show which example is running in run_examples.sh
* Add documentation for all examples (#258 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/258>)
* Update RT setup documentation to point to urcl docs
* Use EXPECT_NEAR vs EXPECT_EQ
* Fix typo in start_ursim.sh help
* Make CI capable to run with urcap
* Use ExampleRobotWrapper in integration tests (#252 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/252>)
* Add a wrapper to handle all robot setup (#252 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/252>)
* Allow clang-format to indent preprocessor directives (#246 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/246>)
* docs: Clarify that the motion functions use script functions for execution (#255 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/255>)
* Update link to sphinx-doc.org using https (#247 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/247>)
* Use joint speed for extrapolation rather than differences (#254 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/254>)
* Move setup instructions to ur_client_library (#248 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/248>)
* Add more information about acceleration/velocity parametrization in trajectory examples (#251 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/251>)
* Contributors: Felix Exner, Rune Søe-Knudsen, jessica-chen-ocado, Dominic Reber
```
