### PR TITLE
kinematics_interface: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3457,7 +3457,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git
-      version: master
+      version: jazzy
     release:
       packages:
       - kinematics_interface
@@ -3469,7 +3469,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git
-      version: master
+      version: jazzy
     status: developed
   kinematics_interface_pinocchio:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3465,7 +3465,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.2.1-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.3.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## kinematics_interface

```
* Remove visibility boilerplate code (#101 <https://github.com/ros-controls/kinematics_interface/issues/101>)
* Calculate Jacobian Inverse (#92 <https://github.com/ros-controls/kinematics_interface/issues/92>)
* Contributors: Christoph Fröhlich, francesco-donofrio
```

## kinematics_interface_kdl

```
* Remove visibility boilerplate code (#101 <https://github.com/ros-controls/kinematics_interface/issues/101>)
* Calculate Jacobian Inverse (#92 <https://github.com/ros-controls/kinematics_interface/issues/92>)
* Contributors: Christoph Fröhlich, francesco-donofrio
```
