### PR TITLE
turtlebot4_setup: 2.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9438,7 +9438,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_setup-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_setup.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4_setup` to `2.0.3-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4_setup.git
- release repository: https://github.com/ros2-gbp/turtlebot4_setup-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## turtlebot4_setup

```
* Update the hostname in /boot/firmware/user-data (#19 <https://github.com/turtlebot/turtlebot4_setup/issues/19>)
  * Update the hostname in /boot/firmware/user-data as well as /etc/hostname to ensure it persists properly across reboots
  * Suppress error output about failure to preserve permissions across filesystems
  * Write the updated hostname to the turtlebot4/system file
* Fix/shm (#21 <https://github.com/turtlebot/turtlebot4_setup/issues/21>)
  Turn off clearing of SHM on log out (interfered with services)
* Replace User=ubuntu with User={os.getlogin()} when generating the discovery server configuration file if necessary (#20 <https://github.com/turtlebot/turtlebot4_setup/issues/20>)
* Fix tag order
* Update package maintainers
* Add an alias to reconnect to a previously-paired game controller
* Add a udev rule for the Logitech F710 family of controllers
* Contributors: Chris Iverach-Brereton, Hilary Luo
```
