### PR TITLE
rviz: 14.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7594,7 +7594,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.2-1
+      version: 14.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.4.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.4.2-1`

## rviz2

```
* uniform CMAKE requirement (#1335 <https://github.com/ros2/rviz/issues/1335>)
* Contributors: mosfet80
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* uniform CMAKE requirement (#1335 <https://github.com/ros2/rviz/issues/1335>)
* Contributors: mosfet80
```

## rviz_default_plugins

```
* Nv12 color format (#1318 <https://github.com/ros2/rviz/issues/1318>)
  Co-authored-by: zycczy <mailto:zycczyby@gmail.com>
* uniform CMAKE requirement (#1335 <https://github.com/ros2/rviz/issues/1335>)
* Contributors: mosfet80, quic-zhaoyuan
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* uniform CMAKE requirement (#1335 <https://github.com/ros2/rviz/issues/1335>)
* Clean ogre_render_window_impl.cpp (#1334 <https://github.com/ros2/rviz/issues/1334>)
* Contributors: mosfet80
```

## rviz_rendering_tests

```
* uniform CMAKE requirement (#1335 <https://github.com/ros2/rviz/issues/1335>)
* Contributors: mosfet80
```

## rviz_visual_testing_framework

```
* uniform CMAKE requirement (#1335 <https://github.com/ros2/rviz/issues/1335>)
* Contributors: mosfet80
```
