### PR TITLE
resource_retriever: 3.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7693,7 +7693,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.1.2-1
+      version: 3.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.1.3-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.2-1`

## libcurl_vendor

```
* uniform  MinCMakeVersion (backport #108 <https://github.com/ros/resource_retriever/issues/108>) (#110 <https://github.com/ros/resource_retriever/issues/110>)
* Contributors: mergify[bot]
```

## resource_retriever

```
* uniform  MinCMakeVersion (backport #108 <https://github.com/ros/resource_retriever/issues/108>) (#110 <https://github.com/ros/resource_retriever/issues/110>)
* Contributors: mergify[bot]
```
