### PR TITLE
rclcpp: 28.1.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6599,7 +6599,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.8-1
+      version: 28.1.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.9-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `28.1.8-1`

## rclcpp

```
* remove redundant typesupport check in serialization module (#2808 <https://github.com/ros2/rclcpp/issues/2808>) (#2815 <https://github.com/ros2/rclcpp/issues/2815>)
  (cherry picked from commit f78ed952b27acc63ef8022d78cb816c309a9ca3d)
  Co-authored-by: Tanishq Chaudhary <mailto:tanishqchaudhary101010@gmail.com>
* Contributors: mergify[bot]
```

## rclcpp_action

```
* fix(rclcpp_action): Fix sleep of expire thread in case of canceled timer (#2800 <https://github.com/ros2/rclcpp/issues/2800>)
  This fixes a bug, that the expire action thread would not sleep as,
  the sleep duration was not computed correctly.
  Co-authored-by: Janosch Machowinski <mailto:J.Machowinski@cellumation.com>
* Contributors: Janosch Machowinski
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
