### PR TITLE
depth_obstacle_detect_ros: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1584,6 +1584,18 @@ repositories:
       version: jazzy
     status: developed
   depth_obstacle_detect_ros:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git
+      version: jazzy-devel
+    release:
+      packages:
+      - depth_obstacle_detect_ros
+      - depth_obstacle_detect_ros_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/depth_obstacle_detect_ros-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depth_obstacle_detect_ros` to `2.0.0-1`:

- upstream repository: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git
- release repository: https://github.com/ros2-gbp/depth_obstacle_detect_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
