### PR TITLE
Add source entries for ros-tooling/graph-monitor

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3215,6 +3215,16 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: ros2-devel
     status: developed
+  graph_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    status: developed
   graph_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2693,6 +2693,16 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: ros2-devel
     status: developed
+  graph_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    status: developed
   graph_msgs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2231,6 +2231,16 @@ repositories:
       url: https://github.com/swri-robotics/gps_umd.git
       version: ros2-devel
     status: developed
+  graph_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    status: developed
   graph_msgs:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

`ros-tooling/graph-monitor`:
- `rosgraph_monitor`
- `rosgraph_monitor_msgs`
- `rmw_stats_shim`

To distros:
- Humble
- Jazzy
- Rolling

Yes, it is a single-branch build to all active distros. See CI https://github.com/ros-tooling/graph-monitor/actions/runs/14367728620 

# The source is here:

https://github.com/ros-tooling/graph-monitor

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
