### PR TITLE
Add ai_worker to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -100,6 +100,16 @@ repositories:
       url: https://github.com/robosoft-ai/ai_prompt_msgs.git
       version: main
     status: developed
+  ai_worker:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ai_worker.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ai_worker.git
+      version: jazzy
+    status: developed
   ament_acceleration:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

https://github.com/ROBOTIS-GIT/ai_worker

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
