### PR TITLE
grpc: 0.0.16-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3863,7 +3863,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.16-1
+      version: 0.0.16-2
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.16-2`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.16-1`

## grpc

```
* Use system library for SSL and ZLIB (#54 <https://github.com/CogRob/catkin_grpc/issues/54>)
* Contributors: Yuki Furuta
```
