### PR TITLE
openeb_vendor: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5189,7 +5189,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/openeb_vendor-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openeb_vendor` to `2.0.2-1`:

- upstream repository: https://github.com/ros-event-camera/openeb_vendor.git
- release repository: https://github.com/ros2-gbp/openeb_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## openeb_vendor

```
* updated README to reflect missing silkyevcam patch
* disable silkyevcam patch as it disables evk4
* upgraded to MV5.0.0 and re-added silkyevcam
* Contributors: Bernd Pfrommer
```
