### PR TITLE
tiago_navigation: 4.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10534,10 +10534,11 @@ repositories:
       - tiago_2dnav
       - tiago_laser_sensors
       - tiago_navigation
+      - tiago_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.5.0-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_navigation` to `4.9.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_navigation.git
- release repository: https://github.com/pal-gbp/tiago_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.5.0-1`

## tiago_2dnav

```
* Merge branch 'abr/fix/public-sim' into 'humble-devel'
  Update tiago_nav_bringup.launch.py
  See merge request robots/tiago_navigation!127
* Update tiago_nav_bringup.launch.py
* Contributors: antoniobrandi
```

## tiago_laser_sensors

- No changes

## tiago_navigation

- No changes

## tiago_rgbd_sensors

- No changes
