### PR TITLE
realtime_tools: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5827,7 +5827,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.1.0-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.2.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-1`

## realtime_tools

```
* Fix realtime publisher race condition upon initialization (#309 <https://github.com/ros-controls/realtime_tools/issues/309>)
* Move the package to a subfolder (#295 <https://github.com/ros-controls/realtime_tools/issues/295>)
* Use ros2_control_cmake (#293 <https://github.com/ros-controls/realtime_tools/issues/293>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
