### PR TITLE
control_toolbox: 5.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.2.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.0-1`

## control_toolbox

```
* Fix clang-format (#327 <https://github.com/ros-controls/control_toolbox/issues/327>)
* Add gravity compensation filter (#153 <https://github.com/ros-controls/control_toolbox/issues/153>)
* Contributors: Christoph Fröhlich, GuiHome, Daniel Zumkeller, Denis Štogl
```
