### PR TITLE
rmw: 7.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6100,7 +6100,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.8.0-1
+      version: 7.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.8.1-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.8.0-1`

## rmw

```
* Added rmw_event_type_is_supported (#395 <https://github.com/ros2/rmw/issues/395>)
* Contributors: Alejandro Hernández Cordero
```

## rmw_implementation_cmake

- No changes

## rmw_security_common

- No changes
