### PR TITLE
leo_common: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4320,7 +4320,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 1.2.4-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `1.3.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.4-1`

## leo

- No changes

## leo_description

```
* Change simulated camera frame to camera_optical_frame
* Reduce camera clip distance (#21 <https://github.com/LeoRover/leo_common-ros2/issues/21>) (#22 <https://github.com/LeoRover/leo_common-ros2/issues/22>)
* Fix imu and camera frame ids (#17 <https://github.com/LeoRover/leo_common-ros2/issues/17>) (#19 <https://github.com/LeoRover/leo_common-ros2/issues/19>)
* Contributors: Błażej Sowa,Jan Hernas
```

## leo_msgs

- No changes

## leo_teleop

- No changes
