### PR TITLE
autoware_lanelet2_extension: 0.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -648,7 +648,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.6.2-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.7.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.2-1`

## autoware_lanelet2_extension

```
* feat(lanelet2_extension)!: remove dependency on autoware_utils (#47 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/47>)
  * chore(lanelet2_extension)!: remove dependency on autoware_utils
  * add test
  * WIP
  * WIP2
  * remove tinyxml2
  * remove from build_depends
  ---------
  Co-authored-by: Yutaka Kondo <mailto:yutaka.kondo@youtalk.jp>
* feat: add query for all waypoints (#56 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/56>)
* Contributors: Mamoru Sobue, Mehmet Dogru
```

## autoware_lanelet2_extension_python

- No changes
