### PR TITLE
control_toolbox: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1132,7 +1132,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.1.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.0-1`

## control_toolbox

```
* Remove unused class variables (#328 <https://github.com/ros-controls/control_toolbox/issues/328>)
* Don't update internal states if called with dt=0 or garbage (#326 <https://github.com/ros-controls/control_toolbox/issues/326>)
* Move the package to a subfolder (#318 <https://github.com/ros-controls/control_toolbox/issues/318>)
* Contributors: Christoph Fröhlich
```
