### PR TITLE
ompl: 1.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5372,7 +5372,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.6.0-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/ompl/ompl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.7.0-1`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-1`
