### PR TITLE
rqt_pose_view: 0.5.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10709,7 +10709,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pose_view-release.git
-      version: 0.5.11-1
+      version: 0.5.12-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pose_view` to `0.5.12-1`:

- upstream repository: https://github.com/ros-visualization/rqt_pose_view.git
- release repository: https://github.com/ros-gbp/rqt_pose_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.11-1`

## rqt_pose_view

```
* Import setup from setuptools instead of distutils.core (#9 <https://github.com/ros-visualization/rqt_pose_view/issues/9>)
* Update maintainers (#8 <https://github.com/ros-visualization/rqt_pose_view/issues/8>)
* Contributors: Arne Hitzmann, David V. Lu!!, Matthijs van der Burgh, Shane Loretz
```
