### PR TITLE
realtime_tools: 3.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6629,7 +6629,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.5.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-1`

## realtime_tools

```
* Fix realtime publisher race condition upon initialization (backport #309 <https://github.com/ros-controls/realtime_tools/issues/309>) (#311 <https://github.com/ros-controls/realtime_tools/issues/311>)
* Move the package to a subfolder (backport #295 <https://github.com/ros-controls/realtime_tools/issues/295>) (#306 <https://github.com/ros-controls/realtime_tools/issues/306>)
* Use ros2_control_cmake (backport #293 <https://github.com/ros-controls/realtime_tools/issues/293>) (#293 <https://github.com/ros-controls/realtime_tools/issues/293>)
* Contributors: mergify[bot]
```
