### PR TITLE
ros2_control: 4.28.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6444,7 +6444,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.27.0-1
+      version: 4.28.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.28.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.27.0-1`

## controller_interface

- No changes

## controller_manager

```
* Fix the enforce_command_limits deactivation (#2181 <https://github.com/ros-controls/ros2_control/issues/2181>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Avoid running joint limit enforcement during initialization (#2188 <https://github.com/ros-controls/ros2_control/issues/2188>)
* Use previous command to enforce the joint limits on position interfaces (#2183 <https://github.com/ros-controls/ros2_control/issues/2183>)
* Add log info for the type of joint limits being used (#2186 <https://github.com/ros-controls/ros2_control/issues/2186>)
* Fix the joint limits enforcement with position and velocity (#2182 <https://github.com/ros-controls/ros2_control/issues/2182>)
* Only log limiting error if something is limited. (#2176 <https://github.com/ros-controls/ros2_control/issues/2176>)
* Contributors: Felix Exner (fexner), Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Use previous command to enforce the joint limits on position interfaces (#2183 <https://github.com/ros-controls/ros2_control/issues/2183>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

```
* Use previous command to enforce the joint limits on position interfaces (#2183 <https://github.com/ros-controls/ros2_control/issues/2183>)
* Fix the joint limits enforcement with position and velocity (#2182 <https://github.com/ros-controls/ros2_control/issues/2182>)
* Contributors: Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
