### PR TITLE
gazebo_ros_pkgs: 2.9.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3406,7 +3406,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
-      version: 2.9.2-1
+      version: 2.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_ros_pkgs` to `2.9.3-1`:

- upstream repository: https://github.com/ros-simulation/gazebo_ros_pkgs.git
- release repository: https://github.com/ros-gbp/gazebo_ros_pkgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.2-1`

## gazebo_dev

```
* Noetic: Add <deprecated> tag to package.xml files (#1566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1566>)
  These packages are now deprecated with Gazebo classic 11 reaching
  end-of-life. This adds the <deprecated> tag (https://www.ros.org/reps/rep-0149.html#deprecated)
  enabling tools to notify users about the deprecation.
* [ROS-O] compatible patches for newer systems (#1543 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1543>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Add ahcorde as maintainer (noetic-devel) (#1437 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1437>)
* Contributors: Addisu Z. Taddese, Jose Luis Rivero, Michael Görner
```

## gazebo_msgs

```
* Noetic: Add <deprecated> tag to package.xml files (#1566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1566>)
  These packages are now deprecated with Gazebo classic 11 reaching
  end-of-life. This adds the <deprecated> tag (https://www.ros.org/reps/rep-0149.html#deprecated)
  enabling tools to notify users about the deprecation.
* Add ahcorde as maintainer (noetic-devel) (#1437 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1437>)
* Contributors: Addisu Z. Taddese, Jose Luis Rivero
```

## gazebo_plugins

```
* Noetic: Add <deprecated> tag to package.xml files (#1566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1566>)
  These packages are now deprecated with Gazebo classic 11 reaching
  end-of-life. This adds the <deprecated> tag (https://www.ros.org/reps/rep-0149.html#deprecated)
  enabling tools to notify users about the deprecation.
* [ROS-O] compatible patches for newer systems (#1543 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1543>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Added parameter to always publish odom twist in local coordinates (#1531 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1531>)
* [gazebo_ros_diff_drive] Fixed spelling mistake (#1516 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1516>)
* Fix typo OpenCV_LIBRARIES (#1451 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1451>)
* gazebo_ros_ft_sensor: Fix incorrect 'imu' with 'ft_sensor' (#1436 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1436>)
* Add ahcorde as maintainer (noetic-devel) (#1437 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1437>)
* Contributors: Addisu Z. Taddese, Jose Luis Rivero, Marc Perales, Martin Oehler, Michael Görner, Tobias Fischer, Wolfgang Merkt
```

## gazebo_ros

```
* Noetic: Add <deprecated> tag to package.xml files (#1566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1566>)
  These packages are now deprecated with Gazebo classic 11 reaching
  end-of-life. This adds the <deprecated> tag (https://www.ros.org/reps/rep-0149.html#deprecated)
  enabling tools to notify users about the deprecation.
* [ROS-O] compatible patches for newer systems (#1543 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1543>)
  Co-authored-by: Jochen Sprickerhof <mailto:git@jochen.sprickerhof.de>
* Add ahcorde as maintainer (noetic-devel) (#1437 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1437>)
* Contributors: Addisu Z. Taddese, Jose Luis Rivero, Michael Görner
```

## gazebo_ros_control

```
* Noetic: Add <deprecated> tag to package.xml files (#1566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1566>)
  These packages are now deprecated with Gazebo classic 11 reaching
  end-of-life. This adds the <deprecated> tag (https://www.ros.org/reps/rep-0149.html#deprecated)
  enabling tools to notify users about the deprecation.
* Typo in error message (#1564 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1564>)
* Add ahcorde as maintainer (noetic-devel) (#1437 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1437>)
* Contributors: Addisu Z. Taddese, DaWiz, Jose Luis Rivero
```

## gazebo_ros_pkgs

```
* Noetic: Add <deprecated> tag to package.xml files (#1566 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1566>)
  These packages are now deprecated with Gazebo classic 11 reaching
  end-of-life. This adds the <deprecated> tag (https://www.ros.org/reps/rep-0149.html#deprecated)
  enabling tools to notify users about the deprecation.
* Add ahcorde as maintainer (noetic-devel) (#1437 <https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1437>)
* Contributors: Addisu Z. Taddese, Jose Luis Rivero
```
