### PR TITLE
gz_ros2_control: 1.2.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3014,7 +3014,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.11-1
+      version: 1.2.12-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.12-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.11-1`

## gz_ros2_control

```
* Set use_sim_time through CM NodeOptions (#533 <https://github.com/ros-controls/gz_ros2_control/issues/533>) (#538 <https://github.com/ros-controls/gz_ros2_control/issues/538>)
* Make the system backward compatible with the old ign* plugins (#520 <https://github.com/ros-controls/gz_ros2_control/issues/520>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## gz_ros2_control_demos

```
* Remove gtest dependency (#543 <https://github.com/ros-controls/gz_ros2_control/issues/543>) (#544 <https://github.com/ros-controls/gz_ros2_control/issues/544>)
* Don't access node after reset (#514 <https://github.com/ros-controls/gz_ros2_control/issues/514>) (#516 <https://github.com/ros-controls/gz_ros2_control/issues/516>)
* Remap to /tf (#506 <https://github.com/ros-controls/gz_ros2_control/issues/506>) (#507 <https://github.com/ros-controls/gz_ros2_control/issues/507>)
* Contributors: mergify[bot]
```
