### PR TITLE
rosbag2: 0.26.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7815,7 +7815,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.6-1
+      version: 0.26.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.7-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.26.6-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* Fix for failing test_record_qos_profiles on Windows (#1949 <https://github.com/ros2/rosbag2/issues/1949>) (#1951 <https://github.com/ros2/rosbag2/issues/1951>)
* CLI - update play verb metavar (#1906 <https://github.com/ros2/rosbag2/issues/1906>) (#1911 <https://github.com/ros2/rosbag2/issues/1911>)
  better show --clock [Hz] than --clock [CLOCK]
* Contributors: mergify[bot], Michael Orlov, Patrick Roncagliolo
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

```
* Avoid using internal modules for examples. (backport #1905 <https://github.com/ros2/rosbag2/issues/1905>) (#1907 <https://github.com/ros2/rosbag2/issues/1907>)
* Contributors: Tomoya Fujita, Alejandro Hernandez Cordero
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Add bindings to close method in PyReader and PyCompressionReader (#1935 <https://github.com/ros2/rosbag2/issues/1935>) (#1937 <https://github.com/ros2/rosbag2/issues/1937>)
* Remove SHARED from pybind11_add_module (#1929 <https://github.com/ros2/rosbag2/issues/1929>) (#1931 <https://github.com/ros2/rosbag2/issues/1931>)
* [jazzy] Upstream quality changes from Apex.AI part 1 (backport #1903 <https://github.com/ros2/rosbag2/issues/1903>) (#1909 <https://github.com/ros2/rosbag2/issues/1909>)
* Contributors: mergify[bot], Øystein Sture, Silvio Traversaro, Michael Orlov
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* [jazzy] Upstream quality changes from Apex.AI part 1 (backport #1903 <https://github.com/ros2/rosbag2/issues/1903>) (#1909 <https://github.com/ros2/rosbag2/issues/1909>)
* Contributors: mergify[bot], Michael Orlov
```

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

```
* [jazzy] Upstream quality changes from Apex.AI part 1 (backport #1903 <https://github.com/ros2/rosbag2/issues/1903>) (#1909 <https://github.com/ros2/rosbag2/issues/1909>)
* [jazzy] Use tmpfs in rosbag2 temporary_directory_fixture (backport #1901 <https://github.com/ros2/rosbag2/issues/1901>) (#1904 <https://github.com/ros2/rosbag2/issues/1904>)
* Contributors: mergify[bot], Michael Orlov
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* [jazzy] Upstream quality changes from Apex.AI part 1 (backport #1903 <https://github.com/ros2/rosbag2/issues/1903>) (#1909 <https://github.com/ros2/rosbag2/issues/1909>)
* Contributors: mergify[bot], Michael Orlov
```

## rosbag2_transport

```
* Initialize filter with namespaced updated topics and services.  (rolling) (#1944 <https://github.com/ros2/rosbag2/issues/1944>) (#1948 <https://github.com/ros2/rosbag2/issues/1948>)
* Fix: QoS incompatibilities are not expected with rmw_zenoh_cpp (#1936 <https://github.com/ros2/rosbag2/issues/1936>) (#1938 <https://github.com/ros2/rosbag2/issues/1938>)
* Don't delete existing subscription if failed to create a new one (#1923 <https://github.com/ros2/rosbag2/issues/1923>) (#1930 <https://github.com/ros2/rosbag2/issues/1930>)
* [jazzy] Upstream quality changes from Apex.AI part 1 (backport #1903 <https://github.com/ros2/rosbag2/issues/1903>) (#1909 <https://github.com/ros2/rosbag2/issues/1909>)
* [jazzy] Use tmpfs in rosbag2 temporary_directory_fixture (backport #1901 <https://github.com/ros2/rosbag2/issues/1901>) (#1904 <https://github.com/ros2/rosbag2/issues/1904>)
* Bugfix: Recorder discovery does not restart after being stopped (#1894 <https://github.com/ros2/rosbag2/issues/1894>) (#1900 <https://github.com/ros2/rosbag2/issues/1900>)
* Bugfix. Event publisher not starting for second run after stop (#1888 <https://github.com/ros2/rosbag2/issues/1888>) (#1890 <https://github.com/ros2/rosbag2/issues/1890>)
* Contributors: mergify[bot], Roderick Taylor, Yuyuan Yuan, Øystein Sture, Michael Orlov
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
