### PR TITLE
pmb2_robot: 5.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6677,7 +6677,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.4.0-1
+      version: 5.7.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.7.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.4.0-1`

## pmb2_bringup

```
* update locks and topics to integrate assisted_teleop
* Contributors: andreacapodacqua
```

## pmb2_controller_configuration

- No changes

## pmb2_description

- No changes

## pmb2_robot

- No changes
