### PR TITLE
std_msgs: 0.5.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12003,7 +12003,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/std_msgs-release.git
-      version: 0.5.13-1
+      version: 0.5.14-1
     source:
       type: git
       url: https://github.com/ros/std_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `std_msgs` to `0.5.14-1`:

- upstream repository: git@github.com:ros/std_msgs.git
- release repository: https://github.com/ros-gbp/std_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.13-1`

## std_msgs

```
* Update package maintainers. (#16 <https://github.com/ros/std_msgs/issues/16>)
* Contributors: Michel Hidalgo
```
