### PR TITLE
Add RHEL rule for libxcb-randr0-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6868,6 +6868,7 @@ libxcb-randr0-dev:
   fedora: [libxcb-devel]
   gentoo: [x11-libs/libxcb]
   nixos: [xorg.libxcb]
+  rhel: [libxcb-devel]
   ubuntu: [libxcb-randr0-dev]
 libxcursor-dev:
   arch: [libxcursor]


### PR DESCRIPTION
http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/libxcb-devel-1.13.1-1.el8.i686.rpm