### PR TITLE
interactive_markers: 1.12.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4429,7 +4429,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.12.0-1
+      version: 1.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.12.1-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.0-1`

## interactive_markers

```
* Fixed deadlock (#103 <https://github.com/ros-visualization/interactive_markers/issues/103>)
* Add public function getNames to expose all marker names (#94 <https://github.com/ros-visualization/interactive_markers/issues/94>)
* Add xml-model; Add missing dep on setuptools (#100 <https://github.com/ros-visualization/interactive_markers/issues/100>)
* Update maintainer (#91 <https://github.com/ros-visualization/interactive_markers/issues/91>)
* Contributors: Dharini Dutia, Matthijs van der Burgh, Omid Heidari, g-kurz
```
