### PR TITLE
xacro: 1.14.20-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13375,7 +13375,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/xacro-release.git
-      version: 1.14.19-1
+      version: 1.14.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `1.14.20-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros-gbp/xacro-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.14.19-1`

## xacro

```
* Handle new argument 'attr' in xml.dom.minidom._write_data() of Python 3.13 (#353 <https://github.com/ros/xacro/issues/353>)
* Contributors: Robert Haschke
```
