### PR TITLE
Add kobuki_ros sources to Humble.

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4010,6 +4010,17 @@ repositories:
       type: git
       url: https://github.com/kobuki-base/kobuki_core.git
       version: release/1.4.x
+  kobuki_ros:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.2.x
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.2.x
+    status: maintained
   kobuki_ros_interfaces:
     doc:
       type: git


### PR DESCRIPTION
This is a copy of what we released in Eloquent, updated to a new branch for Humble.

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

kobuki_ros

# The source is here:

https://github.com/kobuki-base/kobuki_ros.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
