### PR TITLE
open_manipulator: 3.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4649,6 +4649,22 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git
       version: main
+    release:
+      packages:
+      - om_gravity_compensation_controller
+      - om_joint_trajectory_command_broadcaster
+      - om_spring_actuator_controller
+      - open_manipulator
+      - open_manipulator_bringup
+      - open_manipulator_description
+      - open_manipulator_gui
+      - open_manipulator_moveit_config
+      - open_manipulator_playground
+      - open_manipulator_teleop
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/open_manipulator-release.git
+      version: 3.2.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.2.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* None
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Updated link mesh files in the OM-Y leader mesh directory
* Contributors: Woojin Wie
```

## open_manipulator_bringup

```
* None
```

## open_manipulator_description

```
* Updated link mesh files in the OM-Y leader mesh directory
* Contributors: Woojin Wie
```

## open_manipulator_gui

```
* None
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* None
```
