### PR TITLE
open_manipulator: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6244,6 +6244,19 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git
       version: humble
+    release:
+      packages:
+      - open_manipulator
+      - open_manipulator_x_bringup
+      - open_manipulator_x_description
+      - open_manipulator_x_gui
+      - open_manipulator_x_moveit_config
+      - open_manipulator_x_playground
+      - open_manipulator_x_teleop
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/open_manipulator-release.git
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## open_manipulator

```
* Modified Update Rate
* Docker support
* Contributors: Wonho Yun, Woojin Wie
```

## open_manipulator_x_bringup

```
* Modified Update Rate
* Contributors: Wonho Yun
```

## open_manipulator_x_description

```
* None
```

## open_manipulator_x_gui

```
* None
```

## open_manipulator_x_moveit_config

```
* None
```

## open_manipulator_x_playground

```
* None
```

## open_manipulator_x_teleop

```
* None
```
