### PR TITLE
camera_ros: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -876,7 +876,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/camera_ros-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/christianrauch/camera_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_ros` to `0.4.0-1`:

- upstream repository: https://github.com/christianrauch/camera_ros.git
- release repository: https://github.com/ros2-gbp/camera_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`
