### PR TITLE
sicks300_ros2: 1.3.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10029,6 +10029,18 @@ repositories:
       type: git
       url: https://github.com/ajtudela/sicks300_ros2.git
       version: humble
+    release:
+      packages:
+      - sicks300_2
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/sicks300_ros2-release.git
+      version: 1.3.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ajtudela/sicks300_ros2.git
+      version: humble
     status: maintained
   simple_actions:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300_ros2` to `1.3.3-1`:

- upstream repository: https://github.com/ajtudela/sicks300_ros2.git
- release repository: https://github.com/ros2-gbp/sicks300_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## sicks300_2

