### PR TITLE
ros2_controllers: 4.22.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7183,7 +7183,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.21.0-1
+      version: 4.22.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.22.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.21.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Use the custom validators directly from control_toolbox (#1504 <https://github.com/ros-controls/ros2_controllers/issues/1504>)
* Use new handles API in diff_drive_controller (#1565 <https://github.com/ros-controls/ros2_controllers/issues/1565>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## effort_controllers

```
* Fix the ActivateWithWrongJointsNamesFails test (#1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* [ForwardCommandController] Fix the duplicate command interface types when reconfiguring the controller (#1568 <https://github.com/ros-controls/ros2_controllers/issues/1568>)
* Contributors: Sai Kishor Kothakota
```

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* [JSB] cleanup the activation error message (#1584 <https://github.com/ros-controls/ros2_controllers/issues/1584>)
* Contributors: Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* [JTC] Accept larger number of joints than command_joints (#809 <https://github.com/ros-controls/ros2_controllers/issues/809>)
* Use constructor parameters instead of initializer list (#1587 <https://github.com/ros-controls/ros2_controllers/issues/1587>)
* [JTC] Enable feed-forward effort trajectories (#1200 <https://github.com/ros-controls/ros2_controllers/issues/1200>)
* [JTC] Rename open_loop_control parameter and slightly change its scope (#1525 <https://github.com/ros-controls/ros2_controllers/issues/1525>)
* Contributors: Christoph Fröhlich, Felix Exner (fexner), Thies Oelerich, Vladimir Ivan
```

## mecanum_drive_controller

```
* [mecanum_drive_controller] Fix Odometry Initialization  (#1573 <https://github.com/ros-controls/ros2_controllers/issues/1573>)
* Contributors: Julia Jia
```

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

```
* Fix the ActivateWithWrongJointsNamesFails test (#1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* [JTC] Accept larger number of joints than command_joints (#809 <https://github.com/ros-controls/ros2_controllers/issues/809>)
* Update documentation of rqt_joint_trajectory_controller (#1578 <https://github.com/ros-controls/ros2_controllers/issues/1578>)
* Contributors: Aditya Pawar, Christoph Fröhlich
```

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

```
* Fix the ActivateWithWrongJointsNamesFails test (#1570 <https://github.com/ros-controls/ros2_controllers/issues/1570>)
* Contributors: Christoph Fröhlich
```
