### PR TITLE
ros_gz: 2.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6682,7 +6682,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.5-1
+      version: 2.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.6-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.5-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* make linters happy (#709 <https://github.com/gazebosim/ros_gz/issues/709>)
* Add SpawnEntity, DeleteEntity, & SetEntityPose Support (#380 <https://github.com/gazebosim/ros_gz/issues/380>)
* Contributors: Afereti Pama, Alejandro Hernández Cordero
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
