### PR TITLE
image_common: 1.12.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4225,7 +4225,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/image_common-release.git
-      version: 1.12.0-1
+      version: 1.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `1.12.1-1`:

- upstream repository: https://github.com/ros-perception/image_common.git
- release repository: https://github.com/ros-gbp/image_common-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.0-1`

## camera_calibration_parsers

```
* Add support for missing CameraInfo.msg fields (#175 <https://github.com/ros-perception/image_common/issues/175>)
* Drop pkg-config logic to find yaml-cpp. (#280 <https://github.com/ros-perception/image_common/issues/280>)
* Contributors: Mike Purvis, UniBwTAS
```

## camera_info_manager

```
* Revert "Virtualize CameraInfoManager  (#234 <https://github.com/ros-perception/image_common/issues/234>)" (#353 <https://github.com/ros-perception/image_common/issues/353>)
  This reverts commit e9c8c3246007d7717708b5267e1e2e909e4c0694.
  It cannot be released into ROS Noetic because it breaks ABI.
* Add support for missing CameraInfo.msg fields (#175 <https://github.com/ros-perception/image_common/issues/175>)
  Co-authored-by: anre <mailto:andreas.reich@unibw.de>
* Virtualize CameraInfoManager  (#234 <https://github.com/ros-perception/image_common/issues/234>)
  * Virtualize CameraInfoManager so custom camera implementations can support flash operations
  * Update camera_info_manager/src/camera_info_manager.cpp
  Co-authored-by: Geoffrey Biggs <mailto:gbiggs@killbots.net>
  * Move function bodies
  Co-authored-by: Geoffrey Biggs <mailto:gbiggs@killbots.net>
* fix linter warnings due to extra ";" after end of namespace braces (#210 <https://github.com/ros-perception/image_common/issues/210>)
* (camera_info_manager) include own dirs before catkin dirs (#199 <https://github.com/ros-perception/image_common/issues/199>)
* Contributors: Bernd Pfrommer, Matthijs van der Burgh, Shane Loretz, UniBwTAS, jdavidberger
```

## image_common

- No changes

## image_transport

```
* Switch to (non deprecated) hpp headers of pluginlib (#244 <https://github.com/ros-perception/image_common/issues/244>)
* Switch to new boost/bind/bind.hpp (#227 <https://github.com/ros-perception/image_common/issues/227>)
* Specifically defined boost filesystem dependency (#223 <https://github.com/ros-perception/image_common/issues/223>)
* Contributors: Jochen Sprickerhof, fraxker
```

## polled_camera

```
* Switch to new boost/bind/bind.hpp (#227 <https://github.com/ros-perception/image_common/issues/227>)
* Contributors: Jochen Sprickerhof
```
