### PR TITLE
rclcpp: 29.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5749,7 +5749,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.4.0-1
+      version: 29.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.5.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `29.4.0-1`

## rclcpp

```
* Fix a race condition (#2819 <https://github.com/ros2/rclcpp/issues/2819>)
* Remove redundant typesupport check in serialization module (#2808 <https://github.com/ros2/rclcpp/issues/2808>)
* Remove get_typesupport_handle implementation. (#2806 <https://github.com/ros2/rclcpp/issues/2806>)
* Use NodeParameterInterface instead of /parameter_event to update "use_sim_time" (#2378 <https://github.com/ros2/rclcpp/issues/2378>)
* Remove cancel_clock_executor_promise_. (#2797 <https://github.com/ros2/rclcpp/issues/2797>)
* Enable parameter update recursively only when QoS override parameters. (#2742 <https://github.com/ros2/rclcpp/issues/2742>)
* Contributors: Pedro de Azeredo, Tanishq Chaudhary, Tomoya Fujita
```

## rclcpp_action

```
* Use std::recursive_mutex for action requests. (#2798 <https://github.com/ros2/rclcpp/issues/2798>)
* Contributors: Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
