### PR TITLE
moveit: 2.5.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5306,7 +5306,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.5.8-1
+      version: 2.5.9-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.5.9-1`:

- upstream repository: https://github.com/ros-planning/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.8-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_chomp_optimizer_adapter

- No changes

## moveit_common

- No changes

## moveit_configs_utils

```
* Update ompl_defaults.yaml to not have an invalid AnytimePathShortening configuration (#3374 <https://github.com/ros-planning/moveit2/issues/3374>) (#3375 <https://github.com/ros-planning/moveit2/issues/3375>)
* Contributors: Stephanie Eng
```

## moveit_core

- No changes

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

- No changes

## moveit_plugins

- No changes

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

```
* SERVICE_CALL_TIMEOUT = 1 second is harsh 🥵 (#3382 <https://github.com/ros-planning/moveit2/issues/3382>) (#3406 <https://github.com/ros-planning/moveit2/issues/3406>)
* Add logic to Ros2ControlManager to match ros2_control (backport #3332 <https://github.com/ros-planning/moveit2/issues/3332>) (#3342 <https://github.com/ros-planning/moveit2/issues/3342>)
* Contributors: Paul Gesel, Sebastian Castro, Yoan Mollard
```

## moveit_ros_move_group

```
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (backport #3357 <https://github.com/ros-planning/moveit2/issues/3357>) (#3364 <https://github.com/ros-planning/moveit2/issues/3364>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Contributors: Mark Johnson
```

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* Planning scene monitor: reliable QoS (backport #3400 <https://github.com/ros-planning/moveit2/issues/3400>) (#3409 <https://github.com/ros-planning/moveit2/issues/3409>)
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (backport #3357 <https://github.com/ros-planning/moveit2/issues/3357>) (#3364 <https://github.com/ros-planning/moveit2/issues/3364>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Enable allowed_execution_duration_scaling and allowed_goal_duration_margin for each controller (#3335 <https://github.com/ros-planning/moveit2/issues/3335>) (#3337 <https://github.com/ros-planning/moveit2/issues/3337>)
* Contributors: Aleksey Nogin, Daniel García López, Mark Johnson
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_visualization

```
* Planning scene monitor: reliable QoS (backport #3400 <https://github.com/ros-planning/moveit2/issues/3400>) (#3409 <https://github.com/ros-planning/moveit2/issues/3409>)
* Respect robot alpha value in trail trajectory visual (#3353 <https://github.com/ros-planning/moveit2/issues/3353>) (#3358 <https://github.com/ros-planning/moveit2/issues/3358>)
* Contributors: Aleksey Nogin, Florian Beck, Mark Johnson
```

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

- No changes

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

- No changes

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

```
* Ports moveit1 #3689 <https://github.com/ros-planning/moveit/issues/3689> (backport #3357 <https://github.com/ros-planning/moveit2/issues/3357>) (#3364 <https://github.com/ros-planning/moveit2/issues/3364>)
  * Publish planning scene while planning (#3689 <https://github.com/ros-planning/moveit/issues/3689>)
* Contributors: Mark Johnson
```

## pilz_industrial_motion_planner_testutils

- No changes
