### PR TITLE
add python3-soundfile

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9949,6 +9949,11 @@ python3-sounddevice-pip:
   ubuntu:
     pip:
       packages: [sounddevice]
+python3-soundfile:
+  debian:
+    package: [python3-soundfile]
+  ubuntu:
+    package: [python3-soundfile]
 python3-sparkfun-ublox-gps-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-soundfile

## Package Upstream Source:

https://github.com/bastibe/python-soundfile

## Purpose of using this:

This dependency is being used for releasing the package in https://github.com/jsk-ros-pkg/jsk_3rdparty

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-soundfile
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-soundfile&searchon=names&suite=all&section=all

