### PR TITLE
gz_ros2_control: 2.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2523,7 +2523,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.7-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.6-1`

## gz_ros2_control

```
* Set use_sim_time through CM NodeOptions (#533 <https://github.com/ros-controls/gz_ros2_control/issues/533>)
* Cleanup old ign_ remnants (#518 <https://github.com/ros-controls/gz_ros2_control/issues/518>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## gz_ros2_control_demos

```
* Remove gtest dependency (#543 <https://github.com/ros-controls/gz_ros2_control/issues/543>)
* Unify cmd_vel topics for mobile_robots demos (#530 <https://github.com/ros-controls/gz_ros2_control/issues/530>)
* Don't access node after reset (#514 <https://github.com/ros-controls/gz_ros2_control/issues/514>)
* Remap to /tf (#506 <https://github.com/ros-controls/gz_ros2_control/issues/506>)
* Contributors: Aarav Gupta, Christoph Fröhlich
```
