### PR TITLE
Rename release repository in active distributions.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2468,7 +2468,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/fastrtps-release.git
+      url: https://github.com/ros2-gbp/fastdds-release.git
       version: 2.6.9-1
     source:
       test_commits: true

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2094,7 +2094,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/fastrtps-release.git
+      url: https://github.com/ros2-gbp/fastdds-release.git
       version: 2.14.4-1
     source:
       test_commits: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1704,7 +1704,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/fastrtps-release.git
+      url: https://github.com/ros2-gbp/fastdds-release.git
       version: 2.14.4-1
     source:
       test_commits: true


### PR DESCRIPTION
The old repository url will still work via GitHub redirect unless a new fastrtps-release repository is created.