### PR TITLE
autoware_internal_msgs: 1.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -875,13 +875,14 @@ repositories:
     release:
       packages:
       - autoware_internal_debug_msgs
+      - autoware_internal_metric_msgs
       - autoware_internal_msgs
       - autoware_internal_perception_msgs
       - autoware_internal_planning_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.5.0-1
+      version: 1.8.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.8.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.0-1`

## autoware_internal_debug_msgs

- No changes

## autoware_internal_metric_msgs

- No changes

## autoware_internal_msgs

```
* feat(autoware_internal_msgs): make autoware_internal_msgs metapackage (#57 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/57>)
* Contributors: Yutaka Kondo
```

## autoware_internal_perception_msgs

- No changes

## autoware_internal_planning_msgs

- No changes
