### PR TITLE
rosidl_dynamic_typesupport: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7059,7 +7059,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport` to `0.3.1-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## rosidl_dynamic_typesupport

```
* Switch to ament_cmake_ros_core package (#15 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/15>)
* Bump minimum CMake version to 3.20 (#14 <https://github.com/ros2/rosidl_dynamic_typesupport/issues/14>)
* Contributors: Michael Carroll, mosfet80
```
