### PR TITLE
open_sound_control_ros: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5348,6 +5348,19 @@ repositories:
       version: jazzy
     status: developed
   open_sound_control_ros:
+    doc:
+      type: git
+      url: https://github.com/chrisib/open_sound_control_ros.git
+      version: jazzy
+    release:
+      packages:
+      - open_sound_control
+      - open_sound_control_bridge
+      - open_sound_control_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/open_sound_control-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/chrisib/open_sound_control_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_sound_control_ros` to `0.0.2-1`:

- upstream repository: https://github.com/chrisib/open_sound_control_ros.git
- release repository: https://github.com/ros2-gbp/open_sound_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## open_sound_control

```
* Fix license for metapackage
* Contributors: Chris I-B
```

## open_sound_control_bridge

```
* Implement separate static & dynamic OSC->ROS behaviour.
* Separate the code into multiple files to keep things manageable
* Contributors: Chris I-B
```

## open_sound_control_msgs

- No changes
