### PR TITLE
visualization_tutorials: 0.11.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13093,7 +13093,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.11.1-1`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.11.0-1`

## interactive_marker_tutorials

```
* print_function for py3 (#61 <https://github.com/ros-visualization/visualization_tutorials/issues/61>)
* Update maintainers (#63 <https://github.com/ros-visualization/visualization_tutorials/issues/63>)
* Contributors: Mabel Zhang, Tobias Fischer
```

## librviz_tutorial

```
* Update maintainers (#63 <https://github.com/ros-visualization/visualization_tutorials/issues/63>)
* Contributors: Mabel Zhang
```

## rviz_plugin_tutorials

```
* Update maintainers (#63 <https://github.com/ros-visualization/visualization_tutorials/issues/63>)
* Contributors: Mabel Zhang
```

## rviz_python_tutorial

```
* Update maintainers (#63 <https://github.com/ros-visualization/visualization_tutorials/issues/63>)
* Contributors: Mabel Zhang
```

## visualization_marker_tutorials

```
* Update maintainers (#63 <https://github.com/ros-visualization/visualization_tutorials/issues/63>)
* Contributors: Mabel Zhang
```

## visualization_tutorials

```
* Update maintainers (#63 <https://github.com/ros-visualization/visualization_tutorials/issues/63>)
* Contributors: Mabel Zhang
```
