### PR TITLE
rosconsole: 1.14.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10183,7 +10183,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rosconsole-release.git
-      version: 1.14.3-1
+      version: 1.14.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosconsole` to `1.14.4-1`:

- upstream repository: https://github.com/ros/rosconsole.git
- release repository: https://github.com/ros-gbp/rosconsole-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.14.3-1`

## rosconsole

```
* Finding boost dependencies is now required. (#47 <https://github.com/ros/rosconsole/issues/47>)
* Remove undesired blank spaces (#52 <https://github.com/ros/rosconsole/issues/52>)
* Contributors: H Singh, Zheng Qu
```
