### PR TITLE
rqt_bag: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10487,7 +10487,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `0.5.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros-gbp/rqt_bag-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.1-1`

## rqt_bag

```
* Import setup from setuptools instead of distutils.core (#137 <https://github.com/ros-visualization/rqt_bag/issues/137>)
* Contributors: Arne Hitzmann, Matthijs van der Burgh
```

## rqt_bag_plugins

```
* Import setup from setuptools instead of distutils.core (#137 <https://github.com/ros-visualization/rqt_bag/issues/137>)
* Contributors: Arne Hitzmann, Matthijs van der Burgh
```
