### PR TITLE
robot_localization: 3.8.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7035,7 +7035,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.8.1-1
+      version: 3.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.8.2-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.1-1`

## robot_localization

```
* Fix user UTM conversion and catch GeographicErr to not crash navsat_transfrom node (#917 <https://github.com/cra-ros-pkg/robot_localization/issues/917>)
  * Fix user UTM conversion and catch GeographicErr to not crash navsat_transform node
  ---------
  Co-authored-by: Ferry Schoenmakers <mailto:ferry.schoenmakers@nobleo.nl>
* Added FromLLArray service (#912 <https://github.com/cra-ros-pkg/robot_localization/issues/912>)
  * Added FromLLArray service
  ---------
  Co-authored-by: Marcin Słomiany <mailto:m.slomiany93@gmail.com>
* Added subscription to stamped topic (#898 <https://github.com/cra-ros-pkg/robot_localization/issues/898>) (#900 <https://github.com/cra-ros-pkg/robot_localization/issues/900>)
  * Added subscription to stamped topic (#898 <https://github.com/cra-ros-pkg/robot_localization/issues/898>)
* Fixing IMU differential test (#897 <https://github.com/cra-ros-pkg/robot_localization/issues/897>)
* Contributors: Ferry Schoenmakers, Jay Herpin, Pablo, Tom Moore
```
