### PR TITLE
mocap_optitrack: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5116,7 +5116,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mocap_optitrack-release.git
-      version: 1.0.0-3
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/mocap_optitrack.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap_optitrack` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/mocap_optitrack.git
- release repository: https://github.com/ros2-gbp/mocap_optitrack-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-3`

## mocap_optitrack

```
* Added CI and fixed linting.
* Fixed package.xml.
* Contributors: Tony Baltovski
```
