### PR TITLE
rqt_web: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10984,7 +10984,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_web-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_web.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_web` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_web.git
- release repository: https://github.com/ros-gbp/rqt_web-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.10-1`

## rqt_web

```
* Import setup from setuptools instead of distutils.core (#6 <https://github.com/ros-visualization/rqt_web/issues/6>)
* Update maintainers (#5 <https://github.com/ros-visualization/rqt_web/issues/5>)
* Contributors: Arne Hitzmann, David V. Lu!!, Matthijs van der Burgh, Shane Loretz
```
