### PR TITLE
Adding libaditof Package to Ros Index

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5297,6 +5297,12 @@ repositories:
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: noetic-devel
     status: developed
+  libaditof:
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/libaditof.git
+      version: main
+    status: maintained
   libcreate:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5298,6 +5298,10 @@ repositories:
       version: noetic-devel
     status: developed
   libaditof:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/libaditof.git
+      version: main
     source:
       type: git
       url: https://github.com/analogdevicesinc/libaditof.git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libaditof

## Package Upstream Source:

[https://github.com/analogdevicesinc/libaditof/tree/main](https://github.com/analogdevicesinc/libaditof/tree/main)

## Purpose of using this:

This dependency serves as an SDK that provides API calls for the ADTF3175 time of flight sensors developed at ADI.


# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
