### PR TITLE
Add `rmw_desert` to jazzy and foxy

### DIFF
--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -5202,6 +5202,16 @@ repositories:
       url: https://github.com/ros2/rmw_dds_common.git
       version: foxy
     status: maintained
+  rmw_desert:
+    doc:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: foxy
+    source:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: foxy
+    status: maintained
   rmw_fastrtps:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6854,11 +6854,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
-      version: main
+      version: jazzy
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
-      version: main
+      version: jazzy
     status: maintained
   rmw_fastrtps:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6850,6 +6850,16 @@ repositories:
       url: https://github.com/ros2/rmw_dds_common.git
       version: jazzy
     status: maintained
+  rmw_desert:
+    doc:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: main
+    status: maintained
   rmw_fastrtps:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6008,6 +6008,16 @@ repositories:
       url: https://github.com/ros2/rmw_dds_common.git
       version: rolling
     status: maintained
+  rmw_desert:
+    doc:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.wiki.git
+      version: 1.0
+    source:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: 1.0
+    status: maintained
   rmw_fastrtps:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6041,11 +6041,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.wiki.git
-      version: 1.0
+      version: master
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
-      version: 1.0
+      version: main
     status: maintained
   rmw_fastrtps:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6040,8 +6040,8 @@ repositories:
   rmw_desert:
     doc:
       type: git
-      url: https://github.com/signetlabdei/rmw_desert.wiki.git
-      version: master
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: main
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Jazzy and eventually Foxy if still possible

# The source is here:

[https://github.com/signetlabdei/rmw_desert](https://github.com/signetlabdei/rmw_desert)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
