### PR TITLE
rosbridge_suite: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7564,7 +7564,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.2.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## rosapi

```
* New async rosapi params module implementation (#1001 <https://github.com/RobotWebTools/rosbridge_suite/issues/1001>)
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Prevent parameter retrieval crashes (#978 <https://github.com/RobotWebTools/rosbridge_suite/issues/978>)
* Add namespace to services names (#992 <https://github.com/RobotWebTools/rosbridge_suite/issues/992>)
* Add new service to retrieve the different interfaces in the ROS Network (#988 <https://github.com/RobotWebTools/rosbridge_suite/issues/988>)
* Add ament_mypy test and fix all mypy errors (#980 <https://github.com/RobotWebTools/rosbridge_suite/issues/980>)
* Contributors: Błażej Sowa, Lebecque Florian, Mehsias, Matthias Rathauscher, Lebecque Florian
```

## rosapi_msgs

```
* New async rosapi params module implementation (#1001 <https://github.com/RobotWebTools/rosbridge_suite/issues/1001>)
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Add new service to retrieve the different interfaces in the ROS Network (#988 <https://github.com/RobotWebTools/rosbridge_suite/issues/988>)
* Contributors: Błażej Sowa, Lebecque Florian
```

## rosbridge_library

```
* Default subscriber QOS to BestEffort, account for TRANSIENT_LOCAL (#991 <https://github.com/RobotWebTools/rosbridge_suite/issues/991>)
* Fix action cancelling/aborting (#1013 <https://github.com/RobotWebTools/rosbridge_suite/issues/1013>)
* Fix randomly failing subscribe unsubscribe test (#1008 <https://github.com/RobotWebTools/rosbridge_suite/issues/1008>)
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Add timeout option to call_service messages (#984 <https://github.com/RobotWebTools/rosbridge_suite/issues/984>)
* Fix infinite loop in QueueMessageHandler (#983 <https://github.com/RobotWebTools/rosbridge_suite/issues/983>)
* Use monotonic clock for time measuring (#982 <https://github.com/RobotWebTools/rosbridge_suite/issues/982>)
* Add ament_mypy test and fix all mypy errors (#980 <https://github.com/RobotWebTools/rosbridge_suite/issues/980>)
* Drop support for ROS 2 Iron (#981 <https://github.com/RobotWebTools/rosbridge_suite/issues/981>)
* Remove first handler update as queue update is blocked (#974 <https://github.com/RobotWebTools/rosbridge_suite/issues/974>)
* Contributors: Błażej Sowa, Sebastian Castro, ewak, William Wedler, Mike Wake, Daisuke Sato, lboorman
```

## rosbridge_msgs

```
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Contributors: Błażej Sowa
```

## rosbridge_server

```
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Prevent parameter retrieval crashes (#978 <https://github.com/RobotWebTools/rosbridge_suite/issues/978>)
* Call services and send action goals in new threads by default (#996 <https://github.com/RobotWebTools/rosbridge_suite/issues/996>)
* Add timeout option to call_service messages (#984 <https://github.com/RobotWebTools/rosbridge_suite/issues/984>)
* Add ament_mypy test and fix all mypy errors (#980 <https://github.com/RobotWebTools/rosbridge_suite/issues/980>)
* Add namespace and respawn parameters to the nodes in the launch file (#977 <https://github.com/RobotWebTools/rosbridge_suite/issues/977>)
* fix: add url_path parameter in rosbridge_websocket_launch.xml (#963 <https://github.com/RobotWebTools/rosbridge_suite/issues/963>)
* Contributors: Błażej Sowa, Lebecque Florian, Mehsias, Matthias Rathauscher, SeanPai
```

## rosbridge_suite

```
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Contributors: Błażej Sowa
```

## rosbridge_test_msgs

```
* Update maintainers (#1000 <https://github.com/RobotWebTools/rosbridge_suite/issues/1000>)
* Contributors: Błażej Sowa
```
