### PR TITLE
Index `open_sound_control_ros`

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5224,6 +5224,12 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
+  open_sound_control_ros:
+    source:
+      type: git
+      url: https://github.com/chrisib/open_sound_control_ros.git
+      version: jazzy
+    status: developed
   openeb_vendor:
     doc:
       type: git


### PR DESCRIPTION
Indexing for review so new release team can be added.

See: https://github.com/ros2-gbp/ros2-gbp-github-org/issues/719

## Package name:

* `open_sound_control_bridge`
* `open_sound_control_msgs`

# Please Add This Package to be indexed in the rosdistro.

Jazzy

# The source is here:

https://github.com/chrisib/open_sound_control_ros

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
