### PR TITLE
clearpath_config: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1401,7 +1401,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `1.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-1`

## clearpath_config

```
* Feature: Add delay to manipulator controller (#141 <https://github.com/clearpathrobotics/clearpath_config/issues/141>)
* Feature: Manipulator URDF Parameters (#140 <https://github.com/clearpathrobotics/clearpath_config/issues/140>)
* Contributors: Luis Camero
```
