### PR TITLE
Add libc++-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3214,6 +3214,11 @@ libbsd-dev:
     homebrew:
       packages: [libbsd]
   ubuntu: [libbsd-dev]
+libc++-dev:
+  arch: [libc++]
+  debian: [libc++-dev]
+  fedora: [libcxx-devel]
+  ubuntu: [libc++-dev]
 libcairo2-dev:
   arch: [cairo]
   debian: [libcairo2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3215,9 +3215,16 @@ libbsd-dev:
       packages: [libbsd]
   ubuntu: [libbsd-dev]
 libc++-dev:
+  alpine: [libc++-dev]
   arch: [libc++]
   debian: [libc++-dev]
   fedora: [libcxx-devel]
+  gentoo: [llvm-runtimes/libcxx]
+  nixos: [libcxx]
+  opensuse: [libc++1]
+  osx:
+    homebrew:
+      packages: [llvm]
   ubuntu: [libc++-dev]
 libcairo2-dev:
   arch: [cairo]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libc++-dev

## Package Upstream Source:

https://github.com/llvm/llvm-project

## Purpose of using this:

I need to build Open3D from source as a vendor package.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?keywords=libc%2B%2B-dev&searchon=names&suite=stable&section=all
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/focal/libc++-dev
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/search?query=libcxx-devel
  - available
- Arch: https://archlinux.org/packages/?sort=&q=libc%2B%2B&maintainer=&flagged=
  - available
- Gentoo: https://packages.gentoo.org/packages/llvm-runtimes/libcxx
  - available
- macOS: https://formulae.brew.sh/formula/llvm#default
  - available
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/libc++-dev
  - available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/libc++1?
  - available
- rhel: https://rhel.pkgs.org/
  - not available
