### PR TITLE
nixos: Update names of alsa* packages after renaming

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -45,7 +45,7 @@ alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
   gentoo: [media-libs/alsa-oss]
-  nixos: [alsaOss]
+  nixos: [alsa-oss]
   openembedded: [alsa-oss@meta-oe]
   opensuse: [alsa-oss]
   ubuntu: [alsa-oss]
@@ -2656,7 +2656,7 @@ libasound2-dev:
   debian: [libasound2-dev]
   fedora: [alsa-lib]
   gentoo: [media-libs/alsa-lib]
-  nixos: [alsaLib]
+  nixos: [alsa-lib]
   openembedded: [alsa-lib@openembedded-core]
   ubuntu: [libasound2-dev]
 libatomic:


### PR DESCRIPTION
The packages have been [renamed in the nixpkgs repository](https://github.com/NixOS/nixpkgs/blob/303bd8071377433a2d8f76e684ec773d70c5b642/pkgs/top-level/aliases.nix#L151-L152).