### PR TITLE
autoware_cmake: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -602,7 +602,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.0.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## autoware_cmake

```
* fix(autoware_cmake): fix links to issues in CHANGELOG.rst files (#13 <https://github.com/autowarefoundation/autoware_cmake/issues/13>)
* Contributors: Esteve Fernandez
```

## autoware_lint_common

```
* fix(autoware_cmake): fix links to issues in CHANGELOG.rst files (#13 <https://github.com/autowarefoundation/autoware_cmake/issues/13>)
* Contributors: Esteve Fernandez
```
