### PR TITLE
rqt: 0.5.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10454,7 +10454,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.5.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.3-1`

## rqt

```
* Import setup from setuptools instead of distutils.core (#287 <https://github.com/ros-visualization/rqt/issues/287>)
* Update maintainer (#269 <https://github.com/ros-visualization/rqt/issues/269>)
* Contributors: Arne Hitzmann, Dharini Dutia, quarkytale
```

## rqt_gui

```
* Import setup from setuptools instead of distutils.core (#287 <https://github.com/ros-visualization/rqt/issues/287>)
* Update maintainer (#269 <https://github.com/ros-visualization/rqt/issues/269>)
* Contributors: Arne Hitzmann, Dharini Dutia, quarkytale
```

## rqt_gui_cpp

```
* Use non deprecated pluginlib header (#284 <https://github.com/ros-visualization/rqt/issues/284>)
* Import setup from setuptools instead of distutils.core (#287 <https://github.com/ros-visualization/rqt/issues/287>)
* Update maintainer (#269 <https://github.com/ros-visualization/rqt/issues/269>)
* Contributors: Arne Hitzmann, Dharini Dutia, Jochen Sprickerhof, quarkytale
```

## rqt_gui_py

```
* Import setup from setuptools instead of distutils.core (#287 <https://github.com/ros-visualization/rqt/issues/287>)
* Update maintainer (#269 <https://github.com/ros-visualization/rqt/issues/269>)
* Contributors: Arne Hitzmann, Dharini Dutia, quarkytale
```

## rqt_py_common

```
* Import setup from setuptools instead of distutils.core (#287 <https://github.com/ros-visualization/rqt/issues/287>)
* Update maintainer (#269 <https://github.com/ros-visualization/rqt/issues/269>)
* Contributors: Arne Hitzmann, Dharini Dutia, quarkytale
```
