### PR TITLE
mp2p_icp: 1.6.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4477,7 +4477,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.6.5-1
+      version: 1.6.6-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.6.6-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.5-1`

## mp2p_icp

```
* Docs: add page for mm-georef
* docs: Update 2025 paper citation
* print metric_map_t as string: show lat/lon coordinates in a format directly compatible with Google Map searches.
* New cli tool: mm-georef, to manipulate the geo-referencing metadata of metric map files
* Contributors: Jose Luis Blanco-Claraco
```
