### PR TITLE
autoware_msgs: 1.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -665,6 +665,7 @@ repositories:
       - autoware_control_msgs
       - autoware_localization_msgs
       - autoware_map_msgs
+      - autoware_msgs
       - autoware_perception_msgs
       - autoware_planning_msgs
       - autoware_sensing_msgs
@@ -674,7 +675,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.4.0-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.6.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.0-1`

## autoware_common_msgs

- No changes

## autoware_control_msgs

- No changes

## autoware_localization_msgs

- No changes

## autoware_map_msgs

- No changes

## autoware_msgs

```
* feat(autoware msgs): create metapackage (#123 <https://github.com/autowarefoundation/autoware_msgs/issues/123>)
  * create autoware_msgs
  * add maintainer
  * style(pre-commit): autofix
  * Update autoware_msgs/package.xml
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Yutaka Kondo
```

## autoware_perception_msgs

- No changes

## autoware_planning_msgs

- No changes

## autoware_sensing_msgs

- No changes

## autoware_system_msgs

- No changes

## autoware_v2x_msgs

- No changes

## autoware_vehicle_msgs

- No changes
