### PR TITLE
play_motion2: 1.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6578,7 +6578,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.5.1-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.0-1`

## play_motion2

```
* Remap description topics
* Handle generate_parameter_library include for different versions
* Ignore set_value output
* Use set value output depending on hardware interface version
* Add optional argument rclcpp::NodeOptions to play_motion_client
* Contributors: Noel Jimenez, Sai Kishor Kothakota, thomasung
```

## play_motion2_msgs

- No changes
