### PR TITLE
apriltag_detector: 3.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -368,10 +368,11 @@ repositories:
       - apriltag_detector_mit
       - apriltag_detector_umich
       - apriltag_draw
+      - apriltag_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 2.0.0-1
+      version: 3.0.1-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `3.0.1-2`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## apriltag_detector

- No changes

## apriltag_detector_mit

- No changes

## apriltag_detector_umich

- No changes

## apriltag_draw

- No changes

## apriltag_tools

```
* removed unnecessary pluginlib dependency
* Contributors: Bernd Pfrommer
```
