### PR TITLE
open_sound_control_ros: 0.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5200,6 +5200,25 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
+  open_sound_control_ros:
+    doc:
+      type: git
+      url: https://github.com/chrisib/open_sound_control_ros.git
+      version: jazzy
+    release:
+      packages:
+      - open_sound_control
+      - open_sound_control_bridge
+      - open_sound_control_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/chrisib/open_sound_control_ros-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/chrisib/open_sound_control_ros.git
+      version: jazzy
+    status: developed
   openeb_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository open_sound_control_ros to 0.0.1-1:

* upstream repository: https://github.com/chrisib/open_sound_control_ros.git
* release repository: https://github.com/chrisib/open_sound_control_ros-release.git
    distro file: jazzy/distribution.yaml
    bloom version: 0.12.0
    previous version for package: null

## open_sound_control_ros

```
* Initial release
* Contributors: Chris I-B
```

## Relationship with `rososc`

In ROS 1 there was a package called [`rososc`](https://wiki.ros.org/rososc) that implemented a similar OSC/ROS bridge interface. However, that package appears to have been abandoned, as the latest update was [13 years ago](https://github.com/Auburn-Automow/rososc).

This package is a wholly new implementation intended for ROS 2.

## Note on MR

Having issues creating the merge request automatically with `bloom-release` (permission issues I haven't ironed out), so this MR was made manually following the normal `bloom` template.