### PR TITLE
rmw_cyclonedds: 4.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6137,7 +6137,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_cyclonedds` to `4.0.1-1`:

- upstream repository: https://github.com/ros2/rmw_cyclonedds.git
- release repository: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.0-1`

## rmw_cyclonedds_cpp

```
* Added rmw_event_type_is_supported (#532 <https://github.com/ros2/rmw_cyclonedds/issues/532>)
* use rmw_enclave_options_xxx APIs instead. (#531 <https://github.com/ros2/rmw_cyclonedds/issues/531>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```
