### PR TITLE
Add rosdep key for re2: Google's library for regular expressions

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6150,7 +6150,7 @@ libre2-dev:
   fedora: [re2-devel]
   gentoo: [dev-libs/re2]
   nixos: [re2]
-  opensuse: [re2]
+  opensuse: [re2-devel]
   osx:
     homebrew:
       packages: [re2]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6143,6 +6143,19 @@ librdkafka-dev:
   nixos: [rdkafka]
   openembedded: [librdkafka@meta-oe]
   ubuntu: [librdkafka-dev]
+libre2-dev:
+  alpine: [re2]
+  arch: [re2]
+  debian: [libre2-dev]
+  fedora: [re2-devel]
+  gentoo: [dev-libs/re2]
+  nixos: [re2]
+  opensuse: [re2]
+  osx:
+    homebrew:
+      packages: [re2]
+  rhel: [re2-devel]
+  ubuntu: [libre2-dev]
 libreadline:
   arch: [readline]
   debian: [libreadline-dev]
@@ -8400,21 +8413,6 @@ rclone:
   opensuse: [rclone]
   rhel: [rclone]
   ubuntu: [rclone]
-re2:
-  alpine: [re2]
-  arch: [re2]
-  debian: [libre2-dev]
-  fedora: [re2-devel]
-  gentoo: [dev-libs/re2]
-  nixos: [re2]
-  opensuse: [re2]
-  osx:
-    homebrew:
-      packages: [re2]
-  rhel: [re2-devel]
-  ubuntu:
-    '*': [libre2-dev]
-    xenial: null
 readline-dev:
   arch: [readline]
   debian: [libreadline-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8400,6 +8400,21 @@ rclone:
   opensuse: [rclone]
   rhel: [rclone]
   ubuntu: [rclone]
+re2:
+  alpine: [re2]
+  arch: [re2]
+  debian: [libre2-dev]
+  fedora: [re2-devel]
+  gentoo: [dev-libs/re2]
+  nixos: [re2]
+  opensuse: [re2]
+  osx:
+    homebrew:
+      packages: [re2]
+  rhel: [re2-devel]
+  ubuntu:
+    '*': [libre2-dev]
+    xenial: null
 readline-dev:
   arch: [readline]
   debian: [libreadline-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

re2

## Package Upstream Source:

https://github.com/google/re2

## Purpose of using this:

The dependency is used for performing regular expressions in C++. The standard library's regular expression library is known to be slow [see here](https://github.com/HFTrader/regex-performance). This library is one of the faster alternatives, and is relatively easy to use.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=libre2-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/search?keywords=libre2-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/pkgs/re2/re2/
- Arch: https://archlinux.org/packages/extra/x86_64/re2/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/re2
- macOS: https://formulae.brew.sh/formula/re2
- Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/re2
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=24.11&show=re2&from=0&size=50&sort=relevance&type=packages&query=re2
- openSUSE: https://software.opensuse.org/package/re2
- rhel:
  - https://rhel.pkgs.org/10/epel-aarch64/re2-devel-20240702-3.el10_0.aarch64.rpm.html
  - https://rhel.pkgs.org/10/epel-x86_64/re2-devel-20240702-3.el10_0.x86_64.rpm.html
  - https://rhel.pkgs.org/9/epel-x86_64/re2-devel-20211101-20.el9.x86_64.rpm.html
