### PR TITLE
control_toolbox: 3.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1640,7 +1640,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.6.0-1
+      version: 3.6.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.6.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.0-1`

## control_toolbox

```
* Add copyright owner (#330 <https://github.com/ros-controls/control_toolbox/issues/330>) (#332 <https://github.com/ros-controls/control_toolbox/issues/332>)
* Bump version of pre-commit hooks (#321 <https://github.com/ros-controls/control_toolbox/issues/321>) (#324 <https://github.com/ros-controls/control_toolbox/issues/324>)
* Make downstream job a semi-binary build (backport #301 <https://github.com/ros-controls/control_toolbox/issues/301>) (#307 <https://github.com/ros-controls/control_toolbox/issues/307>)
* Update upstream/downstream repository branches (#309 <https://github.com/ros-controls/control_toolbox/issues/309>) (#310 <https://github.com/ros-controls/control_toolbox/issues/310>)
* Change workflows and readme for jazzy branch (#292 <https://github.com/ros-controls/control_toolbox/issues/292>) (#295 <https://github.com/ros-controls/control_toolbox/issues/295>)
* Bump version of pre-commit hooks (#288 <https://github.com/ros-controls/control_toolbox/issues/288>) (#289 <https://github.com/ros-controls/control_toolbox/issues/289>)
* Bump version of pre-commit hooks (#282 <https://github.com/ros-controls/control_toolbox/issues/282>) (#283 <https://github.com/ros-controls/control_toolbox/issues/283>)
* Use ABI workflow from ros2_control_ci (backport #278 <https://github.com/ros-controls/control_toolbox/issues/278>) (#281 <https://github.com/ros-controls/control_toolbox/issues/281>)
* Use jazzy branch for realtime_tools (#279 <https://github.com/ros-controls/control_toolbox/issues/279>) (#280 <https://github.com/ros-controls/control_toolbox/issues/280>)
* Contributors: mergify[bot]
```
