### PR TITLE
ros_gz: 1.0.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7497,7 +7497,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.9-1
+      version: 1.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.11-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.9-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Add SpawnEntity, DeleteEntity, & SetEntityPose Support (backport #380 <https://github.com/gazebosim/ros_gz/issues/380>) (#712 <https://github.com/gazebosim/ros_gz/issues/712>)
  Co-authored-by: Afereti Pama <mailto:79831813+retinfai@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
