### PR TITLE
marti_common: 2.15.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5671,7 +5671,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.15.2-1
+      version: 2.15.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.15.3-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.15.2-1`

## marti_data_structures

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_cli_tools

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Fall back to distutils.core.setup for swri_cli_tools setup.py (#687 <https://github.com/swri-robotics/marti_common/issues/687>)
* Contributors: Daniel D'Souza, Robert Brothers
```

## swri_console_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Fully specifying return type (#718 <https://github.com/swri-robotics/marti_common/issues/718>)
  Fixes build warnings with Arm.
* Contributors: Daniel D'Souza, David Anthony
```

## swri_dbw_interface

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_geometry_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_image_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_math_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_nodelet

```
* 757: Configure CMP0167 (#758 <https://github.com/swri-robotics/marti_common/issues/758>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Update Package Maintainers (#719 <https://github.com/swri-robotics/marti_common/issues/719>)
* Contributors: Daniel D'Souza, David Anthony
```

## swri_opencv_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_prefix_tools

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Updating psutil call for new API (#726 <https://github.com/swri-robotics/marti_common/issues/726>)
  * Updating psutil call for new API
* Update Package Maintainers (#719 <https://github.com/swri-robotics/marti_common/issues/719>)
* Contributors: Daniel D'Souza, David Anthony
```

## swri_roscpp

```
* Fixing possible problem with calculating duration when time is misbehaving (#734 <https://github.com/swri-robotics/marti_common/issues/734>)
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Update Package Maintainers (#719 <https://github.com/swri-robotics/marti_common/issues/719>)
* 683 add advertise apis to swri nodehandle (#684 <https://github.com/swri-robotics/marti_common/issues/684>)
  * Added a connection cb advertise overload for swri::NodeHandle and lightly tested that it works.
  * Refactored swri nodehandle test a bit. Tested for topic documentation with new advertise API.
  * Added advertise options API to swri::NodeHandle
  Co-authored-by: David Anthony <djanthony@gmail.com>
* Contributors: Daniel D'Souza, David Anthony, Robert Brothers
```

## swri_rospy

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Update Package Maintainers (#719 <https://github.com/swri-robotics/marti_common/issues/719>)
* Contributors: Daniel D'Souza, David Anthony
```

## swri_route_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_serial_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_string_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_system_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Contributors: Daniel D'Souza
```

## swri_transform_util

```
* Updating for New Proj Versions (#733 <https://github.com/swri-robotics/marti_common/issues/733>)
  Updated using changes from the ros2-devel branch to support new PROJ versions.
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Adding Adelaide test case for UTM coordinate conversion (#724 <https://github.com/swri-robotics/marti_common/issues/724>)
* Contributors: Daniel D'Souza, David Anthony
```

## swri_yaml_util

```
* Increase minimum CMake version to 3.16 to satisfy the compatiblity check in newer CMake versions (#732 <https://github.com/swri-robotics/marti_common/issues/732>)
  Co-authored-by: Daniel D'Souza <mailto:daniel.dsouza@swri.org>
* Removed auto_ptr from swri_yaml_util (#699 <https://github.com/swri-robotics/marti_common/issues/699>)
* Contributors: Daniel D'Souza, Robert Brothers
```
