### PR TITLE
Add ros2_control_cmake

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7083,6 +7083,16 @@ repositories:
       url: https://github.com/ros-controls/ros2_control.git
       version: master
     status: developed
+  ros2_control_cmake:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control_cmake.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control_cmake.git
+      version: master
+    status: developed
   ros2_controllers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6367,6 +6367,16 @@ repositories:
       url: https://github.com/ros-controls/ros2_control.git
       version: master
     status: developed
+  ros2_control_cmake:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control_cmake.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control_cmake.git
+      version: master
+    status: developed
   ros2_controllers:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Package name: `ros2_control_cmake`
This package provides CMake macros and will be part of the ros2_control framework.

# The source is here:

https://github.com/ros-controls/ros2_control_cmake/

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
