### PR TITLE
common_interfaces: 5.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1050,7 +1050,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.4.2-1
+      version: 5.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.5.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.4.2-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Complete Removal of PoseStampedArray (#270 <https://github.com/ros2/common_interfaces/issues/270>)
* Move geometry_msgs/PoseStampedArray to nav_msgs/Goals (#269 <https://github.com/ros2/common_interfaces/issues/269>)
* Add PoseStampedArray (#262 <https://github.com/ros2/common_interfaces/issues/262>)
* Contributors: Tony Najjar, Tully Foote
```

## nav_msgs

```
* Move geometry_msgs/PoseStampedArray to nav_msgs/Goals (#269 <https://github.com/ros2/common_interfaces/issues/269>)
* Contributors: Tully Foote
```

## sensor_msgs

```
* Add NV12 to color formats (#253 <https://github.com/ros2/common_interfaces/issues/253>)
* Contributors: Lukas Schäper
```

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
