### PR TITLE
add python3-filelock to rosdistro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5950,6 +5950,7 @@ python3-filelock:
   fedora: [python3-filelock]
   ubuntu: [python3-filelock]
   rhel: [python3-filelock]
+  opensuse: [python3-filelock]
 python3-filetype-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5949,8 +5949,7 @@ python3-filelock:
   debian: [python3-filelock]
   fedora: [python3-filelock]
   ubuntu: [python3-filelock]
-  rhel:
-    '*': [python3-filelock]
+  rhel: [python3-filelock]
 python3-filetype-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5946,6 +5946,8 @@ python3-fastnumbers-pip:
       packages: [fastnumbers]
 python3-fcn-pip: *migrate_eol_2025_04_30_python3_fcn_pip
 python3-filelock:
+  alpine: [py3-filelock]
+  arch: [python-filelock]
   debian: [python3-filelock]
   fedora: [python3-filelock]
   ubuntu: [python3-filelock]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5949,6 +5949,9 @@ python3-filelock:
   debian: [python3-filelock]
   fedora: [python3-filelock]
   ubuntu: [python3-filelock]
+  rhel:
+    '*': [python3-filelock]
+    '7': null
 python3-filetype-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5951,7 +5951,6 @@ python3-filelock:
   ubuntu: [python3-filelock]
   rhel:
     '*': [python3-filelock]
-    '7': null
 python3-filetype-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5950,9 +5950,9 @@ python3-filelock:
   arch: [python-filelock]
   debian: [python3-filelock]
   fedora: [python3-filelock]
-  ubuntu: [python3-filelock]
-  rhel: [python3-filelock]
   opensuse: [python3-filelock]
+  rhel: [python3-filelock]
+  ubuntu: [python3-filelock]
 python3-filetype-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5945,6 +5945,10 @@ python3-fastnumbers-pip:
     pip:
       packages: [fastnumbers]
 python3-fcn-pip: *migrate_eol_2025_04_30_python3_fcn_pip
+python3-filelock:
+  debian: [python3-filelock]
+  fedora: [python3-filelock]
+  ubuntu: [python3-filelock]
 python3-filetype-pip:
   debian:
     pip:


### PR DESCRIPTION
Add `python3-filelock` to the rosdistro to make it installable with rosdep