### PR TITLE
Add python3-einops-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5749,6 +5749,13 @@ python3-easydict:
     focal:
       pip:
         packages: [easydict]
+python3-einops-pip:
+  debian:
+    pip:
+      packages: [einops]
+  ubuntu:
+    pip:
+      packages: [einops]
 python3-elasticsearch:
   debian: [python3-elasticsearch]
   fedora: [python3-elasticsearch]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

einops

## Package Upstream Source:

[PyPI - Einops](https://pypi.org/project/einops/)

## Purpose of using this:

Flexible and powerful tensor operations for readable and reliable code.
Supports numpy, pytorch, tensorflow, jax, and [others](https://pypi.org/project/einops/#supported-frameworks).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://pypi.org/project/einops/
  - Its from PyPi
- Ubuntu: https://pypi.org/project/einops/
  - Its from PyPi