### PR TITLE
rclcpp: 16.0.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7532,7 +7532,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.11-1
+      version: 16.0.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.12-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `16.0.11-1`

## rclcpp

```
* doc: Added warning to not instantiate Clock directly with RCL_ROS_TIME (#2768 <https://github.com/ros2/rclcpp/issues/2768>) (#2770 <https://github.com/ros2/rclcpp/issues/2770>)
* apply actual QoS from rmw to the IPC publisher. (backport #2707 <https://github.com/ros2/rclcpp/issues/2707>) (#2711 <https://github.com/ros2/rclcpp/issues/2711>)
* Adding in topic name to logging on IPC issues (#2706 <https://github.com/ros2/rclcpp/issues/2706>) (#2709 <https://github.com/ros2/rclcpp/issues/2709>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Redundant .c_str() usage in rclcpp_components triggers ament_clang_tidy warning (#2718 <https://github.com/ros2/rclcpp/issues/2718>)
* Contributors: LihanChen2004
```

## rclcpp_lifecycle

- No changes
