### PR TITLE
ld08_driver: 1.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3796,7 +3796,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ld08_driver-release.git
-      version: 1.1.1-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ld08_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ld08_driver` to `1.1.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ld08_driver.git
- release repository: https://github.com/ros2-gbp/ld08_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## ld08_driver

```
* Support flexible configuration of the frame_id used when publishing the scan topic
* Reduce CPU usage of the ld08 LiDAR node by adding sleep to its main loop, related PR(https://github.com/ROBOTIS-GIT/ld08_driver/pull/23)
* Contributors: Hyungyu Kim, Xander Soldaat
```
