### PR TITLE
Use ros2-gbp release repository for Rolling.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8224,7 +8224,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/synapticon/synapticon_ros2_control-release.git
+      url: https://github.com/ros2-gbp/synapticon_ros2_control-release.git
       version: 0.1.2-1
     source:
       type: git


### PR DESCRIPTION
As we prepare for the kilted branching, things go much smoother if all repositories are already in the ros2-gbp GitHub org.

There is no ros2-gbp PR since this repository was previously mirrored into ros2-gbp. I've updated the release repo on ros2-gbp with all of the new changes in the other release repository.

FYI @floweisshardt, @zvezdan94

