### PR TITLE
rqt_plot: 1.1.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9252,7 +9252,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.1.3-1
+      version: 1.1.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.1.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.3-1`

## rqt_plot

```
* Fix f-string and add single quote around field name (backport #100 <https://github.com/ros-visualization/rqt_plot/issues/100>) (#105 <https://github.com/ros-visualization/rqt_plot/issues/105>)
* Contributors: mergify[bot]
```
