### PR TITLE
control_msgs: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1109,7 +1109,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.3.0-1
+      version: 6.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `6.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.0-1`

## control_msgs

```
* Cleanup duplicate entries in the msg definition (#179 <https://github.com/ros-controls/control_msgs/issues/179>)
* Add documentation to fields (#173 <https://github.com/ros-controls/control_msgs/issues/173>)
* Contributors: Christoph Fröhlich
```
