### PR TITLE
rqt_topic: 0.4.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10969,7 +10969,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_topic-release.git
-      version: 0.4.13-1
+      version: 0.4.14-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `0.4.14-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros-gbp/rqt_topic-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.13-1`

## rqt_topic

```
* Import setup from setuptools instead of distutils.core (#44 <https://github.com/ros-visualization/rqt_topic/issues/44>)
* Contributors: Arne Hitzmann, David V. Lu!!, Matthijs van der Burgh
```
