### PR TITLE
rqt_dep: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10533,7 +10533,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_dep-release.git
-      version: 0.4.12-1
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_dep.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dep` to `0.4.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_dep.git
- release repository: https://github.com/ros-gbp/rqt_dep-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.12-1`

## rqt_dep

```
* Import setup from setuptools instead of distutils.core (#18 <https://github.com/ros-visualization/rqt_dep/issues/18>)
* Contributors: Arne Hitzmann, Matthijs van der Burgh
```
