### PR TITLE
rmw_connextdds: 0.22.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6851,7 +6851,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.22.0-2
+      version: 0.22.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.22.1-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.22.0-2`

## rmw_connextdds

```
* Added rmw_event_type_is_supported (#173 <https://github.com/ros2/rmw_connextdds/issues/173>) (#175 <https://github.com/ros2/rmw_connextdds/issues/175>)
* Contributors: mergify[bot]
```

## rmw_connextdds_common

```
* Added rmw_event_type_is_supported (#173 <https://github.com/ros2/rmw_connextdds/issues/173>) (#175 <https://github.com/ros2/rmw_connextdds/issues/175>)
* Contributors: mergify[bot]
```

## rti_connext_dds_cmake_module

```
* Quiet a warning when CONNEXTDDS_DIR or NDDSHOME is not found. (#158 <https://github.com/ros2/rmw_connextdds/issues/158>) (#161 <https://github.com/ros2/rmw_connextdds/issues/161>)
* Contributors: mergify[bot]
```
