### PR TITLE
control_toolbox: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1124,7 +1124,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.0.1-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.0.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-1`

## control_toolbox

```
* Replaced gMock instead of gTest (#300 <https://github.com/ros-controls/control_toolbox/issues/300>)
* Update downstream repository branches for humble (#312 <https://github.com/ros-controls/control_toolbox/issues/312>)
* Update upstream/downstream repository branches (#309 <https://github.com/ros-controls/control_toolbox/issues/309>)
* Make downstream job a semi-binary build (#301 <https://github.com/ros-controls/control_toolbox/issues/301>)
* Cleanup duplicate entries in the msg definition (#299 <https://github.com/ros-controls/control_toolbox/issues/299>)
* [Pid] Save i_term instead of error integral (#294 <https://github.com/ros-controls/control_toolbox/issues/294>)
* Fix mergify config (#296 <https://github.com/ros-controls/control_toolbox/issues/296>)
* [Pid] Remove deprecated variables and methods (#293 <https://github.com/ros-controls/control_toolbox/issues/293>)
* Change workflows and readme for jazzy branch (#292 <https://github.com/ros-controls/control_toolbox/issues/292>)
* Bump version of pre-commit hooks (#288 <https://github.com/ros-controls/control_toolbox/issues/288>)
* Contributors: Aditya Pawar, Christoph Fröhlich, github-actions[bot]
```
