### PR TITLE
ros2_controllers: 2.43.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8346,6 +8346,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - mecanum_drive_controller
       - pid_controller
       - pose_broadcaster
       - position_controllers
@@ -8360,7 +8361,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.42.1-1
+      version: 2.43.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.43.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.42.1-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

```
* [ForwardCommandController] Fix the duplicate command interface types when reconfiguring the controller (backport #1568 <https://github.com/ros-controls/ros2_controllers/issues/1568>, #1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>) (#1569 <https://github.com/ros-controls/ros2_controllers/issues/1569>)
* Contributors: mergify[bot]
```

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* [ForwardCommandController] Fix the duplicate command interface types when reconfiguring the controller (backport #1568 <https://github.com/ros-controls/ros2_controllers/issues/1568>, #1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>) (#1569 <https://github.com/ros-controls/ros2_controllers/issues/1569>)
* Contributors: mergify[bot]
```

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Use constructor parameters instead of initializer list (backport #1587 <https://github.com/ros-controls/ros2_controllers/issues/1587>) (#1589 <https://github.com/ros-controls/ros2_controllers/issues/1589>)
* Contributors: Felix Exner (fexner)
```

## mecanum_drive_controller

```
* Add changelog for mecanum_drive_controller
* [mecanum_drive_controller] Fix Odometry Initialization  (backport #1573 <https://github.com/ros-controls/ros2_controllers/issues/1573>) (#1583 <https://github.com/ros-controls/ros2_controllers/issues/1583>)
* Add Mecanum Drive Controller (backport #512 <https://github.com/ros-controls/ros2_controllers/issues/512>, #1444 <https://github.com/ros-controls/ros2_controllers/issues/1444>, #1547 <https://github.com/ros-controls/ros2_controllers/issues/1547>) (#1376 <https://github.com/ros-controls/ros2_controllers/issues/1376>)
* Contributors: Christoph Froehlich, Julia Jia, mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

```
* [ForwardCommandController] Fix the duplicate command interface types when reconfiguring the controller (backport #1568 <https://github.com/ros-controls/ros2_controllers/issues/1568>, #1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>) (#1569 <https://github.com/ros-controls/ros2_controllers/issues/1569>)
* Contributors: mergify[bot]
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Add Mecanum Drive Controller (backport #512 <https://github.com/ros-controls/ros2_controllers/issues/512>, #1444 <https://github.com/ros-controls/ros2_controllers/issues/1444>, #1547 <https://github.com/ros-controls/ros2_controllers/issues/1547>) (#1376 <https://github.com/ros-controls/ros2_controllers/issues/1376>)
  Co-authored-by: Dr. Denis <mailto:denis@stoglrobotics.de>
  Co-authored-by: Christoph Froehlich <mailto:christoph.froehlich@ait.ac.at>
  Co-authored-by: Shankar-Balajee <mailto:ssbalajee08@gmail.com>
  Co-authored-by: Soham Patil <mailto:sohampatil45939@gmail.com>
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Update documentation of rqt_joint_trajectory_controller (backport #1578 <https://github.com/ros-controls/ros2_controllers/issues/1578>) (#1582 <https://github.com/ros-controls/ros2_controllers/issues/1582>)
* Contributors: Aditya Pawar
```

## steering_controllers_library

```
* Add Mecanum Drive Controller (backport #512 <https://github.com/ros-controls/ros2_controllers/issues/512>, #1444 <https://github.com/ros-controls/ros2_controllers/issues/1444>, #1547 <https://github.com/ros-controls/ros2_controllers/issues/1547>) (#1376 <https://github.com/ros-controls/ros2_controllers/issues/1376>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

```
* [ForwardCommandController] Fix the duplicate command interface types when reconfiguring the controller (backport #1568 <https://github.com/ros-controls/ros2_controllers/issues/1568>, #1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>) (#1569 <https://github.com/ros-controls/ros2_controllers/issues/1569>)
* Contributors: mergify[bot]
```
