### PR TITLE
picknik_controllers: 0.0.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4902,7 +4902,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
-      version: 0.0.3-2
+      version: 0.0.4-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/picknik_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `picknik_controllers` to `0.0.4-2`:

- upstream repository: https://github.com/PickNikRobotics/picknik_controllers.git
- release repository: https://github.com/ros2-gbp/picknik_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.3-2`

## picknik_reset_fault_controller

```
* Fix deprecated realtime_tools header imports (#14 <https://github.com/PickNikRobotics/picknik_controllers/issues/14>)
* Contributors: Sebastian Castro
```

## picknik_twist_controller

```
* Fix deprecated realtime_tools header imports (#14 <https://github.com/PickNikRobotics/picknik_controllers/issues/14>)
* Contributors: Sebastian Castro
```
