### PR TITLE
pybind11_vendor: 3.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6017,7 +6017,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.1.2-2
+      version: 3.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_vendor` to `3.1.3-1`:

- upstream repository: https://github.com/ros2/pybind11_vendor.git
- release repository: https://github.com/ros2-gbp/pybind11_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.2-2`

## pybind11_vendor

```
* Merge pull request #30 <https://github.com/ros2/pybind11_vendor/issues/30> from ros2/mergify/bp/jazzy/pr-29
  Remove CODEOWNERS and mirror-rolling-to-master workflow. (backport #29 <https://github.com/ros2/pybind11_vendor/issues/29>)
* Contributors: mergify[bot]
```
