### PR TITLE
clearpath_config: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1345,7 +1345,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.2.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## clearpath_config

```
* Feature Franka (#133 <https://github.com/clearpathrobotics/clearpath_config/issues/133>)
* Feature Humble Ouster (#123 <https://github.com/clearpathrobotics/clearpath_config/issues/123>)
* Feature: MoveIt Parameters and Enable (#128 <https://github.com/clearpathrobotics/clearpath_config/issues/128>)
* Feature: Manipulator Samples and Poses (#127 <https://github.com/clearpathrobotics/clearpath_config/issues/127>)
* Feature: Link Material (#126 <https://github.com/clearpathrobotics/clearpath_config/issues/126>)
* Contributors: Luis Camero
```
