### PR TITLE
Add rosbag2_broll source entries

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8882,6 +8882,17 @@ repositories:
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
     status: maintained
+  rosbag2_broll:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    status: developed
   rosbag2_to_video:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7734,6 +7734,17 @@ repositories:
       version: master
     status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
+  rosbag2_broll:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    status: developed
   rosbag2_to_video:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6866,6 +6866,17 @@ repositories:
       version: master
     status_description: Maintained in source form only since no ROS 1 packages available
       in Rolling
+  rosbag2_broll:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    status: developed
   rosbag2_to_video:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

`rosbag2_broll` repository with packages:
- `broll`
- `rosbag2_storage_broll`

# The source is here:

https://github.com/ros-tooling/rosbag2_broll

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
