### PR TITLE
Add RHEL and Fedora rules for libqt5-multimedia

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5919,7 +5919,9 @@ libqt5-gui:
 libqt5-multimedia:
   arch: [qt5-multimedia]
   debian: [libqt5multimedia5]
+  fedora: [qt5-qtmultimedia]
   nixos: [qt5.qtmultimedia]
+  rhel: [qt5-qtmultimedia]
   ubuntu: [libqt5multimedia5]
 libqt5-network:
   arch: [qt5-base]


### PR DESCRIPTION
Fedora: https://packages.fedoraproject.org/pkgs/qt5-qtmultimedia/qt5-qtmultimedia/
RHEL 8: http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtmultimedia-5.15.3-1.el8.i686.rpm
RHEL 9: http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtmultimedia-5.15.9-1.el9.i686.rpm