### PR TITLE
ur_client_library: 1.7.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11127,7 +11127,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.7.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.0-1`

## ur_client_library

```
* Fix trajectory result in trajectory forward mode when no trajectory is running (#276 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/276>)
* Remove sending an idle command in quintic spline test (#275 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/275>)
* In servo mode always allow targets close to current pose (#273 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/273>)
* Contributors: Felix Exner
```
