### PR TITLE
rclcpp: 28.1.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6481,7 +6481,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.7-2
+      version: 28.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.8-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `28.1.7-2`

## rclcpp

- No changes

## rclcpp_action

```
* Harden rclcpp_action::convert(). (#2786 <https://github.com/ros2/rclcpp/issues/2786>) (#2789 <https://github.com/ros2/rclcpp/issues/2789>)
  * Harden rclcpp_action::convert().
  * update docstring.
  ---------
  (cherry picked from commit ce86ef7e621d96ce50d6ec1b49e9e1cd4f0a828b)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* should pull valid transition before trying to change the state. (#2774 <https://github.com/ros2/rclcpp/issues/2774>) (#2784 <https://github.com/ros2/rclcpp/issues/2784>)
  (cherry picked from commit 7b6ee8a2e7a13d73f9f69368970390a9e0930448)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```
