### PR TITLE
turtlebot3_manipulation: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10851,7 +10851,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_manipulation` to `2.2.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
- release repository: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-1`

## turtlebot3_manipulation

```
* Added gripper control in teleoperation.
* Resolved the issue where teleoperation was not functioning on the actual robot.
* Fixed the intermittent issue of Gazebo not launching.
* Fixed the error log related to the mimic joint.
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_bringup

```
* Updated maintainer information
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_cartographer

```
* Updated maintainer information
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_description

```
* Fixed the intermittent issue of Gazebo not launching
* Fixed the error log related to the mimic joint.
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_hardware

```
* Resolved the issue where teleoperation was not functioning on the actual robot
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_moveit_config

```
* Resolved the issue where teleoperation was not functioning on the actual robot
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_navigation2

```
* Updated maintainer information
* Contributors: Sungho Woo
```

## turtlebot3_manipulation_teleop

```
* Added gripper control in teleoperation
* Contributors: Sungho Woo
```
