### PR TITLE
rmw_desert: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8050,6 +8050,11 @@ repositories:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_desert-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_desert` to `1.0.2-1`:

- upstream repository: https://github.com/signetlabdei/rmw_desert.git
- release repository: https://github.com/ros2-gbp/rmw_desert-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rmw_desert

```
* Removed circular dependancies
* Contributors: matlin
```
