### PR TITLE
aruco_markers: 0.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -591,6 +591,18 @@ repositories:
       version: master
     status: developed
   aruco_markers:
+    doc:
+      type: git
+      url: https://github.com/namo-robotics/aruco_markers.git
+      version: humble
+    release:
+      packages:
+      - aruco_markers
+      - aruco_markers_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/namo-robotics/aruco_markers-release.git
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/namo-robotics/aruco_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_markers` to `0.0.1-2`:

- upstream repository: https://github.com/namo-robotics/aruco_markers.git
- release repository: https://github.com/namo-robotics/aruco_markers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## aruco_markers

```
* uncrustify
* add tf2_geometry_msgs dep
* fix opencv dependency
* complete renaming
* rename to aruco_markers
* Contributors: David Brown
```

## aruco_markers_msgs

```
* rename to aruco_markers
* Contributors: David Brown
```
