### PR TITLE
Add RHEL rule for qtmultimedia5-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8357,6 +8357,7 @@ qtmultimedia5-dev:
   gentoo: ['dev-qt/qtmultimedia:5']
   nixos: [qt5.qtmultimedia]
   openembedded: [qtmultimedia@meta-qt5]
+  rhel: [qt5-qtmultimedia-devel]
   ubuntu: [qtmultimedia5-dev]
 qtpositioning5-dev:
   arch: [qt5-location]


### PR DESCRIPTION
RHEL 8: http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtmultimedia-devel-5.15.3-1.el8.i686.rpm
RHEL 9: http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtmultimedia-devel-5.15.9-1.el9.i686.rpm