### PR TITLE
Adding libaditof to Jazzy and humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4393,6 +4393,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libaditof:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/libaditof.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/libaditof.git
+      version: main
+    status: maintained
   libcaer:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3880,6 +3880,16 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libaditof:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/libaditof.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/libaditof.git
+      version: main
+    status: maintained
   libcaer:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
libaditof
## Package Upstream Source:
[analogdevicesinc/libaditof](https://github.com/analogdevicesinc/libaditof)
## Purpose of using this:
Provides a SDK for using ADSD3100 sensor based time of flight devices.


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
    - Please refer to #44883 regarding our stance on licensing. We currently will not add a binary release tag until we have converted submodules to system based dependencies.
 - [x] This package is expected to build on the submitted rosdistro
