### PR TITLE
Drop 'community' repository for Arch

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -7,7 +7,6 @@ package_sources:
   arch:
   - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ core
   - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ extra
-  - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ community
   debian:
   - !deb_base_url http://deb.debian.org/debian main
   - !deb_base_url http://deb.debian.org/debian contrib


### PR DESCRIPTION
This repository was merged into the 'extra' repository upstream, and was recently dropped entirely.

https://archlinux.org/news/git-migration-announcement/