### PR TITLE
abb: 1.5.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,6 +6,39 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  abb:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: noetic
+    release:
+      packages:
+      - abb
+      - abb_crb15000_support
+      - abb_irb1200_support
+      - abb_irb120_support
+      - abb_irb1600_support
+      - abb_irb2400_support
+      - abb_irb2600_support
+      - abb_irb4400_support
+      - abb_irb4600_support
+      - abb_irb52_support
+      - abb_irb5400_support
+      - abb_irb6600_support
+      - abb_irb6640_support
+      - abb_irb6650s_support
+      - abb_irb6700_support
+      - abb_irb7600_support
+      - abb_resources
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-industrial-release/abb-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/abb.git
+      version: noetic-devel
+    status: maintained
   abb_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `abb` to `1.5.0-1`:

- upstream repository: https://github.com/ros-industrial/abb.git
- release repository: https://github.com/ros-industrial-release/abb-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## abb

```
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Delete deprecated (and broken) IKFast plugin for IRB 2400 (#215 <https://github.com/ros-industrial/abb/issues/215>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Do not release deprecated MoveIt and Gazebo packages.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_crb15000_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb1200_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb120_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb1600_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb2400_support

```
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Remove URDF files from packages: only provide XACROs.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb2600_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb4400_support

```
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb4600_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb52_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb5400_support

```
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Fix joint names in the ``xacro:macro`` (#219 <https://github.com/ros-industrial/abb/issues/219>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Remove URDF files from packages: only provide XACROs.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: Aaryan Murgunde, gavanderhoorn
```

## abb_irb6600_support

```
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Remove URDF files from packages: only provide XACROs.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb6640_support

```
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Remove URDF files from packages: only provide XACROs.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb6650s_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Add preamble to launch files if missing (#220 <https://github.com/ros-industrial/abb/issues/220>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb6700_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_irb7600_support

```
* First release of this package.
* Switch to JSP GUI in all support packages (#221 <https://github.com/ros-industrial/abb/issues/221>).
* Remove ``--inorder`` xacro arg everywhere (#217 <https://github.com/ros-industrial/abb/issues/217>).
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* Promote experimental packages for IRB 52, 120, 1200, 1600, 2600, 4600, 6650s, 6700, 7600 and CRB 15000 to main repository.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```

## abb_resources

```
* Update all manifests and build scripts (#216 <https://github.com/ros-industrial/abb/issues/216>).
* Update maintainers everywhere.
* Add license files and install them.
* Use SPDX license identifiers everywhere.
* For a complete list of changes see the commit log for 1.5.0 <https://github.com/ros-industrial/abb/compare/1.3.1...1.5.0>.
* Contributors: gavanderhoorn
```
