### PR TITLE
yasmin: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9327,7 +9327,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `3.2.0-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-1`

## yasmin

```
* Fix python YASMIN_LOG_ERROR method (#51 <https://github.com/uleroboticsgroup/yasmin/issues/51>)
* fixing c++ version in CMakeLists
* Add Concurrence - Running Parallel/Concurrent States (#50 <https://github.com/uleroboticsgroup/yasmin/issues/50>)
  * add concurrence state
  * add mutex for intermedaite state dict
  * prefix self vars with underscore
  * add concurrence str definition
  * add comment docs conform 120 character limit
  * fix init comment on concurrence
  * fix str gen for concurrence
  * replace state string representation as outcome map key with an integer alternative
  * add logic and tests to protect against running a state instance concurrently with itself
  * add newlines at end of files
  * verify intermedaite state outcome registration
  * add untested cpp implementation
  * fix compile warnings and add a demo
  * add licensing
  * run clang format on c files
  * run black format on py files
  * add python demo for concurrence
  * adjust to match python demo better
  ---------
  Co-authored-by: William Freidank <mailto:william.freidank@gtri.gatech.edu>
* Set remappings as empty dict instead of None (#49 <https://github.com/uleroboticsgroup/yasmin/issues/49>)
* adding remapping to C++ version
* Feat/remmaping (#47 <https://github.com/uleroboticsgroup/yasmin/issues/47>)
  * started remmaping
  * remmaping working with demo
  * reformated with black
  * formated again with --line-length 90
  * added remap documentation to the code
* Contributors: LuisMilczarek, Miguel Ángel González Santamarta, Noel Jiménez García, William Freidank
```

## yasmin_demos

```
* fixing c++ version in CMakeLists
* Add Concurrence - Running Parallel/Concurrent States (#50 <https://github.com/uleroboticsgroup/yasmin/issues/50>)
  * add concurrence state
  * add mutex for intermedaite state dict
  * prefix self vars with underscore
  * add concurrence str definition
  * add comment docs conform 120 character limit
  * fix init comment on concurrence
  * fix str gen for concurrence
  * replace state string representation as outcome map key with an integer alternative
  * add logic and tests to protect against running a state instance concurrently with itself
  * add newlines at end of files
  * verify intermedaite state outcome registration
  * add untested cpp implementation
  * fix compile warnings and add a demo
  * add licensing
  * run clang format on c files
  * run black format on py files
  * add python demo for concurrence
  * adjust to match python demo better
  ---------
  Co-authored-by: William Freidank <mailto:william.freidank@gtri.gatech.edu>
* adding remapping to C++ version
* Preempt monitor state on cancel request (#46 <https://github.com/uleroboticsgroup/yasmin/issues/46>)
  * Preempt monitor state on cancel request
  * Add canceled outcome to monitor_state and monitor_demo
  * Implement monitor_state cancel check in Python
* Feat/remmaping (#47 <https://github.com/uleroboticsgroup/yasmin/issues/47>)
  * started remmaping
  * remmaping working with demo
  * reformated with black
  * formated again with --line-length 90
  * added remap documentation to the code
* Contributors: LuisMilczarek, Miguel Ángel González Santamarta, Paul Verhoeckx, William Freidank
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* fixing c++ version in CMakeLists
* Preempt monitor state on cancel request (#46 <https://github.com/uleroboticsgroup/yasmin/issues/46>)
  * Preempt monitor state on cancel request
  * Add canceled outcome to monitor_state and monitor_demo
  * Implement monitor_state cancel check in Python
* Contributors: Miguel Ángel González Santamarta, Paul Verhoeckx
```

## yasmin_viewer

```
* fixing c++ version in CMakeLists
* Contributors: Miguel Ángel González Santamarta
```
