### PR TITLE
fkie_message_filters: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2649,6 +2649,15 @@ repositories:
       version: humble-devel
     status: maintained
   fkie_message_filters:
+    doc:
+      type: git
+      url: https://github.com/fkie/message_filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/fkie_message_filters-release.git
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/fkie/message_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `3.0.1-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/ros2-gbp/fkie_message_filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## fkie_message_filters

```
* Recheck image_transport version when library is used
* Improve exception message for noncopyable types
* Enable BUILD_SHARED_LIBS by default
* Fix prefix for namespace macro
* Contributors: Timo Röhling
```
