### PR TITLE
navigation2: 1.3.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4955,7 +4955,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.3.5-1
+      version: 1.3.6-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.3.6-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.5-1`
