### PR TITLE
rqt_top: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10954,7 +10954,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_top-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_top.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_top` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_top.git
- release repository: https://github.com/ros-gbp/rqt_top-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.10-1`

## rqt_top

```
* Import setup from setuptools instead of distutils.core (#16 <https://github.com/ros-visualization/rqt_top/issues/16>)
* Contributors: Arne Hitzmann
```
