### PR TITLE
dynamixel_workbench: 2.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2056,7 +2056,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench` to `2.2.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ros2-gbp/dynamixel_workbench-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.3-1`

## dynamixel_workbench

```
* Fixed the issue where the Workbench example was not building on SBC by adding the ARM option.
* Added the CI for ROS 2 rolling, jazzy and Humble.
* Contributoers: Wonho Yun
```

## dynamixel_workbench_toolbox

```
* Fixed the issue where the Workbench example was not building on SBC by adding the ARM option.
* Added the CI for ROS 2 rolling, jazzy and Humble.
* Contributoers: Wonho Yun
```
