### PR TITLE
ros2_control: 2.49.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8321,7 +8321,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.48.0-1
+      version: 2.49.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.49.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.48.0-1`

## controller_interface

- No changes

## controller_manager

```
* Move test_utils module from demos repo (backport #1955 <https://github.com/ros-controls/ros2_control/issues/1955>) (#2110 <https://github.com/ros-controls/ros2_control/issues/2110>)
* Update memlock values in doc (#2066 <https://github.com/ros-controls/ros2_control/issues/2066>) (#2069 <https://github.com/ros-controls/ros2_control/issues/2069>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Improve API/lifecycle docs (#2081 <https://github.com/ros-controls/ros2_control/issues/2081>) (#2085 <https://github.com/ros-controls/ros2_control/issues/2085>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Move test_utils module from demos repo (backport #1955 <https://github.com/ros-controls/ros2_control/issues/1955>) (#2110 <https://github.com/ros-controls/ros2_control/issues/2110>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
