### PR TITLE
xacro: 2.0.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11861,7 +11861,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.8-1
+      version: 2.0.13-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.0.13-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.8-1`

## xacro

```
* Pass AMENT_PREFIX_PATH to xacro (#359 <https://github.com/ros/xacro/issues/359>)
* Add Bazel build rules (#350 <https://github.com/ros/xacro/issues/350>)
* Contributors: Michael Carroll, Robert Haschke, Sean Fish
```
