### PR TITLE
dynamixel_sdk: 3.8.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1744,7 +1744,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
-      version: 3.8.2-1
+      version: 3.8.3-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `3.8.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ros2-gbp/dynamixel_sdk-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.2-1`

## dynamixel_sdk

```
* Modified the getError function for Group Read methods
* Contributors: Wonho Yun
```

## dynamixel_sdk_custom_interfaces

```
* None
```

## dynamixel_sdk_examples

```
* None
```
