### PR TITLE
rclpy: 3.3.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7548,7 +7548,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.15-1
+      version: 3.3.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.16-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.15-1`

## rclpy

```
* Check parameter callback signature during registration. (backport #1425 <https://github.com/ros2/rclpy/issues/1425>) (#1430 <https://github.com/ros2/rclpy/issues/1430>)
* Remove SHARED (#1305 <https://github.com/ros2/rclpy/issues/1305>) (#1422 <https://github.com/ros2/rclpy/issues/1422>)
* publish action goal status once accepted before execution. (#1228 <https://github.com/ros2/rclpy/issues/1228>) (#1416 <https://github.com/ros2/rclpy/issues/1416>)
* Fix doc generation for Humble (#1414 <https://github.com/ros2/rclpy/issues/1414>)
* Check if Task(Future) is canceled. (backport #1377 <https://github.com/ros2/rclpy/issues/1377>) (#1403 <https://github.com/ros2/rclpy/issues/1403>)
* Contributors: Scotrraaj Gopal, mergify[bot]
```
