### PR TITLE
ur_description: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11255,7 +11255,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.11-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.5.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.11-1`

## ur_description

```
* Update inertia matrix for UR3e and UR5e from measurements (backport of #256 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/256>) (#274 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/274>)
* Auto-update pre-commit hooks (backport #268 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/268>) (#269 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/269>)
* Add support for UR7e and UR12e (backport of #266 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/266>) (#267 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/267>)
* Update README.md (#264 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/264>) (#265 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/265>)
* Contributors: mergify[bot]
```
