### PR TITLE
Add rai_interfaces to be indexed in the rosdistro.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7292,6 +7292,12 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.1-3
     status: maintained
+  rai_interfaces:
+    source:
+      type: git
+      url: https://github.com/RobotecAI/rai_interfaces.git
+      version: main
+    status: maintained
   random_numbers:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6162,6 +6162,12 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.2-4
     status: maintained
+  rai_interfaces:
+    source:
+      type: git
+      url: https://github.com/RobotecAI/rai_interfaces.git
+      version: main
+    status: maintained
   random_numbers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5449,6 +5449,12 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.2-3
     status: maintained
+  rai_interfaces:
+    source:
+      type: git
+      url: https://github.com/RobotecAI/rai_interfaces.git
+      version: main
+    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Humble, Jazzy, Rolling

# The source is here:

https://github.com/RobotecAI/rai_interfaces

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
