### PR TITLE
clearpath_tests: 0.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1141,6 +1141,21 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
       version: jazzy
     status: maintained
+  clearpath_tests:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_tests.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_tests-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_tests.git
+      version: jazzy
+    status: developed
   clips_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_tests` to `0.2.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_tests.git
- release repository: https://github.com/clearpath-gbp/clearpath_tests-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## clearpath_tests

```
* Fix simple_term_menu_vendor dependency
* Contributors: Chris Iverach-Brereton
```
