### PR TITLE
leo_common: 3.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3807,7 +3807,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 3.0.4-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `3.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.4-1`

## leo

- No changes

## leo_description

```
* Change simulated camera frame to camera_optical_frame
* Reduce camera clip distance (#21 <https://github.com/LeoRover/leo_common-ros2/issues/21>)
* Remove ignition references from urdf (#20 <https://github.com/LeoRover/leo_common-ros2/issues/20>)
* Fix imu and camera frame ids (#17 <https://github.com/LeoRover/leo_common-ros2/issues/17>)
* Contributors: Błażej Sowa, Jan Hernas
```

## leo_msgs

- No changes

## leo_teleop

- No changes
