### PR TITLE
ddynamic_reconfigure: 0.4.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2080,7 +2080,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/pal-gbp/ddynamic_reconfigure.git
-      version: 0.3.2-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/ddynamic_reconfigure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ddynamic_reconfigure` to `0.4.2-1`:

- upstream repository: https://github.com/pal-robotics/ddynamic_reconfigure.git
- release repository: https://github.com/pal-gbp/ddynamic_reconfigure.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.2-1`

## ddynamic_reconfigure

```
* advertise services/topics only once (#29)
* Add pre and post update Callback Function Triggers to Parameter Update Process (#28)
* Contributors: Yuki Furuta
```
