### PR TITLE
Add RHEL rule for qtdeclarative5-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8343,6 +8343,7 @@ qtdeclarative5-dev:
   gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt5]
+  rhel: [qt5-qtdeclarative-devel]
   ubuntu: [qtdeclarative5-dev]
 qtmobility-dev:
   debian: [qtmobility-dev]


### PR DESCRIPTION
RHEL 8: http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtdeclarative-devel-5.15.3-2.el8.i686.rpm
RHEL 9: http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtdeclarative-devel-5.15.9-3.el9.i686.rpm