### PR TITLE
multisensor_calibration: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4707,10 +4707,11 @@ repositories:
       packages:
       - multisensor_calibration
       - multisensor_calibration_interface
+      - small_gicp_vendor
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/multisensor_calibration-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisensor_calibration` to `2.0.2-1`:

- upstream repository: https://github.com/FraunhoferIOSB/multisensor_calibration.git
- release repository: https://github.com/ros2-gbp/multisensor_calibration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## multisensor_calibration

```
* feat: create small_gicp_vendor package
* fix: export library target
* fix: read version from package.xml and not from git
* Contributors: Miguel Granero
```

## multisensor_calibration_interface

```
* fix: export library target
* fix: read version from package.xml and not from git
* Contributors: Miguel Granero
```

## small_gicp_vendor

```
* feat: create small_gicp_vendor package
* Contributors: Miguel Granero
```
