### PR TITLE
Add RHEL rule for python3-pyside2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8783,6 +8783,9 @@ python3-pyside2:
   fedora: [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
   gentoo: [dev-python/pyside2, dev/python/shiboken2]
   nixos: [python3Packages.pyside2]
+  rhel:
+    '*': [python3-pyside2, pyside2-tools, python3-pyside2-devel, python3-shiboken2, python3-shiboken2-devel, shiboken2]
+    '8': null
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, python3-pyside2.qtcore, python3-pyside2.qtgui, python3-pyside2.qthelp, python3-pyside2.qtnetwork, python3-pyside2.qtprintsupport, python3-pyside2.qtsvg, python3-pyside2.qttest, python3-pyside2.qtwidgets, python3-pyside2.qtxml, shiboken2]
     bionic: null


### PR DESCRIPTION
All of these packages are part of EPEL:
https://packages.fedoraproject.org/pkgs/python-pyside2/python3-pyside2/
https://packages.fedoraproject.org/pkgs/python-pyside2/pyside2-tools/
https://packages.fedoraproject.org/pkgs/python-pyside2/python3-pyside2-devel/
https://packages.fedoraproject.org/pkgs/python-pyside2/python3-shiboken2/
https://packages.fedoraproject.org/pkgs/python-pyside2/python3-shiboken2-devel/
https://packages.fedoraproject.org/pkgs/python-pyside2/shiboken2/