### PR TITLE
laser_geometry: 1.6.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5155,7 +5155,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/laser_geometry-release.git
-      version: 1.6.7-1
+      version: 1.6.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `1.6.8-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros-gbp/laser_geometry-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.7-1`

## laser_geometry

```
* [ROS-O] fix package.xml bugs and compatibility with modern systems (#97 <https://github.com/ros-perception/laser_geometry/issues/97>)
* Reduce boost and eigen dependency scope (#87 <https://github.com/ros-perception/laser_geometry/issues/87>)
* Contributors: Michael Görner, Stephan
```
