### PR TITLE
ur_robot_driver: 2.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11219,7 +11219,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.5.2-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.6.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.2-1`

## ur

- No changes

## ur_bringup

```
* Fix doc links (#1247 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1247>)
* Contributors: Felix Exner
```

## ur_calibration

- No changes

## ur_controllers

```
* ur_controllers: doc -- Fix link to index page of driver (backport of #1284 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1284>) (#1285 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1285>)
* Remove build warnings for Humble (#1234 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1234>)
* Contributors: Felix Exner, mergify[bot]
```

## ur_dashboard_msgs

```
* Port robot_state_helper to ROS2 (backport of  #933 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/933>) (#1286 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1286>)
* Contributors: mergify[bot]
```

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Update transformForceTorque to handle whether it is a cb3 or an e-Series robot (backport of #1287 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1287>) (#1299 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1299>)
* Port robot_state_helper to ROS2 (backport of  #933 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/933>) (#1286 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1286>)
* Fix crashes on shutting down (#1270 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1270>) (#1271 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1271>)
* Remove build warnings for Humble (#1234 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1234>)
* Auto-update pre-commit hooks (backport #1260 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1260>) (#1261 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1261>)
* Fix doc links (#1247 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1247>)
* Remove urdf folder (#1257 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1257>)
* Contributors: Felix Exner, mergify[bot]
```
