### PR TITLE
rosidl_typesupport_fastrtps: 3.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7066,7 +7066,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.7.1-3
+      version: 3.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.8.0-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.1-3`

## rosidl_typesupport_fastrtps_c

```
* Switch to ament_cmake_ros_core package (#127 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/127>)
* Remove dependency on fastrtps_cmake_module (#120 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/120>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow (#124 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/124>)
* Contributors: Chris Lalancette, Miguel Company, Scott K Logan
```

## rosidl_typesupport_fastrtps_cpp

```
* Switch to ament_cmake_ros_core package (#127 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/127>)
* Remove dependency on fastrtps_cmake_module (#120 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/120>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow (#124 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/124>)
* Contributors: Chris Lalancette, Miguel Company, Scott K Logan
```
