### PR TITLE
leo_simulator: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3354,7 +3354,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
-      version: 2.0.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_simulator-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_simulator` to `2.0.2-1`:

- upstream repository: https://github.com/LeoRover/leo_simulator-ros2.git
- release repository: https://github.com/ros2-gbp/leo_simulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## leo_gz_bringup

- No changes

## leo_gz_plugins

- No changes

## leo_gz_worlds

```
* Add imu plugin to each world (#13 <https://github.com/LeoRover/leo_simulator-ros2/issues/13>)
* Contributors: Jan Hernas
```

## leo_simulator

- No changes
