### PR TITLE
realtime_tools: 2.13.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7763,7 +7763,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `2.13.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.0-1`

## realtime_tools

```
* Fix realtime publisher race condition upon initialization (backport #309 <https://github.com/ros-controls/realtime_tools/issues/309>) (#310 <https://github.com/ros-controls/realtime_tools/issues/310>)
* [RTPublisher] use NON_POLLING as default for the realtime pubisher  (backport #280 <https://github.com/ros-controls/realtime_tools/issues/280>) (#281 <https://github.com/ros-controls/realtime_tools/issues/281>)
* Update the docstring for realtime_publisher.hpp (backport #287 <https://github.com/ros-controls/realtime_tools/issues/287>) (#288 <https://github.com/ros-controls/realtime_tools/issues/288>)
* Contributors: mergify[bot], Julia Jia
```
