### PR TITLE
open_manipulator: 3.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4683,7 +4683,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.2.1-1
+      version: 3.2.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.2.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.1-1`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* Handle lint errors
* Contributors: Woojin Wie
```

## om_spring_actuator_controller

```
* Handle lint errors
* Contributors: Woojin Wie
```

## open_manipulator

```
* Optimized ROS2 control configurations for better performance
* Handle lint errors
* Contributors: Woojin Wie
```

## open_manipulator_bringup

```
* Optimized ROS2 control configurations for better performance
* Contributors: Woojin Wie
```

## open_manipulator_description

```
* Streamlined Ros2 control config files and Handle lint errors
* Contributors: Woojin Wie
```

## open_manipulator_gui

```
* Updated CMakeLists.txt and Handle lint errors
* Contributors: Woojin Wie
```

## open_manipulator_moveit_config

```
* Handling lint errors
* Contributors: Woojin Wie
```

## open_manipulator_playground

```
* Handle lint errors
* Contributors: Woojin Wie
```

## open_manipulator_teleop

```
* OM-X Gripper Control Bug Fix
* Contributors: Woojin Wie
```
