### PR TITLE
apriltag_detector: 3.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -373,10 +373,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: rolling
     release:
+      packages:
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
+      - apriltag_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 1.0.0-3
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `3.0.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-3`

## apriltag_detector

- No changes

## apriltag_detector_mit

- No changes

## apriltag_detector_umich

- No changes

## apriltag_draw

- No changes

## apriltag_tools

```
* removed unnecessary pluginlib dependency
* Contributors: Bernd Pfrommer
```
