### PR TITLE
ros2_control: 2.50.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8433,7 +8433,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.49.0-1
+      version: 2.50.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.50.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.49.0-1`

## controller_interface

```
* Bump version of pre-commit hooks (backport #2156 <https://github.com/ros-controls/ros2_control/issues/2156>) (#2157 <https://github.com/ros-controls/ros2_control/issues/2157>)
* Trigger shutdown transition in destructor (backport #1979 <https://github.com/ros-controls/ros2_control/issues/1979>) (#2142 <https://github.com/ros-controls/ros2_control/issues/2142>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Bump version of pre-commit hooks (backport #2156 <https://github.com/ros-controls/ros2_control/issues/2156>) (#2157 <https://github.com/ros-controls/ros2_control/issues/2157>)
* Fix generate_controllers_spawner_launch_description_from_dict (#2146 <https://github.com/ros-controls/ros2_control/issues/2146>) (#2148 <https://github.com/ros-controls/ros2_control/issues/2148>)
* Fix ~/robot_description in docs
* Fix documentation of robot_description in CM (#2117 <https://github.com/ros-controls/ros2_control/issues/2117>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Bump version of pre-commit hooks (backport #2156 <https://github.com/ros-controls/ros2_control/issues/2156>) (#2157 <https://github.com/ros-controls/ros2_control/issues/2157>)
* [RM] Add error handling for missing plugin tags in URDF parsing (backport #2138 <https://github.com/ros-controls/ros2_control/issues/2138>) (#2145 <https://github.com/ros-controls/ros2_control/issues/2145>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Bump version of pre-commit hooks (backport #2156 <https://github.com/ros-controls/ros2_control/issues/2156>) (#2157 <https://github.com/ros-controls/ros2_control/issues/2157>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Trigger shutdown transition in destructor (backport #1979 <https://github.com/ros-controls/ros2_control/issues/1979>) (#2142 <https://github.com/ros-controls/ros2_control/issues/2142>)
* Add header to import limits from standard URDF definition (backport #1298 <https://github.com/ros-controls/ros2_control/issues/1298>) (#2125 <https://github.com/ros-controls/ros2_control/issues/2125>)
* Contributors: Sebastian Castro, mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
