### PR TITLE
Add galois to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6336,16 +6336,7 @@ python3-future:
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
 python3-galois-pip:
-  debian:
-    pip:
-      packages: [galois]
-  fedora:
-    pip:
-      packages: [galois]
-  gentoo:
-    pip:
-      packages: [galois]
-  ubuntu:
+  '*':
     pip:
       packages: [galois]
 python3-gdal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6335,6 +6335,19 @@ python3-future:
   openembedded: [python3-future@meta-python]
   rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
+python3-galois-pip:
+  debian:
+    pip:
+      packages: [galois]
+  fedora:
+    pip:
+      packages: [galois]
+  gentoo:
+    pip:
+      packages: [galois]
+  ubuntu:
+    pip:
+      packages: [galois]
 python3-gdal:
   arch: [python-gdal]
   debian: [python3-gdal]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-galois-pip

## Package Upstream Source:
https://github.com/mhostetter/galois


## Purpose of using this:

A performant NumPy extension for Galois fields and their applications


Distro packaging links:

## Links to Distribution Packages
Package not found in most distros package manager. It can be found in PyPI:  [https://pypi.org/project/galois/](https://pypi.org/project/galois/)
