### PR TITLE
autoware_cmake: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -618,7 +618,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.0.2-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## autoware_cmake

```
* fix(autoware_package.cmake): workaround to avoid missing tinyxml2::tinyxml2 (#24 <https://github.com/autowarefoundation/autoware_cmake/issues/24>)
  * add tinyxml2 workaround
  * move
  ---------
* Contributors: Yutaka Kondo
```

## autoware_lint_common

- No changes
