### PR TITLE
ur_description: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8672,7 +8672,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.0.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## ur_description

```
* Fix UR3 mesh positioning (#258 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/258>)
* Auto-update pre-commit hooks (#254 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/254>)
* Auto-update pre-commit hooks (#252 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/252>)
* Auto-update pre-commit hooks (#249 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/249>)
* Contributors: Felix Exner, github-actions[bot]
```
