### PR TITLE
image_pipeline: 6.0.10-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2774,7 +2774,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.9-1
+      version: 6.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.10-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.9-1`

## camera_calibration

- No changes

## depth_image_proc

```
* fix depth_image_proc launch files (#1077 <https://github.com/ros-perception/image_pipeline/issues/1077>)
* Contributors: Christian Rauch
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

```
* fix depth_image_proc launch files (#1077 <https://github.com/ros-perception/image_pipeline/issues/1077>)
* Contributors: Christian Rauch
```

## image_view

```
* image_view: sleep if no new image (#1082 <https://github.com/ros-perception/image_pipeline/issues/1082>)
* Contributors: Michael Ferguson
```

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
