### PR TITLE
clearpath_tests: 0.2.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1169,7 +1169,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_tests-release.git
-      version: 0.2.3-1
+      version: 0.2.9-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_tests` to `0.2.9-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_tests.git
- release repository: https://github.com/clearpath-gbp/clearpath_tests-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-1`

## clearpath_tests

```
* Rewrite rotation test (#2 <https://github.com/clearpathrobotics/clearpath_tests/issues/2>)
  * Overhaul the logic of the rotation to use an accumulator instead of relying on the latest odom data. Factor in the rate of the EKF + the odometry twist instead of just looking at positional data. On 00005 we're still overshooting slightly, but it's now within the margin of error
* Append the can interface to the node name to suppress duplicate node name warning
* Contributors: Chris Iverach-Brereton
```
