### PR TITLE
mapviz: 2.4.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3533,7 +3533,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.5-1
+      version: 2.4.6-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.6-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.5-1`

## mapviz

```
* Fixed textured_marker_plugin subscriptions. Added some additional error handling to mapviz plugin loading to avoid early exits. (#836 <https://github.com/swri-robotics/mapviz/issues/836>)
  Co-authored-by: Robert Brothers <mailto:robert.j.brothers21.ctr@army.mil>
* Contributors: Robert Brothers
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Fixed textured_marker_plugin subscriptions. Added some additional error handling to mapviz plugin loading to avoid early exits. (#836 <https://github.com/swri-robotics/mapviz/issues/836>)
  Co-authored-by: Robert Brothers <mailto:robert.j.brothers21.ctr@army.mil>
* Contributors: Robert Brothers
```

## multires_image

- No changes

## tile_map

- No changes
