### PR TITLE
googletest: 1.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2216,7 +2216,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.15.0-1
+      version: 1.15.1-1
     source:
       type: git
       url: https://github.com/ament/googletest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.15.1-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.15.0-1`

## gmock_vendor

```
* Bump minimum CMake version to 3.15 (#31 <https://github.com/ament/googletest/issues/31>)
* Contributors: mosfet80
```

## gtest_vendor

```
* Bump minimum CMake version to 3.15 (#33 <https://github.com/ament/googletest/issues/33>)
* Contributors: mosfet80
```
