### PR TITLE
ros2_roboreg source entry

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8137,6 +8137,16 @@ repositories:
       url: https://github.com/robosoft-ai/robosoft_openai.git
       version: humble
     status: developed
+  ros2_roboreg:
+    doc:
+      type: git
+      url: https://github.com/lbr-stack/ros2_roboreg.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/lbr-stack/ros2_roboreg.git
+      version: humble
+    status: developed
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
Dear Maintainers!

This is my first release, so please bear with me :)

This PR is a draft, and I wanted to get some initial feedback.

I wish to release the following packages:

- `roboreg_all`
- `roboreg_idl`
- `roboreg_nodes`
- `roboreg_rviz`

These packages live under a folder named `ros2_roboreg` (users will not be exposed to it so should **not** conflict with `REP 144`).

Is adding the source entry all that needs to be done? Thank you for the help in advance!

I shall further note that we separated the core library into a `pip`-installable library (distributed through PyPI), and that the ROS integration builds on top of it. Is this to be considered for `rosdep`? I.e. here: https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml

# Please Add This Package to be indexed in the rosdistro.

- Rolling
- Jazzy
- Humble

# The source is here:

https://github.com/lbr-stack/ros2_roboreg (private right now)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

Also relates to https://github.com/ros2-gbp/ros2-gbp-github-org/issues/519
