### PR TITLE
dynamixel_interfaces: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2014,7 +2014,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_interfaces-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_interfaces` to `1.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
- release repository: https://github.com/ros2-gbp/dynamixel_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## dynamixel_interfaces

```
* Fixed the dependencies setting for the release version
* Contributors: Pyo
```
