### PR TITLE
Add silero-vad pip package rule to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9731,6 +9731,10 @@ python3-sila2lib-pip:
   ubuntu:
     pip:
       packages: [sila2lib]
+python3-silero-vad-pip:
+  '*':
+    pip:
+      packages: [silero-vad]
 python3-simple-pid-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

silero-vad

## Package Upstream Source:

https://github.com/snakers4/silero-vad

## Purpose of using this:

The `silero-vad` package is used for voice activity detection (VAD) in speech processing. It is a lightweight, high-performance VAD model for real-time applications.

## Links to Distribution Packages

https://pypi.org/project/silero-vad/
