### PR TITLE
rqt_pr2_dashboard: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10724,7 +10724,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/pr2/rqt_pr2_dashboard.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pr2_dashboard` to `0.4.2-1`:

- upstream repository: https://github.com/PR2/rqt_pr2_dashboard.git
- release repository: https://github.com/ros-gbp/rqt_pr2_dashboard-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.1-1`

## rqt_pr2_dashboard

```
* catkin_install_python to let catkin to fix shebang (#28 <https://github.com/PR2/rqt_pr2_dashboard/issues/28>)
* Contributors: Yoshiki Obinata
```
