### PR TITLE
laser_segmentation: 3.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3683,6 +3683,16 @@ repositories:
       type: git
       url: https://github.com/ajtudela/laser_segmentation.git
       version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_segmentation-release.git
+      version: 3.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ajtudela/laser_segmentation.git
+      version: main
     status: maintained
   launch:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_segmentation` to `3.0.4-1`:

- upstream repository: https://github.com/ajtudela/laser_segmentation.git
- release repository: https://github.com/ros2-gbp/laser_segmentation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
