### PR TITLE
ros: 1.15.9-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9637,7 +9637,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.8-1
+      version: 1.15.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.9-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.15.8-1`

## mk

- No changes

## ros

- No changes

## rosbash

```
* roszsh: Fix rosmv completion (#280 <https://github.com/ros/ros/issues/280>)
* Keep rosed from running if the file doesn't exist in the package (#278 <https://github.com/ros/ros/issues/278>)
* Contributors: Timon Engelke
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* Fix typos (#306 <https://github.com/ros/ros/issues/306>)
* Contributors: Yang Hau
```

## rosmake

```
* Fix typos (#306 <https://github.com/ros/ros/issues/306>)
* Contributors: Yang Hau
```

## rosunit

- No changes
