### PR TITLE
rqt_reconfigure: 0.5.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10784,7 +10784,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_reconfigure-release.git
-      version: 0.5.5-1
+      version: 0.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `0.5.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros-gbp/rqt_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.5-1`

## rqt_reconfigure

```
* Add xml-model (#125 <https://github.com/ros-visualization/rqt_reconfigure/issues/125>)
* Update maintainer (#114 <https://github.com/ros-visualization/rqt_reconfigure/issues/114>)
* Contributors: Dharini Dutia, Matthijs van der Burgh, quarkytale
```
