### PR TITLE
ur_client_library: 2.0.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12680,7 +12680,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
-      version: 1.9.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.9.0-1`

## ur_client_library

```
* Add functionality to send MoveP and MoveC instructions to the robot (#303 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/303>)
* Fix naming issues (#307 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/307>)
* Add more tests for start_ursim.sh (#305 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/305>)
* [start_ursim.sh] Use direct web pages instead of GitHub API to download URCap (#308 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/308>)
* Fix typo in freedrive example document (#304 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/304>)
* Always download and install the latest URCap(X) if not present (#301 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/301>)
* Document robot setup for PolyScope X (#302 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/302>)
* Bump bats-core/bats-action from 3.0.0 to 3.0.1 (#300 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/300>)
* Polyscope x integration tests (#295 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/295>)
* Contributors: Felix Exner, dependabot[bot], xndcn
```
