### PR TITLE
realtime_tools: 2.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7668,7 +7668,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.12.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.11.0-1`

## realtime_tools

```
* CI downstream build (backport #214 <https://github.com/ros-controls/realtime_tools/issues/214>) (#283 <https://github.com/ros-controls/realtime_tools/issues/283>)
* Bump version of pre-commit hooks (backport #276 <https://github.com/ros-controls/realtime_tools/issues/276>) (#277 <https://github.com/ros-controls/realtime_tools/issues/277>)
* Install boost on jazzy as well (backport #273 <https://github.com/ros-controls/realtime_tools/issues/273>) (#274 <https://github.com/ros-controls/realtime_tools/issues/274>)
* Use ABI workflow from ros2_control_ci (backport #264 <https://github.com/ros-controls/realtime_tools/issues/264>) (#271 <https://github.com/ros-controls/realtime_tools/issues/271>)
* Add Lock-free Queue (backport #253 <https://github.com/ros-controls/realtime_tools/issues/253>) (#269 <https://github.com/ros-controls/realtime_tools/issues/269>)
* Improve has_realtime_kernel method (backport #260 <https://github.com/ros-controls/realtime_tools/issues/260>) (#267 <https://github.com/ros-controls/realtime_tools/issues/267>)
* Branch for jazzy (backport #263 <https://github.com/ros-controls/realtime_tools/issues/263>) (#265 <https://github.com/ros-controls/realtime_tools/issues/265>)
* Contributors: mergify[bot]
```
