### PR TITLE
Fix branches for ros-controls repos on jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1321,7 +1321,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: master
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -1330,13 +1330,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
-      version: master
+      version: jazzy
     status: maintained
   control_toolbox:
     doc:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -1345,7 +1345,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: jazzy
     status: maintained
   cpp_polyfills:
     release:
@@ -6588,7 +6588,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: master
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -6597,7 +6597,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: master
+      version: jazzy
     status: maintained
   resource_retriever:
     doc:


### PR DESCRIPTION
I missed to update the branches here.

According to
https://github.com/ros2-gbp/control_toolbox-release/blob/master/tracks.yaml#L187
https://github.com/ros2-gbp/control_toolbox-release/blob/master/tracks.yaml#L187
https://github.com/ros2-gbp/realtime_tools-release/blob/master/tracks.yaml#L233