### PR TITLE
boost_sml_vendor: 1.1.11-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -835,6 +835,21 @@ repositories:
       type: git
       url: https://github.com/tesseract-robotics/boost_plugin_loader.git
       version: main
+  boost_sml_vendor:
+    doc:
+      type: git
+      url: https://github.com/nobleo/boost_sml_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/boost_sml_vendor-release.git
+      version: 1.1.11-1
+    source:
+      type: git
+      url: https://github.com/nobleo/boost_sml_vendor.git
+      version: main
+    status: maintained
   camera_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml_vendor` to `1.1.11-1`:

- upstream repository: https://github.com/nobleo/boost_sml_vendor.git
- release repository: https://github.com/ros2-gbp/boost_sml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
