### PR TITLE
rmw_zenoh: 0.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7198,7 +7198,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.4-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-1`

## rmw_zenoh_cpp

```
* Change serialization format in attachment_helpers.cpp (#605 <https://github.com/ros2/rmw_zenoh/issues/605>)
* Fix the comment. (#598 <https://github.com/ros2/rmw_zenoh/issues/598>)
* Bump Zenoh to v1.3.2 and improve e2e reliability with HeartbeatSporadic (#593 <https://github.com/ros2/rmw_zenoh/issues/593>)
* Trigger qos event callback if there are changes before registration  (#589 <https://github.com/ros2/rmw_zenoh/issues/589>)
* Set wait_set->triggered flag to false (#584 <https://github.com/ros2/rmw_zenoh/issues/584>)
* Add space after id token in rmw_zenohd log string (#578 <https://github.com/ros2/rmw_zenoh/issues/578>)
* fix: use std::unique_lock to unlock correctly on Windows (#573 <https://github.com/ros2/rmw_zenoh/issues/573>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Luca Cominardi, Patrick Roncagliolo, Yadunund, yellowhatter, Yuyuan Yuan
```

## zenoh_cpp_vendor

```
* Bump Zenoh to v1.3.2 and improve e2e reliability with HeartbeatSporadic (#593 <https://github.com/ros2/rmw_zenoh/issues/593>)
* Contributors: Julien Enoch
```
