### PR TITLE
marti_common: 2.15.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5671,7 +5671,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 2.15.3-1
+      version: 2.15.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `2.15.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/swri-robotics-gbp/marti_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.15.3-1`

## marti_data_structures

- No changes

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_nodelet

- No changes

## swri_opencv_util

- No changes

## swri_prefix_tools

- No changes

## swri_roscpp

```
* Removing version check on Kinetic for C++ standard (#760 <https://github.com/swri-robotics/marti_common/issues/760>)
* Contributors: David Anthony
```

## swri_rospy

- No changes

## swri_route_util

```
* Removing version check on Kinetic for C++ standard (#760 <https://github.com/swri-robotics/marti_common/issues/760>)
* Contributors: David Anthony
```

## swri_serial_util

- No changes

## swri_string_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

```
* Removing version check on Kinetic for C++ standard (#760 <https://github.com/swri-robotics/marti_common/issues/760>)
* Contributors: David Anthony
```

## swri_yaml_util

```
* Removing version check on Kinetic for C++ standard (#760 <https://github.com/swri-robotics/marti_common/issues/760>)
* Contributors: David Anthony
```
