### PR TITLE
launch_ros: 0.28.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3275,7 +3275,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.28.0-1
+      version: 0.28.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.28.1-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.28.0-1`

## launch_ros

```
* Remove the slash stripping since leading slash matters (#456 <https://github.com/ros2/launch_ros/issues/456>)
* Fixing lifecycle node autostart issue #445 <https://github.com/ros2/launch_ros/issues/445> (#449 <https://github.com/ros2/launch_ros/issues/449>)
* Change docstring markdown code blocks to RST (#450 <https://github.com/ros2/launch_ros/issues/450>)
* Autostarting lifecycle nodes and example launch file demo (#430 <https://github.com/ros2/launch_ros/issues/430>)
* Add YAML dumper representator for str type to keep quotes always. (#436 <https://github.com/ros2/launch_ros/issues/436>)
* Mock launch components causing rosdoc2 to fail Python API (#425 <https://github.com/ros2/launch_ros/issues/425>)
* Contributors: Christophe Bedard, Olivia/F.F., R Kent James, Steve Macenski, Tomoya Fujita
```

## launch_testing_ros

```
* WaitForTopics: let the user inject a trigger function to be executed after starting the subscribers (#356 <https://github.com/ros2/launch_ros/issues/356>)
* Add EnableRmwIsolation action for starting rmw_test_fixture (#459 <https://github.com/ros2/launch_ros/issues/459>)
* Fix function params indentation (#446 <https://github.com/ros2/launch_ros/issues/446>)
* Contributors: Christophe Bedard, Giorgio Pintaudi, Scott K Logan
```

## ros2launch

- No changes
