### PR TITLE
ros2_controllers: 4.21.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7118,7 +7118,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.20.0-1
+      version: 4.21.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.21.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.20.0-1`

## ackermann_steering_controller

```
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Contributors: Sai Kishor Kothakota
```

## admittance_controller

```
* Cleanup dependencies (add angles, rm filters) (#1555 <https://github.com/ros-controls/ros2_controllers/issues/1555>)
* [Admittance] multiple state/command interfaces (#1196 <https://github.com/ros-controls/ros2_controllers/issues/1196>)
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Remove dependency of admittance controller on JTC (#1532 <https://github.com/ros-controls/ros2_controllers/issues/1532>)
* Contributors: Christoph Fröhlich, Marco Magri, Sai Kishor Kothakota
```

## bicycle_steering_controller

```
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Contributors: Sai Kishor Kothakota
```

## diff_drive_controller

```
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Fix reference in chained diff drive controller (#1529 <https://github.com/ros-controls/ros2_controllers/issues/1529>)
* docs for chainable diff_drive_controller (#1518 <https://github.com/ros-controls/ros2_controllers/issues/1518>)
* Contributors: Arthur Lovekin, Christoph Fröhlich, Sai Kishor Kothakota, Thibault Poignonec
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Contributors: Sai Kishor Kothakota
```

## forward_command_controller

```
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

```
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Contributors: Christoph Fröhlich
```

## gripper_controllers

```
* Update API of PID class (#1437 <https://github.com/ros-controls/ros2_controllers/issues/1437>)
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Bump version of pre-commit hooks (#1514 <https://github.com/ros-controls/ros2_controllers/issues/1514>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* [JTC] Renaming variables, reordering trajectory checks (#1032 <https://github.com/ros-controls/ros2_controllers/issues/1032>)
* [JTC] Use time of the last command for set_point_before_trajectory_msg in open-loop mode (#780 <https://github.com/ros-controls/ros2_controllers/issues/780>)
* Update API of PID class (#1437 <https://github.com/ros-controls/ros2_controllers/issues/1437>)
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* [JTC]: Abort goal on deactivate (#1517 <https://github.com/ros-controls/ros2_controllers/issues/1517>)
* Contributors: Christoph Fröhlich, Dr. Denis, Felix Exner
```

## mecanum_drive_controller

```
* Fix mecanum_drive_controller documentation (#1547 <https://github.com/ros-controls/ros2_controllers/issues/1547>)
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## parallel_gripper_controller

```
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Bump version of pre-commit hooks (#1514 <https://github.com/ros-controls/ros2_controllers/issues/1514>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```

## pid_controller

```
* [pid_controller] Update tests (#1538 <https://github.com/ros-controls/ros2_controllers/issues/1538>)
* Reset PID controllers on activation and add save_i_term parameter (#1507 <https://github.com/ros-controls/ros2_controllers/issues/1507>)
* Update API of PID class (#1437 <https://github.com/ros-controls/ros2_controllers/issues/1437>)
* [pid_controller] Fix logic for feedforward_mode with single reference interface (#1520 <https://github.com/ros-controls/ros2_controllers/issues/1520>)
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Contributors: Christoph Fröhlich, Julia Jia, Sai Kishor Kothakota
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Fix use of M_PI in steering_controllers_library and tricycle_controller (#1536 <https://github.com/ros-controls/ros2_controllers/issues/1536>)
* Contributors: Sai Kishor Kothakota, Silvio Traversaro
```

## tricycle_controller

```
* Cleanup wrong lifecycle transitions in tests and unnecessary checks (#1534 <https://github.com/ros-controls/ros2_controllers/issues/1534>)
* Fix use of M_PI in steering_controllers_library and tricycle_controller (#1536 <https://github.com/ros-controls/ros2_controllers/issues/1536>)
* Contributors: Christoph Fröhlich, Silvio Traversaro
```

## tricycle_steering_controller

```
* Fix the exported interface naming in the chainable controllers (#1528 <https://github.com/ros-controls/ros2_controllers/issues/1528>)
* Contributors: Sai Kishor Kothakota
```

## velocity_controllers

- No changes
