### PR TITLE
removed libcaer (obsolete)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4393,21 +4393,6 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
-  libcaer:
-    doc:
-      type: git
-      url: https://github.com/ros-event-camera/libcaer.git
-      version: ros_event_camera
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/libcaer-release.git
-      version: 1.1.2-2
-    source:
-      type: git
-      url: https://github.com/ros-event-camera/libcaer.git
-      version: ros_event_camera
-    status: developed
   libcaer_driver:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3880,21 +3880,6 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
-  libcaer:
-    doc:
-      type: git
-      url: https://github.com/ros-event-camera/libcaer.git
-      version: ros_event_camera
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/libcaer-release.git
-      version: 1.0.2-3
-    source:
-      type: git
-      url: https://github.com/ros-event-camera/libcaer.git
-      version: ros_event_camera
-    status: developed
   libcaer_driver:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3370,21 +3370,6 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
-  libcaer:
-    doc:
-      type: git
-      url: https://github.com/ros-event-camera/libcaer.git
-      version: ros_event_camera
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/libcaer-release.git
-      version: 1.0.2-2
-    source:
-      type: git
-      url: https://github.com/ros-event-camera/libcaer.git
-      version: ros_event_camera
-    status: developed
   libcaer_driver:
     doc:
       type: git


### PR DESCRIPTION
The libcaer package needs to be removed from rosdistro as it is now obsolete because it has been replaced by libcaer_vendor.
