### PR TITLE
update apriltag detector source and doc repositories

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -511,7 +511,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: humble
+      version: release
     release:
       packages:
       - apriltag_detector
@@ -526,13 +526,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: humble
+      version: release
     status: developed
   apriltag_mit:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -541,7 +541,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
-      version: humble
+      version: release
     status: developed
   apriltag_msgs:
     release:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -371,7 +371,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: rolling
+      version: release
     release:
       packages:
       - apriltag_detector
@@ -386,13 +386,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: rolling
+      version: release
     status: developed
   apriltag_mit:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -401,7 +401,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
-      version: rolling
+      version: release
     status: developed
   apriltag_msgs:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -361,7 +361,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: rolling
+      version: release
     release:
       packages:
       - apriltag_detector
@@ -376,13 +376,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
-      version: rolling
+      version: release
     status: developed
   apriltag_mit:
     doc:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -391,7 +391,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
-      version: rolling
+      version: release
     status: developed
   apriltag_msgs:
     release:


### PR DESCRIPTION
This PR updates the source and docs branches for repositories related to apriltags