### PR TITLE
Use ros2-gbp release repository for Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3075,7 +3075,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/justagist/kinematics_interface_pinocchio-release.git
+      url: https://github.com/ros2-gbp/kinematics_interface_pinocchio-release.git
       version: 0.0.1-1
     source:
       type: git


### PR DESCRIPTION
As we prepare for the kilted branching, things go much smoother if all repositories are already in the ros2-gbp GitHub org.

ros2-gbp PR: https://github.com/ros2-gbp/ros2-gbp-github-org/pull/755