### PR TITLE
autoware_utils: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -682,6 +682,31 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_msgs.git
       version: main
     status: developed
+  autoware_utils:
+    release:
+      packages:
+      - autoware_utils
+      - autoware_utils_debug
+      - autoware_utils_diagnostics
+      - autoware_utils_geometry
+      - autoware_utils_logging
+      - autoware_utils_math
+      - autoware_utils_pcl
+      - autoware_utils_rclcpp
+      - autoware_utils_system
+      - autoware_utils_tf
+      - autoware_utils_uuid
+      - autoware_utils_visualization
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_utils-release.git
+      version: 1.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/autowarefoundation/autoware_utils.git
+      version: main
+    status: developed
   avt_vimba_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_utils` to `1.4.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_utils.git
- release repository: https://github.com/ros2-gbp/autoware_utils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## autoware_utils

```
* feat: remove managed transform buffer (#41 <https://github.com/autowarefoundation/autoware_utils/issues/41>)
* Contributors: Amadeusz Szymko
```

## autoware_utils_debug

```
* chore: sync files (#61 <https://github.com/autowarefoundation/autoware_utils/issues/61>)
  * chore: sync files
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* ci(pre-commit): quarterly autoupdate (#60 <https://github.com/autowarefoundation/autoware_utils/issues/60>)
  * ci(pre-commit): quarterly autoupdate
  updates:
  - [github.com/igorshubovych/markdownlint-cli: v0.43.0 → v0.44.0](https://github.com/igorshubovych/markdownlint-cli/compare/v0.43.0...v0.44.0)
  - [github.com/adrienverge/yamllint: v1.35.1 → v1.37.0](https://github.com/adrienverge/yamllint/compare/v1.35.1...v1.37.0)
  - [github.com/scop/pre-commit-shfmt: v3.10.0-2 → v3.11.0-1](https://github.com/scop/pre-commit-shfmt/compare/v3.10.0-2...v3.11.0-1)
  - [github.com/pycqa/isort: 5.13.2 → 6.0.1](https://github.com/pycqa/isort/compare/5.13.2...6.0.1)
  - [github.com/psf/black: 24.10.0 → 25.1.0](https://github.com/psf/black/compare/24.10.0...25.1.0)
  - [github.com/pre-commit/mirrors-clang-format: v19.1.6 → v20.1.0](https://github.com/pre-commit/mirrors-clang-format/compare/v19.1.6...v20.1.0)
  - [github.com/cpplint/cpplint: 2.0.0 → 2.0.1](https://github.com/cpplint/cpplint/compare/2.0.0...2.0.1)
  - [github.com/python-jsonschema/check-jsonschema: 0.30.0 → 0.32.1](https://github.com/python-jsonschema/check-jsonschema/compare/0.30.0...0.32.1)
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: awf-autoware-bot[bot], pre-commit-ci[bot]
```

## autoware_utils_diagnostics

- No changes

## autoware_utils_geometry

```
* chore: sync files (#61 <https://github.com/autowarefoundation/autoware_utils/issues/61>)
  * chore: sync files
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* feat(autoware_utils_geometry): resolve jazzy maybe-uninitialized (#63 <https://github.com/autowarefoundation/autoware_utils/issues/63>)
  feat(autoware_geometry_utils): resolve maybe-uninitizlied error in jazzy
* ci(pre-commit): quarterly autoupdate (#60 <https://github.com/autowarefoundation/autoware_utils/issues/60>)
  * ci(pre-commit): quarterly autoupdate
  updates:
  - [github.com/igorshubovych/markdownlint-cli: v0.43.0 → v0.44.0](https://github.com/igorshubovych/markdownlint-cli/compare/v0.43.0...v0.44.0)
  - [github.com/adrienverge/yamllint: v1.35.1 → v1.37.0](https://github.com/adrienverge/yamllint/compare/v1.35.1...v1.37.0)
  - [github.com/scop/pre-commit-shfmt: v3.10.0-2 → v3.11.0-1](https://github.com/scop/pre-commit-shfmt/compare/v3.10.0-2...v3.11.0-1)
  - [github.com/pycqa/isort: 5.13.2 → 6.0.1](https://github.com/pycqa/isort/compare/5.13.2...6.0.1)
  - [github.com/psf/black: 24.10.0 → 25.1.0](https://github.com/psf/black/compare/24.10.0...25.1.0)
  - [github.com/pre-commit/mirrors-clang-format: v19.1.6 → v20.1.0](https://github.com/pre-commit/mirrors-clang-format/compare/v19.1.6...v20.1.0)
  - [github.com/cpplint/cpplint: 2.0.0 → 2.0.1](https://github.com/cpplint/cpplint/compare/2.0.0...2.0.1)
  - [github.com/python-jsonschema/check-jsonschema: 0.30.0 → 0.32.1](https://github.com/python-jsonschema/check-jsonschema/compare/0.30.0...0.32.1)
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* fix(autoware_utils_geometry): fix procedure to check if point is on edge (#56 <https://github.com/autowarefoundation/autoware_utils/issues/56>)
  * fix procedure to check if point is on edge
  * add test cases
  ---------
* fix: convex_full header not found (#62 <https://github.com/autowarefoundation/autoware_utils/issues/62>)
* test(autoware_utils): port unit tests from autoware.universe (#28 <https://github.com/autowarefoundation/autoware_utils/issues/28>)
* fix: boost convex_hull for newer boost versions (#58 <https://github.com/autowarefoundation/autoware_utils/issues/58>)
  * Fix boost convex_hull for newer boost versions
  * Specify the distros for searchability
  * Use boost version for explicity
  ---------
* Contributors: Mitsuhiro Sakamoto, Takagi, Isamu, Tim Clephas, awf-autoware-bot[bot], pre-commit-ci[bot], storrrrrrrrm
```

## autoware_utils_logging

- No changes

## autoware_utils_math

- No changes

## autoware_utils_pcl

```
* test(autoware_utils): port unit tests from autoware.universe (#28 <https://github.com/autowarefoundation/autoware_utils/issues/28>)
* feat: remove managed transform buffer (#41 <https://github.com/autowarefoundation/autoware_utils/issues/41>)
* Contributors: Amadeusz Szymko, storrrrrrrrm
```

## autoware_utils_rclcpp

- No changes

## autoware_utils_system

- No changes

## autoware_utils_tf

- No changes

## autoware_utils_uuid

- No changes

## autoware_utils_visualization

- No changes
