### PR TITLE
ffmpeg_image_transport_tools: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2213,7 +2213,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
-      version: 1.0.1-2
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_tools` to `2.1.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-2`

## ffmpeg_image_transport_tools

```
* use encoder/decoder instead of transport
* fixed README status badges
* Contributors: Bernd Pfrommer
```
