### PR TITLE
geometry_tutorials: 0.2.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3695,7 +3695,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry_tutorials-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry_tutorials` to `0.2.4-1`:

- upstream repository: https://github.com/ros/geometry_tutorials
- release repository: https://github.com/ros-gbp/geometry_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-1`

## geometry_tutorials

- No changes

## turtle_tf

```
* Do away with boost::bind (#86 <https://github.com/ros/geometry_tutorials/issues/86>)
* Contributors: Michael Görner
```

## turtle_tf2

```
* Do away with boost::bind (#86 <https://github.com/ros/geometry_tutorials/issues/86>)
* Contributors: Michael Görner
```
