### PR TITLE
launch_ros: 0.19.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4207,7 +4207,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.8-1
+      version: 0.19.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.9-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.19.8-1`

## launch_ros

```
* Change docstring markdown code blocks to RST (#450 <https://github.com/ros2/launch_ros/issues/450>) (#452 <https://github.com/ros2/launch_ros/issues/452>)
* mock launch components causing rosdoc2 to fail Python API (#425 <https://github.com/ros2/launch_ros/issues/425>) (#440 <https://github.com/ros2/launch_ros/issues/440>)
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
