### PR TITLE
indexing depth_obstacle_detect_ros package in noetic and jazzy distributions

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1555,7 +1555,7 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: jazzy
     status: developed
-  depth-obstacle-detect-ros:
+  depth_obstacle_detect_ros:
     source:
       type: git
       url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1555,6 +1555,12 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: jazzy
     status: developed
+  depth-obstacle-detect-ros:
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git
+      version: jazzy-devel
+    status: maintained
   depthai:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2058,7 +2058,7 @@ repositories:
       url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
       version: master
     status: maintained
-  depth-obstacle-detect-ros:
+  depth_obstacle_detect_ros:
     source:
       type: git
       url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2058,6 +2058,12 @@ repositories:
       url: https://github.com/pal-robotics/ddynamic_reconfigure_python.git
       version: master
     status: maintained
+  depth-obstacle-detect-ros:
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git
+      version: noetic-devel
+    status: maintained
   depthai:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

depth_obstacle_detect_ros

## Package Upstream Source:

https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git

## Purpose of using this:

The Depth Obstacle Detection ROS package for the Robot Operating System (ROS) identifies surfaces near the depth camera within a specified threshold. The image is divided into a grid of multiple cells, and the minimum value in each cell is detected. Values below the threshold are highlighted in red to indicate the presence of an obstacle. There are two packages in this installation, the core package depth_obstacle_detect_ros which is dependant on depth_obstacle_detect_ros_msg.




# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
