### PR TITLE
Add RHEL and Fedora rules for various qml-module-* keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8176,7 +8176,9 @@ qhull-bin:
 qml-module-qt-labs-folderlistmodel:
   arch: [qt5-declarative]
   debian: [qml-module-qt-labs-folderlistmodel]
+  fedora: [qt5-qtdeclarative]
   nixos: [qt5.qtdeclarative]
+  rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qt-labs-folderlistmodel]
 qml-module-qt-labs-platform:
   arch: [qt5-quickcontrols2]
@@ -8184,11 +8186,14 @@ qml-module-qt-labs-platform:
   fedora: [qt5-qtquickcontrols2]
   gentoo: [dev-qt/qtquickcontrols2]
   nixos: [qt5.qtquickcontrols2]
+  rhel: [qt5-qtquickcontrols2]
   ubuntu: [qml-module-qt-labs-platform]
 qml-module-qt-labs-settings:
   arch: [qt5-declarative]
   debian: [qml-module-qt-labs-settings]
+  fedora: [qt5-qtdeclarative]
   nixos: [qt5.qtdeclarative]
+  rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qt-labs-settings]
 qml-module-qtcharts:
   arch: [qt5-charts]
@@ -8196,11 +8201,14 @@ qml-module-qtcharts:
   fedora: [qt5-qtcharts]
   gentoo: [dev-qt/qtcharts]
   nixos: [qt5.qtcharts]
+  rhel: [qt5-qtcharts]
   ubuntu: [qml-module-qtcharts]
 qml-module-qtgraphicaleffects:
   arch: [qt5-graphicaleffects]
   debian: [qml-module-qtgraphicaleffects]
+  fedora: [qt5-qtgraphicaleffects]
   nixos: [qt5.qtgraphicaleffects]
+  rhel: [qt5-qtgraphicaleffects]
   ubuntu: [qml-module-qtgraphicaleffects]
 qml-module-qtlocation:
   arch: [qt5-location]
@@ -8208,6 +8216,7 @@ qml-module-qtlocation:
   fedora: [qt5-qtlocation]
   gentoo: [dev-qt/qtlocation]
   nixos: [qt5.qtlocation]
+  rhel: [qt5-qtlocation]
   ubuntu: [qml-module-qtlocation]
 qml-module-qtmultimedia:
   arch: [qt5-multimedia]
@@ -8220,22 +8229,29 @@ qml-module-qtpositioning:
   fedora: [qt5-qtlocation]
   gentoo: [dev-qt/qtpositioning]
   nixos: [qt5.qtpositioning]
+  rhel: [qt5-qtlocation]
   ubuntu: [qml-module-qtpositioning]
 qml-module-qtquick-controls:
   arch: [qt5-quickcontrols]
   debian: [qml-module-qtquick-controls]
+  fedora: [qt5-qtquickcontrols]
   gentoo: [dev-qt/qtquickcontrols]
   nixos: [qt5.qtquickcontrols]
+  rhel: [qt5-qtquickcontrols]
   ubuntu: [qml-module-qtquick-controls]
 qml-module-qtquick-controls2:
   arch: [qt5-quickcontrols2]
   debian: [qml-module-qtquick-controls2]
+  fedora: [qt5-qtquickcontrols2]
   nixos: [qt5.qtquickcontrols2]
+  rhel: [qt5-qtquickcontrols2]
   ubuntu: [qml-module-qtquick-controls2]
 qml-module-qtquick-dialogs:
   arch: [qt5-quickcontrols]
   debian: [qml-module-qtquick-dialogs]
+  fedora: [qt5-qtquickcontrols]
   nixos: [qt5.qtquickcontrols]
+  rhel: [qt5-qtquickcontrols]
   ubuntu: [qml-module-qtquick-dialogs]
 qml-module-qtquick-extras:
   arch: [qt5-quickcontrols]
@@ -8249,22 +8265,30 @@ qml-module-qtquick-extras:
 qml-module-qtquick-layouts:
   arch: [qt5-declarative]
   debian: [qml-module-qtquick-layouts]
+  fedora: [qt5-qtdeclarative]
   nixos: [qt5.qtdeclarative]
+  rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qtquick-layouts]
 qml-module-qtquick-templates2:
   arch: [qt5-quickcontrols2]
   debian: [qml-module-qtquick-templates2]
+  fedora: [qt5-qtquickcontrols2]
   nixos: [qt5.qtquickcontrols2]
+  rhel: [qt5-qtquickcontrols2]
   ubuntu: [qml-module-qtquick-templates2]
 qml-module-qtquick-window2:
   arch: [qt5-declarative]
   debian: [qml-module-qtquick-window2]
+  fedora: [qt5-qtdeclarative]
   nixos: [qt5.qtdeclarative]
+  rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qtquick-window2]
 qml-module-qtquick2:
   arch: [qt5-quickcontrols2]
   debian: [qml-module-qtquick2]
+  fedora: [qt5-qtdeclarative]
   nixos: [qt5.qtquickcontrols2]
+  rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qtquick2]
 qrencode:
   arch: [qrencode]


### PR DESCRIPTION
Fedora:
https://packages.fedoraproject.org/pkgs/qt5-qtdeclarative/qt5-qtdeclarative/
https://packages.fedoraproject.org/pkgs/qt5-qtgraphicaleffects/qt5-qtgraphicaleffects/
https://packages.fedoraproject.org/pkgs/qt5-qtquickcontrols/qt5-qtquickcontrols/
https://packages.fedoraproject.org/pkgs/qt5-qtquickcontrols2/qt5-qtquickcontrols2/

RHEL 8:
https://packages.fedoraproject.org/pkgs/qt5-qtcharts/qt5-qtcharts/
http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtdeclarative-5.15.3-2.el8.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtgraphicaleffects-5.15.3-1.el8.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtlocation-5.15.3-1.el8.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtquickcontrols-5.15.3-1.el8.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/8.10/AppStream/x86_64/os/Packages/qt5-qtquickcontrols2-5.15.3-1.el8.i686.rpm

RHEL 9:
https://packages.fedoraproject.org/pkgs/qt5-qtcharts/qt5-qtcharts/
http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtdeclarative-5.15.9-3.el9.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtgraphicaleffects-5.15.9-1.el9.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtlocation-5.15.9-1.el9.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtquickcontrols-5.15.9-1.el9.i686.rpm
http://mnvoip.mm.fcix.net/almalinux/9.5/AppStream/x86_64/os/Packages/qt5-qtquickcontrols2-5.15.9-1.el9.i686.rpm