### PR TITLE
pal_gripper: 3.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6270,7 +6270,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.5.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

- No changes

## pal_gripper_description

```
* Fix inertia + update interface link to match the real interface of the gripper
* Contributors: thomas.peyrucain
```

## pal_gripper_simulation

- No changes
