### PR TITLE
Add python3-utm-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10548,11 +10548,11 @@ python3-usb:
   gentoo: [dev-python/pyusb]
   nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
+  ubuntu: [python3-usb]
 python3-utm-pip:
   '*':
     pip:
       packages: [utm]
-  ubuntu: [python3-usb]
 python3-uvicorn:
   alpine: [uvicorn]
   debian: [python3-uvicorn]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10548,6 +10548,10 @@ python3-usb:
   gentoo: [dev-python/pyusb]
   nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
+python3-utm-pip:
+  '*':
+    pip:
+      packages: [utm]
   ubuntu: [python3-usb]
 python3-uvicorn:
   alpine: [uvicorn]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-utm-pip

## Package Upstream Source:

[TODO link to source repository](https://pypi.org/project/utm/)

## Purpose of using this:

UTM conversions with python

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE