### PR TITLE
ament_lint: 0.12.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -355,7 +355,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.12.11-1
+      version: 0.12.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.12.12-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.12.11-1`

## ament_clang_format

- No changes

## ament_clang_tidy

- No changes

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

- No changes

## ament_cmake_cppcheck

- No changes

## ament_cmake_cpplint

- No changes

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

- No changes

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

- No changes

## ament_cmake_xmllint

- No changes

## ament_copyright

- No changes

## ament_cppcheck

- No changes

## ament_cpplint

- No changes

## ament_flake8

- No changes

## ament_lint

- No changes

## ament_lint_auto

```
* Add docu for AMENT_LINT_AUTO_EXCLUDE (#524 <https://github.com/ament/ament_lint/issues/524>) (#526 <https://github.com/ament/ament_lint/issues/526>)
* Contributors: mergify[bot]
```

## ament_lint_cmake

- No changes

## ament_lint_common

- No changes

## ament_mypy

```
* Add support for type stubs (#516 <https://github.com/ament/ament_lint/issues/516>) (#521 <https://github.com/ament/ament_lint/issues/521>)
* Contributors: mergify[bot]
```

## ament_pclint

- No changes

## ament_pep257

- No changes

## ament_pycodestyle

- No changes

## ament_pyflakes

- No changes

## ament_uncrustify

- No changes

## ament_xmllint

- No changes
