### PR TITLE
novatel_oem7_driver: 24.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5046,7 +5046,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 24.0.0-1
+      version: 24.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `24.1.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `24.0.0-1`

## novatel_oem7_driver

```
Odometry Bug Fixes
Modifications:
* Odometry is no longer published when the receiver position type = None
* Similar Changes as Release 20.7.0 for Humble
```
