### PR TITLE
robot_state_publisher: 1.15.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9500,7 +9500,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_state_publisher-release.git
-      version: 1.15.2-1
+      version: 1.15.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `1.15.3-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros-gbp/robot_state_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.15.2-1`

## robot_state_publisher

```
* Drop CXX standards for log4cxx (#190 <https://github.com/ros/robot_state_publisher/issues/190>)
* Added launch parameter for listener queue size. (#222 <https://github.com/ros/robot_state_publisher/issues/222>)
* Upgrade to C++17 for compatibility with Eigen 3.40.90 (#208 <https://github.com/ros/robot_state_publisher/issues/208>)
* Contributors: Jochen Sprickerhof, JoeOnderko, daizhirui
```
