### PR TITLE
Revert "mp2p_icp: 1.6.7-1 in 'noetic/distribution.yaml' [bloom] (#449…

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6400,7 +6400,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mp2p_icp-release.git
-      version: 1.6.7-1
+      version: 1.6.6-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
…74)"

This reverts commit 4a5a0d7e81929cf2e7b244fca6fa069569d7d9d0.

https://github.com/ros/rosdistro/pull/44974 was merged during a Noetic Sync freeze, and appears to not be building on the buildfarm: https://build.ros.org/job/Nbin_uF64__mp2p_icp__ubuntu_focal_amd64__binary/79/ . This PR reverts the release to avoid creating a regression 

@jlblancoc FYI