### PR TITLE
genpy: 0.6.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3591,7 +3591,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.15-1
+      version: 0.6.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.17-1`:

- upstream repository: https://github.com/ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.15-1`

## genpy

```
* Fix bug in reduce_pattern (#152 <https://github.com/ros/genpy/issues/152>)
* Update maintainers (#144 <https://github.com/ros/genpy/issues/144>)
* Fix typos discovered by codespell (#142 <https://github.com/ros/genpy/issues/142>)
* (docs) Add automodule (#143 <https://github.com/ros/genpy/issues/143>)
* Contributors: Christian Clauss, Geoffrey Biggs, Matthijs van der Burgh, bigolol
```
