### PR TITLE
graph_monitor: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2267,6 +2267,15 @@ repositories:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git
       version: main
+    release:
+      packages:
+      - rmw_stats_shim
+      - rosgraph_monitor
+      - rosgraph_monitor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/graph_monitor-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_monitor` to `0.1.1-1`:

- upstream repository: https://github.com/ros-tooling/graph-monitor.git
- release repository: https://github.com/ros2-gbp/graph_monitor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rmw_stats_shim

```
* Initial package setup
* Contributors: Emerson Knapp
```

## rosgraph_monitor

```
* Remove telegraf bridge and update some language
* RAII initialization of RosgraphMonitor (#12 <https://github.com/ros-tooling/graph-monitor/issues/12>)
* Fix build issues with latest generate_parameter_library (#11 <https://github.com/ros-tooling/graph-monitor/issues/11>)
* Action CI - support Humble, Jazzy, Rolling (#1 <https://github.com/ros-tooling/graph-monitor/issues/1>)
* Initial package setup
* Contributors: Emerson Knapp, Troy Gibb, Joshua Whitley
```

## rosgraph_monitor_msgs

```
* Initial package setup
* Contributors: Emerson Knapp
```
