### PR TITLE
microstrain_inertial: 4.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4364,7 +4364,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.5.0-1
+      version: 4.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.6.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.5.0-1`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* ROS: Adds system time sync status and adds valid_flags to gps_timestamp in MIP header (#380 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/380>)
* Contributors: Rob
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* ROS: Adds system time sync status and adds valid_flags to gps_timestamp in MIP header (#380 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/380>)
* Contributors: Rob
```

## microstrain_inertial_rqt

- No changes
