### PR TITLE
qoi_image_transport: 1.0.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8733,7 +8733,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/qoi_image_transport.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/qoi_image_transport.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8724,6 +8724,21 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbshin-ros.git
       version: production-noetic
     status: developed
+  qoi_image_transport:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/qoi_image_transport.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://gitlab.fel.cvut.cz/cras/ros-release/qoi_image_transport.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ctu-vras/qoi_image_transport.git
+      version: master
+    status: developed
   qpoases_vendor:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8733,7 +8733,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/qoi_image_transport.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/qoi_image_transport.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8733,7 +8733,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://gitlab.fel.cvut.cz/cras/ros-release/qoi_image_transport.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ctu-vras/qoi_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qoi_image_transport` to `1.0.4-1`:

- upstream repository: https://github.com/ctu-vras/qoi_image_transport
- release repository: https://gitlab.fel.cvut.cz/cras/ros-release/qoi_image_transport.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## qoi_image_transport

```
* Fixed licenses.
* CI: Added CI.
* Added unit tests, fixed little bugs.
* Initial commit.
* Contributors: Martin Pecka
```
