### PR TITLE
joint_state_publisher: 1.15.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4682,7 +4682,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.15.1-1
+      version: 1.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `1.15.2-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros-gbp/joint_state_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.15.1-1`

## joint_state_publisher

- No changes

## joint_state_publisher_gui

```
* Show 3 decimal places of joint angle (#91 <https://github.com/ros/joint_state_publisher/issues/91>)
* Enforce int type for slider values (#77 <https://github.com/ros/joint_state_publisher/issues/77>)
* Contributors: Michael Görner, VideoSystemsTech
```
