### PR TITLE
Revert "rviz: 14.4.3-1 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7593,7 +7593,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.3-1
+      version: 14.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#44636

See https://github.com/ros/rosdistro/pull/44636#issuecomment-2705187947 for explanation.