### PR TITLE
depthai-ros: 2.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1876,7 +1876,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 2.10.5-1
+      version: 2.11.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `2.11.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.5-1`

## depthai-ros

```
* Add Thermal support
* Fix issues in TF Publisher
* (ROS2) Separate callback groups for services
```
