### PR TITLE
mapviz: 2.4.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4049,7 +4049,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.5-1
+      version: 2.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.6-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.5-1`

## mapviz

```
* Fixed textured_marker_plugin subscriptions. Added some additional error handling to mapviz plugin loading to avoid early exits. (#836 <https://github.com/swri-robotics/mapviz/issues/836>)
  Co-authored-by: Robert Brothers <mailto:robert.j.brothers21.ctr@army.mil>
* Contributors: Robert Brothers
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Fixed textured_marker_plugin subscriptions. Added some additional error handling to mapviz plugin loading to avoid early exits. (#836 <https://github.com/swri-robotics/mapviz/issues/836>)
  Co-authored-by: Robert Brothers <mailto:robert.j.brothers21.ctr@army.mil>
* Contributors: Robert Brothers
```

## multires_image

- No changes

## tile_map

- No changes
