### PR TITLE
pmb2_navigation: 4.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6654,10 +6654,11 @@ repositories:
       - pmb2_2dnav
       - pmb2_laser_sensors
       - pmb2_navigation
+      - pmb2_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.5.0-1
+      version: 4.11.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.11.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.5.0-1`

## pmb2_2dnav

```
* Update pmb2_nav_bringup.launch.py
* Contributors: antoniobrandi
```

## pmb2_laser_sensors

- No changes

## pmb2_navigation

- No changes

## pmb2_rgbd_sensors

- No changes
