### PR TITLE
zed-ros2-interfaces: 4.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9228,6 +9228,23 @@ repositories:
       url: https://github.com/ros-drivers/zbar_ros.git
       version: rolling
     status: maintained
+  zed-ros2-interfaces:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: master
+    release:
+      packages:
+      - zed_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
+      version: 4.2.5-1
+    source:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: rolling
+    status: maintained
   zenoh_bridge_dds:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-interfaces` to `4.2.5-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-interfaces.git
- release repository: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## zed_msgs

```
* Update Object.msg
* Update README.md
```
