### PR TITLE
filters: 1.9.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3102,7 +3102,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/filters-release.git
-      version: 1.9.2-1
+      version: 1.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `1.9.3-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros-gbp/filters-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.9.2-1`

## filters

```
* [ROS-O] update pluginlib include names (#64 <https://github.com/ros/filters/issues/64>)
* [ROS-O] remove obsolete register keyword (#63 <https://github.com/ros/filters/issues/63>)
* Contributors: Jonathan Binney, v4hn
```
