### PR TITLE
ros_comm_msgs: 1.11.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9739,7 +9739,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm_msgs-release.git
-      version: 1.11.3-1
+      version: 1.11.4-1
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm_msgs` to `1.11.4-1`:

- upstream repository: https://github.com/ros/ros_comm_msgs.git
- release repository: https://github.com/ros-gbp/ros_comm_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.11.3-1`

## rosgraph_msgs

```
* Update maintainers (#12 <https://github.com/ros/ros_comm_msgs/issues/12>)
* Contributors: Michel Hidalgo
```

## std_srvs

```
* Update maintainers (#12 <https://github.com/ros/ros_comm_msgs/issues/12>)
* Contributors: Michel Hidalgo
```
