### PR TITLE
ament_lint: 0.19.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -271,7 +271,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.19.1-1
+      version: 0.19.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.19.2-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.19.1-1`

## ament_clang_format

- No changes

## ament_clang_tidy

- No changes

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

- No changes

## ament_cmake_cppcheck

- No changes

## ament_cmake_cpplint

- No changes

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

- No changes

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

- No changes

## ament_cmake_xmllint

- No changes

## ament_copyright

- No changes

## ament_cppcheck

- No changes

## ament_cpplint

```
* Enable a quiet mode for cpplint (#532 <https://github.com/ament/ament_lint/issues/532>)
* Contributors: Nils-Christian Iseke
```

## ament_flake8

- No changes

## ament_lint

- No changes

## ament_lint_auto

```
* Add docu for AMENT_LINT_AUTO_EXCLUDE (#524 <https://github.com/ament/ament_lint/issues/524>)
* Contributors: Alexander Reimann
```

## ament_lint_cmake

- No changes

## ament_lint_common

- No changes

## ament_mypy

```
* Fix Windows Regression by removing removesuffix() (#530 <https://github.com/ament/ament_lint/issues/530>)
* Export typing information (#487 <https://github.com/ament/ament_lint/issues/487>)
* Contributors: Michael Carlstrom
```

## ament_pclint

- No changes

## ament_pep257

- No changes

## ament_pycodestyle

- No changes

## ament_pyflakes

- No changes

## ament_uncrustify

- No changes

## ament_xmllint

- No changes
