### PR TITLE
ros2_control: 4.28.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7271,7 +7271,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.27.0-1
+      version: 4.28.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.28.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.27.0-1`

## controller_interface

```
* Make all packages use gmock, not gtest (#2162 <https://github.com/ros-controls/ros2_control/issues/2162>)
* Fix async controllers deactivation regime (#2017 <https://github.com/ros-controls/ros2_control/issues/2017>)
* Bump version of pre-commit hooks (#2156 <https://github.com/ros-controls/ros2_control/issues/2156>)
* Use ros2_control_cmake (#2134 <https://github.com/ros-controls/ros2_control/issues/2134>)
* [Handle] Add support for booleans in the handles (#2065 <https://github.com/ros-controls/ros2_control/issues/2065>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota, Soham Patil, github-actions[bot]
```

## controller_manager

```
* Integrate joint limit enforcement into ros2_control framework functional with Async controllers and components  (#2047 <https://github.com/ros-controls/ros2_control/issues/2047>)
* Make all packages use gmock, not gtest (#2162 <https://github.com/ros-controls/ros2_control/issues/2162>)
* Fix async controllers deactivation regime (#2017 <https://github.com/ros-controls/ros2_control/issues/2017>)
* apply pre-commit changes (#2160 <https://github.com/ros-controls/ros2_control/issues/2160>)
* Add tests for multiple controller ros args (#2155 <https://github.com/ros-controls/ros2_control/issues/2155>)
* Bump version of pre-commit hooks (#2156 <https://github.com/ros-controls/ros2_control/issues/2156>)
* Allow for multiple controller-ros-args arguments in spawner.py (#2150 <https://github.com/ros-controls/ros2_control/issues/2150>)
* Update rqt_controller_manager controller state color scheme to match list_controllers color scheme (#2143 <https://github.com/ros-controls/ros2_control/issues/2143>)
* Fix generate_controllers_spawner_launch_description_from_dict (#2146 <https://github.com/ros-controls/ros2_control/issues/2146>)
* Use ros2_control_cmake (#2134 <https://github.com/ros-controls/ros2_control/issues/2134>)
* [Docs] Update determinism section (#2131 <https://github.com/ros-controls/ros2_control/issues/2131>)
* Remove the dangling param flag for robot_description fom ROS parameters (#2115 <https://github.com/ros-controls/ros2_control/issues/2115>)
* [Doc] Add documentation of different controller manager clocks (#2109 <https://github.com/ros-controls/ros2_control/issues/2109>)
* [CM] Extend the list controller and hardware components messages (#2102 <https://github.com/ros-controls/ros2_control/issues/2102>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Reject duplicate state/command interfaces after configuring the controller  (#2090 <https://github.com/ros-controls/ros2_control/issues/2090>)
* [CM] Add message field to the switch_controller service (#2088 <https://github.com/ros-controls/ros2_control/issues/2088>)
* Update doc: async update support for controller (#2096 <https://github.com/ros-controls/ros2_control/issues/2096>)
* Use monotonic clock for triggering read-update-write cycles + fix for overruns (#2046 <https://github.com/ros-controls/ros2_control/issues/2046>)
* Add some logging for unload_on_kill keyboard interrupt (#2097 <https://github.com/ros-controls/ros2_control/issues/2097>)
* [CM] Add controller_manager activity topic (#2006 <https://github.com/ros-controls/ros2_control/issues/2006>)
* Improve diagnostics strings (#2078 <https://github.com/ros-controls/ros2_control/issues/2078>)
* Contributors: Bence Magyar, Christoph Fröhlich, Julia Jia, Sai Kishor Kothakota, Soham Patil, danielcostanzi18, github-actions[bot]
```

## controller_manager_msgs

```
* [CM] Extend the list controller and hardware components messages (#2102 <https://github.com/ros-controls/ros2_control/issues/2102>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* [CM] Add message field to the switch_controller service (#2088 <https://github.com/ros-controls/ros2_control/issues/2088>)
* [CM] Add controller_manager activity topic (#2006 <https://github.com/ros-controls/ros2_control/issues/2006>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## hardware_interface

```
* [HW Interface] Use new handle API inside the hardware components (#2092 <https://github.com/ros-controls/ros2_control/issues/2092>)
* Integrate joint limit enforcement into ros2_control framework functional with Async controllers and components  (#2047 <https://github.com/ros-controls/ros2_control/issues/2047>)
* Make all packages use gmock, not gtest (#2162 <https://github.com/ros-controls/ros2_control/issues/2162>)
* Bump version of pre-commit hooks (#2156 <https://github.com/ros-controls/ros2_control/issues/2156>)
* [RM] Add error handling for missing plugin tags in URDF parsing (#2138 <https://github.com/ros-controls/ros2_control/issues/2138>)
* Use ros2_control_cmake (#2134 <https://github.com/ros-controls/ros2_control/issues/2134>)
* [Handle] Add support for booleans in the handles (#2065 <https://github.com/ros-controls/ros2_control/issues/2065>)
* Docs: Remove link to gazebo_ros2_control (#2106 <https://github.com/ros-controls/ros2_control/issues/2106>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Use monotonic clock for triggering read-update-write cycles + fix for overruns (#2046 <https://github.com/ros-controls/ros2_control/issues/2046>)
* [RM] Fix skipped cycles by adjusting rw_rate handling (#2091 <https://github.com/ros-controls/ros2_control/issues/2091>)
* [CM] Add controller_manager activity topic (#2006 <https://github.com/ros-controls/ros2_control/issues/2006>)
* Improve API/lifecycle docs (#2081 <https://github.com/ros-controls/ros2_control/issues/2081>)
* Contributors: Bence Magyar, Christoph Fröhlich, Mehul Anand, RobertWilbrandt, Sai Kishor Kothakota, Soham Patil, github-actions[bot]
```

## hardware_interface_testing

```
* Integrate joint limit enforcement into ros2_control framework functional with Async controllers and components  (#2047 <https://github.com/ros-controls/ros2_control/issues/2047>)
* Make all packages use gmock, not gtest (#2162 <https://github.com/ros-controls/ros2_control/issues/2162>)
* Bump version of pre-commit hooks (#2156 <https://github.com/ros-controls/ros2_control/issues/2156>)
* Use ros2_control_cmake (#2134 <https://github.com/ros-controls/ros2_control/issues/2134>)
* [Handle] Add support for booleans in the handles (#2065 <https://github.com/ros-controls/ros2_control/issues/2065>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* [RM] Fix skipped cycles by adjusting rw_rate handling (#2091 <https://github.com/ros-controls/ros2_control/issues/2091>)
* Contributors: Bence Magyar, Christoph Fröhlich, RobertWilbrandt, Sai Kishor Kothakota, Soham Patil, github-actions[bot]
```

## joint_limits

```
* Integrate joint limit enforcement into ros2_control framework functional with Async controllers and components  (#2047 <https://github.com/ros-controls/ros2_control/issues/2047>)
* Change to ament_add_gmock in joint_limits (#2165 <https://github.com/ros-controls/ros2_control/issues/2165>)
* Make all packages use gmock, not gtest (#2162 <https://github.com/ros-controls/ros2_control/issues/2162>)
* Use ros2_control_cmake (#2134 <https://github.com/ros-controls/ros2_control/issues/2134>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota, Soham Patil
```

## ros2_control

```
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Contributors: Bence Magyar
```

## ros2_control_test_assets

```
* Integrate joint limit enforcement into ros2_control framework functional with Async controllers and components  (#2047 <https://github.com/ros-controls/ros2_control/issues/2047>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## ros2controlcli

```
* [CLI] print update_rate and is_async on verbose (#2126 <https://github.com/ros-controls/ros2_control/issues/2126>)
* [CM] Extend the list controller and hardware components messages (#2102 <https://github.com/ros-controls/ros2_control/issues/2102>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* [CM] Add message field to the switch_controller service (#2088 <https://github.com/ros-controls/ros2_control/issues/2088>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## rqt_controller_manager

```
* Update rqt_controller_manager controller state color scheme to match list_controllers color scheme (#2143 <https://github.com/ros-controls/ros2_control/issues/2143>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Contributors: Bence Magyar, Soham Patil
```

## transmission_interface

```
* Make all packages use gmock, not gtest (#2162 <https://github.com/ros-controls/ros2_control/issues/2162>)
* Use ros2_control_cmake (#2134 <https://github.com/ros-controls/ros2_control/issues/2134>)
* Improve package descriptions & update maintainers (#2103 <https://github.com/ros-controls/ros2_control/issues/2103>)
* Contributors: Bence Magyar, Christoph Fröhlich, Soham Patil
```
