### PR TITLE
Add replay testing pkg to humble, jazzy and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7775,7 +7775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
-      version: humble
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -7784,7 +7784,7 @@ repositories:
     source:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
-      version: humble
+      version: main
     status: maintained
   resource_retriever:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7776,16 +7776,11 @@ repositories:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/polymathrobotics/replay_testing-release.git
-      version: 0.0.1
     source:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
-    status: maintained
+    status: developed
   resource_retriever:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7771,6 +7771,21 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: humble
     status: maintained
+  replay_testing:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/polymathrobotics/replay_testing-release.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: humble
+    status: maintained
   resource_retriever:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5481,6 +5481,21 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: master
     status: maintained
+  replay_testing:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/polymathrobotics/replay_testing-release.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    status: maintained
   resource_retriever:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5481,21 +5481,6 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: master
     status: maintained
-  replay_testing:
-    doc:
-      type: git
-      url: https://github.com/polymathrobotics/replay_testing.git
-      version: main
-    release:
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/polymathrobotics/replay_testing-release.git
-      version: 0.0.1
-    source:
-      type: git
-      url: https://github.com/polymathrobotics/replay_testing.git
-      version: main
-    status: maintained
   resource_retriever:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6658,6 +6658,21 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: jazzy
     status: maintained
+  replay_testing:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/polymathrobotics/replay_testing-release.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    status: maintained
   resource_retriever:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6663,16 +6663,11 @@ repositories:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/polymathrobotics/replay_testing-release.git
-      version: 0.0.1
     source:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
-    status: maintained
+    status: developed
   resource_retriever:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5844,7 +5844,6 @@ repositories:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
-    status: maintained
   resource_retriever:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5840,11 +5840,6 @@ repositories:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/polymathrobotics/replay_testing-release.git
-      version: 0.0.1
     source:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5844,6 +5844,7 @@ repositories:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
+    status: developed
   resource_retriever:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5835,6 +5835,21 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: master
     status: maintained
+  replay_testing:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/polymathrobotics/replay_testing-release.git
+      version: 0.0.1
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    status: maintained
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`replay_testing`

(Currently waiting on a release repo to be created here: https://github.com/ros2-gbp/ros2-gbp-github-org/issues/736)

## Package Upstream Source:

https://github.com/polymathrobotics/replay_testing

## Purpose of using this:

This replay_testing package is useful for general use cases like iterative development and regression testing. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209997465221164