### PR TITLE
ur_client_library: 1.9.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12579,7 +12579,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `1.9.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`

## ur_client_library

```
* Make start_ursim.sh support polyscopex (#294 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/294>)
* Reduce usage of dashboard client in tests and examples (#296 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/296>)
* Try catch RTDE setup (#285 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/285>)
* add missing headers (#290 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/290>)
* PrimaryClient: Add methods to unlock protective stop and stop the program (#292 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/292>)
* Set increased timeout in dashboard client test (#293 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/293>)
* Do not print a warning when querying the dashboard server for a running program (#287 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/287>)
* Primary client power on (#289 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/289>)
* Contributors: Andrei Kholodnyi, Dominic Reber, Felix Exner
```
