### PR TITLE
mola_state_estimation: 1.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3850,7 +3850,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.6.1-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.7.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.1-1`

## mola_imu_preintegration

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Add parameter enforce_planar_motion
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Use more generic localization source name
* make it thread safe; fix replaying extrapolated poses using past timestamps
* Documentation: explain the different types of factors and kinematic models
* Smoother: observe the enforce_planar_motion parameter
* FIX: use last guess as initial values to improve optimization stability; expose more parameters
* StateEstimationSmoother: Publish pose updates in a timely manner
* Add parameter enforce_planar_motion
* Fix gtsam must be a runtime depend too
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```
