### PR TITLE
Add RHEL, fix Fedora rule for python3-websockets

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10762,10 +10762,11 @@ python3-websocket:
 python3-websockets:
   arch: [python-websockets]
   debian: [python3-websockets]
-  fedora: [python-websockets]
+  fedora: [python3-websockets]
   gentoo: [dev-python/websockets]
   nixos: [python3Packages.websockets]
   openembedded: [python3-websockets@meta-python]
+  rhel: [python3-websockets]
   ubuntu: [python3-websockets]
 python3-werkzeug:
   arch: [python-werkzeug]


### PR DESCRIPTION
Fedora, RHEL 8: https://packages.fedoraproject.org/pkgs/python-websockets/python3-websockets/
RHEL 9: http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/python3-websockets-11.0.3-6.el9.x86_64.rpm