### PR TITLE
Add adi imu

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -112,6 +112,16 @@ repositories:
       url: https://github.com/analogdevicesinc/iio_ros2.git
       version: humble
     status: maintained
+  adi_imu:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/imu_ros2.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/imu_ros2.git
+      version: humble
+    status: maintained
   adi_tmc_coe:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -90,6 +90,16 @@ repositories:
       url: https://github.com/analogdevicesinc/iio_ros2.git
       version: jazzy
     status: maintained
+  adi_imu:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/imu_ros2.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/imu_ros2.git
+      version: jazzy
+    status: maintained
   ai_prompt_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -90,6 +90,16 @@ repositories:
       url: https://github.com/analogdevicesinc/iio_ros2.git
       version: rolling
     status: maintained
+  adi_imu:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/imu_ros2.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/imu_ros2.git
+      version: rolling
+    status: maintained
   ai_worker:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

`humble` `jazzy` `rolling`

# The source is here:

https://github.com/analogdevicesinc/imu_ros2

## Purpose of using this:

`adi_imu`: a C++ ROS2 node that read sensor data from ADI IMU and publishes message to topic. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
