### PR TITLE
rviz: 14.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7599,7 +7599,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.2-1
+      version: 14.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.4.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.4.2-1`

## rviz2

```
* Expose the possibility to create ROS node with custom NodeOptions (#1347 <https://github.com/ros2/rviz/issues/1347>)
* Contributors: Patrick Roncagliolo
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Expose the possibility to create ROS node with custom NodeOptions (#1347 <https://github.com/ros2/rviz/issues/1347>)
* Contributors: Patrick Roncagliolo
```

## rviz_default_plugins

```
* fix: add rclcpp::shutdown (#1343 <https://github.com/ros2/rviz/issues/1343>)
* Contributors: Yuyuan Yuan
```

## rviz_ogre_vendor

```
* Use official freetype github mirror instead of savannah (#1348 <https://github.com/ros2/rviz/issues/1348>)
* Contributors: Silvio Traversaro
```

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
