### PR TITLE
Add rosdep key for libserialport

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6193,6 +6193,20 @@ libsensors4-dev:
 libserial-dev:
   debian: [libserial-dev]
   ubuntu: [libserial-dev]
+libserialport-dev:
+  alpine: [libserialport-dev]
+  arch: [libserialport]
+  debian: [libserialport-dev]
+  fedora: [libserialport-devel]
+  gentoo: [dev-libs/libserialport]
+  opensuse: [libserialport-devel]
+  osx:
+    homebrew:
+      packages: [libserialport]
+  rhel:
+    '*': [libserialport-devel]
+    '8': null
+  ubuntu: [libserialport-dev]
 libshaderc-dev:
   alpine: [shaderc-dev]
   arch: [shaderc]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.


## Package name: `libserialport-dev`

## Package Upstream Source:

- https://sigrok.org/gitweb/?p=libserialport.git

## Purpose of using this:

- `libserialport` is used for writing software that interfaces via serial ports.

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libserialport-dev
- Ubuntu: https://packages.ubuntu.com/search?keywords=libserialport-dev
- Fedora: https://packages.fedoraproject.org/pkgs/libserialport/libserialport-devel/
- Arch: https://archlinux.org/packages/extra/x86_64/libserialport/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/libserialport
- macOS: https://formulae.brew.sh/formula/libserialport
- Alpine: https://pkgs.alpinelinux.org/package/edge/testing/x86/libserialport-dev
- Opensuse: https://packagehub.suse.com/packages/libserialport/
- rhel: https://rhel.pkgs.org/9/epel-x86_64/libserialport-0.1.1-1.el9.x86_64.rpm.html