### PR TITLE
ros2_controllers: 2.44.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8473,7 +8473,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.43.0-1
+      version: 2.44.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.44.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.43.0-1`

## ackermann_steering_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## admittance_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

```
* Replace RCLCPP_*_STREAM macros with RCLCPP_* (backport #1600 <https://github.com/ros-controls/ros2_controllers/issues/1600>) (#1602 <https://github.com/ros-controls/ros2_controllers/issues/1602>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Replace RCLCPP_*_STREAM macros with RCLCPP_* (backport #1600 <https://github.com/ros-controls/ros2_controllers/issues/1600>) (#1602 <https://github.com/ros-controls/ros2_controllers/issues/1602>)
* [jtc tests] avoid dangling ref of command / state interfaces (backport #1596 <https://github.com/ros-controls/ros2_controllers/issues/1596>) (#1597 <https://github.com/ros-controls/ros2_controllers/issues/1597>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## pid_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Fix open-loop odometry in case of ref timeout (backport #1454 <https://github.com/ros-controls/ros2_controllers/issues/1454>) (#1460 <https://github.com/ros-controls/ros2_controllers/issues/1460>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

```
* Bump version of pre-commit hooks (backport #1618 <https://github.com/ros-controls/ros2_controllers/issues/1618>) (#1620 <https://github.com/ros-controls/ros2_controllers/issues/1620>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
