### PR TITLE
rosidl: 4.9.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6987,7 +6987,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.9.3-1
+      version: 4.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.9.4-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.9.3-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Switch to ament_cmake_ros_core package (#856 <https://github.com/ros2/rosidl/issues/856>)
* Contributors: Michael Carroll
```

## rosidl_generator_cpp

```
* Add name and data_type traits for actions (#848 <https://github.com/ros2/rosidl/issues/848>)
* Contributors: Nathan Wiebe Neufeldt
```

## rosidl_generator_type_description

```
* Switch to ament_cmake_ros_core package (#856 <https://github.com/ros2/rosidl/issues/856>)
* Contributors: Michael Carroll
```

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* Switch to ament_cmake_ros_core package (#856 <https://github.com/ros2/rosidl/issues/856>)
* Contributors: Michael Carroll
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Switch to ament_cmake_ros_core package (#860 <https://github.com/ros2/rosidl/issues/860>)
* Contributors: Scott K Logan
```

## rosidl_typesupport_introspection_cpp

```
* Switch to ament_cmake_ros_core package (#860 <https://github.com/ros2/rosidl/issues/860>)
* Contributors: Scott K Logan
```
