### PR TITLE
rclcpp: 29.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5699,7 +5699,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.3.0-1
+      version: 29.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.4.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `29.3.0-1`

## rclcpp

```
* Removed trailing whitespace from the codebase. (#2791 <https://github.com/ros2/rclcpp/issues/2791>)
* Expanded docstring of get_rmw_qos_profile() (#2787 <https://github.com/ros2/rclcpp/issues/2787>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#2776 <https://github.com/ros2/rclcpp/issues/2776>)
* fix: Compilefix for clang (#2775 <https://github.com/ros2/rclcpp/issues/2775>)
* add exception doc for configure_introspection. (#2773 <https://github.com/ros2/rclcpp/issues/2773>)
* feat: Add ClockWaiter and ClockConditionalVariable (#2691 <https://github.com/ros2/rclcpp/issues/2691>)
* doc: Added warning to not instantiate Clock directly with RCL_ROS_TIME (#2768 <https://github.com/ros2/rclcpp/issues/2768>)
* Use rmw_event_type_is_supported in test_qos_event (#2761 <https://github.com/ros2/rclcpp/issues/2761>)
* Support action typesupport helper (#2750 <https://github.com/ros2/rclcpp/issues/2750>)
* use maybe_unused attribute for the portability. (#2758 <https://github.com/ros2/rclcpp/issues/2758>)
* Executor strong reference fix (#2745 <https://github.com/ros2/rclcpp/issues/2745>)
* Cleanup of https://github.com/ros2/rclcpp/pull/2683 (#2714 <https://github.com/ros2/rclcpp/issues/2714>)
* Fix typo in doc section for get_service_typesupport_handle (#2751 <https://github.com/ros2/rclcpp/issues/2751>)
* Test case and fix for for https://github.com/ros2/rclcpp/issues/2652 (#2713 <https://github.com/ros2/rclcpp/issues/2713>)
* fix(timer): Delete node, after executor thread terminated (#2737 <https://github.com/ros2/rclcpp/issues/2737>)
* update doc section for spin_xxx methods. (#2730 <https://github.com/ros2/rclcpp/issues/2730>)
* fix: Expose timers used by rclcpp::Waitables (#2699 <https://github.com/ros2/rclcpp/issues/2699>)
* use rmw_qos_profile_rosout_default instead of rcl. (#2663 <https://github.com/ros2/rclcpp/issues/2663>)
* fix(Executor): Fixed entities not beeing executed after just beeing added (#2724 <https://github.com/ros2/rclcpp/issues/2724>)
* fix: make the loop condition align with the description (#2726 <https://github.com/ros2/rclcpp/issues/2726>)
* Collect log messages from rcl, and reset. (#2720 <https://github.com/ros2/rclcpp/issues/2720>)
* Contributors: Abhishek Kashyap, Alejandro Hernández Cordero, Barry Xu, Janosch Machowinski, Leander Stephen D'Souza, Tomoya Fujita, Yuyuan Yuan
```

## rclcpp_action

```
* Remove warning (#2790 <https://github.com/ros2/rclcpp/issues/2790>)
* Harden rclcpp_action::convert(). (#2786 <https://github.com/ros2/rclcpp/issues/2786>)
* Add new interfaces to enable introspection for action (#2743 <https://github.com/ros2/rclcpp/issues/2743>)
* use maybe_unused attribute for the portability. (#2758 <https://github.com/ros2/rclcpp/issues/2758>)
* fix: Expose timers used by rclcpp::Waitables (#2699 <https://github.com/ros2/rclcpp/issues/2699>)
* Collect log messages from rcl, and reset. (#2720 <https://github.com/ros2/rclcpp/issues/2720>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Janosch Machowinski, Tomoya Fujita
```

## rclcpp_components

```
* Removed trailing whitespace from the codebase. (#2791 <https://github.com/ros2/rclcpp/issues/2791>)
* add NO_UNDEFINED_SYMBOLS to rclcpp_components_register_node cmake macro (#2746 <https://github.com/ros2/rclcpp/issues/2746>) (#2764 <https://github.com/ros2/rclcpp/issues/2764>)
* use maybe_unused attribute for the portability. (#2758 <https://github.com/ros2/rclcpp/issues/2758>)
* ComponentManager should just ignore unknown extra argument in the bas… (#2723 <https://github.com/ros2/rclcpp/issues/2723>)
* Contributors: Leander Stephen D'Souza, Tomoya Fujita, Jonas Otto
```

## rclcpp_lifecycle

```
* should pull valid transition before trying to change the state. (#2774 <https://github.com/ros2/rclcpp/issues/2774>)
* use maybe_unused attribute for the portability. (#2758 <https://github.com/ros2/rclcpp/issues/2758>)
* Collect log messages from rcl, and reset. (#2720 <https://github.com/ros2/rclcpp/issues/2720>)
* Contributors: Tomoya Fujita
```
