### PR TITLE
autoware_cmake: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -823,7 +823,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.0.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## autoware_cmake

```
* fix(autoware_cmake): fix links to issues in CHANGELOG.rst files (#13 <https://github.com/autowarefoundation/autoware_cmake/issues/13>)
* Contributors: Esteve Fernandez
```

## autoware_lint_common

```
* fix(autoware_cmake): fix links to issues in CHANGELOG.rst files (#13 <https://github.com/autowarefoundation/autoware_cmake/issues/13>)
* Contributors: Esteve Fernandez
```
