### PR TITLE
Add adi iio to humble, jazzy and rolling index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -92,6 +92,16 @@ repositories:
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
       version: humble-devel
     status: maintained
+  adi_iio:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: humble
+    status: maintained
   adi_tmc_coe:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  adi_iio:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: jazzy
+    status: maintained
   ai_prompt_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -80,6 +80,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  adi_iio:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: rolling
+    status: maintained
   ament_acceleration:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

`humble` `jazzy` `rolling`

# The source is here:

https://github.com/analogdevicesinc/iio_ros2

## Purpose of using this:

`adi_iio` facilitates seamless communication and data exchange between IIO devices and ROS2 nodes, the package serves as a comprehensive framework for integrating industrial I/O systems into modern robotics solutions. 


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
