### PR TITLE
hatchbed_common: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2633,7 +2633,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hatchbed_common-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/hatchbed/hatchbed_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hatchbed_common` to `0.1.2-1`:

- upstream repository: https://github.com/hatchbed/hatchbed_common.git
- release repository: https://github.com/ros2-gbp/hatchbed_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## hatchbed_common

```
* Add simple timing profiler utility.
* Add global callback for any changes to registered dynamic parameter.
* Contributors: Marc Alban
```
