### PR TITLE
clearpath_tests: 2.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1197,7 +1197,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_tests-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_tests.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_tests` to `2.3.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_tests.git
- release repository: https://github.com/clearpath-gbp/clearpath_tests-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## clearpath_tests

```
* Fix a bug where the e-stop test could cause the test node to crash
* Add a 2s delay between clearing the e-stop and moving the wheels to allow CAN reconnections as needed
* Remove CAN device ID count for platforms that don't use CANopen
* Lower the time threshold for linear drive test to 0.75 (from 0.8)
* Change the default serial device for Jackal
* Contributors: Chris Iverach-Brereton
```
