### PR TITLE
fkie_message_filters: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1854,6 +1854,15 @@ repositories:
       version: rolling-devel
     status: maintained
   fkie_message_filters:
+    doc:
+      type: git
+      url: https://github.com/fkie/message_filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fkie_message_filters-release.git
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/fkie/message_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `3.0.2-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/ros2-gbp/fkie_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## fkie_message_filters

```
* Use tf2_ros native function for timestamp conversions
* Inherit additional constructors for Buffer, Sequencer, and TfFilter
* Contributors: Timo Röhling
```
