### PR TITLE
openrtm_aist_python: 1.1.0-8 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7525,7 +7525,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/openrtm_aist_python-release.git
-      version: 1.1.0-6
+      version: 1.1.0-8
     status: maintained
   openslam_gmapping:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `openrtm_aist_python` to `1.1.0-8`:

- upstream repository: https://github.com/OpenRTM/OpenRTM-aist-Python.git
- release repository: https://github.com/tork-a/openrtm_aist_python-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.1.0-6`
