### PR TITLE
image_common: 5.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3266,7 +3266,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.5-1
+      version: 5.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.6-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.5-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* fix: add rclcpp::shutdown (#347 <https://github.com/ros-perception/image_common/issues/347>) (#348 <https://github.com/ros-perception/image_common/issues/348>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 0cc6ab2de0b1a600d2d6a69108cf2131d778ec56)
  Co-authored-by: Yuyuan Yuan <mailto:az6980522@gmail.com>
* Contributors: mergify[bot]
```
