### PR TITLE
qt_gui_core: 0.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8793,7 +8793,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `0.4.3-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros-gbp/qt_gui_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.2-1`

## qt_dotgraph

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>)
* Contributors: Shane Loretz
```

## qt_gui

```
* Fix 'dict_keys' object not subscriptable (#245 <https://github.com/ros-visualization/qt_gui_core/issues/245>)
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>)
* Allow hide title in standalone (#235 <https://github.com/ros-visualization/qt_gui_core/issues/235>)
* Contributors: Adi Vardi, Michael Jeronimo, Shane Loretz
```

## qt_gui_app

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>)
* Contributors: Shane Loretz
```

## qt_gui_core

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>)
* Contributors: Shane Loretz
```

## qt_gui_cpp

```
* Backport https://github.com/ros-visualization/qt_gui_core/pull/176 (#260 <https://github.com/ros-visualization/qt_gui_core/issues/260>)
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>)
* Contributors: Shane Loretz, Tobias Fischer
```

## qt_gui_py_common

```
* Update Maintainers (#240 <https://github.com/ros-visualization/qt_gui_core/issues/240>)
* Contributors: Shane Loretz
```
