### PR TITLE
rmw_zenoh: 0.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6346,10 +6346,11 @@ repositories:
       packages:
       - rmw_zenoh_cpp
       - zenoh_cpp_vendor
+      - zenoh_security_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-1`

## rmw_zenoh_cpp

```
* Change serialization format in attachment_helpers.cpp (#601 <https://github.com/ros2/rmw_zenoh/issues/601>)
* Bump Zenoh to v1.3.2 and improve e2e reliability with HeartbeatSporadic (#591 <https://github.com/ros2/rmw_zenoh/issues/591>)
* Implement rmw_test_fixture to start the Zenoh router (#583 <https://github.com/ros2/rmw_zenoh/issues/583>)
* Add quality declaration (#483 <https://github.com/ros2/rmw_zenoh/issues/483>)
* Trigger qos event callback if there are changes before registration  (#587 <https://github.com/ros2/rmw_zenoh/issues/587>)
* Set wait_set->triggered flag to false (#575 <https://github.com/ros2/rmw_zenoh/issues/575>)
* Add space after id token in rmw_zenohd log string (#576 <https://github.com/ros2/rmw_zenoh/issues/576>)
* Use std::unique_lock to unlock correctly on Windows (#570 <https://github.com/ros2/rmw_zenoh/issues/570>)
* Contributors: Alejandro Hernández Cordero, ChenYing Kuo (CY), Julien Enoch, Luca Cominardi, Patrick Roncagliolo, Scott K Logan, Yuyuan Yuan, yadunund, yellowhatter
```

## zenoh_cpp_vendor

```
* Bump Zenoh to v1.3.2 and improve e2e reliability with HeartbeatSporadic (#591 <https://github.com/ros2/rmw_zenoh/issues/591>)
* Add quality declaration (#483 <https://github.com/ros2/rmw_zenoh/issues/483>)
* Contributors: Alejandro Hernández Cordero, Julien Enoch
```

## zenoh_security_tools

```
* Add zenoh_security_tools (#595 <https://github.com/ros2/rmw_zenoh/issues/595>)
* Contributors: yadunund
```
