### PR TITLE
ur_client_library: 1.8.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12579,7 +12579,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.7.1-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.8.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.1-1`

## ur_client_library

```
* Remove unused variables (#288 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/288>)
* Remove direct primary and secondary stream from UrDriver (#283 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/283>)
* Configure gcovr to ignore negative hits as errors (#284 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/284>)
* Add an explicit CMake option to turn on/off integration tests (#282 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/282>)
* instruction_executor: Allow canceling an instruction (#281 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/281>)
* instruction_executor: fix movel test (#280 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/280>)
* Fix buffer order of acceleration and velocity (#279 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/279>)
* Support compilation on Windows (#229 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/229>)
* Contributors: Felix Exner, VDm
```
