### PR TITLE
clearpath_common: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1051,7 +1051,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Feature Jazzy Ouster (#170 <https://github.com/clearpathrobotics/clearpath_common/issues/170>)
  * Add OusteOS1 description
  * Custom OusterOS1 generator
  * Ouster use custom description generator
  * Use appropriate generator for Ouster
* Add D455, D456 support (#176 <https://github.com/clearpathrobotics/clearpath_common/issues/176>)
  * Add URDFs for all supported RealSense cameras
  * Pass the device_type as the model parameter to the master URDF, move specific types into a sub-directory and include them as necessary
* Add support for OAK-D Pro W PoE (#174 <https://github.com/clearpathrobotics/clearpath_common/issues/174>)
  * Add the model for the OAK-D Pro W; it's identical to the OAK-D Pro. Add model type support to the OAK-D description
* Feature/generate aggregator config (#173 <https://github.com/clearpathrobotics/clearpath_common/issues/173>)
  * Generate diagnostic aggregator sensor params based on robot.yaml
  * Remove redundant read of the default param file
* Add URDF, STL files for the Seyond Robin W lidar (#169 <https://github.com/clearpathrobotics/clearpath_common/issues/169>)
  * Add URDF, STL files for the Seyond Robin W lidar
* Contributors: Chris Iverach-Brereton, Hilary Luo, luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

```
* Feature Jazzy Ouster (#170 <https://github.com/clearpathrobotics/clearpath_common/issues/170>)
  * Add OusteOS1 description
  * Custom OusterOS1 generator
  * Ouster use custom description generator
  * Use appropriate generator for Ouster
* Add D455, D456 support (#176 <https://github.com/clearpathrobotics/clearpath_common/issues/176>)
  * Add URDFs for all supported RealSense cameras
  * Pass the device_type as the model parameter to the master URDF, move specific types into a sub-directory and include them as necessary
* Add support for OAK-D Pro W PoE (#174 <https://github.com/clearpathrobotics/clearpath_common/issues/174>)
  * Add the model for the OAK-D Pro W; it's identical to the OAK-D Pro. Add model type support to the OAK-D description
* Add URDF, STL files for the Seyond Robin W lidar (#169 <https://github.com/clearpathrobotics/clearpath_common/issues/169>)
  * Add URDF, STL files for the Seyond Robin W lidar
* Contributors: Chris Iverach-Brereton, luis-camero
```
