### PR TITLE
rqt_image_view: 0.4.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10593,7 +10593,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_image_view-release.git
-      version: 0.4.17-1
+      version: 0.4.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `0.4.18-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros-gbp/rqt_image_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.17-1`

## rqt_image_view

```
* [ROS-O] no longer use c++11 (#72 <https://github.com/ros-visualization/rqt_image_view/issues/72>)
* Contributors: Lucas Walter, Matthijs van der Burgh
```
