### PR TITLE
etsi_its_messages: 3.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2040,6 +2040,9 @@ repositories:
       - etsi_its_mapem_ts_coding
       - etsi_its_mapem_ts_conversion
       - etsi_its_mapem_ts_msgs
+      - etsi_its_mcm_uulm_coding
+      - etsi_its_mcm_uulm_conversion
+      - etsi_its_mcm_uulm_msgs
       - etsi_its_messages
       - etsi_its_msgs
       - etsi_its_msgs_utils
@@ -2054,7 +2057,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `3.2.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ros2-gbp/etsi_its_messages-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-1`

## etsi_its_cam_coding

- No changes

## etsi_its_cam_conversion

- No changes

## etsi_its_cam_msgs

- No changes

## etsi_its_cam_ts_coding

- No changes

## etsi_its_cam_ts_conversion

- No changes

## etsi_its_cam_ts_msgs

- No changes

## etsi_its_coding

- No changes

## etsi_its_conversion

```
* Merge pull request #75 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/75> from ika-rwth-aachen/uulm-mcm
  Add MCM version of Ulm University
* Merge branch 'main' into uulm-mcm
* Merge pull request #72 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/72> from ika-rwth-aachen/fix-runtime-error
  Fix critical runtime bug
* Merge pull request #69 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/69> from ika-rwth-aachen/fix-udp-pub-sub
  Only create UDP publisher/subscriber if required
* Contributors: Jean-Pierre Busch, Lennart Reiher
```

## etsi_its_cpm_ts_coding

- No changes

## etsi_its_cpm_ts_conversion

- No changes

## etsi_its_cpm_ts_msgs

- No changes

## etsi_its_denm_coding

- No changes

## etsi_its_denm_conversion

- No changes

## etsi_its_denm_msgs

- No changes

## etsi_its_denm_ts_coding

- No changes

## etsi_its_denm_ts_conversion

- No changes

## etsi_its_denm_ts_msgs

- No changes

## etsi_its_mapem_ts_coding

- No changes

## etsi_its_mapem_ts_conversion

- No changes

## etsi_its_mapem_ts_msgs

- No changes

## etsi_its_mcm_uulm_coding

```
* Merge pull request #75 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/75> from ika-rwth-aachen/uulm-mcm
  Add MCM version of Ulm University
* Contributors: Jean-Pierre Busch
```

## etsi_its_mcm_uulm_conversion

```
* Merge pull request #75 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/75> from ika-rwth-aachen/uulm-mcm
  Add MCM version of Ulm University
* Contributors: Jean-Pierre Busch
```

## etsi_its_mcm_uulm_msgs

```
* Merge pull request #75 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/75> from ika-rwth-aachen/uulm-mcm
  Add MCM version of Ulm University
* Contributors: Jean-Pierre Busch
```

## etsi_its_messages

- No changes

## etsi_its_msgs

- No changes

## etsi_its_msgs_utils

```
* Merge pull request #76 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/76> from ika-rwth-aachen/feature/sensorinformation-utils
  Add setter functions for SensorInformationContainer
* Merge branch 'main' into uulm-mcm
* Merge pull request #74 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/74> from FabianThomsen/feature/var-utils
  Add setters and getters for (co)variances
* Contributors: Jean-Pierre Busch
```

## etsi_its_primitives_conversion

- No changes

## etsi_its_rviz_plugins

```
* Merge branch 'main' into uulm-mcm
* Merge pull request #73 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/73> from ika-rwth-aachen/fix/spatem-viz
  Fix visualization of SPATEMS on Startup of RViz
* Merge pull request #70 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/70> from ika-rwth-aachen/improvement/display_different_utm_zones_at_once
  Improvement/display different utm zones at once
* Contributors: Guido Küppers, Jean-Pierre Busch
```

## etsi_its_spatem_ts_coding

- No changes

## etsi_its_spatem_ts_conversion

- No changes

## etsi_its_spatem_ts_msgs

- No changes

## etsi_its_vam_ts_coding

- No changes

## etsi_its_vam_ts_conversion

- No changes

## etsi_its_vam_ts_msgs

- No changes
