### PR TITLE
rosidl_python: 0.24.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7093,7 +7093,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.24.0-1
+      version: 0.24.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.24.1-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.24.0-1`

## rosidl_generator_py

```
* Fix __eq__ for Array fields (#224 <https://github.com/ros2/rosidl_python/issues/224>)
* Remove use of ament_target_dependencies (#222 <https://github.com/ros2/rosidl_python/issues/222>)
* Contributors: Michael Carlstrom, Shane Loretz
```
