### PR TITLE
nav2_minimal_turtlebot_simulation: 1.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4328,7 +4328,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
-      version: 1.0.2-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_minimal_turtlebot_simulation` to `1.1.0-2`:

- upstream repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
- release repository: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`
