### PR TITLE
ld08_driver: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4235,7 +4235,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ld08_driver-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ld08_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ld08_driver` to `1.1.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ld08_driver.git
- release repository: https://github.com/ros2-gbp/ld08_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`

## ld08_driver

```
* Added the boost and libudev-dev dependency for release
* Modified the CI and lint
* Contributors: Pyo, Hyungyu Kim
```
