### PR TITLE
rmw_zenoh: 0.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6996,7 +6996,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.3-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.2-1`

## rmw_zenoh_cpp

```
* Switch to std::map for TopicTypeMap (#565 <https://github.com/ros2/rmw_zenoh/issues/565>)
* Support zenoh config override (#559 <https://github.com/ros2/rmw_zenoh/issues/559>)
* Align the config with the latest Zenoh. (#557 <https://github.com/ros2/rmw_zenoh/issues/557>)
* Added documentation note in the code (#541 <https://github.com/ros2/rmw_zenoh/issues/541>)
* fix: unlock the mutex before making get (#539 <https://github.com/ros2/rmw_zenoh/issues/539>)
* Take wait_set_lock before condition_variable notification for subscriptions (#534 <https://github.com/ros2/rmw_zenoh/issues/534>)
* Switch default durability to volatile (#530 <https://github.com/ros2/rmw_zenoh/issues/530>)
* Added rmw_event_type_is_supported (#525 <https://github.com/ros2/rmw_zenoh/issues/525>)
* Fixed windows warning (#518 <https://github.com/ros2/rmw_zenoh/issues/518>)
* Config: tune some values for ROS use case, especially with large number of Nodes (>200) (#515 <https://github.com/ros2/rmw_zenoh/issues/515>)
* Honor ignore_local_publications in subscription options (#513 <https://github.com/ros2/rmw_zenoh/issues/513>)
* Bump zenoh-cpp to 2a127bb, zenoh-c to 3540a3c, and zenoh to f735bf5 (#511 <https://github.com/ros2/rmw_zenoh/issues/511>)
* Fix calculation of current_count_change when event status is updated (#506 <https://github.com/ros2/rmw_zenoh/issues/506>)
* Fix checks for invalid arguments (#501 <https://github.com/ros2/rmw_zenoh/issues/501>)
* Fail creation of entities if qos contains unknown settings (#499 <https://github.com/ros2/rmw_zenoh/issues/499>)
* Enable Zenoh UDP transport (#488 <https://github.com/ros2/rmw_zenoh/issues/488>)
* fix: use the default destructor that automatically drops the zenoh reply/query and hence sends the final signal (#474 <https://github.com/ros2/rmw_zenoh/issues/474>)
* Contributors: Alejandro Hernández Cordero, ChenYing Kuo (CY), Hugal31, Luca Cominardi, Tomoya Fujita, Yuyuan Yuan, Yadunund
```

## zenoh_cpp_vendor

```
* Fix liveliness crash in debugg mode (#549 <https://github.com/ros2/rmw_zenoh/issues/549>)
* Bump zenoh-cpp to 2a127bb, zenoh-c to 3540a3c, and zenoh to f735bf5 (#503 <https://github.com/ros2/rmw_zenoh/issues/503>) (#511 <https://github.com/ros2/rmw_zenoh/issues/511>)
* Enable Zenoh UDP transport (#486 <https://github.com/ros2/rmw_zenoh/issues/486>) (#488 <https://github.com/ros2/rmw_zenoh/issues/488>)
* Contributors: Hugal31, Luca Cominardi, Yuyuan Yuan
```
