### PR TITLE
Add rosdep key for libaio

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2612,6 +2612,18 @@ libadolc-dev:
   nixos: [adolc]
   opensuse: [adolc-devel]
   ubuntu: [libadolc-dev]
+libaio-dev:
+  alpine: [libaio-dev]
+  arch: [libaio]
+  debian: [libaio-dev]
+  fedora: [libaio-devel]
+  gentoo: [dev-libs/libaio]
+  opensuse: [libaio]
+  osx:
+    homebrew:
+      packages: [libaio]
+  rhel: [libaio-devel]
+  ubuntu: [libaio-dev]
 libalglib-dev:
   arch: [alglib]
   debian: [libalglib-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: `libaio`

## Package Upstream Source:

- https://pagure.io/libaio.git

## Purpose of using this:

- `libaio` enables linux-native asynchronous I/O.

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libaio-dev
- Ubuntu: https://packages.ubuntu.com/search?keywords=libaio-dev
- Fedora: https://packages.fedoraproject.org/pkgs/libaio/libaio-devel/
- Arch: https://archlinux.org/packages/core/x86_64/libaio/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/libaio
- macOS: https://formulae.brew.sh/formula/libaio
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86/libaio-dev
- openSUSE: https://software.opensuse.org/package/libaio
- rhel: https://oraclelinux.pkgs.org/9/ol9-appstream-x86_64/libaio-devel-0.3.111-13.el9.i686.rpm.html