### PR TITLE
cmake_modules: 0.5.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1072,7 +1072,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/cmake_modules-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cmake_modules` to `0.5.1-1`:

- upstream repository: https://github.com/ros/cmake_modules.git
- release repository: https://github.com/ros-gbp/cmake_modules-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-1`

## cmake_modules

```
* Update maintainers (#53 <https://github.com/ros/cmake_modules/issues/53>)
* 0.5 Noetic release only (#52 <https://github.com/ros/cmake_modules/issues/52>)
* Contributors: Mabel Zhang, Shane Loretz
```
