### PR TITLE
Add rosdep key for libexpected-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3651,6 +3651,19 @@ libexpat1-dev:
   gentoo: [dev-libs/expat]
   openembedded: [expat@openembedded-core]
   ubuntu: [libexpat1-dev]
+libexpected-dev:
+  alpine: [tl-expected]
+  arch: [tl-expected]
+  debian: [libexpected-dev]
+  fedora: [expected-devel]
+  gentoo: [dev-cpp/expected]
+  nixos: [tl-expected]
+  opensuse: [expected]
+  osx:
+    homebrew:
+      packages: [tl-expected]
+  rhel: [expected-devel]
+  ubuntu: [libexpected-dev]
 libext2fs-dev:
   alpine: [e2fsprogs-dev]
   arch: [e2fsprogs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3658,7 +3658,6 @@ libexpected-dev:
   fedora: [expected-devel]
   gentoo: [dev-cpp/expected]
   nixos: [tl-expected]
-  opensuse: [expected]
   osx:
     homebrew:
       packages: [tl-expected]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libexpected-dev

## Package Upstream Source:

https://github.com/TartanLlama/expected

## Purpose of using this:

`std::expected` is available from C++23, but it cannot be used with C++20 or earlier. Therefore, we would like to use `tl::expected` as an alternative.
It seems that it has already been integrated into `rclutils` and also packaged as `tl_expected`.
* https://github.com/ros2/rcpputils/pull/185
* https://github.com/PickNikRobotics/cpp_polyfills

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=libexpected-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?suite=all&section=all&arch=any&keywords=libexpected-dev&searchon=names
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/expected/expected-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/tl-expected/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/expected
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/tl-expected#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/tl-expected
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=tl-expected
- openSUSE: https://software.opensuse.org/package/
  - ~~https://software.opensuse.org/package/expected~~
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/10/epel-aarch64/expected-devel-1.1.0-1.el10_0.noarch.rpm.html