### PR TITLE
fkie_message_filters: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2601,6 +2601,21 @@ repositories:
       url: https://github.com/introlab/find-object.git
       version: humble-devel
     status: maintained
+  fkie_message_filters:
+    doc:
+      type: git
+      url: https://github.com/fkie/message_filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/fkie-release/message_filters-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/fkie/message_filters.git
+      version: ros2
+    status: maintained
   flex_sync:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `2.0.0-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/fkie-release/message_filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## fkie_message_filters

```
* Reimplementation for ROS 2
* Contributors: Timo Röhling
```
