### PR TITLE
Update Patch for depth_obstacle_detect_ros package

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2113,7 +2113,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/anilsripadarao/depth-obstacle-detect-ros-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/analogdevicesinc/depth-obstacle-detect-ros.git


### PR DESCRIPTION
Updating the release for [depth_obstacle_detect_ros](https://github.com/anilsripadarao/depth-obstacle-detect-ros-release) package to address a minor patch.