### PR TITLE
moveit: 2.13.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4028,7 +4028,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.13.0-1
+      version: 2.13.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.13.1-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.13.0-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* Update ompl_defaults.yaml to not have an invalid AnytimePathShortening configuration (#3374 <https://github.com/ros-planning/moveit2/issues/3374>)
* Contributors: Stephanie Eng
```

## moveit_core

```
* Make the destructors of the base classes of planning adapters virtual and close move_group gracefully (#3435 <https://github.com/ros-planning/moveit2/issues/3435>)
* fix: ensure attached objects update during motion execution (#3327 <https://github.com/ros-planning/moveit2/issues/3327>)
* Contributors: Cihat Kurtuluş Altıparmak, Marco Magri
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_planners_stomp

```
* Add stomp target link to moveit_planners_stomp tests (#3437 <https://github.com/ros-planning/moveit2/issues/3437>)
* Contributors: Bckempa
```

## moveit_plugins

- No changes

## moveit_py

```
* Allow conversion from list[str] to std::vector<std::string> (#3423 <https://github.com/ros-planning/moveit2/issues/3423>)
* feat: add remapping argument to MoveItPy initialization (#3367 <https://github.com/ros-planning/moveit2/issues/3367>)
* Contributors: Jens Vanhooydonck, Kazuya Oguma
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* ROS Parameter for service call timeout for ros_control controllers (#3419 <https://github.com/ros-planning/moveit2/issues/3419>)
* SERVICE_CALL_TIMEOUT = 1 second is harsh 🥵 (#3382 <https://github.com/ros-planning/moveit2/issues/3382>)
* Contributors: Ashwin Sajith Nambiar, Yoan Mollard
```

## moveit_ros_move_group

```
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (#3357 <https://github.com/ros-planning/moveit2/issues/3357>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Contributors: Mark Johnson
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Make the destructors of the base classes of planning adapters virtual and close move_group gracefully (#3435 <https://github.com/ros-planning/moveit2/issues/3435>)
* fix: ensure attached objects update during motion execution (#3327 <https://github.com/ros-planning/moveit2/issues/3327>)
* Planning scene monitor: reliable QoS (#3400 <https://github.com/ros-planning/moveit2/issues/3400>)
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (#3357 <https://github.com/ros-planning/moveit2/issues/3357>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* fix: explicitly add the same namespace as the parent node (#3360 <https://github.com/ros-planning/moveit2/issues/3360>)
* Contributors: Aleksey Nogin, Cihat Kurtuluş Altıparmak, Kazuya Oguma, Marco Magri, Mark Johnson
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

- No changes

## moveit_ros_visualization

```
* Planning scene monitor: reliable QoS (#3400 <https://github.com/ros-planning/moveit2/issues/3400>)
* Respect robot alpha value in trail trajectory visual (#3353 <https://github.com/ros-planning/moveit2/issues/3353>)
* Contributors: Aleksey Nogin, Florian Beck, Mark Johnson
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Minor typo fix in simulated Panda servo config (#3444 <https://github.com/ros-planning/moveit2/issues/3444>)
* Fix Servo JointJog Crash (#3351 <https://github.com/ros-planning/moveit2/issues/3351>)
* Contributors: Gautham Sam, Matthew Foran
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

```
* Use ament_cmake_ros build tool in moveit_setup_assistant packages (#3441 <https://github.com/ros-planning/moveit2/issues/3441>)
* Contributors: Sebastian Castro
```

## moveit_setup_core_plugins

```
* Use ament_cmake_ros build tool in moveit_setup_assistant packages (#3441 <https://github.com/ros-planning/moveit2/issues/3441>)
* Contributors: Sebastian Castro
```

## moveit_setup_framework

```
* Use ament_cmake_ros build tool in moveit_setup_assistant packages (#3441 <https://github.com/ros-planning/moveit2/issues/3441>)
* Contributors: Sebastian Castro
```

## moveit_setup_srdf_plugins

```
* Use ament_cmake_ros build tool in moveit_setup_assistant packages (#3441 <https://github.com/ros-planning/moveit2/issues/3441>)
* Contributors: Sebastian Castro
```

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (#3357 <https://github.com/ros-planning/moveit2/issues/3357>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Contributors: Mark Johnson
```

## pilz_industrial_motion_planner_testutils

- No changes
