### PR TITLE
slg_msgs: 3.9.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8905,6 +8905,16 @@ repositories:
       type: git
       url: https://github.com/ajtudela/slg_msgs.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/slg_msgs-release.git
+      version: 3.9.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ajtudela/slg_msgs.git
+      version: main
     status: maintained
   slider_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `slg_msgs` to `3.9.2-1`:

- upstream repository: https://github.com/ajtudela/slg_msgs.git
- release repository: https://github.com/ros2-gbp/slg_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## slg_msgs

```
* First jazzy release.
```
