### PR TITLE
fix python3-soundfile key syntax

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9954,10 +9954,8 @@ python3-sounddevice-pip:
     pip:
       packages: [sounddevice]
 python3-soundfile:
-  debian:
-    package: [python3-soundfile]
-  ubuntu:
-    package: [python3-soundfile]
+  debian: [python3-soundfile]
+  ubuntu: [python3-soundfile]
 python3-sparkfun-ublox-gps-pip:
   debian:
     pip:


### PR DESCRIPTION
I'm sorry but I wrongly edited `python3-soundfile` key in https://github.com/ros/rosdistro/pull/45168 . It causes the error in rosdep  cli 
```
❯ rosdep resolve python3-soundfile

ERROR: No definition of [python3-soundfile] for OS version [focal]

No definition of [python3-soundfile] for OS version [focal]
        rosdep key : python3-soundfile
        OS name    : ubuntu
        OS version : focal
        Data:
debian:
                  package:
                  - python3-soundfile
                ubuntu:
                  package:
                  - python3-soundfile
```