### PR TITLE
mp2p_icp: 1.6.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4073,7 +4073,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.6.6-1
+      version: 1.6.7-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.6.7-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.6-1`

## mp2p_icp

```
* mm-georef cli app: support reading/writing georef info in YAML format
* georeferencing metadata now can be read/writen as YAML files
* clang-format: switch to column limit=100
* Update to robin-map v1.4.0
* Contributors: Jose Luis Blanco-Claraco
```
