### PR TITLE
ur_robot_driver: 2.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12613,7 +12613,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
-      version: 2.1.5-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.5-1`

## ur_calibration

```
* Update package maintainers (#735 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/735>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

```
* Update package maintainers (#735 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/735>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Allow setting the speed slider fraction to 0.0 from service (#738 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/738>)
* Update package maintainers (#735 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/735>)
* Parse the rx and tx idle chars as floats (#729 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/729>)
* Add a set_analog_output service (#714 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/714>)
* set receive timeout after connecting the client (#596 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/596>)
* Implemented get version service (#695 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/695>)
* Specify velocities for trajectory forwarding test (#721 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/721>)
* Updated the UR family photo on the readme (#713 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/713>)
* Contributors: Felix Exner, Rune Søe-Knudsen, URJala, steffen-roperobotics
```
