### PR TITLE
Fix branches for control_toolbox on humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1607,7 +1607,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1616,7 +1616,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: humble
     status: maintained
   cpp_polyfills:
     release:


### PR DESCRIPTION
I missed to update the branches here.

According to
https://github.com/ros2-gbp/control_toolbox-release/blob/master/tracks.yaml#L69