### PR TITLE
launch: 1.0.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4157,7 +4157,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.7-1
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.8-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.7-1`

## launch

```
* Document substitutions concatenation in architecture doc (#845 <https://github.com/ros2/launch/issues/845>) (#847 <https://github.com/ros2/launch/issues/847>)
* Update docs to use proper RST literals (#837 <https://github.com/ros2/launch/issues/837>) (#840 <https://github.com/ros2/launch/issues/840>)
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
