### PR TITLE
control_toolbox: 4.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1379,7 +1379,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.1.0-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.2.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-1`

## control_toolbox

```
* Fix clang-format (backport #327 <https://github.com/ros-controls/control_toolbox/issues/327>) (#336 <https://github.com/ros-controls/control_toolbox/issues/336>)
* Add gravity compensation filter (#153 <https://github.com/ros-controls/control_toolbox/issues/153>) (#334 <https://github.com/ros-controls/control_toolbox/issues/334>)
* Contributors: Christoph Fröhlich, Daniel Zumkeller, Denis Štogl, GuiHome
```
