### PR TITLE
ur_simulation_gz: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8864,7 +8864,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `2.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## ur_simulation_gz

```
* Add support for UR7e and UR12e (#86 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/86>)
* Allow ros namespace to be specified (#85 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/85>)
* Update package maintainers (#74 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/74>)
  This commit updates the package maintainers as the project's governance has changed a bit.
* Contributors: Felix Exner, Kenji Brameld (TRACLabs)
```
