### PR TITLE
clearpath_simulator: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1182,7 +1182,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## clearpath_generator_gz

```
* Add exception handlers to the generators for Unsupported* exceptions (#78 <https://github.com/clearpathrobotics/clearpath_simulator/issues/78>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_gz

- No changes

## clearpath_simulator

- No changes
