### PR TITLE
ament_package: 0.17.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -298,7 +298,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.17.1-1
+      version: 0.17.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.17.2-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.17.1-1`

## ament_package

```
* Simplify removing leading and trailing separators (#152 <https://github.com/ament/ament_package/issues/152>)
* Remove CODEOWNERS and mirror-rolling-to-master. (#149 <https://github.com/ament/ament_package/issues/149>)
* Contributors: Chris Lalancette, Rob Woolley
```
