### PR TITLE
depthai: 2.30.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2067,7 +2067,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.29.0-1
+      version: 2.30.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.30.0-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.29.0-1`

## depthai

```
* Features
* Add RVC4 discovery to point users to v3 version of the library for OAK4 devices
* Add support for a new VCM enabling autofocus on new IMX378 CCMs
* Bug fixes
* Fix an edge case in ImageManip to make https://github.com/geaxgx/depthai_hand_tracker run in edge mode again
* Fix an edge case when sending MessageGroup from host to device and using more than 4 messages
```
