### PR TITLE
class_loader: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -941,7 +941,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.5.1-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-1`

## class_loader

```
* Declare newly-required boost component (#208 <https://github.com/ros/class_loader/issues/208>)
* Resolve symlinks fully before loading the library. (#207 <https://github.com/ros/class_loader/issues/207>)
* Include library name into library unload exceptions to make debugging easier. (#194 <https://github.com/ros/class_loader/issues/194>)
* Switch to new boost/bind/bind.hpp (#193 <https://github.com/ros/class_loader/issues/193>)
* Fix spelling mistake (#183 <https://github.com/ros/class_loader/issues/183>)
* Update package maintainers. (#170 <https://github.com/ros/class_loader/issues/170>)
* Contributors: David V. Lu!!, Ivor Wanders, Jochen Sprickerhof, Michael Görner, Michel Hidalgo, Remo Diethelm
```
