### PR TITLE
aruco_markers: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -618,7 +618,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/namo-robotics/aruco_markers-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/namo-robotics/aruco_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_markers` to `0.0.2-1`:

- upstream repository: https://github.com/namo-robotics/aruco_markers.git
- release repository: https://github.com/namo-robotics/aruco_markers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-2`

## aruco_markers

```
* support namespacing of topic names
* Contributors: David Brown
```

## aruco_markers_msgs

- No changes
