### PR TITLE
zed-ros2-interfaces: 4.2.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10373,6 +10373,23 @@ repositories:
       url: https://github.com/ros-drivers/zbar_ros.git
       version: jazzy
     status: maintained
+  zed-ros2-interfaces:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: master
+    release:
+      packages:
+      - zed_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
+      version: 4.2.5-1
+    source:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: jazzy
+    status: maintained
   zenoh_bridge_dds:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-interfaces` to `4.2.5-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-interfaces.git
- release repository: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## zed_msgs

```
* Update Object.msg
* Update README.md
```
