### PR TITLE
xacro: 2.0.13-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9155,7 +9155,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.12-1
+      version: 2.0.13-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.13-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.12-1`

## xacro

```
* Pass AMENT_PREFIX_PATH to xacro (#359 <https://github.com/ros/xacro/issues/359>)
* Add Bazel build rules (#350 <https://github.com/ros/xacro/issues/350>)
* Contributors: Michael Carroll, Robert Haschke, Sean Fish
```
