### PR TITLE
geometry2: 0.7.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3675,7 +3675,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/geometry2-release.git
-      version: 0.7.7-1
+      version: 0.7.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.7.8-1`:

- upstream repository: https://github.com/ros/geometry_experimental.git
- release repository: https://github.com/ros-gbp/geometry2-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.7-1`

## geometry2

- No changes

## tf2

```
* Longer char array for null termination needed  (#514 <https://github.com/ros/geometry2/issues/514>)
* Fixed error message when fixed_frame is not found (#559 <https://github.com/ros/geometry2/issues/559>)
* Add missing #include to buffer_core.cpp (#558 <https://github.com/ros/geometry2/issues/558>)
* Contributors: Lucas Walter, Martin Pecka, vslashg
```

## tf2_bullet

```
* Use only find_package to find bullet3. (#553 <https://github.com/ros/geometry2/issues/553>)
* Contributors: Mike Purvis
```

## tf2_eigen

- No changes

## tf2_geometry_msgs

```
* Add torque due to force offset (#554 <https://github.com/ros/geometry2/issues/554>)
* Contributors: Michael Görner
```

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

```
* Replace deprecated PyEval_CallObject in tf2_py (#575 <https://github.com/ros/geometry2/issues/575>)
* Contributors: Ken
```

## tf2_ros

```
* Fix typos in error messages of buffer_interface.py (#489 <https://github.com/ros/geometry2/issues/489>)
* Contributors: Michael Grupp
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
