### PR TITLE
rcpputils: 2.4.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7564,7 +7564,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.4.4-1
+      version: 2.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.4.5-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.4-1`

## rcpputils

```
* Added missing include (backport #207 <https://github.com/ros2/rcpputils/issues/207>) (#209 <https://github.com/ros2/rcpputils/issues/209>)
* Contributors: mergify[bot]
```
