### PR TITLE
Adding adi_3dtof_adtf31xx package to ROS index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -77,6 +77,16 @@ repositories:
       url: https://github.com/ros-acceleration/adaptive_component.git
       version: rolling
     status: developed
+  adi_3dtof_adtf31xx:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_adtf31xx.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_adtf31xx.git
+      version: humble-devel
+    status: maintained
   adi_3dtof_image_stitching:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -108,6 +108,16 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: noetic-devel
     status: maintained
+  adi_3dtof_adtf31xx:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_adtf31xx.git
+      version: noetic-devel
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_adtf31xx.git
+      version: noetic-devel
+    status: maintained
   adi_3dtof_image_stitching:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
adi_3dtof_adtf31xx

## Package Upstream Source:
[analogdevicesinc/adi_3dtof_adtf31xx](https://github.com/analogdevicesinc/adi_3dtof_adtf31xx)

## Purpose of using this:
ROS package for using the libaditof SDK for reading depth images from ADTF3175D Time of Flight Sensors.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
   - Package has a dependency of libaditof, PR for which is raised in #45116 . This dependency needs to be built from source within the same workspace.
