### PR TITLE
ur_description: 3.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9890,7 +9890,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.0.2-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.2-1`

## ur_description

```
* Update inertia matrix for UR3e and UR5e from measurements (#256 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/256>)
* Auto-update pre-commit hooks (#268 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/268>)
* Add support for UR7e and UR12e (#266 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/266>)
* Update README.md (#264 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/264>)
* Contributors: Chalongrath Pholsiri, Felix Exner, Michael Behrens, github-actions[bot]
```
