### PR TITLE
Add rosdep key 'python3-platformdirs'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8132,6 +8132,15 @@ python3-pkg-resources:
   opensuse: [python3-setuptools]
   rhel: ['python%{python3_pkgversion}-setuptools']
   ubuntu: [python3-pkg-resources]
+python3-platformdirs:
+  debian: [python3-platformdirs]
+  fedora: [python3-platformdirs]
+  rhel:
+    '*': [python3-platformdirs]
+    '8': null
+  ubuntu:
+    '*': [python3-platformdirs]
+    focal: null
 python3-playsound-pip:
   alpine:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: platformdirs

 A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir". 

## Package Upstream Source:

https://github.com/tox-dev/platformdirs

## Purpose of using this:

TODO Replace. This dependency is being used for this reason. This is why I think it's valuable to be added to the rosdep database.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=python3-platformdirs&searchon=names&exact=1&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-platformdirs&searchon=names&exact=1&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-platformdirs/python3-platformdirs/
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - https://packages.fedoraproject.org/pkgs/python-platformdirs/python3-platformdirs/