### PR TITLE
ros2_tracing: 8.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6591,7 +6591,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.5.0-1
+      version: 8.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.6.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.5.0-1`

## lttngpy

```
* Remove SHARED from pybind11_add_module (#154 <https://github.com/ros2/ros2_tracing/issues/154>)
* Contributors: Silvio Traversaro
```

## ros2trace

```
* Expose types for tracing tools (#153 <https://github.com/ros2/ros2_tracing/issues/153>)
* Contributors: Michael Carlstrom
```

## tracetools

```
* Switch to ament_cmake_ros_core package (#162 <https://github.com/ros2/ros2_tracing/issues/162>)
* Contributors: Michael Carroll
```

## tracetools_launch

```
* Fix or ignore new mypy issues (#161 <https://github.com/ros2/ros2_tracing/issues/161>)
* Improve Python typing annotations (#152 <https://github.com/ros2/ros2_tracing/issues/152>)
* Expose types for tracing tools (#153 <https://github.com/ros2/ros2_tracing/issues/153>)
* Contributors: Christophe Bedard, Michael Carlstrom
```

## tracetools_read

```
* Improve Python typing annotations (#152 <https://github.com/ros2/ros2_tracing/issues/152>)
* Expose types for tracing tools (#153 <https://github.com/ros2/ros2_tracing/issues/153>)
* Contributors: Christophe Bedard, Michael Carlstrom
```

## tracetools_test

```
* Fix or ignore new mypy issues (#161 <https://github.com/ros2/ros2_tracing/issues/161>)
* Improve Python typing annotations (#152 <https://github.com/ros2/ros2_tracing/issues/152>)
* Expose types for tracing tools (#153 <https://github.com/ros2/ros2_tracing/issues/153>)
* Contributors: Christophe Bedard, Michael Carlstrom
```

## tracetools_trace

```
* Improve Python typing annotations (#152 <https://github.com/ros2/ros2_tracing/issues/152>)
* Expose types for tracing tools (#153 <https://github.com/ros2/ros2_tracing/issues/153>)
* Remove unnecessary 'type: ignore' comments in tracetools_trace (#151 <https://github.com/ros2/ros2_tracing/issues/151>)
* Contributors: Christophe Bedard, Michael Carlstrom
```
