### PR TITLE
Add keys for rti-connext-dds-7.3.0.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8474,6 +8474,11 @@ rti-connext-dds-6.0.1:
   ubuntu:
     '*': [rti-connext-dds-6.0.1]
     bionic: null
+rti-connext-dds-7.3.0:
+  nixos: []
+  ubuntu:
+    '*': [rti-connext-dds-7.3.0]
+    jammy: null
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]


### PR DESCRIPTION
Available for both Ubuntu Noble amd64 and arm64. Unlike previous releases where we used an empty package for arm64.

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rti-connext-dds-7.3.0

## Package Upstream Source:
Sourced from the [RTI APT repository](https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/debian_packages/repo.html) imported into ros_bootstrap.

## Purpose of using this:

Updated package for a ROS 2 middleware implementation.

Distro packaging links:

## Links to Distribution Packages

https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/debian_packages/repo.html
