### PR TITLE
synapticon_ros2_control: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10244,6 +10244,15 @@ repositories:
       version: ros2-devel
     status: developed
   synapticon_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/synapticon/synapticon_ros2_control-release.git
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `synapticon_ros2_control` to `0.1.2-1`:

- upstream repository: https://github.com/synapticon/synapticon_ros2_control.git
- release repository: https://github.com/synapticon/synapticon_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
