### PR TITLE
ros2_control: 4.27.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7077,7 +7077,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.26.0-1
+      version: 4.27.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.27.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.26.0-1`

## controller_interface

```
* [Handle] Use get_optional instead of get_value<double> (#2061 <https://github.com/ros-controls/ros2_control/issues/2061>)
* Cleanup chainable controller exported interfaces to allow reconfiguring  (#2073 <https://github.com/ros-controls/ros2_control/issues/2073>)
* Use new get_value API for newly added tests and semantic components (#2055 <https://github.com/ros-controls/ros2_control/issues/2055>)
* Add new get_value API for Handles and Interfaces (#1976 <https://github.com/ros-controls/ros2_control/issues/1976>)
* Integrate pal_statistics for introspection of controllers, hardware components and more (#1918 <https://github.com/ros-controls/ros2_control/issues/1918>)
* [ControllerInterface] Improve the prefix name check for the chainable controllers (#2038 <https://github.com/ros-controls/ros2_control/issues/2038>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* [HW Components] Add fix for async hardware components improper rate (#2076 <https://github.com/ros-controls/ros2_control/issues/2076>)
* [CM] Skip robot_description topic remapping for controllers (#2082 <https://github.com/ros-controls/ros2_control/issues/2082>)
* [Spawner] Fix case with wildcard AND explicit controller in the same file (#2080 <https://github.com/ros-controls/ros2_control/issues/2080>)
* [Handle] Use get_optional instead of get_value<double> (#2061 <https://github.com/ros-controls/ros2_control/issues/2061>)
* [CM] Fix switch_controller behaviour with unknown controller switch request (#2060 <https://github.com/ros-controls/ros2_control/issues/2060>)
* Cleanup chainable controller exported interfaces to allow reconfiguring  (#2073 <https://github.com/ros-controls/ros2_control/issues/2073>)
* Update memlock values in doc (#2066 <https://github.com/ros-controls/ros2_control/issues/2066>)
* Add new get_value API for Handles and Interfaces (#1976 <https://github.com/ros-controls/ros2_control/issues/1976>)
* Fix unused timeouts in load/unload controller (#2052 <https://github.com/ros-controls/ros2_control/issues/2052>)
* [CM] Improve memory allocation with buffer variables (#1801 <https://github.com/ros-controls/ros2_control/issues/1801>)
* Integrate pal_statistics for introspection of controllers, hardware components and more (#1918 <https://github.com/ros-controls/ros2_control/issues/1918>)
* [CM] Fix the controller deactivation on the control cycles returning ERROR  (#1756 <https://github.com/ros-controls/ros2_control/issues/1756>)
* Contributors: Christoph Fröhlich, Dawid Kmak, Sai Kishor Kothakota, bijoua29
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [HW Components] Add fix for async hardware components improper rate (#2076 <https://github.com/ros-controls/ros2_control/issues/2076>)
* [Handle] Update get_value deprecation note (#2074 <https://github.com/ros-controls/ros2_control/issues/2074>)
* [Handle] Use get_optional instead of get_value<double> (#2061 <https://github.com/ros-controls/ros2_control/issues/2061>)
* Use new get_value API for newly added tests and semantic components (#2055 <https://github.com/ros-controls/ros2_control/issues/2055>)
* Fix introspection for handles with variable references (#2050 <https://github.com/ros-controls/ros2_control/issues/2050>)
* Add new get_value API for Handles and Interfaces (#1976 <https://github.com/ros-controls/ros2_control/issues/1976>)
* Integrate pal_statistics for introspection of controllers, hardware components and more (#1918 <https://github.com/ros-controls/ros2_control/issues/1918>)
* Add scoped lock (#2045 <https://github.com/ros-controls/ros2_control/issues/2045>)
* add tests for copy and move operations of the Handle class (#2011 <https://github.com/ros-controls/ros2_control/issues/2011>)
* Contributors: Sai Kishor Kothakota, Wiktor Bajor
```

## hardware_interface_testing

```
* [Handle] Use get_optional instead of get_value<double> (#2061 <https://github.com/ros-controls/ros2_control/issues/2061>)
* Add new get_value API for Handles and Interfaces (#1976 <https://github.com/ros-controls/ros2_control/issues/1976>)
* [CM] Fix the controller deactivation on the control cycles returning ERROR  (#1756 <https://github.com/ros-controls/ros2_control/issues/1756>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* [CM] Fix the controller deactivation on the control cycles returning ERROR  (#1756 <https://github.com/ros-controls/ros2_control/issues/1756>)
* Contributors: Sai Kishor Kothakota
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
