### PR TITLE
novatel_oem7_driver: 20.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5860,7 +5860,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 20.6.0-1
+      version: 20.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `20.7.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `20.6.0-1`

## novatel_oem7_driver

```
Odometry Bug Fixes
Modifications:
* Odometry is no longer published when the receiver position type = None
* Suppressed regularly occurring output logs from INFO to DEBUG verbosity
```
