### PR TITLE
diagnostics: 4.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1952,13 +1952,14 @@ repositories:
       packages:
       - diagnostic_aggregator
       - diagnostic_common_diagnostics
+      - diagnostic_remote_logging
       - diagnostic_updater
       - diagnostics
       - self_test
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.0.3-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.2-1`

## diagnostic_remote_logging

```
* cleanup (#450 <https://github.com/ros/diagnostics/issues/450>)
* Grafana Integration (#425 <https://github.com/ros/diagnostics/issues/425>)
  * First working version of remote_logging
  * Added more error handling, and skipping values when new line is present in stat
  * Changed default telegraf url to reflect the change to influxdb_v2_listener
  * Made node composable and changed name to influx to better reflect use cases
  * Added README
  ---------
  Co-authored-by: Daan Wijffels <mailto:dwijffels@lely.com>
  Co-authored-by: Thiever Base <mailto:thiever@lely.com>
  Co-authored-by: Christian Henkel <mailto:6976069+ct2034@users.noreply.github.com>
* Contributors: Christian Henkel, Daan Wijffels
```
