### PR TITLE
ffmpeg_image_transport_tools: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1773,7 +1773,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
-      version: 1.0.1-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_tools` to `2.1.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## ffmpeg_image_transport_tools

```
* use encoder/decoder instead of transport
* fixed README status badges
* Contributors: Bernd Pfrommer
```
