### PR TITLE
ardrone_sdk and ardrone_sumo from ardrone-ros2 in humble, jazzy and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -590,6 +590,12 @@ repositories:
       url: https://github.com/christianrauch/apriltag_ros.git
       version: master
     status: developed
+  ardrone_ros:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    status: developed
   aruco_markers:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -440,6 +440,12 @@ repositories:
       type: git
       url: https://github.com/ycheng517/ar4_ros_driver.git
       version: main
+  ardrone_ros:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    status: developed
   aruco_markers:
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -428,6 +428,12 @@ repositories:
       url: https://github.com/christianrauch/apriltag_ros.git
       version: master
     status: developed
+  ardrone_ros:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    status: developed
   aruco_markers:
     source:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- ardrone_sdk
- ardrone_sumo

## Package Upstream Source:

https://github.com/vtalpaert/ardrone-ros2

## Purpose of using this:

Parrot released the ARDRONE SDK (ARSDK for short) version 3 almost 9 years ago. Some projects made use for ROS1 notably
- https://github.com/AutonomyLab/parrot_arsdk
- https://github.com/arnaud-ramey/rossumo

Their build process is not suited for release due to the `repo init` which git clones during the installation process.
Instead, we use github actions to build the library into a tarball available for download at
- https://github.com/vtalpaert/ardrone-sdk-native

The proposed packages to index make ARSDK3 available to developers, users should include a `ardrone_sdk` dependency in package.xml/CmakeLists.txt, as showed in the `ardrone_sumo` package.

Note that the build requires an intermediate `arsdk3` package before building `ardrone_sdk` for release

# Please Add This Package to be indexed in the rosdistro.

- humble
- jazzy
- rolling

# The source is here:

https://github.com/vtalpaert/ardrone-ros2

The [license permission from Parrot](https://github.com/Parrot-Developers/ARSDKBuildUtils/blob/master/LICENSE.md) for the SDK is BSD 3. Therefore the `ardrone_sdk` package includes the license file.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
