### PR TITLE
google_benchmark_vendor: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2201,7 +2201,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.6.1-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-1`

## google_benchmark_vendor

```
* Bump minimum CMake version to 3.10 (#35 <https://github.com/ament/google_benchmark_vendor/issues/35>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow. (#31 <https://github.com/ament/google_benchmark_vendor/issues/31>)
* Contributors: Chris Lalancette, mosfet80
```
