### PR TITLE
resource_retriever: 1.12.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9200,7 +9200,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.8-1
+      version: 1.12.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.9-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.8-1`

## resource_retriever

```
* use CURL::libcurl instead of ${CURL_LIBRARIES} in cmakelists.txt (#102 <https://github.com/ros/resource_retriever/issues/102>)
* change to setuptools in accordance with migration guide (#83 <https://github.com/ros/resource_retriever/issues/83>)
* Contributors: Arne Hitzmann, Lucas Walter
```
