### PR TITLE
ros2_kortex: 0.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8363,6 +8363,7 @@ repositories:
       packages:
       - kinova_gen3_6dof_robotiq_2f_85_moveit_config
       - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_lite_moveit_config
       - kortex_api
       - kortex_bringup
       - kortex_description
@@ -8370,7 +8371,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.3-1`:

- upstream repository: https://github.com/Kinovarobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.2-1`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* Repo update (#220 <https://github.com/Kinovarobotics/ros2_kortex/issues/220>)
  * Updating MoveIt configurations
  * Updating and restructuring instructions
* Update planner_plugin parameters (#199 <https://github.com/Kinovarobotics/ros2_kortex/issues/199>)
* Remove outdated config artifacts (#198 <https://github.com/Kinovarobotics/ros2_kortex/issues/198>)
* Cleanup robots for visualization & sim (#180 <https://github.com/Kinovarobotics/ros2_kortex/issues/180>)
* Update planning pipeline configurations (#187 <https://github.com/Kinovarobotics/ros2_kortex/issues/187>)
* Contributors: Marq Rasmussen, Sebastian Castro, Sebastian Jahr, smoya23
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* Repo update (#220 <https://github.com/Kinovarobotics/ros2_kortex/issues/220>)
  * Updating MoveIt configurations
  * Updating and restructuring instructions
* Update planner_plugin parameters (#199 <https://github.com/Kinovarobotics/ros2_kortex/issues/199>)
* Remove outdated config artifacts (#198 <https://github.com/Kinovarobotics/ros2_kortex/issues/198>)
* Cleanup robots for visualization & sim (#180 <https://github.com/Kinovarobotics/ros2_kortex/issues/180>)
* Update planning pipeline configurations (#187 <https://github.com/Kinovarobotics/ros2_kortex/issues/187>)
* Contributors: Marq Rasmussen, Sebastian Castro, Sebastian Jahr, smoya23
```

## kinova_gen3_lite_moveit_config

```
* Fixed the Gazebo Fortress Simulation + Separated the arm and gripper control for Gen3_Lite + Fixed bugs (#252 <https://github.com/Kinovarobotics/ros2_kortex/issues/252>)
  * Modified the Gen3_Lite Moveit Package for arm-gripper control separation
* Added a Moveit2 package for Gen3-Lite (#231 <https://github.com/Kinovarobotics/ros2_kortex/issues/231>)
* Contributors: aalmrad
```

## kortex_api

- No changes

## kortex_bringup

```
* Separated the arm and gripper control for Gen3_Lite + Fixed bugs (#252 <https://github.com/Kinovarobotics/ros2_kortex/issues/252>)
  * Separated the arm and gripper controllers for Gen3_Lite in Kortex_bringup
* Added the empty gripper option for gen3.launch.py (#242 <https://github.com/Kinovarobotics/ros2_kortex/issues/242>)
* Fix mock_hardware and enable simulating gen3_lite (#196 <https://github.com/Kinovarobotics/ros2_kortex/issues/196>)
  * Add additional guards if user sets use_fake_hardware and use_internal_bus_gripper_comm true
* Contributors: Marq Rasmussen, aalmrad, smoya23
```

## kortex_description

```
* Added a missing robot description argument: "moveit_active" (#253 <https://github.com/Kinovarobotics/ros2_kortex/issues/253>)
* Added the empty gripper option for gen3.launch.py (#242 <https://github.com/Kinovarobotics/ros2_kortex/issues/242>)
* Modified the joint limits of Gen3 and Gen3 Lite robots as per the values in the User Guides (#241 <https://github.com/Kinovarobotics/ros2_kortex/issues/241>)
* Added  .STL files for the Gen3 7dof meshes (#235 <https://github.com/Kinovarobotics/ros2_kortex/issues/235>)
* Repo update (#220 <https://github.com/Kinovarobotics/ros2_kortex/issues/220>)
  * Creating Gen3 Lite specific instructions and launch file
  * Updating MoveIt configurations
  * Updating and restructuring instructions
* Update gripper descriptions for use on HW (#206 <https://github.com/Kinovarobotics/ros2_kortex/issues/206>)
  Pass though more hardware parameters for gripper control:
  * use_internal_bus_gripper_comm: specify if gripper comms will pass
  through the robot internally
  * (gripper_)com_port: specify the port the gripper can be exected on
  Use internal comm param in gripper macros:
  * Consider use_internal_bus_gripper_comm param in determination
  for whether or not to launch a ros2_control instance for the gripper. If
  use_internal_bus_gripper_comm is false and we're not running in
  simulation, that means we're expecting to communicate with the gripper
  via USB and we'll need to launch a separate ros2_control instance to
  control it.
  Add documentation on load_robot macro parameters
* fake_components->mock_components (#197 <https://github.com/Kinovarobotics/ros2_kortex/issues/197>)
* Fix mock_hardware and enable simulating gen3_lite (#196 <https://github.com/Kinovarobotics/ros2_kortex/issues/196>)
  * Add additional guards if user sets use_fake_hardware and use_internal_bus_gripper_comm true
* Update gen3 lite and gripper macros (#191 <https://github.com/Kinovarobotics/ros2_kortex/issues/191>)
* Fix wrist with vision mesh (#195 <https://github.com/Kinovarobotics/ros2_kortex/issues/195>)
* Fix mention of nonexistent STL file (#194 <https://github.com/Kinovarobotics/ros2_kortex/issues/194>)
* Enable initial position param in kinova xacros (#190 <https://github.com/Kinovarobotics/ros2_kortex/issues/190>)
* Cleanup robots for visualization & sim (#180 <https://github.com/Kinovarobotics/ros2_kortex/issues/180>)
* Contributors: Abishalini Sivaraman, David Yackzan, Marq Rasmussen, aalmrad, smoya23
```

## kortex_driver

```
* Add force and velocity hardware interfaces (#204 <https://github.com/Kinovarobotics/ros2_kortex/issues/204>)
  Co-authored-by: Ashton Larkin <mailto:42042756+adlarkin@users.noreply.github.com>
* Contributors: Paul Gesel
```
