### PR TITLE
point_cloud_transport: 4.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5742,7 +5742,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 4.0.3-1
+      version: 4.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.4-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.3-1`

## point_cloud_transport

```
* fix: add rclcpp::shutdown (#110 <https://github.com/ros-perception/point_cloud_transport/issues/110>) (#111 <https://github.com/ros-perception/point_cloud_transport/issues/111>)
  (cherry picked from commit 40fec8f3e30b2ed68f6f5ad4915b098cece4c68a)
  Co-authored-by: Yuyuan Yuan <mailto:az6980522@gmail.com>
* Contributors: mergify[bot]
```

## point_cloud_transport_py

- No changes
