### PR TITLE
rmw_zenoh: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6247,7 +6247,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.5.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## rmw_zenoh_cpp

```
* Switch to std::map for TopicTypeMap (#546 <https://github.com/ros2/rmw_zenoh/issues/546>)
* Support zenoh config override (#551 <https://github.com/ros2/rmw_zenoh/issues/551>)
* Align the config with the latest Zenoh. (#556 <https://github.com/ros2/rmw_zenoh/issues/556>)
* Added documentation note in the code (#540 <https://github.com/ros2/rmw_zenoh/issues/540>)
* fix: unlock the mutex before making get (#537 <https://github.com/ros2/rmw_zenoh/issues/537>)
* Take wait_set_lock before condition_variable notification for subscriptions (#528 <https://github.com/ros2/rmw_zenoh/issues/528>)
* Switch default durability to volatile (#521 <https://github.com/ros2/rmw_zenoh/issues/521>)
* Added rmw_event_type_is_supported (#502 <https://github.com/ros2/rmw_zenoh/issues/502>)
* Fixed windows warning (#500 <https://github.com/ros2/rmw_zenoh/issues/500>)
* Config: tune some values for ROS use case, especially with large number of Nodes (>200) (#509 <https://github.com/ros2/rmw_zenoh/issues/509>)
* Honor ignore_local_publications in subscription options (#508 <https://github.com/ros2/rmw_zenoh/issues/508>)
* Bump zenoh-cpp to 2a127bb, zenoh-c to 3540a3c, and zenoh to f735bf5 (#503 <https://github.com/ros2/rmw_zenoh/issues/503>)
* Fix calculation of current_count_change when event status is updated (#504 <https://github.com/ros2/rmw_zenoh/issues/504>)
* Fix checks for invalid arguments (#497 <https://github.com/ros2/rmw_zenoh/issues/497>)
* Fail creation of entities if qos contains unknown settings (#494 <https://github.com/ros2/rmw_zenoh/issues/494>)
* use rmw_enclave_options_xxx APIs instead. (#491 <https://github.com/ros2/rmw_zenoh/issues/491>)
* Enable Zenoh UDP transport (#486 <https://github.com/ros2/rmw_zenoh/issues/486>)
* fix: use the default destructor that automatically drops the zenoh reply/query and hence sends the final signal (#473 <https://github.com/ros2/rmw_zenoh/issues/473>)
* Contributors: Alejandro Hernández Cordero, ChenYing Kuo (CY), Hugal31, Luca Cominardi, Tomoya Fujita, Yuyuan Yuan, Yadunund
```

## zenoh_cpp_vendor

```
* Fix liveliness crash in debug mode (#544 <https://github.com/ros2/rmw_zenoh/issues/544>)
* Bump zenoh-cpp to 2a127bb, zenoh-c to 3540a3c, and zenoh to f735bf5 (#503 <https://github.com/ros2/rmw_zenoh/issues/503>)
* Enable Zenoh UDP transport (#486 <https://github.com/ros2/rmw_zenoh/issues/486>)
* Contributors: Hugal31, Luca Cominardi, Yuyuan Yuan
```
