### PR TITLE
dynamixel_workbench_msgs: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2065,7 +2065,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
-      version: 2.0.3-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench_msgs` to `2.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
- release repository: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## dynamixel_workbench_msgs

```
* Added lint and CI for ROS 2 humble, jazzy and rolling
* Modified the readme file for ROS 2 and changed feature
* Contributors: Pyo
```
