### PR TITLE
nobleo_socketcan_bridge: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4368,6 +4368,17 @@ repositories:
       version: ros2
     status: developed
     status_description: ROS2 support is work-in-progress. Help wanted!
+  nobleo_socketcan_bridge:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/nobleo_socketcan_bridge.git
+      version: main
+    status: maintained
   nodl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nobleo_socketcan_bridge` to `1.0.1-1`:

- upstream repository: https://github.com/nobleo/nobleo_socketcan_bridge.git
- release repository: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## nobleo_socketcan_bridge

```
* Disable clang_format on humble
  This version of clang_format has a different output.
* Contributors: Ramon Wijnands
```
