### PR TITLE
pluginlib: 1.13.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8040,7 +8040,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.13.0-1
+      version: 1.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.13.1-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.13.0-1`

## pluginlib

```
* Documented possible exception being thrown in ClassLoader destructor. (#234 <https://github.com/ros/pluginlib/issues/234>)
* Avoid throwing on symlink loops. (#244 <https://github.com/ros/pluginlib/issues/244>)
* Drop unused include (#233 <https://github.com/ros/pluginlib/issues/233>)
* Use ifdef instead of if for win32 (#238 <https://github.com/ros/pluginlib/issues/238>)
* Contributors: Ivor Wanders, Jochen Sprickerhof, Matthijs van der Burgh, Remo Diethelm
```
