### PR TITLE
Add rustup dependency to rosdep base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8487,6 +8487,15 @@ rustc:
   opensuse: [rust]
   rhel: [rust]
   ubuntu: [rustc]
+rustup:
+  arch: [rustup]
+  debian: [rustup]
+  fedora: [rustup]
+  gentoo: [dev-util/rustup]
+  nixos: [rustup]
+  opensuse: [rustup]
+  rhel: [rustup]
+  ubuntu: [rustup]
 sbcl:
   alpine: [sbcl]
   arch: [sbcl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8495,7 +8495,6 @@ rustup:
   gentoo: [dev-util/rustup]
   nixos: [rustup]
   opensuse: [rustup]
-  rhel: [rustup]
   ubuntu: [rustup]
 sbcl:
   alpine: [sbcl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8488,6 +8488,7 @@ rustc:
   rhel: [rust]
   ubuntu: [rustc]
 rustup:
+  alpine: [rustup]
   arch: [rustup]
   debian: [rustup]
   fedora: [rustup]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rustup

## Package Upstream Source:

https://github.com/rust-lang/rustup

## Purpose of using this:

[rmw_zenoh](https://github.com/ros2/rmw_zenoh) internal core is written in Rust and it uses the `cargo` as dependency for the build. While this is currently working, installing directly `cargo` is pinning the Rust toolchain to a quite old version in many distributions. For example, on Ubuntu `24.04` the shipped Rust toolchain is `1.75`.

Since Jazzy the Zenoh project has globally pinned the Rust version to [1.75](https://github.com/eclipse-zenoh/zenoh/blob/2311334ebb82378e341d350a08d0667169c7f211/rust-toolchain.toml).
However, this is now a limitation for the project since newer Rust toolchains have been release and downstream dependencies already started requiring more recent Rust versions (e.g. https://github.com/eclipse-zenoh/zenoh/pull/1800).

[rustup](https://rustup.rs/) is a tool that installs [Rust](https://www.rust-lang.org/) on the system from the official release channels, enabling to easily switch between toolchain versions and keep them updated.
By depending on `rustup` instead of `cargo` [rmw_zenoh](https://github.com/ros2/rmw_zenoh) (and any other Rust project) will be able to use the required Rust toolchain and not forced to use the toolchain shipped with any distro.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/rustup
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=rustup&searchon=names&suite=noble&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/rustup/rustup/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=rustup&maintainer=&flagged=
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-util/rustup
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/rustup
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/rustup
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://nixos.wiki/wiki/Rust
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/rustup
- rhel: https://rhel.pkgs.org/
  - Not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->
