### PR TITLE
rmw_fastrtps: 8.4.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6919,7 +6919,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 8.4.1-1
+      version: 8.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `8.4.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.4.1-1`

## rmw_fastrtps_cpp

```
* Added rmw_event_type_is_supported (#809 <https://github.com/ros2/rmw_fastrtps/issues/809>) (#813 <https://github.com/ros2/rmw_fastrtps/issues/813>)
* Contributors: mergify[bot]
```

## rmw_fastrtps_dynamic_cpp

```
* Added rmw_event_type_is_supported (#809 <https://github.com/ros2/rmw_fastrtps/issues/809>) (#813 <https://github.com/ros2/rmw_fastrtps/issues/813>)
* Contributors: mergify[bot]
```

## rmw_fastrtps_shared_cpp

```
* Added rmw_event_type_is_supported (#809 <https://github.com/ros2/rmw_fastrtps/issues/809>) (#813 <https://github.com/ros2/rmw_fastrtps/issues/813>)
* Contributors: mergify[bot]
```
