### PR TITLE
marti_common: 3.7.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4786,7 +4786,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.7.3-2
+      version: 3.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.7.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.3-2`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

```
* use random library (#762 <https://github.com/swri-robotics/marti_common/issues/762>)
* Contributors: dfranklin-swri
```

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_system_util

- No changes

## swri_transform_util

- No changes
