### PR TITLE
dynamic_reconfigure: 1.7.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2375,7 +2375,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.7.3-1
+      version: 1.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.7.4-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.3-1`

## dynamic_reconfigure

```
* Remove roslib.load_manifest (#201 <https://github.com/ros/dynamic_reconfigure/issues/201>)
* Fix unsafe yaml load on dynparam (#202 <https://github.com/ros/dynamic_reconfigure/issues/202>)
* Set ns as '~' when namespace is '~' (#169 <https://github.com/ros/dynamic_reconfigure/issues/169>)
* Support float('inf') for cfg file (#168 <https://github.com/ros/dynamic_reconfigure/issues/168>)
* Add BSD LICENSE file (#193 <https://github.com/ros/dynamic_reconfigure/issues/193>)
* Contributors: Florencia, Shane Loretz, Shingo Kitagawa, Yuki Furuta
```
