### PR TITLE
ur_robot_driver: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8853,7 +8853,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.1.1-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.1-1`

## ur

- No changes

## ur_calibration

```
* Use modern CMake to link against yaml-cpp (#1295 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1295>)
* Contributors: Felix Exner
```

## ur_controllers

```
* Added controller to enable and disable tool contact (#940 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/940>)
* Start executing passthrough trajectories earlier than all points are transferred. (#1313 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1313>)
* Update ci (#1315 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1315>)
* Fix passthrough controller to not read non-existing state_interfaces (#1314 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1314>)
* Contributors: Felix Exner, URJala
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for UR7e and UR12e (#1320 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1320>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Added controller to enable and disable tool contact (#940 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/940>)
* Start executing passthrough trajectories earlier than all points are transferred. (#1313 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1313>)
* Support PolyScopeX robots (#1318 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1318>)
* Add support for UR7e and UR12e (#1320 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1320>)
* Use UrDriverConfig struct to initialize UrDriver (#1328 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1328>)
* Fix passthrough controller to not read non-existing state_interfaces (#1314 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1314>)
* Fix links to forward command controllers (#1303 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1303>)
* Contributors: Felix Exner, URJala
```
