### PR TITLE
control_toolbox: 4.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1361,7 +1361,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.0.1-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.1.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-1`

## control_toolbox

```
* Move the package to a subfolder (backport #318 <https://github.com/ros-controls/control_toolbox/issues/318>) (#329 <https://github.com/ros-controls/control_toolbox/issues/329>)
* Use global cmake macros (backport #316 <https://github.com/ros-controls/control_toolbox/issues/316>) (#317 <https://github.com/ros-controls/control_toolbox/issues/317>)
* Replaced gMock instead of gTest (backport #300 <https://github.com/ros-controls/control_toolbox/issues/300>) (#315 <https://github.com/ros-controls/control_toolbox/issues/315>)
* Contributors: mergify[bot]
```
