### PR TITLE
Add adi_tmc_coe to humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -92,6 +92,16 @@ repositories:
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
       version: humble-devel
     status: maintained
+  adi_tmc_coe:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe_ros2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_tmc_coe_ros2.git
+      version: humble
+    status: maintained
   adi_tmcl:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/analogdevicesinc/adi_tmc_coe_ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
