### PR TITLE
zed-ros2-interfaces: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9302,7 +9302,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
-      version: 4.2.5-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-interfaces` to `5.0.0-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-interfaces.git
- release repository: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.5-1`

## zed_msgs

```
* Add new SvoStatus topic
* Add new HealthStatusStamped topic
* Add new SetSvoFrame service
```
