### PR TITLE
ur_description: 2.1.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11181,7 +11181,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.10-1
+      version: 2.1.11-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.1.11-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.10-1`

## ur_description

```
* Fix UR3 mesh positioning (backport of #258 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/258>) (#259 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/259>)
* Auto-update pre-commit hooks (backport of #254 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/254>) (#255 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/255>)
* Auto-update pre-commit hooks (backport #252 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/252>) (#253 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/253>)
* Add missing gpio interfaces for force_mode and freedrive_mode (#251 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/251>)
* Auto-update pre-commit hooks (#250 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/250>)
* Contributors: Felix Exner
```
