### PR TITLE
mola_lidar_odometry: 0.7.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5067,7 +5067,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.7.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.0-1`

## mola_lidar_odometry

```
* FIX: Handle correctly the case of input scans with non-normal numbers
* docs: format of ros2 launch argument
* FIX: reset map to start again might lead to divergence; Add new 'reset_state' command via MOLA dynamic variables
* Force requiring valid poses for IMU and GNSS inputs
* Refactor implementation source into several smaller files
* FIX: mola-lo didn't exit due to waiting ICP queue if fed faster than ICP processing
* FIX: mola-lo-gui apps may show duplicated UI controls in particular circumstances
* Drop frames warning message now tells the exact drop ratio
* Initial localization method is now loadable from yaml or ros2 launch file
* MOLA-LO no longer subscribes to wheels odometry. That is now delegated directly to state estimation modules.
* Add new ROS2 launch argument: forward_ros_tf_odom_to_mola
* Contributors: Jose Luis Blanco-Claraco
```
