### PR TITLE
Update libqt5-core rosdep key for Ubuntu 24.04 (Noble) compatibility

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5888,9 +5888,7 @@ libqt5-core:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu:
-    bionic: [libqt5core5a]
-    focal: [libqt5core5a]
-    jammy: [libqt5core5a]
+    '*': [libqt5core5a]
     noble: [libqt5core5t64]
 libqt5-gstreamer-dev:
   debian: [libqt5gstreamer-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5888,8 +5888,10 @@ libqt5-core:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu:
-    '*': [libqt5core5a]
-    noble: [libqt5core5t64]
+    bionic: [libqt5core5a]
+    focal: [libqt5core5a]
+    jammy: [libqt5core5a]
+    '*': [libqt5core5t64]
 libqt5-gstreamer-dev:
   debian: [libqt5gstreamer-dev]
   ubuntu: [libqt5gstreamer-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5887,7 +5887,11 @@ libqt5-core:
   opensuse: [libQt5Core5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
-  ubuntu: [libqt5core5a]
+  ubuntu:
+    bionic: [libqt5core5a]
+    focal: [libqt5core5a]
+    jammy: [libqt5core5a]
+    noble: [libqt5core5t64]
 libqt5-gstreamer-dev:
   debian: [libqt5gstreamer-dev]
   ubuntu: [libqt5gstreamer-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5888,10 +5888,9 @@ libqt5-core:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu:
-    bionic: [libqt5core5a]
+    '*': [libqt5core5t64]
     focal: [libqt5core5a]
     jammy: [libqt5core5a]
-    '*': [libqt5core5t64]
 libqt5-gstreamer-dev:
   debian: [libqt5gstreamer-dev]
   ubuntu: [libqt5gstreamer-dev]


### PR DESCRIPTION
The libqt5-core rosdep key was mapped to libqt5core5a for all Ubuntu versions, but in Ubuntu 24.04 (Noble), that package no longer exists and has been replaced with libqt5core5t64. As a result, attempting to install this dependency via rosdep on Noble fails. This update fixes the issue by mapping libqt5core5t64 for Noble specifically, while retaining libqt5core5a for earlier Ubuntu releases using a wildcard entry.
Hopefully solves: https://github.com/ros/rosdistro/issues/44826