### PR TITLE
launch: 3.4.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3700,7 +3700,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.3-1
+      version: 3.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.3-1`

## launch

```
* Document substitutions concatenation in architecture doc (#845 <https://github.com/ros2/launch/issues/845>) (#846 <https://github.com/ros2/launch/issues/846>)
  (cherry picked from commit 6fcc79e38fa711e04be3d392a6691a36ea5de214)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Update docs to use proper RST literals (#837 <https://github.com/ros2/launch/issues/837>) (#839 <https://github.com/ros2/launch/issues/839>)
  (cherry picked from commit 3694dc2a14fdf0dd5ccf9e950ab9d8b60bee8a79)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Merge pull request #834 <https://github.com/ros2/launch/issues/834> from ros2/mergify/bp/jazzy/pr-833
  Fix function params indentation (backport #833 <https://github.com/ros2/launch/issues/833>)
* Fix function params indentation (#833 <https://github.com/ros2/launch/issues/833>)
  (cherry picked from commit 151b024a7cfac06f0d56798cbe87ab180b9ea3ab)
* Contributors: Alejandro Hernández Cordero, Christophe Bedard, mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

```
* Merge pull request #834 <https://github.com/ros2/launch/issues/834> from ros2/mergify/bp/jazzy/pr-833
  Fix function params indentation (backport #833 <https://github.com/ros2/launch/issues/833>)
* Fix function params indentation (#833 <https://github.com/ros2/launch/issues/833>)
  (cherry picked from commit 151b024a7cfac06f0d56798cbe87ab180b9ea3ab)
* Contributors: Alejandro Hernández Cordero, Christophe Bedard
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
