### PR TITLE
rviz_satellite: 4.1.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8444,7 +8444,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/nobleo/rviz_satellite-release.git
-      version: 4.1.0-1
+      version: 4.1.0-2
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.1.0-2`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-1`

## rviz_satellite

```
* Fix tile map not moving
* tiles: Add support for reading tiles from filesystem. (#121 <https://github.com/nobleo/rviz_satellite/issues/121>)
* Fix Demo
* Contributors: Jack Geissinger, Ramon Wijnands, Tim Clephas, Karl Schulz
```
