### PR TITLE
add python3-apscheduler to rosdep for Debian and Ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4935,6 +4935,9 @@ python3-apa102-pi-pip:
   ubuntu:
     pip:
       packages: [apa102-pi]
+python3-apscheduler:
+  debian: [python3-apscheduler]
+  ubuntu: [python3-apscheduler]
 python3-argcomplete:
   alpine: [py3-argcomplete]
   arch: [python-argcomplete]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4937,6 +4937,7 @@ python3-apa102-pi-pip:
       packages: [apa102-pi]
 python3-apscheduler:
   debian: [python3-apscheduler]
+  fedora: [python3-APScheduler]
   ubuntu: [python3-apscheduler]
 python3-apt:
   debian: [python3-apt]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

apscheduler

## Package Upstream Source:

[https://github.com/agronholm/apscheduler](https://github.com/agronholm/apscheduler)

## Purpose of using this:

This package is useful when you want to do events using cron. It also has various support for working at different timezones. I use it for a task scheduler package within ros.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - [https://packages.debian.org/bookworm/python3-apscheduler](https://packages.debian.org/bookworm/python3-apscheduler)
- Ubuntu: https://packages.ubuntu.com/
  - [https://packages.ubuntu.com/focal/python3-apscheduler](https://packages.ubuntu.com/focal/python3-apscheduler)
  - [https://packages.ubuntu.com/jammy/python3-apscheduler](https://packages.ubuntu.com/jammy/python3-apscheduler)
  - [https://packages.ubuntu.com/noble/python3-apscheduler](https://packages.ubuntu.com/noble/python3-apscheduler)

