### PR TITLE
rqt_action: 0.4.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10469,7 +10469,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_action-release.git
-      version: 0.4.9-1
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `0.4.10-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros-gbp/rqt_action-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.9-1`

## rqt_action

```
* Import setup from setuptools instead of distutils.core (#15 <https://github.com/ros-visualization/rqt_action/issues/15>)
* Update Maintainers (#10 <https://github.com/ros-visualization/rqt_action/issues/10>)
* Fix linting (#3 <https://github.com/ros-visualization/rqt_action/issues/3>)
* Contributors: Arne Hitzmann, David V. Lu!!, Dirk Thomas, Mabel Zhang, Matthijs van der Burgh, Mike Lautman
```
