### PR TITLE
multisensor_calibration: 2.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4711,7 +4711,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/multisensor_calibration-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisensor_calibration` to `2.0.3-1`:

- upstream repository: https://github.com/FraunhoferIOSB/multisensor_calibration.git
- release repository: https://github.com/ros2-gbp/multisensor_calibration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## multisensor_calibration

```
* refactor: remove unused rviz config files
* fix: set LICENSE path to own package for bin packaging
* feat: add LICENSE file to single packages
* Contributors: Miguel Granero
```

## multisensor_calibration_interface

```
* feat: add LICENSE file to single packages
* Contributors: Miguel Granero
```

## small_gicp_vendor

```
* fix: fix license name in package.xml
* feat: add LICENSE file to single packages
* Contributors: Miguel Granero
```
