### PR TITLE
off_highway_sensor_drivers: 0.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6105,7 +6105,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 0.7.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `0.8.0-1`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-1`

## off_highway_can

```
* Move test to emphasize external FOSS
* Add tests for encoding by round
* Replace truncation of physical value with round outside of FOSS
  Minimizes the floating point error such that half
  offset of resolution in tests is not needed
  anymore.
* Contributors: Calin-Vasile Sopterean, Robin Petereit
```

## off_highway_general_purpose_radar

```
* Replace truncation of physical value with round outside of FOSS
  Minimizes the floating point error such that half
  offset of resolution in tests is not needed
  anymore.
* Do not force warnings as errors for General Purpose Radar (#12)
  Fixup of #11.
* Contributors: Robin Petereit, Tim Clephas
```

## off_highway_general_purpose_radar_msgs

```
* rosidl_default_generators is technically a <buildtool_depend> (#13)
  rosidl_default_generators is technically a buildtool_depend
* Do not force warnings as errors for General Purpose Radar (#12)
  Fixup of #11.
* Contributors: Tim Clephas
```

## off_highway_premium_radar_sample

- No changes

## off_highway_premium_radar_sample_msgs

```
* rosidl_default_generators is technically a <buildtool_depend> (#13)
  rosidl_default_generators is technically a buildtool_depend
* Contributors: Tim Clephas
```

## off_highway_radar

- No changes

## off_highway_radar_msgs

```
* rosidl_default_generators is technically a <buildtool_depend> (#13)
  rosidl_default_generators is technically a buildtool_depend
* Contributors: Tim Clephas
```

## off_highway_sensor_drivers

- No changes

## off_highway_sensor_drivers_examples

```
* Fix path for checkout
* Checkout compatible pcl_ros version (#14)
  Update README.md
  Compatible pcl_ros versione with off_highway_sensor_drivers_examples
* Contributors: Jacopo Zecchi, Robin Petereit
```

## off_highway_uss

- No changes

## off_highway_uss_msgs

```
* rosidl_default_generators is technically a <buildtool_depend> (#13)
  rosidl_default_generators is technically a buildtool_depend
* Contributors: Tim Clephas
```
