### PR TITLE
autoware_cmake: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -587,7 +587,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.0.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## autoware_cmake

```
* fix(autoware_cmake): fix links to issues in CHANGELOG.rst files (#13 <https://github.com/autowarefoundation/autoware_cmake/issues/13>)
* Contributors: Esteve Fernandez
```

## autoware_lint_common

```
* fix(autoware_cmake): fix links to issues in CHANGELOG.rst files (#13 <https://github.com/autowarefoundation/autoware_cmake/issues/13>)
* Contributors: Esteve Fernandez
```
