### PR TITLE
dbw_ros: 2.3.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1511,7 +1511,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.2-1
+      version: 2.3.3-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.3-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.2-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2025/03/28 release package
* Add system parameter hash
* Add remote control report (mode/state/timeout)
* Add steering stall limit diagnostic
* Add actuator temperature and warm/hot diagnostics
* Add GPIO/SSR status and control
* Documentation updates
* Remove option to ignore system enable/disable buttons
* Remove unused option to filter received CAN messages
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```

## ds_dbw_joystick_demo

```
* Documentation updates
* Change joystick demo sys launch arg default to true
* Remove option to ignore system enable/disable buttons
* Contributors: Kevin Hallenbeck
```

## ds_dbw_msgs

```
* Add remote control report (mode/state/timeout)
* Add steering stall limit diagnostic
* Add actuator temperature and warm/hot diagnostics
* Add GPIO/SSR status and control
* Contributors: Kevin Hallenbeck
```
