### PR TITLE
multisensor_calibration: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4680,6 +4680,14 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git
       version: main
+    release:
+      packages:
+      - multisensor_calibration
+      - multisensor_calibration_interface
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/multisensor_calibration-release.git
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisensor_calibration` to `2.0.1-1`:

- upstream repository: https://github.com/FraunhoferIOSB/multisensor_calibration.git
- release repository: https://github.com/ros2-gbp/multisensor_calibration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## multisensor_calibration

```
* refactor: remove compilation warnings
* fix: remove deprecated pointer type
* Contributors: Miguel Granero
```

## multisensor_calibration_interface

- No changes
