### PR TITLE
dynamixel_hardware_interface: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1327,6 +1327,11 @@ repositories:
       version: rolling
     status: developed
   dynamixel_hardware_interface:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `1.3.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## dynamixel_hardware_interface

```
* Enhance Error Handling and Timeout Management
* Use GroupFastSyncRead and GroupFastBulkRead
* Remove deprecated parameter ros_update_freq_ to prevent stoi failure
* Contributors: Woojin Wie
```
