### PR TITLE
rmw: 7.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6208,7 +6208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.8.1-1
+      version: 7.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw` to `7.8.2-1`:

- upstream repository: https://github.com/ros2/rmw.git
- release repository: https://github.com/ros2-gbp/rmw-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `7.8.1-1`

## rmw

```
* Switch to ament_cmake_ros_core package (#397 <https://github.com/ros2/rmw/issues/397>)
* Contributors: Michael Carroll
```

## rmw_implementation_cmake

- No changes

## rmw_security_common

```
* Export rmw dependency (#400 <https://github.com/ros2/rmw/issues/400>)
* Contributors: yadunund
```
