### PR TITLE
launch_pal: 0.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4167,7 +4167,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.10.0-1
+      version: 0.11.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.11.0-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/pal-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.0-1`

## launch_pal

```
* Add comments
* fix ament_pep8 linting
* add generic string substitution concat
* Contributors: thomasung
```
