### PR TITLE
teleop_tools: 1.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8264,7 +8264,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
-      version: 1.7.0-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_tools` to `1.8.0-1`:

- upstream repository: https://github.com/ros-teleop/teleop_tools.git
- release repository: https://github.com/ros2-gbp/teleop_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.0-1`

## joy_teleop

- No changes

## key_teleop

```
* Default to TwistStamped (#90 <https://github.com/ros-teleop/teleop_tools/issues/90>)
* Contributors: Bence Magyar
```

## mouse_teleop

```
* Default to TwistStamped (#90 <https://github.com/ros-teleop/teleop_tools/issues/90>)
* Contributors: Bence Magyar
```

## teleop_tools

- No changes

## teleop_tools_msgs

- No changes
