### PR TITLE
resource_retriever: 3.4.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6647,7 +6647,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.4.3-1
+      version: 3.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.4.4-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.3-1`

## libcurl_vendor

```
* uniform  MinCMakeVersion (#108 <https://github.com/ros/resource_retriever/issues/108>) (#109 <https://github.com/ros/resource_retriever/issues/109>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 168300fba1c4f507d1e3bea0c4f97d468cbad477)
  Co-authored-by: mosfet80 <mailto:realeandrea@yahoo.it>
* Contributors: mergify[bot]
```

## resource_retriever

```
* uniform  MinCMakeVersion (#108 <https://github.com/ros/resource_retriever/issues/108>) (#109 <https://github.com/ros/resource_retriever/issues/109>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 168300fba1c4f507d1e3bea0c4f97d468cbad477)
  Co-authored-by: mosfet80 <mailto:realeandrea@yahoo.it>
* Contributors: mergify[bot]
```
