### PR TITLE
rosbag_migration_rule: 1.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10071,11 +10071,15 @@ repositories:
       version: master
     status: developed
   rosbag_migration_rule:
+    doc:
+      type: git
+      url: https://github.com/ros/rosbag_migration_rule.git
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros/rosbag_migration_rule.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_migration_rule` to `1.0.2-1`:

- upstream repository: https://github.com/ros/rosbag_migration_rule.git
- release repository: https://github.com/ros-gbp/rosbag_migration_rule-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-1`

## rosbag_migration_rule

```
* Update maintainers (#2 <https://github.com/ros/rosbag_migration_rule/issues/2>)
* Contributors: Michel Hidalgo
```
