### PR TITLE
ffmpeg_image_transport: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2144,7 +2144,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `1.0.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-2`

## ffmpeg_image_transport

```
* updated badges and fixed deprecation warnings (#36 <https://github.com/ros-misc-utilities/ffmpeg_image_transport/issues/36>)
  * updated badges and fixed deprecation warnings
  * only use AV_FRAME_FLAG_KEY when available
* Configurable CRF (#34 <https://github.com/ros-misc-utilities/ffmpeg_image_transport/issues/34>)
  * Added CRF support
  * fixed gop parameter in the README examples
  ---------
  Co-authored-by: Alexey Shtern <mailto:alexey.shtern@xtend.me>
* README: Add usage instructions for Jazzy
  The syntax mentioned in the README no longer works there.
* fix typo in link
* added documentation for enabling NVMPI on the jetson
* Contributors: Alexey Shtern, Bernd Pfrommer, Danil Tolkachev, Michal Sojka
```
