### PR TITLE
foxglove_compressed_video_transport: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2421,7 +2421,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_compressed_video_transport` to `1.0.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
- release repository: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## foxglove_compressed_video_transport

```
* Merge branch 'master' into release
* Fix segfault: the publish_fn address passed to publish() cannot be cached!
* Contributors: Michal Sojka
```
