### PR TITLE
moveit: 2.12.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4582,7 +4582,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.12.2-1
+      version: 2.12.3-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.12.3-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.2-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* Update ompl_defaults.yaml to not have an invalid AnytimePathShortening configuration (#3374 <https://github.com/ros-planning/moveit2/issues/3374>) (#3376 <https://github.com/ros-planning/moveit2/issues/3376>)
* Contributors: Stephanie Eng
```

## moveit_core

```
* Make the destructors of the base classes of planning adapters virtual and close move_group gracefully (#3435 <https://github.com/ros-planning/moveit2/issues/3435>) (#3443 <https://github.com/ros-planning/moveit2/issues/3443>)
* fix: ensure attached objects update during motion execution (#3327 <https://github.com/ros-planning/moveit2/issues/3327>) (#3414 <https://github.com/ros-planning/moveit2/issues/3414>)
* Contributors: Cihat Kurtuluş Altıparmak, Marco Magri
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_planners_stomp

```
* Add stomp target link to moveit_planners_stomp tests (#3437 <https://github.com/ros-planning/moveit2/issues/3437>) (#3438 <https://github.com/ros-planning/moveit2/issues/3438>)
* Contributors: Bckempa
```

## moveit_plugins

- No changes

## moveit_py

```
* Allow conversion from list[str] to std::vector<std::string> (#3423 <https://github.com/ros-planning/moveit2/issues/3423>) (#3425 <https://github.com/ros-planning/moveit2/issues/3425>)
* feat: add remapping argument to MoveItPy initialization (#3367 <https://github.com/ros-planning/moveit2/issues/3367>) (#3386 <https://github.com/ros-planning/moveit2/issues/3386>).
* Contributors: Jens Vanhooydonck, Kazuya Oguma
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* ROS Parameter for service call timeout for ros_control controllers (#3419 <https://github.com/ros-planning/moveit2/issues/3419>) (#3433 <https://github.com/ros-planning/moveit2/issues/3433>)
* SERVICE_CALL_TIMEOUT = 1 second is harsh 🥵 (#3382 <https://github.com/ros-planning/moveit2/issues/3382>) (#3407 <https://github.com/ros-planning/moveit2/issues/3407>)
* Contributors: Ashwin Sajith Nambiar, Yoan Mollard
```

## moveit_ros_move_group

```
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (#3357 <https://github.com/ros-planning/moveit2/issues/3357>) (#3365 <https://github.com/ros-planning/moveit2/issues/3365>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issue/3689>)
* Contributors: Mark Johnson
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Make the destructors of the base classes of planning adapters virtual and close move_group gracefully (#3435 <https://github.com/ros-planning/moveit2/issues/3435>) (#3443 <https://github.com/ros-planning/moveit2/issues/3443>)
* fix: ensure attached objects update during motion execution (#3327 <https://github.com/ros-planning/moveit2/issues/3327>) (#3414 <https://github.com/ros-planning/moveit2/issues/3414>)
* Planning scene monitor: reliable QoS (#3400 <https://github.com/ros-planning/moveit2/issues/3400>) (#3410 <https://github.com/ros-planning/moveit2/issues/3410>)
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (#3357 <https://github.com/ros-planning/moveit2/issues/3357>) (#3365 <https://github.com/ros-planning/moveit/issues/3365>)
* fix: explicitly add the same namespace as the parent node (#3360 <https://github.com/ros-planning/moveit2/issues/3360>) (#3362 <https://github.com/ros-planning/moveit2/issues/3362>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Contributors: Aleksey Nogin, Cihat Kurtuluş Altıparmak, Kazuya Oguma, Marco Magri, Mark Johnson
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

```
* Fuzzy-matching Trajectory Cache Injectable Traits refactor 🔥🔥 (#2941 <https://github.com/ros-planning/moveit2/issues/2941>) (#3408 <https://github.com/ros-planning/moveit2/issues/3408>)
* Contributors: methylDragon
```

## moveit_ros_visualization

```
* Planning scene monitor: reliable QoS (#3400 <https://github.com/ros-planning/moveit2/issues/3400>) (#3410 <https://github.com/ros-planning/moveit2/issues/3410>)
* Respect robot alpha value in trail trajectory visual (#3353 <https://github.com/ros-planning/moveit2/issues/3353>) (#3359 <https://github.com/ros-planning/moveit2/issues/3359>)
* Contributors: Aleksey Nogin, Florian Beck
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Minor typo fix in simulated Panda servo config (#3444 <https://github.com/ros-planning/moveit2/issues/3444>) (#3445 <https://github.com/ros-planning/moveit2/issues/3445>)
* Fix Servo JointJog Crash (#3351 <https://github.com/ros-planning/moveit2/issues/3351>) (#3401 <https://github.com/ros-planning/moveit2/issues/3401>)
* Contributors: Gautham Sam, Matthew Foran
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

- No changes

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (#3357 <https://github.com/ros-planning/moveit2/issues/3357>) (#3365 <https://github.com/ros-planning/moveit/issues/3365>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Contributors: Mark Johnson
```

## pilz_industrial_motion_planner_testutils

- No changes
