### PR TITLE
clearpath_simulator: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1495,7 +1495,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 1.0.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `1.3.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## clearpath_generator_gz

```
* Add Ouster (#68 <https://github.com/clearpathrobotics/clearpath_simulator/issues/68>)
* Feature: MoveIt Parameters and Enable (#70 <https://github.com/clearpathrobotics/clearpath_simulator/issues/70>)
* Contributors: Luis Camero
```

## clearpath_gz

```
* Fix: Generation disable (#76 <https://github.com/clearpathrobotics/clearpath_simulator/issues/76>)
* Add argument to disable generation (#74 <https://github.com/clearpathrobotics/clearpath_simulator/issues/74>)
* Feature: MoveIt Parameters and Enable (#70 <https://github.com/clearpathrobotics/clearpath_simulator/issues/70>)
* Contributors: Luis Camero
```

## clearpath_simulator

- No changes
