### PR TITLE
rmw: 7.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6099,7 +6099,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.7.0-1
+      version: 7.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.8.0-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.7.0-1`

## rmw

```
* add enclave option functions. (#393 <https://github.com/ros2/rmw/issues/393>)
* a couple of typo fixes for doc section. (#391 <https://github.com/ros2/rmw/issues/391>)
* update cmake version (#389 <https://github.com/ros2/rmw/issues/389>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```

## rmw_implementation_cmake

```
* update cmake version (#389 <https://github.com/ros2/rmw/issues/389>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_security_common

- No changes
