### PR TITLE
turtlebot3: 2.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10780,7 +10780,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3-release.git
-      version: 2.1.5-1
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.2.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.5-1`

## turtlebot3

```
* Modified Obstacle Detection and Position Control PointOp
* Contributors: Wonho Yun, Jeonggeun Lim
```

## turtlebot3_bringup

```
* None
```

## turtlebot3_cartographer

```
* None
```

## turtlebot3_description

```
* None
```

## turtlebot3_example

```
* Modified Obstacle Detection and Position Control PointOp
* Contributors: Wonho Yun, Jeonggeun Lim
```

## turtlebot3_navigation2

```
* None
```

## turtlebot3_node

```
* None
```

## turtlebot3_teleop

```
* None
```
