### PR TITLE
rcpputils: 2.13.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5781,7 +5781,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.13.3-1
+      version: 2.13.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.13.4-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.13.3-1`

## rcpputils

```
* Switch to ament_cmake_ros_core package (#211 <https://github.com/ros2/rcpputils/issues/211>)
* Added marco to disable deprecation warnings (#210 <https://github.com/ros2/rcpputils/issues/210>)
* Added missing include (#207 <https://github.com/ros2/rcpputils/issues/207>)
* Contributors: Alejandro Hernández Cordero, Janosch Machowinski, Michael Carroll
```
