### PR TITLE
Add ai_worker to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -90,6 +90,16 @@ repositories:
       url: https://github.com/analogdevicesinc/iio_ros2.git
       version: rolling
     status: maintained
+  ai_worker:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ai_worker.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ai_worker.git
+      version: jazzy
+    status: developed
   ament_acceleration:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -94,11 +94,11 @@ repositories:
     doc:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git
-      version: jazzy
+      version: main
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git
-      version: jazzy
+      version: main
     status: developed
   ament_acceleration:
     doc:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/ROBOTIS-GIT/ai_worker

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
