### PR TITLE
ur_robot_driver: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8708,7 +8708,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.0.2-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.2-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* ur_controllers: doc -- Fix link to index page of driver (#1284 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1284>)
* Update computeCommand to compute_command (#1265 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1265>)
* Apply renaming of member variables of JTC (#1275 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1275>)
* Contributors: Christoph Fröhlich, Felix Exner
```

## ur_dashboard_msgs

```
* Port robot_state_helper to ROS2 (#933 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/933>)
* Contributors: Felix Durchdewald
```

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Port robot_state_helper to ROS2 (#933 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/933>)
* Fix crashes on shutting down (#1270 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1270>)
* Fix formatting (#1262 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1262>)
* Move some documentation to client_library (#1245 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1245>)
* Contributors: Felix Durchdewald, Felix Exner
```
