### PR TITLE
robot_localization: 3.9.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6276,7 +6276,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.9.1-1
+      version: 3.9.2-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.9.2-2`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.9.1-1`

## robot_localization

```
* Same change on rolling (#918 <https://github.com/cra-ros-pkg/robot_localization/issues/918>)
  Co-authored-by: Ferry Schoenmakers <mailto:ferry.schoenmakers@nobleo.nl>
* Fixing bug with diagonal covariance loading (#909 <https://github.com/cra-ros-pkg/robot_localization/issues/909>)
* Switching stamped control to default true for rolling/future distributions to align with Nav2 and ROS 2 Control (#910 <https://github.com/cra-ros-pkg/robot_localization/issues/910>)
* Added subscription to stamped topic (#898 <https://github.com/cra-ros-pkg/robot_localization/issues/898>)
  * Added subscription to stamped topic
* Fixing IMU differential test (#897 <https://github.com/cra-ros-pkg/robot_localization/issues/897>)
* Contributors: Ferry Schoenmakers, Pablo, Steve Macenski, Tom Moore
```
