### PR TITLE
turtlebot3: 2.2.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10817,7 +10817,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robotis-ros2-release/turtlebot3-release.git
-      version: 2.2.5-1
+      version: 2.2.6-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.2.6-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/robotis-ros2-release/turtlebot3-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.5-1`

## turtlebot3

```
* Added Nav2 parameters for Jazzy
* Made it possible to choose between using the Twist type or the TwistStamped type in cmd_vel through a parameter
* Contributors: Hyungyu Kim
```

## turtlebot3_bringup

```
* Made it possible to choose between using the Twist type or the TwistStamped type in cmd_vel through a parameter
* Contributors: Hyungyu Kim
```

## turtlebot3_cartographer

```
* None
```

## turtlebot3_description

```
* None
```

## turtlebot3_example

```
* None
```

## turtlebot3_navigation2

```
* Added Nav2 parameters for Jazzy
* Made it possible to choose between using the Twist type or the TwistStamped type in cmd_vel through a parameter
* Contributors: Hyungyu Kim
```

## turtlebot3_node

```
* Made it possible to choose between using the Twist type or the TwistStamped type in cmd_vel through a parameter
* Contributors: Hyungyu Kim
```

## turtlebot3_teleop

```
* Jazzy support
* Change msg type of cmd_vel from geometry_msgs/Twist to geometry_msgs/TwistStamped in jazzy
* Contributors: Hyungyu Kim
```
