### PR TITLE
Fix geographiclib for generic Ubuntu version

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1418,7 +1418,7 @@ geographiclib:
   openembedded: [geographiclib@meta-ros-common]
   rhel: [GeographicLib-devel]
   ubuntu:
-    '*': [libgeographiclib-dev]
+    '*': [libgeographic-dev]
     focal: [libgeographic-dev]
     jammy: [libgeographic-dev]
 geographiclib-tools:


### PR DESCRIPTION
## Package name:

geographiclib

## Package Upstream Source:

rosdep

## Purpose of using this:

geographiclib is broken for generic Ubuntu version. The default value `libgeographiclib-dev` is used. The apt package list defines the package as `libgeographic-dev`. 
