### PR TITLE
kinematics_interface: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2998,7 +2998,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.2.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.0.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## kinematics_interface

```
* Add methods for computing frame differences (#93 <https://github.com/ros-controls/kinematics_interface/issues/93>)
* Contributors: francesco-donofrio
```

## kinematics_interface_kdl

```
* Add methods for computing frame differences (#93 <https://github.com/ros-controls/kinematics_interface/issues/93>)
* Contributors: francesco-donofrio
```
