### PR TITLE
rqt_publisher: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10739,7 +10739,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_publisher-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros-gbp/rqt_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.10-1`

## rqt_publisher

```
* Import setup from setuptools instead of distutils.core (#37 <https://github.com/ros-visualization/rqt_publisher/issues/37>)
* Update maintainers #32 <https://github.com/ros-visualization/rqt_publisher/issues/32>
* Contributors: Arne Hitzmann, Geoffrey Biggs, Matthijs van der Burgh
```
