### PR TITLE
ld08_driver: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4225,6 +4225,11 @@ repositories:
       version: humble
     status: maintained
   ld08_driver:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ld08_driver-release.git
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ld08_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ld08_driver` to `1.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ld08_driver.git
- release repository: https://github.com/ros2-gbp/ld08_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ld08_driver

```
* ROS 2 Humble Hawksbill supported
* Added Lint and CI
* Contributors: Hye-Jong Kim, Hyungyu Kim
```
