### PR TITLE
ur_robot_driver: 2.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11353,7 +11353,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.7.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.0-1`

## ur

- No changes

## ur_bringup

```
* Add support for UR7e and UR12e (#1332 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1332>)
* Contributors: mergify[bot]
```

## ur_calibration

```
* Use modern CMake to link against yaml-cpp (backport of #1295 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1295>) (#1304 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1304>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* Start executing passthrough trajectories earlier than all points are transferred. (backport of #1313 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1313>) (#1335 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1335>)
* Fix passthrough controller to not read non-existing state_interfaces (#1314 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1314>) (#1316 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1316>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for UR7e and UR12e (#1332 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1332>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Start executing passthrough trajectories earlier than all points are transferred. (backport of #1313 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1313>) (#1335 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1335>)
* Support PolyScopeX robots (backport of #1318 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1318>) (#1333 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1333>)
* Add support for UR7e and UR12e (#1332 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1332>)
* Use UrDriverConfig struct to initialize UrDriver (backport of #1328 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1328>) (#1330 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1330>)
* Fix passthrough controller to not read non-existing state_interfaces (#1314 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1314>) (#1316 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1316>)
* Contributors: mergify[bot]
```
