### PR TITLE
Added python3-mss-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7394,6 +7394,10 @@ python3-msm-pip:
   ubuntu:
     pip:
       packages: [msm]
+python3-mss-pip:
+  '*':
+    pip:
+      packages: [mss]
 python3-multimethod-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-mss-pip

## Package Upstream Source:

https://github.com/BoboTiG/python-mss

## Purpose of using this:

Fast multiplatform Python screenshotter.

Distro packaging links:

## Links to Distribution Packages

Only found on PyPI: https://pypi.org/project/mss/