### PR TITLE
ros2cli: 0.18.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8552,7 +8552,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.11-1
+      version: 0.18.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.12-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.18.11-1`

## ros2action

```
* Correct the license content (#979 <https://github.com/ros2/ros2cli/issues/979>) (#981 <https://github.com/ros2/ros2cli/issues/981>)
* ros2action: add SIGINT handler to manage cancel request. (#956 <https://github.com/ros2/ros2cli/issues/956>) (#963 <https://github.com/ros2/ros2cli/issues/963>)
* Contributors: mergify[bot]
```

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* Allow space or empty strings when using ros2 param set. (#984 <https://github.com/ros2/ros2cli/issues/984>)
* Contributors: Tomoya Fujita
```

## ros2pkg

```
* Update minimum CMake version in CMakeLists.txt.em (backport #969 <https://github.com/ros2/ros2cli/issues/969>) (#972 <https://github.com/ros2/ros2cli/issues/972>)
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* Adjust topic hz and bw command description. (#987 <https://github.com/ros2/ros2cli/issues/987>) (#989 <https://github.com/ros2/ros2cli/issues/989>)
* start the simulation from 1 second for the test. (#975 <https://github.com/ros2/ros2cli/issues/975>) (#977 <https://github.com/ros2/ros2cli/issues/977>)
* Contributors: mergify[bot]
```
