### PR TITLE
fastdds: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1696,6 +1696,17 @@ repositories:
       url: https://github.com/eProsima/Fast-CDR.git
       version: 2.2.x
     status: maintained
+  fastdds:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fastdds-release.git
+      version: 3.1.2-1
+    source:
+      type: git
+      url: https://github.com/eProsima/Fast-DDS.git
+      version: 3.1.x
+    status: developed
   fastrtps:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1710,7 +1710,7 @@ repositories:
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
       version: 3.1.x
-    status: developed
+    status: maintained
   fastrtps:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1697,6 +1697,10 @@ repositories:
       version: 2.2.x
     status: maintained
   fastdds:
+    doc:
+      type: git
+      url: https://github.com/eProsima/Fast-DDS.git
+      version: 3.1.x
     release:
       tags:
         release: release/rolling/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `fastdds` to `3.1.2-1`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
