### PR TITLE
catkin: 0.8.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -882,7 +882,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.10-1
+      version: 0.8.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.11-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.10-1`

## catkin

```
* Port symlink_install fixes from ament_cmake to catkin (#1199 <https://github.com/ros/catkin/issues/1199>)
* Fix symlink install versioned shared library (#1197 <https://github.com/ros/catkin/issues/1197>)
* Default to number of usable CPUs if possible (#1180 <https://github.com/ros/catkin/issues/1180>)
* Fix non-atomic atomic_configure_file (#1150 <https://github.com/ros/catkin/issues/1150>)
* Fix typo in docstring (#1172 <https://github.com/ros/catkin/issues/1172>)
* Add native support to fish shell (#1168 <https://github.com/ros/catkin/issues/1168>)
* Update package maintainers (#1157 <https://github.com/ros/catkin/issues/1157>)
* Fix catkin_install_python(): ignore whitespaces in shebang (#1156 <https://github.com/ros/catkin/issues/1156>)
* Fix typo (#1147 <https://github.com/ros/catkin/issues/1147>)
* Contributors: Felipe Gomes de Melo, G.A. vd. Hoorn, Gašper Simonič, Geoffrey Biggs, Matthijs van der Burgh, Scott K Logan, Tully Foote, wico-silva, zig-for
```
