### PR TITLE
mola: 1.6.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4251,7 +4251,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.6.2-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.1-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Implement publish Diagnostics per mola module & ROS2 publishers refactored (code clean up)
* BridgeROS2: add source filter for forwarding localization updates to ROS2
* ROS2: base_footprint_frame /tf is broadcasted now as base_link -> base_footprint to avoid /tf warnings (better as a child than as a second parent in the tf tree)
* FIX: In parsing base_footprint_to_base_link_tf
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_kernel

```
* ExecutableBase inteface: added diagnostics API
* Contributors: Jose Luis Blanco Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

- No changes

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
