### PR TITLE
omni_base_robot: 2.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6061,7 +6061,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.4.1-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.9.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.1-1`

## omni_base_bringup

```
* updated maintainer
* update locks topics and teleop to integrate assisted_teleop
* Contributors: andreacapodacqua
```

## omni_base_controller_configuration

- No changes

## omni_base_description

```
* updated maintainer
* Contributors: andreacapodacqua
```

## omni_base_robot

```
* updated maintainer
* Contributors: andreacapodacqua
```
