### PR TITLE
Switch to noetic-devel branch for many repos

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -155,7 +155,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/angles.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -165,7 +165,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/angles.git
-      version: master
+      version: noetic-devel
     status: maintained
   app_manager:
     doc:
@@ -624,7 +624,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       packages:
       - bond
@@ -640,7 +640,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   boost_plugin_loader:
     release:
@@ -3453,7 +3453,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/gencpp.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -3462,7 +3462,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/gencpp.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   geneus:
     doc:
@@ -3483,7 +3483,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genlisp.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -3493,13 +3493,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genlisp.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   genmsg:
     doc:
       type: git
       url: https://github.com/ros/genmsg.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -3509,7 +3509,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   genmypy:
     doc:
@@ -3541,7 +3541,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genpy.git
-      version: main
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -3551,7 +3551,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genpy.git
-      version: main
+      version: noetic-devel
     status: maintained
   geographic_info:
     doc:
@@ -3641,7 +3641,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       packages:
       - geometry_tutorials
@@ -3654,13 +3654,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   gl_dependency:
     doc:
       type: git
       url: https://github.com/ros-visualization/gl_dependency.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -3669,7 +3669,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/gl_dependency.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   gmcl:
     doc:
@@ -5150,7 +5150,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5160,7 +5160,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   laser_pipeline:
     doc:
@@ -5791,7 +5791,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/media_export.git
-      version: indigo-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5801,7 +5801,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/media_export.git
-      version: indigo-devel
+      version: noetic-devel
     status: maintained
   mesh_navigation:
     doc:
@@ -5856,7 +5856,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/message_generation.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5865,13 +5865,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/message_generation.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   message_runtime:
     doc:
       type: git
       url: https://github.com/ros/message_runtime.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -5880,7 +5880,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/message_runtime.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   message_tf_frame_transformer:
     doc:
@@ -8606,7 +8606,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: melodic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -8616,7 +8616,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   qb_chain:
     doc:
@@ -8781,7 +8781,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: melodic-devel
+      version: noetic-devel
     release:
       packages:
       - qt_dotgraph
@@ -8798,7 +8798,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   quanergy_client:
     release:
@@ -8831,7 +8831,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qwt_dependency.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -8840,7 +8840,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/qwt_dependency.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   radar_msgs:
     doc:
@@ -9140,7 +9140,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -9150,7 +9150,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   rgbd_launch:
     doc:
@@ -9676,7 +9676,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       packages:
       - rosgraph_msgs
@@ -9688,7 +9688,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   ros_control:
     doc:
@@ -10024,7 +10024,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/rosbag_migration_rule.git
-      version: master
+      version: noetic-devel
     status: maintained
   rosbag_pandas:
     release:
@@ -10139,7 +10139,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/rosconsole_bridge.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10149,7 +10149,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/rosconsole_bridge.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   roscpp_core:
     doc:
@@ -10443,7 +10443,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       packages:
       - rqt
@@ -10458,13 +10458,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   rqt_action:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10473,13 +10473,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_bag:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: master
+      version: noetic-devel
     release:
       packages:
       - rqt_bag
@@ -10491,13 +10491,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_common_plugins:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10507,13 +10507,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
-      version: master
+      version: noetic-devel
     status: unmaintained
   rqt_console:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10522,13 +10522,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_dep:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_dep.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10537,7 +10537,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_dep.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_ez_publisher:
     doc:
@@ -10558,7 +10558,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10568,7 +10568,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_human_radar:
     doc:
@@ -10588,7 +10588,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10598,7 +10598,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_launch:
     doc:
@@ -10620,7 +10620,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10629,7 +10629,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_moveit:
     doc:
@@ -10650,7 +10650,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10659,7 +10659,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_multiplot_plugin:
     release:
@@ -10689,7 +10689,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10698,13 +10698,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_pose_view:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10713,7 +10713,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_pr2_dashboard:
     doc:
@@ -10734,7 +10734,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10743,13 +10743,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_py_console:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10758,7 +10758,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_py_trees:
     doc:
@@ -10779,7 +10779,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10789,7 +10789,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_robot_dashboard:
     doc:
@@ -10842,7 +10842,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10851,7 +10851,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_runtime_monitor:
     doc:
@@ -10872,7 +10872,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_rviz.git
-      version: melodic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10882,13 +10882,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_rviz.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   rqt_service_caller:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10897,13 +10897,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_shell:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10912,13 +10912,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_srv:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10927,13 +10927,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_tf_tree:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10943,13 +10943,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_top:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_top.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10958,13 +10958,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_top.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_topic:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10973,13 +10973,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: master
+      version: noetic-devel
     status: maintained
   rqt_web:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_web.git
-      version: master
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -10988,7 +10988,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_web.git
-      version: master
+      version: noetic-devel
     status: maintained
   rslidar_sdk:
     doc:
@@ -11943,7 +11943,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/std_msgs.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -11952,7 +11952,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/std_msgs.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   steering_functions:
     doc:
@@ -12650,7 +12650,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdf.git
-      version: melodic-devel
+      version: noetic-devel
     release:
       packages:
       - urdf
@@ -12662,7 +12662,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/urdf.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   urdf_geometry_parser:
     doc:
@@ -13249,7 +13249,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/webkit_dependency.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
@@ -13258,7 +13258,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/webkit_dependency.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   webots_ros:
     doc:


### PR DESCRIPTION
Switch to a `noetic-devel` branch for many repos. I'm planning on making releases for these repos this week after the ROS Noetic sync. I made `noetic-devel` branches for these repos because I want a place to put any final PRs without affecting EOL distros.


I'm focusing on these repos because:
* Either:
   * the `package.xml` lists old OSRC colleagues as maintainers, or
   * [the repo is managed by the ROS PMC](https://docs.ros.org/en/rolling/The-ROS2-Project/Governance.html#repositories-managed-by-the-ros-pmc)
* I have write access
* ROS Noetic `desktop_full` includes packages from these repos
