### PR TITLE
rmw_desert: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6169,7 +6169,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_desert-release.git
-      version: 1.0.3-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_desert` to `2.0.0-1`:

- upstream repository: https://github.com/signetlabdei/rmw_desert.git
- release repository: https://github.com/ros2-gbp/rmw_desert-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-1`

## rmw_desert

```
* Bump to second major release for Jazzy and Rolling
```
