### PR TITLE
launch: 3.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3240,7 +3240,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.0-1
+      version: 3.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.8.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.0-1`

## launch

```
* Provide copy of launch configs to TimerAction's entities (#836 <https://github.com/ros2/launch/issues/836>)
* Allow concatenating each path component of PathJoinSubstitution (#838 <https://github.com/ros2/launch/issues/838>)
* Add StringJoinSubstitution substitution (#843 <https://github.com/ros2/launch/issues/843>)
* Add missing test_depend for launch (#850 <https://github.com/ros2/launch/issues/850>)
* Document substitutions concatenation in architecture doc (#845 <https://github.com/ros2/launch/issues/845>)
* Update docs to use proper RST literals (#837 <https://github.com/ros2/launch/issues/837>)
* Fix function params indentation (#833 <https://github.com/ros2/launch/issues/833>)
* Contributors: Christian Ruf, Christophe Bedard, Michael Carlstrom
```

## launch_pytest

- No changes

## launch_testing

```
* Fix function params indentation (#833 <https://github.com/ros2/launch/issues/833>)
* Contributors: Christophe Bedard
```

## launch_testing_ament_cmake

```
* Add CMake parameter to override launch_testing module (#854 <https://github.com/ros2/launch/issues/854>)
* Contributors: Scott K Logan
```

## launch_xml

- No changes

## launch_yaml

- No changes
