### PR TITLE
add pydub key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8416,6 +8416,10 @@ python3-pydot:
     '*': ['python%{python3_pkgversion}-pydot']
     '7': null
   ubuntu: [python3-pydot]
+python3-pydub:
+  debian: [python3-pydub]
+  opensuse: [python3-pydub]
+  ubuntu: [python3-pydub]
 python3-pyee:
   debian: [python3-pyee]
   fedora: [python3-ee]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pydub

## Package Upstream Source:

https://github.com/jiaaro/pydub

## Purpose of using this:

This dependency is being used for releasing the package in https://github.com/jsk-ros-pkg/jsk_3rdparty/

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/stable/python/python3-pydub
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-pydub&searchon=names&suite=all&section=all

