### PR TITLE
#44821: include rti-connext-7.3.0 in base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8478,8 +8478,8 @@ rti-connext-dds-7.3.0:
   nixos: []
   ubuntu:
     '*': [rti-connext-dds-7.3.0-ros]
-    jammy: null
     focal: null
+    jammy: null
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8475,10 +8475,10 @@ rti-connext-dds-6.0.1:  # Supported until ubuntu 24.04
     focal: [rti-connext-dds-6.0.1]
     jammy: [rti-connext-dds-6.0.1]
     noble: [rti-connext-dds-6.0.1]
-rti-connext-dds-7.3.0-ros:  # supported from ubuntu 20.04 focal
+rti-connext-dds-7.3.0-ros:  # supported from ubuntu 24.04 noble
   nixos: []
   ubuntu:
-    '*': [rti-connext-dds-7.3.0-ros]
+    noble: [rti-connext-dds-7.3.0-ros]
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8472,15 +8472,13 @@ rti-connext-dds-5.3.1:
 rti-connext-dds-6.0.1:  # Supported until ubuntu 24.04
   nixos: []
   ubuntu:
-    bionic: null
     focal: [rti-connext-dds-6.0.1]
     jammy: [rti-connext-dds-6.0.1]
     noble: [rti-connext-dds-6.0.1]
-rti-connext-dds-7.3.0:
+rti-connext-dds-7.3.0:  # supported from ubuntu 20.04 focal
   nixos: []
   ubuntu:
     '*': [rti-connext-dds-7.3.0]
-    bionic: null
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8469,10 +8469,17 @@ rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
-rti-connext-dds-6.0.1:
+rti-connext-dds-6.0.1: # Supported until ubuntu 24.04
   nixos: []
   ubuntu:
-    '*': [rti-connext-dds-6.0.1]
+    bionic: null
+    focal: [rti-connext-dds-6.0.1]
+    jammy: [rti-connext-dds-6.0.1]
+    noble: [rti-connext-dds-6.0.1]
+rti-connext-dds-7.3.0:
+  nixos: []
+  ubuntu:
+    '*': [rti-connext-dds-7.3.0]
     bionic: null
 rtmidi:
   arch: [rtmidi]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8475,7 +8475,7 @@ rti-connext-dds-6.0.1:  # Supported until ubuntu 24.04
     focal: [rti-connext-dds-6.0.1]
     jammy: [rti-connext-dds-6.0.1]
     noble: [rti-connext-dds-6.0.1]
-rti-connext-dds-7.3.0:  # supported from ubuntu 20.04 focal
+rti-connext-dds-7.3.0-ros:  # supported from ubuntu 20.04 focal
   nixos: []
   ubuntu:
     '*': [rti-connext-dds-7.3.0-ros]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8478,7 +8478,7 @@ rti-connext-dds-6.0.1:  # Supported until ubuntu 24.04
 rti-connext-dds-7.3.0:  # supported from ubuntu 20.04 focal
   nixos: []
   ubuntu:
-    '*': [rti-connext-dds-7.3.0]
+    '*': [rti-connext-dds-7.3.0-ros]
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8474,10 +8474,12 @@ rti-connext-dds-6.0.1:
   ubuntu:
     '*': [rti-connext-dds-6.0.1]
     bionic: null
-rti-connext-dds-7.3.0-ros:  # supported from ubuntu 24.04 noble
+rti-connext-dds-7.3.0:
   nixos: []
   ubuntu:
-    noble: [rti-connext-dds-7.3.0-ros]
+    '*': [rti-connext-dds-7.3.0]
+    jammy: null
+    focal: null
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8469,7 +8469,7 @@ rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
-rti-connext-dds-6.0.1: # Supported until ubuntu 24.04
+rti-connext-dds-6.0.1:  # Supported until ubuntu 24.04
   nixos: []
   ubuntu:
     bionic: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8477,7 +8477,7 @@ rti-connext-dds-6.0.1:
 rti-connext-dds-7.3.0:
   nixos: []
   ubuntu:
-    '*': [rti-connext-dds-7.3.0]
+    '*': [rti-connext-dds-7.3.0-ros]
     jammy: null
     focal: null
 rtmidi:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8469,12 +8469,11 @@ rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
-rti-connext-dds-6.0.1:  # Supported until ubuntu 24.04
+rti-connext-dds-6.0.1:
   nixos: []
   ubuntu:
-    focal: [rti-connext-dds-6.0.1]
-    jammy: [rti-connext-dds-6.0.1]
-    noble: [rti-connext-dds-6.0.1]
+    '*': [rti-connext-dds-6.0.1]
+    bionic: null
 rti-connext-dds-7.3.0-ros:  # supported from ubuntu 24.04 noble
   nixos: []
   ubuntu:


### PR DESCRIPTION

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

**As I understand it, previous updates to the rti-connext-dds packages were handled by OSRF—we provided the binaries, and they added them to the ROS bootstrap repositories. @mjcarroll can you confirm that? **

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rti-connext-dds-7.3.0

## Package Upstream Source:

TODO (waiting clarification from OSRF on how to proceed)

## Purpose of using this:

This new package will bring new features, improved stability, and bug fixes compared to rti-connext-dds-6.0.1. We’ve also already had ROS 2 users requesting this update.

## Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED [TODO] 
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED [TODO] we are waiting for getting assistance on this
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here:

http://sourcecode_url

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
