### PR TITLE
hls_lfcd_lds_driver: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2647,7 +2647,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hls_lfcd_lds_driver-release.git
-      version: 2.0.4-5
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hls_lfcd_lds_driver` to `2.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
- release repository: https://github.com/ros2-gbp/hls_lfcd_lds_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-5`

## hls_lfcd_lds_driver

```
* ROS 2 Humble Hawksbill supported
* Contributors: Will Son
```
