### PR TITLE
point to correct doc/source for openeb_vendor repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6096,7 +6096,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -6105,7 +6105,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: humble
+      version: release
     status: developed
   opennav_docking:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5184,7 +5184,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: jazzy
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -5193,7 +5193,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
-      version: jazzy
+      version: release
     status: developed
   openni2_camera:
     doc:


### PR DESCRIPTION
This PR renames the source and doc repository branches for openeb_vendor
