### PR TITLE
clearpath_common: 1.3.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1386,7 +1386,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.2.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `1.3.0-2`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-1`

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_generator_common

```
* Feature: Add delay to manipulator controller (#182 <https://github.com/clearpathrobotics/clearpath_common/issues/182>)
* Feature: Manipulator URDF Parameters (#181 <https://github.com/clearpathrobotics/clearpath_common/issues/181>)
* Contributors: Luis Camero
```

## clearpath_manipulators

```
* Feature: Add delay to manipulator controller (#182 <https://github.com/clearpathrobotics/clearpath_common/issues/182>)
* Contributors: Luis Camero
```

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
