### PR TITLE
launch_ros: 0.26.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3735,7 +3735,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.6-1
+      version: 0.26.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.7-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.26.6-1`

## launch_ros

```
* Fixing lifecycle node autostart issue #445 <https://github.com/ros2/launch_ros/issues/445> (#449 <https://github.com/ros2/launch_ros/issues/449>) (#453 <https://github.com/ros2/launch_ros/issues/453>)
  (cherry picked from commit 98952b58d570cde78d8cfec8c8d697f331b8c982)
  Co-authored-by: Steve Macenski <mailto:stevenmacenski@gmail.com>
* Autostarting lifecycle nodes and example launch file demo (#430 <https://github.com/ros2/launch_ros/issues/430>) (#438 <https://github.com/ros2/launch_ros/issues/438>)
  (cherry picked from commit 3569f0d76c68884ca8796c0134bad29e8732d868)
  Co-authored-by: Steve Macenski <mailto:stevenmacenski@gmail.com>
* Change docstring markdown code blocks to RST (#450 <https://github.com/ros2/launch_ros/issues/450>) (#451 <https://github.com/ros2/launch_ros/issues/451>)
  (cherry picked from commit 9abb3be6c9b482bb9945d9204a0427c7b3c0f450)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* mock launch components causing rosdoc2 to fail Python API (#425 <https://github.com/ros2/launch_ros/issues/425>) (#439 <https://github.com/ros2/launch_ros/issues/439>)
  (cherry picked from commit 2e737c8cb0ad7afc436938c30b5e14b4282ff2f7)
  Co-authored-by: R Kent James <mailto:kent@caspia.com>
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* Merge pull request #447 <https://github.com/ros2/launch_ros/issues/447> from ros2/mergify/bp/jazzy/pr-446
  Fix function params indentation (backport #446 <https://github.com/ros2/launch_ros/issues/446>)
* Fix function params indentation (#446 <https://github.com/ros2/launch_ros/issues/446>)
  And add return type.
  (cherry picked from commit aeff3ca28cfe51c522b04592ec3c7e7077bf2531)
* Contributors: Alejandro Hernández Cordero, Christophe Bedard
```

## ros2launch

- No changes
