### PR TITLE
dynamixel_sdk: 3.8.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1716,7 +1716,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
-      version: 3.8.1-1
+      version: 3.8.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.8.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ros2-gbp/dynamixel_sdk-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.1-1`

## dynamixel_sdk

```
* Added Fast Sync Read, Fast Bulk Read features for Python
* Added ROS 2 Python example
* Contributors: Wonho Yun
```

## dynamixel_sdk_custom_interfaces

```
* None
```

## dynamixel_sdk_examples

```
* Added ROS 2 Python example
* Contributors: Wonho Yun
```
