### PR TITLE
metavision_driver: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4161,7 +4161,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `2.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## metavision_driver

```
* fixed freed memory access bug
* trail filter: fixed unintialized variable bug and handle gen3 cams
* support metavision 5.x
* set serial parameter type to string
* Support for trail filters (#50 <https://github.com/ros-event-camera/metavision_driver/issues/50>)
  * Added support for Metavision SDK trail filters (Andreas Ziegler)
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* added udev files
* support for composable recording under jazzy/rolling
* Contributors: Andreas Ziegler, Bernd Pfrommer
```
