### PR TITLE
depth_obstacle_detect_ros: 1.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2059,6 +2059,18 @@ repositories:
       version: master
     status: maintained
   depth_obstacle_detect_ros:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git
+      version: noetic-devel
+    release:
+      packages:
+      - depth_obstacle_detect_ros
+      - depth_obstacle_detect_ros_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/anilsripadarao/depth-obstacle-detect-ros-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depth_obstacle_detect_ros` to `1.0.0-1`:

- upstream repository: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git
- release repository: https://github.com/anilsripadarao/depth-obstacle-detect-ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
