### PR TITLE
clearpath_mecanum_drive_controller: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1415,7 +1415,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_mecanum_drive_controller-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     status: maintained
   clearpath_msgs:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_mecanum_drive_controller` to `0.1.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_mecanum_drive_controller.git
- release repository: https://github.com/clearpath-gbp/clearpath_mecanum_drive_controller-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## clearpath_mecanum_drive_controller

```
* Fix base_frame_offset uninitialized
* Contributors: Arend-Jan van Hilten
```
