### PR TITLE
Remove velodyne_simulator from jazzy and rolling

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9944,25 +9944,6 @@ repositories:
       url: https://github.com/ros-drivers/velodyne.git
       version: ros2
     status: developed
-  velodyne_simulator:
-    doc:
-      type: git
-      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
-      version: foxy-devel
-    release:
-      packages:
-      - velodyne_description
-      - velodyne_gazebo_plugins
-      - velodyne_simulator
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
-      version: 2.0.3-4
-    source:
-      type: git
-      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
-      version: foxy-devel
-    status: maintained
   vision_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8937,25 +8937,6 @@ repositories:
       url: https://github.com/ros-drivers/velodyne.git
       version: ros2
     status: developed
-  velodyne_simulator:
-    doc:
-      type: git
-      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
-      version: foxy-devel
-    release:
-      packages:
-      - velodyne_description
-      - velodyne_gazebo_plugins
-      - velodyne_simulator
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/velodyne_simulator-release.git
-      version: 2.0.3-3
-    source:
-      type: git
-      url: https://bitbucket.org/DataspeedInc/velodyne_simulator.git
-      version: foxy-devel
-    status: maintained
   vision_msgs:
     doc:
       type: git


### PR DESCRIPTION
Please remove velodyne_simulator from Jazzy and Rolling. The latest supported distribution is Humble.

I am the maintainer and no longer maintain the packages.
https://bitbucket.org/DataspeedInc/velodyne_simulator/commits/03e3ce2e1a92991c31463f8935a98aa344f17da2

Jazzy was added automatically with Rolling, and Rolling builds have failed since Humble.
https://build.ros2.org/job/Jbin_uN64__velodyne_gazebo_plugins__ubuntu_noble_amd64__binary/
https://build.ros2.org/job/Rbin_uN64__velodyne_gazebo_plugins__ubuntu_noble_amd64__binary/

## Package name:

velodyne_simulator

## Package Upstream Source:

https://bitbucket.org/DataspeedInc/velodyne_simulator/
