### PR TITLE
Add RHEL, fix Fedora rule for qtquickcontrols2-5-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8366,9 +8366,10 @@ qtpositioning5-dev:
 qtquickcontrols2-5-dev:
   arch: [qt5-quickcontrols2]
   debian: [qtquickcontrols2-5-dev]
-  fedora: [qt5-qtquickcontrols2]
+  fedora: [qt5-qtquickcontrols2-devel]
   gentoo: [dev-qt/qtquickcontrols2]
   nixos: [qt5.qtquickcontrols]
+  rhel: [qt5-qtquickcontrols2-devel]
   ubuntu: [qtquickcontrols2-5-dev]
 qttools5-dev:
   arch: [qt5-tools]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/qt5-qtquickcontrols2/qt5-qtquickcontrols2-devel/
RHEL 9: http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtquickcontrols2-devel-5.15.9-1.el9.i686.rpm
RHEL 8: http://mnvoip.mm.fcix.net/almalinux/8.10/PowerTools/x86_64/os/Packages/qt5-qtquickcontrols2-devel-5.15.3-1.el8.i686.rpm