### PR TITLE
rosidl_dynamic_typesupport_fastrtps: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6938,7 +6938,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport_fastrtps` to `0.4.0-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## rosidl_dynamic_typesupport_fastrtps

```
* Changes to build against Fast DDS 3.0 (#5 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/5>)
* Contributors: Chris Lalancette, Miguel Company
```
