### PR TITLE
Branch Kilted Kaiju from Rolling Ridley

### DIFF
--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -87,6 +87,12 @@ distributions:
     distribution_status: active
     distribution_type: ros2
     python_version: 3
+  kilted:
+    distribution: [kilted/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/kilted-cache.yaml.gz
+    distribution_status: pre-release
+    distribution_type: ros2
+    python_version: 3
   kinetic:
     distribution: [kinetic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/kinetic-cache.yaml.gz

--- a/index.yaml
+++ b/index.yaml
@@ -45,6 +45,9 @@ distributions:
   jazzy:
     distribution: [jazzy/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/jazzy-cache.yaml.gz
+  kilted:
+    distribution: [kilted/distribution.yaml]
+    distribution_cache: http://repo.ros2.org/rosdistro_cache/kilted-cache.yaml.gz
   kinetic:
     distribution: [kinetic/distribution.yaml]
     distribution_cache: http://repositories.ros.org/rosdistro_cache/kinetic-cache.yaml.gz

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9,6 +9,9441 @@ release_platforms:
   - '9'
   ubuntu:
   - noble
-repositories: {}
+repositories:
+  SMACC2:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: rolling
+    release:
+      packages:
+      - smacc2
+      - smacc2_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/SMACC2-release.git
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: rolling
+    status: developed
+  acado_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/acado_vendor-release.git
+      version: 1.0.0-6
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
+      version: main
+    status: maintained
+  ackermann_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ackermann_msgs-release.git
+      version: 2.0.2-5
+    source:
+      type: git
+      url: https://github.com/ros-drivers/ackermann_msgs.git
+      version: ros2
+    status: maintained
+  actuator_msgs:
+    doc:
+      type: git
+      url: https://github.com/rudislabs/actuator_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/actuator_msgs-release.git
+      version: 0.0.1-3
+    source:
+      type: git
+      url: https://github.com/rudislabs/actuator_msgs.git
+      version: main
+    status: maintained
+  adaptive_component:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/adaptive_component.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/adaptive_component-release.git
+      version: 0.2.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/adaptive_component.git
+      version: rolling
+    status: developed
+  adi_iio:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/iio_ros2.git
+      version: rolling
+    status: maintained
+  ai_worker:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ai_worker.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ai_worker.git
+      version: main
+    status: developed
+  ament_acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ament_acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_acceleration-release.git
+      version: 0.2.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ament_acceleration.git
+      version: rolling
+    status: developed
+  ament_black:
+    release:
+      packages:
+      - ament_black
+      - ament_cmake_black
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_black-release.git
+      version: 0.2.6-1
+    source:
+      type: git
+      url: https://github.com/botsandus/ament_black.git
+      version: main
+    status: maintained
+  ament_cmake:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: rolling
+    release:
+      packages:
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_export_targets
+      - ament_cmake_gen_version_h
+      - ament_cmake_gmock
+      - ament_cmake_google_benchmark
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_vendor_package
+      - ament_cmake_version
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 2.7.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: rolling
+    status: developed
+  ament_cmake_catch2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/ament_cmake_catch2.git
+      version: main
+    status: developed
+  ament_cmake_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: rolling
+    release:
+      packages:
+      - ament_cmake_ros
+      - ament_cmake_ros_core
+      - domain_coordinator
+      - rmw_test_fixture
+      - rmw_test_fixture_implementation
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
+      version: 0.14.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ament_cmake_ros.git
+      version: rolling
+    status: maintained
+  ament_download:
+    doc:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_download-release.git
+      version: 0.0.5-5
+    source:
+      type: git
+      url: https://github.com/samsung-ros/ament_download.git
+      version: ros2
+    status: developed
+  ament_index:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: rolling
+    release:
+      packages:
+      - ament_index_cpp
+      - ament_index_python
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_index-release.git
+      version: 1.10.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_index.git
+      version: rolling
+    status: maintained
+  ament_lint:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: rolling
+    release:
+      packages:
+      - ament_clang_format
+      - ament_clang_tidy
+      - ament_cmake_clang_format
+      - ament_cmake_clang_tidy
+      - ament_cmake_copyright
+      - ament_cmake_cppcheck
+      - ament_cmake_cpplint
+      - ament_cmake_flake8
+      - ament_cmake_lint_cmake
+      - ament_cmake_mypy
+      - ament_cmake_pclint
+      - ament_cmake_pep257
+      - ament_cmake_pycodestyle
+      - ament_cmake_pyflakes
+      - ament_cmake_uncrustify
+      - ament_cmake_xmllint
+      - ament_copyright
+      - ament_cppcheck
+      - ament_cpplint
+      - ament_flake8
+      - ament_lint
+      - ament_lint_auto
+      - ament_lint_cmake
+      - ament_lint_common
+      - ament_mypy
+      - ament_pclint
+      - ament_pep257
+      - ament_pycodestyle
+      - ament_pyflakes
+      - ament_uncrustify
+      - ament_xmllint
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_lint-release.git
+      version: 0.19.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_lint.git
+      version: rolling
+    status: developed
+  ament_nodl:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_nodl-release.git
+      version: 0.1.0-6
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/ament_nodl.git
+      version: master
+    status: developed
+  ament_package:
+    doc:
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_package-release.git
+      version: 0.17.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_package.git
+      version: rolling
+    status: developed
+  ament_vitis:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ament_vitis.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_vitis-release.git
+      version: 0.10.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ament_vitis.git
+      version: rolling
+    status: developed
+  angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/angles-release.git
+      version: 1.16.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/angles.git
+      version: ros2
+    status: maintained
+  apex_test_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: rolling
+    release:
+      packages:
+      - apex_test_tools
+      - test_apex_test_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apex_test_tools-release.git
+      version: 0.0.2-8
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: rolling
+    status: developed
+  apriltag:
+    doc:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag-release.git
+      version: 3.4.3-1
+    source:
+      type: git
+      url: https://github.com/AprilRobotics/apriltag.git
+      version: master
+    status: maintained
+  apriltag_detector:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: release
+    release:
+      packages:
+      - apriltag_detector
+      - apriltag_detector_mit
+      - apriltag_detector_umich
+      - apriltag_draw
+      - apriltag_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_detector-release.git
+      version: 3.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_detector.git
+      version: release
+    status: developed
+  apriltag_mit:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_mit-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/apriltag_mit.git
+      version: release
+    status: developed
+  apriltag_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_msgs-release.git
+      version: 2.0.1-4
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_msgs.git
+      version: master
+    status: maintained
+  apriltag_ros:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/apriltag_ros-release.git
+      version: 3.2.2-1
+    source:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
+    status: developed
+  ardrone_ros:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    status: developed
+  aruco_markers:
+    source:
+      type: git
+      url: https://github.com/namo-robotics/aruco_markers.git
+      version: rolling
+    status: developed
+  aruco_opencv:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/ros_aruco_opencv.git
+      version: rolling
+    release:
+      packages:
+      - aruco_opencv
+      - aruco_opencv_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/aruco_opencv-release.git
+      version: 6.0.1-1
+    source:
+      type: git
+      url: https://github.com/fictionlab/ros_aruco_opencv.git
+      version: rolling
+    status: maintained
+  aruco_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
+    release:
+      packages:
+      - aruco
+      - aruco_msgs
+      - aruco_ros
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/aruco_ros-release.git
+      version: 5.0.5-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/aruco_ros.git
+      version: humble-devel
+    status: maintained
+  astuff_sensor_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    release:
+      packages:
+      - delphi_esr_msgs
+      - delphi_mrr_msgs
+      - delphi_srr_msgs
+      - derived_object_msgs
+      - ibeo_msgs
+      - kartech_linear_actuator_msgs
+      - mobileye_560_660_msgs
+      - neobotix_usboard_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
+      version: 4.0.0-3
+    source:
+      type: git
+      url: https://github.com/astuff/astuff_sensor_msgs.git
+      version: master
+    status: maintained
+  async_web_server_cpp:
+    doc:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: ros2-releases
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/async_web_server_cpp-release.git
+      version: 2.0.0-5
+    source:
+      type: git
+      url: https://github.com/fkie/async_web_server_cpp.git
+      version: ros2-develop
+    status: maintained
+  asyncapi_gencpp:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/asyncapi_gencpp.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/asyncapi_gencpp.git
+      version: main
+    status: developed
+  automatika_embodied_agents:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
+      version: 0.3.2-1
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-agents.git
+      version: main
+    status: developed
+  automatika_ros_sugar:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
+      version: 0.2.9-1
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/ros-sugar.git
+      version: main
+    status: developed
+  automotive_autonomy_msgs:
+    doc:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    release:
+      packages:
+      - automotive_autonomy_msgs
+      - automotive_navigation_msgs
+      - automotive_platform_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
+      version: 3.0.4-5
+    source:
+      type: git
+      url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: maintained
+  autoware_adapi_msgs:
+    release:
+      packages:
+      - autoware_adapi_v1_msgs
+      - autoware_adapi_version_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+      version: main
+    status: developed
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_auto_msgs-release.git
+      version: 1.0.0-6
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    status: developed
+  autoware_cmake:
+    release:
+      packages:
+      - autoware_cmake
+      - autoware_lint_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_cmake-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_cmake.git
+      version: main
+    status: developed
+  autoware_internal_msgs:
+    release:
+      packages:
+      - autoware_internal_debug_msgs
+      - autoware_internal_metric_msgs
+      - autoware_internal_msgs
+      - autoware_internal_perception_msgs
+      - autoware_internal_planning_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
+      version: 1.8.1-2
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+      version: main
+    status: developed
+  autoware_lanelet2_extension:
+    release:
+      packages:
+      - autoware_lanelet2_extension
+      - autoware_lanelet2_extension_python
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+      version: main
+    status: developed
+  autoware_msgs:
+    release:
+      packages:
+      - autoware_common_msgs
+      - autoware_control_msgs
+      - autoware_localization_msgs
+      - autoware_map_msgs
+      - autoware_msgs
+      - autoware_perception_msgs
+      - autoware_planning_msgs
+      - autoware_sensing_msgs
+      - autoware_system_msgs
+      - autoware_v2x_msgs
+      - autoware_vehicle_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_msgs-release.git
+      version: 1.6.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_msgs.git
+      version: main
+    status: developed
+  avt_vimba_camera:
+    doc:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: ros2_master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/avt_vimba_camera-release.git
+      version: 2001.1.0-5
+    source:
+      type: git
+      url: https://github.com/astuff/avt_vimba_camera.git
+      version: ros2_master
+    status: maintained
+  aws-robomaker-small-warehouse-world:
+    doc:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
+    release:
+      packages:
+      - aws_robomaker_small_warehouse_world
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
+    source:
+      type: git
+      url: https://github.com/aws-robotics/aws-robomaker-small-warehouse-world.git
+      version: ros2
+    status: maintained
+  aws_sdk_cpp_vendor:
+    doc:
+      type: git
+      url: https://github.com/wep21/aws_sdk_cpp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release.git
+      version: 0.2.1-2
+    source:
+      type: git
+      url: https://github.com/wep21/aws_sdk_cpp_vendor.git
+      version: main
+    status: maintained
+  azure_iot_sdk_c:
+    doc:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
+      version: 1.14.0-1
+    source:
+      type: git
+      url: https://github.com/Azure/azure-iot-sdk-c.git
+      version: main
+    status: maintained
+  backward_ros:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/backward_ros-release.git
+      version: 1.0.7-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/backward_ros.git
+      version: foxy-devel
+    status: maintained
+  bag2_to_image:
+    doc:
+      type: git
+      url: https://github.com/wep21/bag2_to_image.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/bag2_to_image-release.git
+      version: 0.1.0-4
+    source:
+      type: git
+      url: https://github.com/wep21/bag2_to_image.git
+      version: main
+    status: maintained
+  behaviortree_cpp_v3:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: v3.8
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
+      version: 3.8.6-2
+    source:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: v3.8
+    status: developed
+  behaviortree_cpp_v4:
+    doc:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    release:
+      packages:
+      - behaviortree_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
+      version: 4.6.2-1
+    source:
+      type: git
+      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
+      version: master
+    status: developed
+  bno055:
+    doc:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/bno055-release.git
+      version: 0.5.0-2
+    source:
+      type: git
+      url: https://github.com/flynneva/bno055.git
+      version: main
+    status: maintained
+  bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: ros2
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/bond_core-release.git
+      version: 4.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: ros2
+    status: maintained
+  boost_geometry_util:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/boost_geometry_util.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/boost_geometry_util-release.git
+      version: 0.0.1-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/boost_geometry_util.git
+      version: master
+    status: developed
+  boost_plugin_loader:
+    source:
+      type: git
+      url: https://github.com/tesseract-robotics/boost_plugin_loader.git
+      version: main
+  boost_sml_vendor:
+    doc:
+      type: git
+      url: https://github.com/nobleo/boost_sml_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/boost_sml_vendor-release.git
+      version: 1.1.11-1
+    source:
+      type: git
+      url: https://github.com/nobleo/boost_sml_vendor.git
+      version: main
+    status: maintained
+  camera_ros:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/camera_ros.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/camera_ros-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/christianrauch/camera_ros.git
+      version: main
+    status: developed
+  cartographer:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer-release.git
+      version: 2.0.9003-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer.git
+      version: ros2
+    status: maintained
+  cartographer_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: ros2
+    release:
+      packages:
+      - cartographer_ros
+      - cartographer_ros_msgs
+      - cartographer_rviz
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cartographer_ros-release.git
+      version: 2.0.9003-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/cartographer_ros.git
+      version: ros2
+    status: maintained
+  cascade_lifecycle:
+    doc:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: rolling-devel
+    release:
+      packages:
+      - cascade_lifecycle_msgs
+      - rclcpp_cascade_lifecycle
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/fmrico/cascade_lifecycle.git
+      version: rolling-devel
+    status: maintained
+  catch_ros2:
+    doc:
+      type: git
+      url: https://github.com/ngmor/catch_ros2.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/catch_ros2-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/ngmor/catch_ros2.git
+      version: rolling
+    status: maintained
+  class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/class_loader-release.git
+      version: 2.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: rolling
+    status: maintained
+  classic_bags:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/classic_bags-release.git
+      version: 0.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/classic_bags.git
+      version: main
+    status: developed
+  clips_vendor:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_vendor.git
+      version: main
+    status: maintained
+  coal:
+    doc:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/coal-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/coal-library/coal.git
+      version: master
+    status: developed
+  cob_common:
+    doc:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: foxy
+    release:
+      packages:
+      - cob_actions
+      - cob_msgs
+      - cob_srvs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cob_common-release.git
+      version: 2.8.12-1
+    source:
+      type: git
+      url: https://github.com/4am-robotics/cob_common.git
+      version: foxy
+    status: maintained
+  color_names:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/color_names.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/color_names-release.git
+      version: 0.0.3-5
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/color_names-release.git
+      version: master
+    status: developed
+  color_util:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/color_util.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/color_util-release.git
+      version: 1.0.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/color_util.git
+      version: main
+    status: developed
+  common_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - actionlib_msgs
+      - common_interfaces
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - sensor_msgs_py
+      - shape_msgs
+      - std_msgs
+      - std_srvs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/common_interfaces-release.git
+      version: 5.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/common_interfaces.git
+      version: rolling
+    status: maintained
+  console_bridge_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
+      version: 1.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/console_bridge_vendor.git
+      version: rolling
+    status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/control_box_rst-release.git
+      version: 0.0.7-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: foxy-devel
+    status: developed
+  control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/control_msgs-release.git
+      version: 6.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: master
+    status: maintained
+  control_toolbox:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/control_toolbox-release.git
+      version: 5.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/control_toolbox.git
+      version: ros2-master
+    status: maintained
+  cpp_polyfills:
+    release:
+      packages:
+      - tcb_span
+      - tl_expected
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cpp_polyfills-release.git
+      version: 1.0.2-4
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/cpp_polyfills.git
+      version: main
+    status: maintained
+  cudnn_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/tier4/cudnn_cmake_module.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cudnn_cmake_module-release.git
+      version: 0.0.1-5
+    source:
+      type: git
+      url: https://github.com/tier4/cudnn_cmake_module.git
+      version: main
+    status: maintained
+  cyclonedds:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cyclonedds-release.git
+      version: 0.10.5-1
+    source:
+      type: git
+      url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+      version: releases/0.10.x
+    status: maintained
+  data_tamer:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/data_tamer.git
+      version: main
+    release:
+      packages:
+      - data_tamer_cpp
+      - data_tamer_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/data_tamer-release.git
+      version: 0.9.4-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/PickNikRobotics/data_tamer.git
+      version: main
+    status: developed
+  demos:
+    doc:
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: rolling
+    release:
+      packages:
+      - action_tutorials_cpp
+      - action_tutorials_py
+      - composition
+      - demo_nodes_cpp
+      - demo_nodes_cpp_native
+      - demo_nodes_py
+      - dummy_map_server
+      - dummy_robot_bringup
+      - dummy_sensors
+      - image_tools
+      - intra_process_demo
+      - lifecycle
+      - lifecycle_py
+      - logging_demo
+      - pendulum_control
+      - pendulum_msgs
+      - quality_of_service_demo_cpp
+      - quality_of_service_demo_py
+      - topic_monitor
+      - topic_statistics_demo
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/demos-release.git
+      version: 0.35.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/demos.git
+      version: rolling
+    status: developed
+  depthimage_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
+      version: 2.5.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/depthimage_to_laserscan.git
+      version: ros2
+    status: maintained
+  diagnostics:
+    doc:
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: ros2
+    release:
+      packages:
+      - diagnostic_aggregator
+      - diagnostic_common_diagnostics
+      - diagnostic_remote_logging
+      - diagnostic_updater
+      - diagnostics
+      - self_test
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/diagnostics-release.git
+      version: 4.4.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/diagnostics.git
+      version: ros2
+    status: maintained
+  dolly:
+    doc:
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: galactic
+    release:
+      packages:
+      - dolly
+      - dolly_follow
+      - dolly_gazebo
+      - dolly_ignition
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dolly-release.git
+      version: 0.4.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/chapulina/dolly.git
+      version: galactic
+    status: developed
+  domain_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros2/domain_bridge.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/domain_bridge-release.git
+      version: 0.5.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/domain_bridge.git
+      version: main
+    status: developed
+  doom_ros:
+    source:
+      type: git
+      url: https://github.com/gstavrinos/doom_ros.git
+      version: master
+    status: developed
+  dual_laser_merger:
+    doc:
+      type: git
+      url: https://github.com/pradyum/dual_laser_merger.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dual_laser_merger-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/pradyum/dual_laser_merger.git
+      version: rolling
+    status: developed
+  dynamixel_hardware:
+    doc:
+      type: git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/dynamixel-community/dynamixel_hardware.git
+      version: rolling
+    status: developed
+  dynamixel_hardware_interface:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
+      version: 1.4.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
+      version: main
+    status: developed
+  dynamixel_interfaces:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_interfaces-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
+      version: main
+    status: developed
+  dynamixel_sdk:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: ros2
+    release:
+      packages:
+      - dynamixel_sdk
+      - dynamixel_sdk_custom_interfaces
+      - dynamixel_sdk_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
+      version: 3.8.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
+      version: ros2
+    status: maintained
+  dynamixel_workbench:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: ros2
+    release:
+      packages:
+      - dynamixel_workbench
+      - dynamixel_workbench_toolbox
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
+      version: 2.2.4-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
+      version: ros2
+    status: maintained
+  dynamixel_workbench_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
+      version: ros2
+    status: maintained
+  ecal:
+    doc:
+      type: git
+      url: https://github.com/eclipse-ecal/ecal.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ecal-release.git
+      version: 5.12.0-4
+    source:
+      type: git
+      url: https://github.com/eclipse-ecal/ecal.git
+      version: master
+    status: developed
+  ecl_core:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.2.x
+    release:
+      packages:
+      - ecl_command_line
+      - ecl_concepts
+      - ecl_containers
+      - ecl_converters
+      - ecl_core
+      - ecl_core_apps
+      - ecl_devices
+      - ecl_eigen
+      - ecl_exceptions
+      - ecl_filesystem
+      - ecl_formatters
+      - ecl_geometry
+      - ecl_ipc
+      - ecl_linear_algebra
+      - ecl_manipulators
+      - ecl_math
+      - ecl_mobile_robot
+      - ecl_mpl
+      - ecl_sigslots
+      - ecl_statistics
+      - ecl_streams
+      - ecl_threads
+      - ecl_time
+      - ecl_type_traits
+      - ecl_utilities
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ecl_core-release.git
+      version: 1.2.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_core.git
+      version: release/1.2.x
+    status: maintained
+  ecl_lite:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.2.x
+    release:
+      packages:
+      - ecl_config
+      - ecl_console
+      - ecl_converters_lite
+      - ecl_errors
+      - ecl_io
+      - ecl_lite
+      - ecl_sigslots_lite
+      - ecl_time_lite
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ecl_lite-release.git
+      version: 1.2.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_lite.git
+      version: release/1.2.x
+    status: maintained
+  ecl_tools:
+    doc:
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: release/1.0.x
+    release:
+      packages:
+      - ecl_build
+      - ecl_license
+      - ecl_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ecl_tools-release.git
+      version: 1.0.3-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/stonier/ecl_tools.git
+      version: devel
+    status: maintained
+  eigen3_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/eigen3_cmake_module.git
+      version: rolling
+    status: maintained
+  eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
+      version: 1.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: ros2
+    status: maintained
+  eigenpy:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/eigenpy-release.git
+      version: 3.10.3-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eigenpy.git
+      version: devel
+    status: maintained
+  eiquadprog:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/eiquadprog-release.git
+      version: 1.2.9-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/eiquadprog.git
+      version: devel
+    status: maintained
+  event_camera_codecs:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_codecs.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_codecs-release.git
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_codecs.git
+      version: rolling
+    status: developed
+  event_camera_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_msgs-release.git
+      version: 1.0.6-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_msgs.git
+      version: rolling
+    status: developed
+  event_camera_py:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_py-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: rolling
+    status: developed
+  event_camera_renderer:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_renderer.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_renderer-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_renderer.git
+      version: rolling
+    status: developed
+  example_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/example_interfaces-release.git
+      version: 0.13.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/example_interfaces.git
+      version: rolling
+    status: maintained
+  examples:
+    doc:
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: rolling
+    release:
+      packages:
+      - examples_rclcpp_async_client
+      - examples_rclcpp_cbg_executor
+      - examples_rclcpp_minimal_action_client
+      - examples_rclcpp_minimal_action_server
+      - examples_rclcpp_minimal_client
+      - examples_rclcpp_minimal_composition
+      - examples_rclcpp_minimal_publisher
+      - examples_rclcpp_minimal_service
+      - examples_rclcpp_minimal_subscriber
+      - examples_rclcpp_minimal_timer
+      - examples_rclcpp_multithreaded_executor
+      - examples_rclcpp_wait_set
+      - examples_rclpy_executors
+      - examples_rclpy_guard_conditions
+      - examples_rclpy_minimal_action_client
+      - examples_rclpy_minimal_action_server
+      - examples_rclpy_minimal_client
+      - examples_rclpy_minimal_publisher
+      - examples_rclpy_minimal_service
+      - examples_rclpy_minimal_subscriber
+      - examples_rclpy_pointcloud_publisher
+      - launch_testing_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/examples-release.git
+      version: 0.20.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/examples.git
+      version: rolling
+    status: maintained
+  fastcdr:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fastcdr-release.git
+      version: 2.3.0-1
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/eProsima/Fast-CDR.git
+      version: 2.2.x
+    status: maintained
+  fastdds:
+    doc:
+      type: git
+      url: https://github.com/eProsima/Fast-DDS.git
+      version: 3.1.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fastdds-release.git
+      version: 3.2.1-1
+    source:
+      test_commits: true
+      test_pull_requests: false
+      type: git
+      url: https://github.com/eProsima/Fast-DDS.git
+      version: 3.1.x
+    status: maintained
+  feetech_ros2_driver:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      version: main
+    status: developed
+  ffmpeg_encoder_decoder:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
+      version: release
+    status: developed
+  ffmpeg_image_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
+      version: release
+    status: developed
+  ffmpeg_image_transport_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
+      version: 1.0.2-2
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
+      version: release
+    status: developed
+  ffmpeg_image_transport_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
+      version: release
+    status: developed
+  fields2cover:
+    doc:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fields2cover-release.git
+      version: 2.0.0-15
+    source:
+      type: git
+      url: https://github.com/Fields2Cover/fields2cover.git
+      version: main
+    status: developed
+  filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/filters-release.git
+      version: 2.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/filters.git
+      version: ros2
+    status: maintained
+  find_object_2d:
+    doc:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/find_object_2d-release.git
+      version: 0.7.1-1
+    source:
+      type: git
+      url: https://github.com/introlab/find-object.git
+      version: rolling-devel
+    status: maintained
+  fkie_message_filters:
+    doc:
+      type: git
+      url: https://github.com/fkie/message_filters.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fkie_message_filters-release.git
+      version: 3.0.2-1
+    source:
+      type: git
+      url: https://github.com/fkie/message_filters.git
+      version: ros2
+    status: maintained
+  fkie_potree_rviz_plugin:
+    source:
+      type: git
+      url: https://github.com/fkie/potree_rviz_plugin.git
+      version: ros2
+    status: developed
+  flex_sync:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/flex_sync-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/flex_sync.git
+      version: release
+    status: developed
+  flexbe_behavior_engine:
+    doc:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: rolling
+    release:
+      packages:
+      - flexbe_behavior_engine
+      - flexbe_core
+      - flexbe_input
+      - flexbe_mirror
+      - flexbe_msgs
+      - flexbe_onboard
+      - flexbe_states
+      - flexbe_testing
+      - flexbe_widget
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/flexbe/flexbe_behavior_engine.git
+      version: rolling
+    status: developed
+  flir_camera_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: ros2-release
+    release:
+      packages:
+      - flir_camera_description
+      - flir_camera_msgs
+      - spinnaker_camera_driver
+      - spinnaker_synchronized_camera_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/flir_camera_driver-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/flir_camera_driver.git
+      version: ros2-release
+    status: maintained
+  fluent_rviz:
+    doc:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fluent_rviz-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/ForteFibre/FluentRviz.git
+      version: ros2
+    status: developed
+  fmi_adapter:
+    doc:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: rolling
+    release:
+      packages:
+      - fmi_adapter
+      - fmi_adapter_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fmi_adapter-release.git
+      version: 2.1.2-2
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmi_adapter.git
+      version: rolling
+    status: maintained
+  fmilibrary_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
+      version: 1.0.1-4
+    source:
+      type: git
+      url: https://github.com/boschresearch/fmilibrary_vendor.git
+      version: rolling
+    status: maintained
+  foonathan_memory_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
+      version: 1.3.1-2
+    source:
+      type: git
+      url: https://github.com/eProsima/foonathan_memory_vendor.git
+      version: master
+    status: maintained
+  four_wheel_steering_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/four_wheel_steering_msgs-release.git
+      version: 2.0.1-5
+    source:
+      type: git
+      url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
+      version: ros2
+    status: maintained
+  foxglove_bridge:
+    doc:
+      type: git
+      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/foxglove_bridge-release.git
+      version: 0.8.3-1
+    source:
+      type: git
+      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      version: main
+    status: developed
+  foxglove_compressed_video_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
+      version: release
+    status: developed
+  foxglove_msgs:
+    doc:
+      type: git
+      url: https://github.com/foxglove/schemas.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/foxglove/schemas.git
+      version: main
+    status: maintained
+  fuse:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: rolling
+    release:
+      packages:
+      - fuse
+      - fuse_constraints
+      - fuse_core
+      - fuse_doc
+      - fuse_graphs
+      - fuse_loss
+      - fuse_models
+      - fuse_msgs
+      - fuse_optimizers
+      - fuse_publishers
+      - fuse_tutorials
+      - fuse_variables
+      - fuse_viz
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fuse-release.git
+      version: 1.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/fuse.git
+      version: rolling
+    status: maintained
+  game_controller_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: rolling
+    release:
+      packages:
+      - game_controller_spl
+      - game_controller_spl_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/game_controller_spl-release.git
+      version: 5.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-sports/game_controller_spl.git
+      version: rolling
+    status: developed
+  generate_parameter_library:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
+      version: main
+    release:
+      packages:
+      - cmake_generate_parameter_module_example
+      - generate_parameter_library
+      - generate_parameter_library_example
+      - generate_parameter_library_example_external
+      - generate_parameter_library_py
+      - generate_parameter_module_example
+      - parameter_traits
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/generate_parameter_library.git
+      version: main
+    status: developed
+  geographic_info:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: ros2
+    release:
+      packages:
+      - geodesy
+      - geographic_info
+      - geographic_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/geographic_info-release.git
+      version: 1.0.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-geographic-info/geographic_info.git
+      version: ros2
+    status: maintained
+  geometric_shapes:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/geometric_shapes-release.git
+      version: 2.3.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/geometric_shapes.git
+      version: ros2
+    status: maintained
+  geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: rolling
+    release:
+      packages:
+      - examples_tf2_py
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_eigen_kdl
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_ros_py
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry2-release.git
+      version: 0.40.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/geometry2.git
+      version: rolling
+    status: maintained
+  geometry_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: rolling
+    release:
+      packages:
+      - geometry_tutorials
+      - turtle_tf2_cpp
+      - turtle_tf2_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/geometry_tutorials-release.git
+      version: 0.6.3-1
+    source:
+      type: git
+      url: https://github.com/ros/geometry_tutorials.git
+      version: rolling
+    status: developed
+  google_benchmark_vendor:
+    doc:
+      type: git
+      url: https://github.com/ament/google_benchmark_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
+      version: 0.6.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/google_benchmark_vendor.git
+      version: rolling
+    status: maintained
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.15.1-1
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: rolling
+    status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: ros2-devel
+    release:
+      packages:
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gps_umd-release.git
+      version: 2.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: ros2-devel
+    status: developed
+  graph_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-tooling/graph-monitor.git
+      version: main
+    status: developed
+  graph_msgs:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/graph_msgs-release.git
+      version: 0.2.0-5
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/graph_msgs.git
+      version: ros2
+    status: maintained
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/grasping_msgs-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros2
+    status: maintained
+  grbl_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/grbl_msgs-release.git
+      version: 0.0.2-8
+    source:
+      type: git
+      url: https://github.com/flynneva/grbl_msgs.git
+      version: main
+    status: maintained
+  grbl_ros:
+    doc:
+      type: git
+      url: https://github.com/flynneva/grbl_ros.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/grbl_ros-release.git
+      version: 0.0.16-6
+    source:
+      type: git
+      url: https://github.com/flynneva/grbl_ros.git
+      version: main
+    status: maintained
+  gscam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gscam-release.git
+      version: 2.0.2-4
+    source:
+      type: git
+      url: https://github.com/ros-drivers/gscam.git
+      version: ros2
+    status: developed
+  gtsam:
+    doc:
+      type: git
+      url: https://github.com/borglab/gtsam.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gtsam-release.git
+      version: 4.2.0-6
+    source:
+      type: git
+      url: https://github.com/borglab/gtsam.git
+      version: develop
+    status: developed
+  gz_cmake_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_cmake_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
+      version: 0.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_cmake_vendor.git
+      version: rolling
+    status: maintained
+  gz_common_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_common_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_common_vendor-release.git
+      version: 0.2.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_common_vendor.git
+      version: rolling
+    status: maintained
+  gz_dartsim_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
+      version: 0.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_dartsim_vendor.git
+      version: rolling
+    status: maintained
+  gz_fuel_tools_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
+      version: rolling
+    status: maintained
+  gz_gui_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_gui_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_gui_vendor.git
+      version: rolling
+    status: maintained
+  gz_launch_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_launch_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_launch_vendor.git
+      version: rolling
+    status: maintained
+  gz_math_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_math_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_math_vendor-release.git
+      version: 0.2.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_math_vendor.git
+      version: rolling
+    status: maintained
+  gz_msgs_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_msgs_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
+      version: 0.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_msgs_vendor.git
+      version: rolling
+    status: maintained
+  gz_ogre_next_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_ogre_next_vendor.git
+      version: rolling
+    status: maintained
+  gz_physics_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_physics_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_physics_vendor.git
+      version: rolling
+    status: maintained
+  gz_plugin_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_plugin_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_plugin_vendor.git
+      version: rolling
+    status: maintained
+  gz_rendering_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_rendering_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_rendering_vendor.git
+      version: rolling
+    status: maintained
+  gz_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: rolling
+    release:
+      packages:
+      - gz_ros2_control
+      - gz_ros2_control_demos
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 2.0.7-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/gz_ros2_control.git
+      version: rolling
+    status: maintained
+  gz_sensors_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_sensors_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_sensors_vendor.git
+      version: rolling
+    status: maintained
+  gz_sim_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_sim_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_sim_vendor.git
+      version: rolling
+    status: maintained
+  gz_tools_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_tools_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_tools_vendor-release.git
+      version: 0.1.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_tools_vendor.git
+      version: rolling
+    status: maintained
+  gz_transport_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_transport_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
+      version: 0.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_transport_vendor.git
+      version: rolling
+    status: maintained
+  gz_utils_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/gz_utils_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
+      version: 0.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/gz_utils_vendor.git
+      version: rolling
+    status: maintained
+  hash_library_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/hash_library_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/hash_library_vendor-release.git
+      version: 0.1.1-6
+    source:
+      type: git
+      url: https://github.com/tier4/hash_library_vendor.git
+      version: main
+    status: maintained
+  hatchbed_common:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/hatchbed_common-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_common.git
+      version: main
+    status: developed
+  heaphook:
+    doc:
+      type: git
+      url: https://github.com/tier4/heaphook.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/heaphook-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/tier4/heaphook.git
+      version: main
+    status: maintained
+  hebi_cpp_api:
+    doc:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
+      version: 3.12.3-1
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
+      version: ros2
+    status: maintained
+  hls_lfcd_lds_driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/hls_lfcd_lds_driver-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
+      version: rolling-devel
+    status: developed
+  hpp-fcl:
+    doc:
+      type: git
+      url: https://github.com/humanoid-path-planner/hpp-fcl.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/hpp_fcl-release.git
+      version: 2.4.5-1
+    source:
+      type: git
+      url: https://github.com/humanoid-path-planner/hpp-fcl.git
+      version: devel
+    status: developed
+  hyveos_bridge:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros.git
+      version: main
+    status: developed
+  hyveos_msgs:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros_msgs.git
+      version: main
+    status: developed
+  iceoryx:
+    release:
+      packages:
+      - iceoryx_binding_c
+      - iceoryx_hoofs
+      - iceoryx_introspection
+      - iceoryx_posh
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/iceoryx-release.git
+      version: 2.0.5-5
+    source:
+      type: git
+      url: https://github.com/eclipse-iceoryx/iceoryx.git
+      version: release_2.0
+    status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ifm3d-release.git
+      version: 0.18.0-9
+    status: developed
+  ign_rviz:
+    doc:
+      type: git
+      url: https://github.com/ignitionrobotics/ign-rviz.git
+      version: main
+    release:
+      packages:
+      - ign_rviz
+      - ign_rviz_common
+      - ign_rviz_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ign_rviz-release.git
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ignitionrobotics/ign-rviz.git
+      version: main
+    status: developed
+  image_common:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: rolling
+    release:
+      packages:
+      - camera_calibration_parsers
+      - camera_info_manager
+      - camera_info_manager_py
+      - image_common
+      - image_transport
+      - image_transport_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/image_common-release.git
+      version: 6.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_common.git
+      version: rolling
+    status: maintained
+  image_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: rolling
+    release:
+      packages:
+      - camera_calibration
+      - depth_image_proc
+      - image_pipeline
+      - image_proc
+      - image_publisher
+      - image_rotate
+      - image_view
+      - stereo_image_proc
+      - tracetools_image_pipeline
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/image_pipeline-release.git
+      version: 6.0.10-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_pipeline.git
+      version: rolling
+    status: maintained
+  image_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: rolling
+    release:
+      packages:
+      - compressed_depth_image_transport
+      - compressed_image_transport
+      - image_transport_plugins
+      - theora_image_transport
+      - zstd_image_transport
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/image_transport_plugins-release.git
+      version: 5.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/image_transport_plugins.git
+      version: rolling
+    status: maintained
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_pipeline-release.git
+      version: 0.5.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    status: maintained
+  imu_tools:
+    doc:
+      type: git
+      url: https://github.com/CCNYRoboticsLab/imu_tools.git
+      version: rolling
+    release:
+      packages:
+      - imu_complementary_filter
+      - imu_filter_madgwick
+      - imu_tools
+      - rviz_imu_plugin
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_tools-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/CCNYRoboticsLab/imu_tools.git
+      version: rolling
+    status: maintained
+  interactive_marker_twist_server:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/interactive_marker_twist_server-release.git
+      version: 2.1.0-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/interactive_marker_twist_server.git
+      version: humble-devel
+    status: maintained
+  interactive_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/interactive_markers-release.git
+      version: 2.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/interactive_markers.git
+      version: rolling
+    status: maintained
+  irobot_create_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/irobot_create_msgs-release.git
+      version: 2.1.0-3
+    source:
+      type: git
+      url: https://github.com/iRobotEducation/irobot_create_msgs.git
+      version: rolling
+    status: developed
+  jacro:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/jacro-release.git
+      version: 0.2.0-2
+    source:
+      type: git
+      url: https://github.com/JafarAbdi/jacro.git
+      version: main
+    status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/joint_state_publisher-release.git
+      version: 2.4.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    status: maintained
+  joy_tester:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/joy_tester-release.git
+      version: 0.0.2-3
+    source:
+      type: git
+      url: https://github.com/joshnewans/joy_tester.git
+      version: main
+    status: maintained
+  joystick_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    release:
+      packages:
+      - joy
+      - joy_linux
+      - sdl2_vendor
+      - spacenav
+      - wiimote
+      - wiimote_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/joystick_drivers-release.git
+      version: 3.3.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/joystick_drivers.git
+      version: ros2
+    status: maintained
+  kdl_parser:
+    doc:
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser-release.git
+      version: 2.12.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/kdl_parser.git
+      version: rolling
+    status: maintained
+  keyboard_handler:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/keyboard_handler.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/keyboard_handler-release.git
+      version: 0.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-tooling/keyboard_handler.git
+      version: rolling
+    status: developed
+  kinematics_interface:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    release:
+      packages:
+      - kinematics_interface
+      - kinematics_interface_kdl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kinematics_interface-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/kinematics_interface.git
+      version: master
+    status: developed
+  kinematics_interface_pinocchio:
+    doc:
+      type: git
+      url: https://github.com/justagist/kinematics_interface_pinocchio.git
+      version: ros-rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kinematics_interface_pinocchio-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/justagist/kinematics_interface_pinocchio.git
+      version: ros-rolling
+    status: maintained
+  kobuki_core:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.4.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_core-release.git
+      version: 1.4.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.4.x
+    status: maintained
+  kobuki_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_ros_interfaces-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    status: maintained
+  kobuki_velocity_smoother:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
+      version: release/0.15.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
+      version: 0.15.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_velocity_smoother.git
+      version: release/0.15.x
+    status: maintained
+  kompass:
+    doc:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    release:
+      packages:
+      - kompass
+      - kompass_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kompass-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/automatika-robotics/kompass.git
+      version: main
+    status: developed
+  lanelet2:
+    doc:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    release:
+      packages:
+      - lanelet2
+      - lanelet2_core
+      - lanelet2_examples
+      - lanelet2_io
+      - lanelet2_maps
+      - lanelet2_matching
+      - lanelet2_projection
+      - lanelet2_python
+      - lanelet2_routing
+      - lanelet2_traffic_rules
+      - lanelet2_validation
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/lanelet2-release.git
+      version: 1.2.1-6
+    source:
+      type: git
+      url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
+      version: master
+    status: maintained
+  laser_filters:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_filters-release.git
+      version: 2.0.8-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: ros2
+    status: maintained
+  laser_geometry:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_geometry-release.git
+      version: 2.10.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_geometry.git
+      version: rolling
+    status: maintained
+  laser_proc:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_proc-release.git
+      version: 1.0.2-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/laser_proc.git
+      version: ros2-devel
+    status: maintained
+  laser_segmentation:
+    doc:
+      type: git
+      url: https://github.com/ajtudela/laser_segmentation.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/laser_segmentation-release.git
+      version: 3.0.2-1
+    source:
+      type: git
+      url: https://github.com/ajtudela/laser_segmentation.git
+      version: main
+    status: maintained
+  launch:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: rolling
+    release:
+      packages:
+      - launch
+      - launch_pytest
+      - launch_testing
+      - launch_testing_ament_cmake
+      - launch_xml
+      - launch_yaml
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/launch-release.git
+      version: 3.8.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch.git
+      version: rolling
+    status: developed
+  launch_param_builder:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/launch_param_builder.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_param_builder-release.git
+      version: 0.1.1-3
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/launch_param_builder.git
+      version: main
+    status: maintained
+  launch_ros:
+    doc:
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: rolling
+    release:
+      packages:
+      - launch_ros
+      - launch_testing_ros
+      - ros2launch
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_ros-release.git
+      version: 0.28.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/launch_ros.git
+      version: rolling
+    status: maintained
+  ld08_driver:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ld08_driver-release.git
+      version: 1.1.3-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/ld08_driver.git
+      version: main
+    status: developed
+  leo_common:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_common-ros2.git
+      version: rolling
+    release:
+      packages:
+      - leo
+      - leo_description
+      - leo_msgs
+      - leo_teleop
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_common-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_common-ros2.git
+      version: rolling
+    status: maintained
+  leo_desktop:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop-ros2.git
+      version: rolling
+    release:
+      packages:
+      - leo_desktop
+      - leo_viz
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_desktop-release.git
+      version: 3.0.0-2
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_desktop-ros2.git
+      version: rolling
+    status: maintained
+  leo_robot:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_robot-ros2.git
+      version: rolling
+    release:
+      packages:
+      - leo_bringup
+      - leo_fw
+      - leo_robot
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_robot-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_robot-ros2.git
+      version: rolling
+    status: maintained
+  leo_simulator:
+    doc:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: ros2
+    release:
+      packages:
+      - leo_gz_bringup
+      - leo_gz_plugins
+      - leo_gz_worlds
+      - leo_simulator
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/leo_simulator-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_simulator-ros2.git
+      version: ros2
+    status: maintained
+  lgsvl_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/lgsvl_msgs-release.git
+      version: 0.0.4-4
+    source:
+      type: git
+      url: https://github.com/lgsvl/lgsvl_msgs.git
+      version: foxy-devel
+  libcaer:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer.git
+      version: ros_event_camera
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer-release.git
+      version: 1.0.2-2
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer.git
+      version: ros_event_camera
+    status: developed
+  libcaer_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer_driver-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_driver.git
+      version: rolling
+    status: developed
+  libcaer_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer_vendor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/libcaer_vendor.git
+      version: rolling
+    status: developed
+  libcamera:
+    doc:
+      type: git
+      url: https://git.libcamera.org/libcamera/libcamera.git
+      version: v0.3.1
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcamera-release.git
+      version: 0.5.0-3
+    source:
+      type: git
+      url: https://git.libcamera.org/libcamera/libcamera.git
+      version: master
+    status: maintained
+  libg2o:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libg2o-release.git
+      version: 2020.5.29-5
+    status: maintained
+  libnabo:
+    doc:
+      type: git
+      url: https://github.com/ethz-asl/libnabo.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libnabo-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/ethz-asl/libnabo.git
+      version: master
+    status: maintained
+  libpointmatcher:
+    doc:
+      type: git
+      url: https://github.com/norlab-ulaval/libpointmatcher.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libpointmatcher-release.git
+      version: 1.4.1-1
+    source:
+      type: git
+      url: https://github.com/norlab-ulaval/libpointmatcher.git
+      version: master
+    status: maintained
+  libstatistics_collector:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/libstatistics_collector.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libstatistics_collector-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-tooling/libstatistics_collector.git
+      version: rolling
+    status: developed
+  libyaml_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libyaml_vendor-release.git
+      version: 1.7.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/libyaml_vendor.git
+      version: rolling
+    status: maintained
+  lidar_mirror_fov_reshaper:
+    source:
+      type: git
+      url: https://github.com/ioskn/lidar_mirror_fov_reshaper.git
+      version: rolling
+    status: maintained
+  linux_isolate_process:
+    doc:
+      type: git
+      url: https://github.com/adityapande-1995/linux_isolate_process.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/linux_isolate_process-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://github.com/adityapande-1995/linux_isolate_process.git
+      version: main
+    status: maintained
+  log_view:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/log_view-release.git
+      version: 0.2.5-1
+    source:
+      type: git
+      url: https://github.com/hatchbed/log_view.git
+      version: ros2
+    status: developed
+  magic_enum:
+    doc:
+      type: git
+      url: https://github.com/Neargye/magic_enum.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/magic_enum-release.git
+      version: 0.9.6-1
+    source:
+      type: git
+      url: https://github.com/Neargye/magic_enum.git
+      version: master
+    status: maintained
+  mapviz:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
+    release:
+      packages:
+      - mapviz
+      - mapviz_interfaces
+      - mapviz_plugins
+      - multires_image
+      - tile_map
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mapviz-release.git
+      version: 2.4.6-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/mapviz.git
+      version: ros2-devel
+    status: developed
+  marine_msgs:
+    doc:
+      type: git
+      url: https://github.com/apl-ocean-engineering/marine_msgs.git
+      version: ros2
+    release:
+      packages:
+      - marine_acoustic_msgs
+      - marine_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/marine_msgs-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/apl-ocean-engineering/marine_msgs.git
+      version: ros2
+    status: developed
+  marker_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/marker_msgs-release.git
+      version: 0.0.8-1
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/marker_msgs.git
+      version: ros2
+    status: maintained
+  marti_common:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: ros2-devel
+    release:
+      packages:
+      - swri_cli_tools
+      - swri_console_util
+      - swri_dbw_interface
+      - swri_geometry_util
+      - swri_image_util
+      - swri_math_util
+      - swri_opencv_util
+      - swri_roscpp
+      - swri_route_util
+      - swri_serial_util
+      - swri_system_util
+      - swri_transform_util
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/marti_common-release.git
+      version: 3.7.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_common.git
+      version: ros2-devel
+    status: developed
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: ros2-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_dbw_msgs
+      - marti_introspection_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/marti_messages-release.git
+      version: 1.6.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: ros2-devel
+    status: developed
+  mavlink:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/rolling/mavlink
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mavlink-gbp-release.git
+      version: 2024.10.10-1
+    source:
+      type: git
+      url: https://github.com/mavlink/mavlink-gbp-release.git
+      version: release/rolling/mavlink
+    status: developed
+  mavros:
+    doc:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    release:
+      packages:
+      - libmavconn
+      - mavros
+      - mavros_extras
+      - mavros_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mavros-release.git
+      version: 2.9.0-1
+    source:
+      type: git
+      url: https://github.com/mavlink/mavros.git
+      version: ros2
+    status: developed
+  menge_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/menge_vendor-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/menge_vendor.git
+      version: master
+    status: developed
+  message_filters:
+    doc:
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_message_filters-release.git
+      version: 7.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/message_filters.git
+      version: rolling
+    status: maintained
+  message_tf_frame_transformer:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
+      version: main
+    status: maintained
+  metavision_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/metavision_driver.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/metavision_driver-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/metavision_driver.git
+      version: release
+    status: developed
+  micro_ros_diagnostics:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    release:
+      packages:
+      - micro_ros_diagnostic_bridge
+      - micro_ros_diagnostic_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
+      version: 0.3.0-5
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_diagnostics.git
+      version: master
+    status: developed
+  micro_ros_msgs:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/micro-ROS/micro_ros_msgs.git
+      version: rolling
+    status: maintained
+  microstrain_inertial:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
+    release:
+      packages:
+      - microstrain_inertial_description
+      - microstrain_inertial_driver
+      - microstrain_inertial_examples
+      - microstrain_inertial_msgs
+      - microstrain_inertial_rqt
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/microstrain_inertial-release.git
+      version: 4.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/microstrain_inertial.git
+      version: ros2
+    status: developed
+  mimick_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mimick_vendor-release.git
+      version: 0.8.1-1
+    source:
+      type: git
+      url: https://github.com/ros2/mimick_vendor.git
+      version: rolling
+    status: maintained
+  mini_tof:
+    source:
+      type: git
+      url: https://github.com/uwgraphics/mini_tof.git
+      version: main
+    status: maintained
+  mini_tof_interfaces:
+    source:
+      type: git
+      url: https://github.com/uwgraphics/mini_tof_interfaces.git
+      version: main
+    status: maintained
+  mir_robot:
+    doc:
+      type: git
+      url: https://github.com/DFKI-NI/mir_robot.git
+      version: rolling
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DFKI-NI/mir_robot.git
+      version: rolling
+    status: developed
+  mola:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola.git
+      version: develop
+    release:
+      packages:
+      - kitti_metrics_eval
+      - mola
+      - mola_bridge_ros2
+      - mola_demos
+      - mola_input_euroc_dataset
+      - mola_input_kitti360_dataset
+      - mola_input_kitti_dataset
+      - mola_input_mulran_dataset
+      - mola_input_paris_luco_dataset
+      - mola_input_rawlog
+      - mola_input_rosbag2
+      - mola_kernel
+      - mola_launcher
+      - mola_metric_maps
+      - mola_msgs
+      - mola_pose_list
+      - mola_relocalization
+      - mola_traj_tools
+      - mola_viz
+      - mola_yaml
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola-release.git
+      version: 1.6.3-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola.git
+      version: develop
+    status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_common-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
+  mola_gnss_to_markers:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_gnss_to_markers.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_gnss_to_markers-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_gnss_to_markers.git
+      version: develop
+    status: developed
+  mola_lidar_odometry:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_lidar_odometry.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
+      version: 0.7.1-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_lidar_odometry.git
+      version: develop
+    status: developed
+  mola_state_estimation:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_state_estimation.git
+      version: develop
+    release:
+      packages:
+      - mola_imu_preintegration
+      - mola_state_estimation
+      - mola_state_estimation_simple
+      - mola_state_estimation_smoother
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_state_estimation-release.git
+      version: 1.8.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_state_estimation.git
+      version: develop
+    status: developed
+  mola_test_datasets:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_test_datasets.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_test_datasets-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_test_datasets.git
+      version: develop
+    status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    release:
+      packages:
+      - motion_capture_tracking
+      - motion_capture_tracking_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
+      version: 1.0.3-2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
+  moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    release:
+      packages:
+      - chomp_motion_planner
+      - moveit
+      - moveit_common
+      - moveit_configs_utils
+      - moveit_core
+      - moveit_hybrid_planning
+      - moveit_kinematics
+      - moveit_planners
+      - moveit_planners_chomp
+      - moveit_planners_ompl
+      - moveit_planners_stomp
+      - moveit_plugins
+      - moveit_py
+      - moveit_resources_prbt_ikfast_manipulator_plugin
+      - moveit_resources_prbt_moveit_config
+      - moveit_resources_prbt_pg70_support
+      - moveit_resources_prbt_support
+      - moveit_ros
+      - moveit_ros_benchmarks
+      - moveit_ros_control_interface
+      - moveit_ros_move_group
+      - moveit_ros_occupancy_map_monitor
+      - moveit_ros_perception
+      - moveit_ros_planning
+      - moveit_ros_planning_interface
+      - moveit_ros_robot_interaction
+      - moveit_ros_tests
+      - moveit_ros_trajectory_cache
+      - moveit_ros_visualization
+      - moveit_ros_warehouse
+      - moveit_runtime
+      - moveit_servo
+      - moveit_setup_app_plugins
+      - moveit_setup_assistant
+      - moveit_setup_controllers
+      - moveit_setup_core_plugins
+      - moveit_setup_framework
+      - moveit_setup_srdf_plugins
+      - moveit_simple_controller_manager
+      - pilz_industrial_motion_planner
+      - pilz_industrial_motion_planner_testutils
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit2-release.git
+      version: 2.13.2-1
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/ros-planning/moveit2.git
+      version: main
+    status: developed
+  moveit_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit_msgs-release.git
+      version: 2.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_msgs.git
+      version: ros2
+    status: developed
+  moveit_resources:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: ros2
+    release:
+      packages:
+      - dual_arm_panda_moveit_config
+      - moveit_resources
+      - moveit_resources_fanuc_description
+      - moveit_resources_fanuc_moveit_config
+      - moveit_resources_panda_description
+      - moveit_resources_panda_moveit_config
+      - moveit_resources_pr2_description
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit_resources-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_resources.git
+      version: ros2
+    status: developed
+  moveit_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
+      version: 4.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/moveit_visual_tools.git
+      version: ros2
+    status: maintained
+  mp2p_icp:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mp2p_icp-release.git
+      version: 1.6.7-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    status: developed
+  mqtt_client:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/mqtt_client.git
+      version: main
+    release:
+      packages:
+      - mqtt_client
+      - mqtt_client_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mqtt_client-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/mqtt_client.git
+      version: main
+    status: maintained
+  mrpt_msgs:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_msgs-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
+      version: master
+    status: maintained
+  mrpt_navigation:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    release:
+      packages:
+      - mrpt_map_server
+      - mrpt_msgs_bridge
+      - mrpt_nav_interfaces
+      - mrpt_navigation
+      - mrpt_pf_localization
+      - mrpt_pointcloud_pipeline
+      - mrpt_rawlog
+      - mrpt_reactivenav2d
+      - mrpt_tps_astar_planner
+      - mrpt_tutorials
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_navigation-release.git
+      version: 2.2.1-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
+      version: ros2
+    status: developed
+  mrpt_path_planning:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
+      version: 0.2.1-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_path_planning.git
+      version: develop
+    status: developed
+  mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    release:
+      packages:
+      - mrpt_apps
+      - mrpt_libapps
+      - mrpt_libbase
+      - mrpt_libgui
+      - mrpt_libhwdrivers
+      - mrpt_libmaps
+      - mrpt_libmath
+      - mrpt_libnav
+      - mrpt_libobs
+      - mrpt_libopengl
+      - mrpt_libposes
+      - mrpt_libros_bridge
+      - mrpt_libslam
+      - mrpt_libtclap
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_ros-release.git
+      version: 2.14.7-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros.git
+      version: main
+    status: developed
+  mrpt_sensors:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    release:
+      packages:
+      - mrpt_generic_sensor
+      - mrpt_sensor_bumblebee_stereo
+      - mrpt_sensor_gnss_nmea
+      - mrpt_sensor_gnss_novatel
+      - mrpt_sensor_imu_taobotics
+      - mrpt_sensorlib
+      - mrpt_sensors
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_sensors-release.git
+      version: 0.2.3-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
+      version: ros2
+    status: developed
+  mrt_cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrt_cmake_modules-release.git
+      version: 1.0.11-1
+    source:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    status: maintained
+  mvsim:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mvsim-release.git
+      version: 0.13.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MRPT/mvsim.git
+      version: develop
+    status: developed
+  nao_button_sim:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_button_sim-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_button_sim.git
+      version: rolling
+    status: developed
+  nao_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ijnek/nao_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - nao_command_msgs
+      - nao_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_interfaces-release.git
+      version: 1.0.0-2
+    source:
+      type: git
+      url: https://github.com/ijnek/nao_interfaces.git
+      version: rolling
+    status: developed
+  nao_lola:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/nao_lola.git
+      version: rolling
+    release:
+      packages:
+      - nao_lola
+      - nao_lola_client
+      - nao_lola_command_msgs
+      - nao_lola_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nao_lola-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/nao_lola.git
+      version: rolling
+    status: developed
+  nav2_minimal_turtlebot_simulation:
+    doc:
+      type: git
+      url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
+      version: main
+    release:
+      packages:
+      - nav2_minimal_tb3_sim
+      - nav2_minimal_tb4_description
+      - nav2_minimal_tb4_sim
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
+      version: main
+    status: maintained
+  navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: rolling
+    release:
+      packages:
+      - map_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/navigation_msgs-release.git
+      version: 2.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: rolling
+    status: maintained
+  neo_simulation2:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/neo_simulation2-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/neobotix/neo_simulation2.git
+      version: rolling
+    status: maintained
+  nlohmann_json_schema_validator_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
+      version: main
+    status: developed
+  nmea_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
+      version: 0.0.1-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
+      version: master
+    status: developed
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_msgs-release.git
+      version: 2.1.0-2
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    status: maintained
+  nmea_navsat_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: 2.0.1
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_navsat_driver-release.git
+      version: 2.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/nmea_navsat_driver.git
+      version: ros2
+    status: developed
+    status_description: ROS2 support is work-in-progress. Help wanted!
+  nobleo_socketcan_bridge:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/nobleo/nobleo_socketcan_bridge.git
+      version: main
+    status: maintained
+  nodl:
+    doc:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    release:
+      packages:
+      - nodl_python
+      - ros2nodl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nodl-release.git
+      version: 0.3.1-4
+    source:
+      type: git
+      url: https://github.com/ubuntu-robotics/nodl.git
+      version: master
+    status: developed
+  nodl_to_policy:
+    doc:
+      type: git
+      url: https://github.com/osrf/nodl_to_policy.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nodl_to_policy-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/nodl_to_policy.git
+      version: master
+    status: maintained
+  novatel_gps_driver:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: ros2-devel
+    release:
+      packages:
+      - novatel_gps_driver
+      - novatel_gps_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
+      version: 4.2.0-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/novatel_gps_driver.git
+      version: ros2-devel
+    status: developed
+  ntpd_driver:
+    doc:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ntpd_driver-release.git
+      version: 2.2.0-3
+    source:
+      type: git
+      url: https://github.com/vooon/ntpd_driver.git
+      version: ros2
+    status: maintained
+  ntrip_client:
+    doc:
+      type: git
+      url: https://github.com/LORD-MicroStrain/ntrip_client.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ntrip_client-release.git
+      version: 1.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LORD-MicroStrain/ntrip_client.git
+      version: ros2
+    status: developed
+  object_recognition_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/object_recognition_msgs-release.git
+      version: 2.0.0-4
+    source:
+      type: git
+      url: https://github.com/wg-perception/object_recognition_msgs.git
+      version: ros2
+    status: maintained
+  octomap_mapping:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: ros2
+    release:
+      packages:
+      - octomap_mapping
+      - octomap_server
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_mapping-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_mapping.git
+      version: ros2
+    status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_msgs-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/octomap/octomap_msgs.git
+      version: ros2
+    status: maintained
+  octomap_ros:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_ros-release.git
+      version: 0.4.4-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_ros.git
+      version: ros2
+    status: maintained
+  octomap_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/OctoMap/octomap_rviz_plugins.git
+      version: ros2
+    status: maintained
+  odom_to_tf_ros2:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/odom_to_tf_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
+      version: 1.0.5-2
+    source:
+      type: git
+      url: https://github.com/gstavrinos/odom_to_tf_ros2.git
+      version: master
+    status: maintained
+  odri_master_board:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
+      version: main
+    release:
+      packages:
+      - odri_master_board_sdk
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
+      version: 1.0.7-2
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
+      version: main
+    status: maintained
+  ompl:
+    doc:
+      type: git
+      url: https://github.com/ompl/ompl.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ompl-release.git
+      version: 1.7.0-1
+    source:
+      type: git
+      url: https://github.com/ompl/ompl.git
+      version: main
+    status: developed
+  open_manipulator:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator.git
+      version: main
+    release:
+      packages:
+      - om_gravity_compensation_controller
+      - om_joint_trajectory_command_broadcaster
+      - om_spring_actuator_controller
+      - open_manipulator
+      - open_manipulator_bringup
+      - open_manipulator_description
+      - open_manipulator_gui
+      - open_manipulator_moveit_config
+      - open_manipulator_playground
+      - open_manipulator_teleop
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/open_manipulator-release.git
+      version: 3.2.1-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/open_manipulator.git
+      version: main
+    status: developed
+  openeb_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/openeb_vendor-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/openeb_vendor.git
+      version: release
+    status: developed
+  openni2_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/openni2_camera-release.git
+      version: 2.2.2-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/openni2_camera.git
+      version: ros2
+    status: maintained
+  opensw:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/opensw.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/opensw.git
+      version: main
+    status: developed
+  opensw_ros:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/opensw_ros.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/hatchbed/opensw_ros.git
+      version: ros2
+    status: developed
+  orocos_kdl_vendor:
+    release:
+      packages:
+      - orocos_kdl_vendor
+      - python_orocos_kdl_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
+      version: 0.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/orocos_kdl_vendor.git
+      version: rolling
+    status: developed
+  ortools_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ortools_vendor-release.git
+      version: 9.9.0-9
+  osqp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/osqp_vendor-release.git
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/tier4/osqp_vendor.git
+      version: main
+    status: maintained
+  osrf_pycommon:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_pycommon-release.git
+      version: 2.1.4-2
+    source:
+      type: git
+      url: https://github.com/osrf/osrf_pycommon.git
+      version: master
+    status: maintained
+  osrf_testing_tools_cpp:
+    doc:
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
+      version: 2.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/osrf_testing_tools_cpp.git
+      version: rolling
+    status: maintained
+  ouster-ros:
+    doc:
+      type: git
+      url: https://github.com/ouster-lidar/ouster-ros.git
+      version: rolling-devel
+    release:
+      packages:
+      - ouster_ros
+      - ouster_sensor_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ouster-ros-release.git
+      version: 0.11.1-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ouster-lidar/ouster-ros.git
+      version: rolling-devel
+    status: developed
+  ouxt_common:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    release:
+      packages:
+      - ouxt_common
+      - ouxt_lint_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ouxt_common-release.git
+      version: 0.0.8-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/ouxt_common.git
+      version: master
+    status: developed
+  pal_statistics:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_statistics
+      - pal_statistics_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pal_statistics-release.git
+      version: 2.6.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_statistics.git
+      version: humble-devel
+    status: maintained
+  pangolin:
+    doc:
+      type: git
+      url: https://github.com/stevenlovegrove/Pangolin.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/Pangolin-release.git
+      version: 0.9.3-1
+    source:
+      type: git
+      url: https://github.com/stevenlovegrove/Pangolin.git
+      version: master
+    status: maintained
+  pcl_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pcl_msgs-release.git
+      version: 1.0.0-8
+    source:
+      type: git
+      url: https://github.com/ros-perception/pcl_msgs.git
+      version: ros2
+    status: maintained
+  perception_open3d:
+    release:
+      packages:
+      - open3d_conversions
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/perception_open3d-release.git
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/ros-perception/perception_open3d.git
+      version: ros2
+    status: developed
+  perception_pcl:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: ros2
+    release:
+      packages:
+      - pcl_conversions
+      - pcl_ros
+      - perception_pcl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/perception_pcl-release.git
+      version: 2.6.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/perception_pcl.git
+      version: ros2
+    status: maintained
+  performance_test:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/performance_test.git
+      version: master
+    status: maintained
+  performance_test_fixture:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/performance_test_fixture-release.git
+      version: 0.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/performance_test_fixture.git
+      version: rolling
+    status: maintained
+  phidgets_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: rolling
+    release:
+      packages:
+      - libphidget22
+      - phidgets_accelerometer
+      - phidgets_analog_inputs
+      - phidgets_analog_outputs
+      - phidgets_api
+      - phidgets_digital_inputs
+      - phidgets_digital_outputs
+      - phidgets_drivers
+      - phidgets_gyroscope
+      - phidgets_high_speed_encoder
+      - phidgets_ik
+      - phidgets_magnetometer
+      - phidgets_motors
+      - phidgets_msgs
+      - phidgets_spatial
+      - phidgets_temperature
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/phidgets_drivers-release.git
+      version: 2.3.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/phidgets_drivers.git
+      version: rolling
+    status: maintained
+  pick_ik:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/pick_ik.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pick_ik-release.git
+      version: 1.1.1-1
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/pick_ik.git
+      version: main
+    status: developed
+  picknik_ament_copyright:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/picknik_ament_copyright-release.git
+      version: 0.0.2-4
+  picknik_controllers:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/picknik_controllers.git
+      version: main
+    release:
+      packages:
+      - picknik_reset_fault_controller
+      - picknik_twist_controller
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/picknik_controllers-release.git
+      version: 0.0.4-2
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/picknik_controllers.git
+      version: main
+    status: developed
+  pinocchio:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pinocchio-release.git
+      version: 3.4.0-3
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/pinocchio.git
+      version: devel
+    status: developed
+  plotjuggler:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/plotjuggler-release.git
+      version: 3.9.2-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/PlotJuggler.git
+      version: main
+    status: developed
+  plotjuggler_msgs:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/plotjuggler_msgs-release.git
+      version: 0.2.3-4
+    source:
+      type: git
+      url: https://github.com/facontidavide/plotjuggler_msgs.git
+      version: ros2
+    status: developed
+  plotjuggler_ros:
+    doc:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
+      version: 2.1.3-1
+    source:
+      type: git
+      url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
+      version: main
+    status: developed
+  pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pluginlib-release.git
+      version: 5.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: rolling
+    status: maintained
+  point_cloud_msg_wrapper:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_msg_wrapper-release.git
+      version: 1.0.7-4
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
+      version: rolling
+    status: developed
+  point_cloud_transport:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport.git
+      version: rolling
+    release:
+      packages:
+      - point_cloud_transport
+      - point_cloud_transport_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_transport-release.git
+      version: 5.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport.git
+      version: rolling
+    status: maintained
+  point_cloud_transport_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_plugins.git
+      version: rolling
+    release:
+      packages:
+      - draco_point_cloud_transport
+      - point_cloud_interfaces
+      - point_cloud_transport_plugins
+      - zlib_point_cloud_transport
+      - zstd_point_cloud_transport
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
+      version: 5.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_plugins.git
+      version: rolling
+    status: maintained
+  point_cloud_transport_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
+      version: rolling
+    status: maintained
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
+      version: 2.0.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: rolling
+    status: maintained
+  polygon_ros:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    release:
+      packages:
+      - polygon_demos
+      - polygon_msgs
+      - polygon_rviz_plugins
+      - polygon_utils
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/polygon_ros-release.git
+      version: 1.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/polygon_ros.git
+      version: main
+    status: developed
+  pose_cov_ops:
+    doc:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pose_cov_ops-release.git
+      version: 0.3.13-1
+    source:
+      type: git
+      url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
+  proxsuite:
+    doc:
+      type: git
+      url: https://github.com/Simple-Robotics/proxsuite.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/proxsuite-release.git
+      version: 0.6.5-1
+    source:
+      type: git
+      url: https://github.com/Simple-Robotics/proxsuite.git
+      version: devel
+    status: developed
+  py_binding_tools:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_binding_tools-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/py_binding_tools.git
+      version: ros2
+    status: maintained
+  py_trees:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees.git
+      version: devel
+    status: developed
+  py_trees_js:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_js-release.git
+      version: 0.6.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_js.git
+      version: devel
+    status: maintained
+  py_trees_ros:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros.git
+      version: devel
+    status: developed
+  py_trees_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
+      version: 2.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
+      version: devel
+    status: developed
+  py_trees_ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    status: developed
+  py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
+      version: 0.2.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: developed
+  pybind11_json_vendor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/pybind11_json_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/pybind11_json_vendor.git
+      version: main
+    status: developed
+  pybind11_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_vendor-release.git
+      version: 3.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/pybind11_vendor.git
+      version: rolling
+    status: maintained
+  python_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/python_cmake_module-release.git
+      version: 0.12.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/python_cmake_module.git
+      version: rolling
+    status: developed
+  python_mrpt_ros:
+    doc:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    release:
+      packages:
+      - python_mrpt
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
+      version: 2.14.7-1
+    source:
+      type: git
+      url: https://github.com/MRPT/python_mrpt_ros.git
+      version: main
+    status: developed
+  python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/python_qt_binding-release.git
+      version: 2.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: rolling
+    status: maintained
+  qml_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml_ros2_plugin.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
+      version: 2.25.2-2
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml_ros2_plugin.git
+      version: master
+    status: developed
+  qpoases_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/qpoases_vendor-release.git
+      version: 3.2.3-4
+    source:
+      type: git
+      url: https://github.com/Autoware-AI/qpoases_vendor.git
+      version: ros2
+    status: maintained
+  qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: rolling
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/qt_gui_core-release.git
+      version: 2.9.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: rolling
+    status: maintained
+  quaternion_operation:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/quaternion_operation-release.git
+      version: 0.0.7-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/quaternion_operation.git
+      version: ros2
+    status: maintained
+  r2r_spl:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: rolling
+    release:
+      packages:
+      - r2r_spl_7
+      - splsm_7
+      - splsm_7_conversion
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/r2r_spl-release.git
+      version: 3.0.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/r2r_spl.git
+      version: rolling
+    status: developed
+  radar_msgs:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/radar_msgs-release.git
+      version: 0.2.2-3
+    status: maintained
+  random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/random_numbers-release.git
+      version: 2.0.1-4
+    source:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: ros2
+    status: maintained
+  raspimouse2:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: jazzy
+    release:
+      packages:
+      - raspimouse
+      - raspimouse_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/raspimouse2-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/raspimouse2.git
+      version: jazzy
+    status: maintained
+  rc_common_msgs:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_common_msgs_ros2-release.git
+      version: 0.5.3-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_common_msgs_ros2.git
+      version: master
+    status: developed
+  rc_dynamics_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
+      version: 0.10.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_dynamics_api.git
+      version: master
+    status: developed
+  rc_genicam_api:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_genicam_api-release.git
+      version: 2.6.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_api.git
+      version: master
+    status: developed
+  rc_genicam_driver:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_genicam_driver_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
+      version: 0.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_genicam_driver_ros2.git
+      version: master
+    status: developed
+  rc_reason_clients:
+    doc:
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros2.git
+      version: master
+    release:
+      packages:
+      - rc_reason_clients
+      - rc_reason_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rc_reason_clients-release.git
+      version: 0.4.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rc_reason_clients_ros2.git
+      version: master
+    status: developed
+  rcdiscover:
+    doc:
+      type: git
+      url: https://github.com/roboception/rcdiscover.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcdiscover-release.git
+      version: 1.1.7-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/roboception/rcdiscover.git
+      version: master
+    status: developed
+  rcl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: rolling
+    release:
+      packages:
+      - rcl
+      - rcl_action
+      - rcl_lifecycle
+      - rcl_yaml_param_parser
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl-release.git
+      version: 10.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl.git
+      version: rolling
+    status: maintained
+  rcl_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - action_msgs
+      - builtin_interfaces
+      - composition_interfaces
+      - lifecycle_msgs
+      - rcl_interfaces
+      - rosgraph_msgs
+      - service_msgs
+      - statistics_msgs
+      - test_msgs
+      - type_description_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_interfaces-release.git
+      version: 2.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_interfaces.git
+      version: rolling
+    status: maintained
+  rcl_logging:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: rolling
+    release:
+      packages:
+      - rcl_logging_interface
+      - rcl_logging_noop
+      - rcl_logging_spdlog
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging-release.git
+      version: 3.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcl_logging.git
+      version: rolling
+    status: maintained
+  rcl_logging_rcutils:
+    doc:
+      type: git
+      url: https://github.com/sloretz/rcl_logging_rcutils.git
+      version: master
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/sloretz/rcl_logging_rcutils.git
+      version: master
+    status: maintained
+  rclc:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: rolling
+    release:
+      packages:
+      - rclc
+      - rclc_examples
+      - rclc_lifecycle
+      - rclc_parameter
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rclc-release.git
+      version: 6.2.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclc.git
+      version: rolling
+    status: developed
+  rclcpp:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: rolling
+    release:
+      packages:
+      - rclcpp
+      - rclcpp_action
+      - rclcpp_components
+      - rclcpp_lifecycle
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rclcpp-release.git
+      version: 29.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclcpp.git
+      version: rolling
+    status: maintained
+  rclpy:
+    doc:
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rclpy-release.git
+      version: 9.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rclpy.git
+      version: rolling
+    status: maintained
+  rcpputils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcpputils-release.git
+      version: 2.13.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcpputils.git
+      version: rolling
+    status: developed
+  rcss3d_agent:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    release:
+      packages:
+      - rcss3d_agent
+      - rcss3d_agent_basic
+      - rcss3d_agent_msgs
+      - rcss3d_agent_msgs_to_soccer_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcss3d_agent-release.git
+      version: 0.4.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_agent.git
+      version: rolling
+    status: developed
+  rcss3d_nao:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_nao.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcss3d_nao-release.git
+      version: 1.2.0-2
+    source:
+      type: git
+      url: https://github.com/ros-sports/rcss3d_nao.git
+      version: rolling
+    status: developed
+  rcutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcutils-release.git
+      version: 6.9.5-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rcutils.git
+      version: rolling
+    status: maintained
+  reach:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach.git
+      version: master
+  reach_ros:
+    source:
+      type: git
+      url: https://github.com/ros-industrial/reach_ros2.git
+      version: master
+  realtime_support:
+    doc:
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: rolling
+    release:
+      packages:
+      - rttest
+      - tlsf_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_support-release.git
+      version: 0.18.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/realtime_support.git
+      version: rolling
+    status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/realtime_tools-release.git
+      version: 4.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: master
+    status: maintained
+  resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: rolling
+    release:
+      packages:
+      - libcurl_vendor
+      - resource_retriever
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever-release.git
+      version: 3.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: rolling
+    status: maintained
+  rig_reconfigure:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rig_reconfigure-release.git
+      version: 1.5.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/teamspatzenhirn/rig_reconfigure.git
+      version: master
+    status: developed
+  rmf_api_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_api_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_api_msgs.git
+      version: main
+    status: developed
+  rmf_battery:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_battery-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_battery.git
+      version: main
+    status: developed
+  rmf_building_map_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_building_map_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_building_map_msgs.git
+      version: main
+    status: developed
+  rmf_cmake_uncrustify:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
+      version: 1.2.0-5
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
+      version: rolling
+    status: developed
+  rmf_demos:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_demos.git
+      version: main
+    release:
+      packages:
+      - rmf_demos
+      - rmf_demos_assets
+      - rmf_demos_bridges
+      - rmf_demos_fleet_adapter
+      - rmf_demos_gz
+      - rmf_demos_maps
+      - rmf_demos_tasks
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_demos-release.git
+      version: 2.5.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_demos.git
+      version: main
+    status: developed
+  rmf_internal_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_internal_msgs.git
+      version: main
+    release:
+      packages:
+      - rmf_charger_msgs
+      - rmf_dispenser_msgs
+      - rmf_door_msgs
+      - rmf_fleet_msgs
+      - rmf_ingestor_msgs
+      - rmf_lift_msgs
+      - rmf_obstacle_msgs
+      - rmf_reservation_msgs
+      - rmf_scheduler_msgs
+      - rmf_site_map_msgs
+      - rmf_task_msgs
+      - rmf_traffic_msgs
+      - rmf_workcell_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
+      version: 3.4.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_internal_msgs.git
+      version: main
+    status: developed
+  rmf_ros2:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: main
+    release:
+      packages:
+      - rmf_charging_schedule
+      - rmf_fleet_adapter
+      - rmf_fleet_adapter_python
+      - rmf_reservation_node
+      - rmf_task_ros2
+      - rmf_traffic_ros2
+      - rmf_websocket
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_ros2-release.git
+      version: 2.9.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_ros2.git
+      version: main
+    status: developed
+  rmf_simulation:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: main
+    release:
+      packages:
+      - rmf_building_sim_gz_plugins
+      - rmf_robot_sim_common
+      - rmf_robot_sim_gz_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_simulation-release.git
+      version: 2.4.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_simulation.git
+      version: main
+    status: developed
+  rmf_task:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: main
+    release:
+      packages:
+      - rmf_task
+      - rmf_task_sequence
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_task-release.git
+      version: 2.7.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_task.git
+      version: main
+    status: developed
+  rmf_traffic:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: main
+    release:
+      packages:
+      - rmf_traffic
+      - rmf_traffic_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic-release.git
+      version: 3.4.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic.git
+      version: main
+    status: developed
+  rmf_traffic_editor:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: main
+    release:
+      packages:
+      - rmf_building_map_tools
+      - rmf_traffic_editor
+      - rmf_traffic_editor_assets
+      - rmf_traffic_editor_test_maps
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
+      version: 1.11.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_traffic_editor.git
+      version: main
+    status: developed
+  rmf_utils:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_utils.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_utils-release.git
+      version: 1.7.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_utils.git
+      version: main
+    status: developed
+  rmf_variants:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_variants.git
+      version: main
+    release:
+      packages:
+      - rmf_dev
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_variants-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_variants.git
+      version: main
+    status: developed
+  rmf_visualization:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization.git
+      version: main
+    release:
+      packages:
+      - rmf_visualization
+      - rmf_visualization_building_systems
+      - rmf_visualization_fleet_states
+      - rmf_visualization_floorplans
+      - rmf_visualization_navgraphs
+      - rmf_visualization_obstacles
+      - rmf_visualization_rviz2_plugins
+      - rmf_visualization_schedule
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization-release.git
+      version: 2.4.1-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization.git
+      version: main
+    status: developed
+  rmf_visualization_msgs:
+    doc:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
+      version: 1.5.0-1
+    source:
+      type: git
+      url: https://github.com/open-rmf/rmf_visualization_msgs.git
+      version: main
+    status: developed
+  rmw:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: rolling
+    release:
+      packages:
+      - rmw
+      - rmw_implementation_cmake
+      - rmw_security_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw-release.git
+      version: 7.8.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw.git
+      version: rolling
+    status: maintained
+  rmw_connextdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_connextdds.git
+      version: rolling
+    release:
+      packages:
+      - rmw_connextdds
+      - rmw_connextdds_common
+      - rti_connext_dds_cmake_module
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_connextdds-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_connextdds.git
+      version: rolling
+    status: developed
+  rmw_cyclonedds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: rolling
+    release:
+      packages:
+      - rmw_cyclonedds_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
+      version: 4.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_cyclonedds.git
+      version: rolling
+    status: developed
+  rmw_dds_common:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_dds_common.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_dds_common-release.git
+      version: 3.2.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_dds_common.git
+      version: rolling
+    status: maintained
+  rmw_desert:
+    doc:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_desert-release.git
+      version: 3.0.0-2
+    source:
+      type: git
+      url: https://github.com/signetlabdei/rmw_desert.git
+      version: main
+    status: maintained
+  rmw_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: rolling
+    release:
+      packages:
+      - rmw_fastrtps_cpp
+      - rmw_fastrtps_dynamic_cpp
+      - rmw_fastrtps_shared_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
+      version: 9.3.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_fastrtps.git
+      version: rolling
+    status: developed
+  rmw_gurumdds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: rolling
+    release:
+      packages:
+      - gurumdds_cmake_module
+      - rmw_gurumdds_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 5.0.0-3
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_gurumdds.git
+      version: rolling
+    status: developed
+  rmw_implementation:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_implementation-release.git
+      version: 3.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rmw_implementation.git
+      version: rolling
+    status: developed
+  rmw_zenoh:
+    doc:
+      type: git
+      url: https://github.com/ros2/rmw_zenoh.git
+      version: rolling
+    release:
+      packages:
+      - rmw_zenoh_cpp
+      - zenoh_cpp_vendor
+      - zenoh_security_tools
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_zenoh-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/rmw_zenoh.git
+      version: rolling
+    status: developed
+  robot_calibration:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros2
+    release:
+      packages:
+      - robot_calibration
+      - robot_calibration_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_calibration-release.git
+      version: 0.10.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/robot_calibration.git
+      version: ros2
+    status: developed
+  robot_localization:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_localization-release.git
+      version: 3.9.2-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: ros2
+    status: maintained
+  robot_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/robot_state_publisher-release.git
+      version: 3.4.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/robot_state_publisher.git
+      version: rolling
+    status: maintained
+  robotraconteur:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/robotraconteur-release.git
+      version: 1.2.2-1
+    source:
+      type: git
+      url: https://github.com/robotraconteur/robotraconteur.git
+      version: ros
+    status: maintained
+  ros1_bridge:
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/ros1_bridge.git
+      version: master
+    status_description: Maintained in source form only since no ROS 1 packages available
+      in Rolling
+  ros2_canopen:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ros2_canopen.git
+      version: master
+    release:
+      packages:
+      - canopen
+      - canopen_402_driver
+      - canopen_base_driver
+      - canopen_core
+      - canopen_fake_slaves
+      - canopen_interfaces
+      - canopen_master_driver
+      - canopen_proxy_driver
+      - canopen_ros2_control
+      - canopen_ros2_controllers
+      - canopen_tests
+      - canopen_utils
+      - lely_core_libraries
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_canopen-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros2_canopen.git
+      version: master
+    status: developed
+  ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_manager_msgs
+      - hardware_interface
+      - hardware_interface_testing
+      - joint_limits
+      - ros2_control
+      - ros2_control_test_assets
+      - ros2controlcli
+      - rqt_controller_manager
+      - transmission_interface
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control-release.git
+      version: 4.28.1-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    status: developed
+  ros2_control_cmake:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control_cmake.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_control_cmake.git
+      version: master
+    status: developed
+  ros2_controllers:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    release:
+      packages:
+      - ackermann_steering_controller
+      - admittance_controller
+      - bicycle_steering_controller
+      - diff_drive_controller
+      - effort_controllers
+      - force_torque_sensor_broadcaster
+      - forward_command_controller
+      - gpio_controllers
+      - gps_sensor_broadcaster
+      - gripper_controllers
+      - imu_sensor_broadcaster
+      - joint_state_broadcaster
+      - joint_trajectory_controller
+      - mecanum_drive_controller
+      - parallel_gripper_controller
+      - pid_controller
+      - pose_broadcaster
+      - position_controllers
+      - range_sensor_broadcaster
+      - ros2_controllers
+      - ros2_controllers_test_nodes
+      - rqt_joint_trajectory_controller
+      - steering_controllers_library
+      - tricycle_controller
+      - tricycle_steering_controller
+      - velocity_controllers
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_controllers-release.git
+      version: 4.23.0-1
+    source:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: master
+    status: developed
+  ros2_easy_test:
+    doc:
+      type: git
+      url: https://github.com/felixdivo/ros2-easy-test.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/felixdivo/ros2-easy-test.git
+      version: main
+    status: developed
+  ros2_kortex:
+    doc:
+      type: git
+      url: https://github.com/Kinovarobotics/ros2_kortex.git
+      version: main
+    release:
+      packages:
+      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kortex_api
+      - kortex_bringup
+      - kortex_description
+      - kortex_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_kortex-release.git
+      version: 0.2.2-2
+    source:
+      type: git
+      url: https://github.com/Kinovarobotics/ros2_kortex.git
+      version: main
+    status: developed
+  ros2_robotiq_gripper:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+      version: main
+    release:
+      packages:
+      - robotiq_controllers
+      - robotiq_description
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
+      version: main
+    status: maintained
+  ros2_socketcan:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/ros2_socketcan.git
+      version: main
+    release:
+      packages:
+      - ros2_socketcan
+      - ros2_socketcan_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_socketcan-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/ros2_socketcan.git
+      version: main
+    status: developed
+  ros2_tracing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2_tracing.git
+      version: rolling
+    release:
+      packages:
+      - lttngpy
+      - ros2trace
+      - tracetools
+      - tracetools_launch
+      - tracetools_read
+      - tracetools_test
+      - tracetools_trace
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_tracing-release.git
+      version: 8.6.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2_tracing.git
+      version: rolling
+    status: developed
+  ros2acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/ros2acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2acceleration-release.git
+      version: 0.5.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/ros2acceleration.git
+      version: rolling
+    status: developed
+  ros2cli:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: rolling
+    release:
+      packages:
+      - ros2action
+      - ros2cli
+      - ros2cli_test_interfaces
+      - ros2component
+      - ros2doctor
+      - ros2interface
+      - ros2lifecycle
+      - ros2lifecycle_test_fixtures
+      - ros2multicast
+      - ros2node
+      - ros2param
+      - ros2pkg
+      - ros2run
+      - ros2service
+      - ros2topic
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli-release.git
+      version: 0.37.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros2cli.git
+      version: rolling
+    status: maintained
+  ros2cli_common_extensions:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/ros2cli_common_extensions.git
+      version: rolling
+    status: maintained
+  ros2launch_security:
+    doc:
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    release:
+      packages:
+      - ros2launch_security
+      - ros2launch_security_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2launch_security-release.git
+      version: 1.0.0-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/ros2launch_security.git
+      version: main
+    status: maintained
+  ros_babel_fish:
+    doc:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: rolling
+    release:
+      packages:
+      - ros_babel_fish
+      - ros_babel_fish_test_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_babel_fish-release.git
+      version: 3.25.2-1
+    source:
+      type: git
+      url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
+      version: rolling
+    status: developed
+  ros_battery_monitoring:
+    doc:
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
+    release:
+      packages:
+      - battery_state_broadcaster
+      - battery_state_rviz_overlay
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
+      version: 1.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ipa320/ros_battery_monitoring.git
+      version: main
+    status: developed
+  ros_canopen:
+    release:
+      packages:
+      - can_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_canopen-release.git
+      version: 2.0.0-5
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ros_canopen.git
+      version: dashing-devel
+    status: developed
+  ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_environment-release.git
+      version: 4.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: rolling
+    status: maintained
+  ros_gz:
+    doc:
+      type: git
+      url: https://github.com/gazebosim/ros_gz.git
+      version: ros2
+    release:
+      packages:
+      - ros_gz
+      - ros_gz_bridge
+      - ros_gz_image
+      - ros_gz_interfaces
+      - ros_gz_sim
+      - ros_gz_sim_demos
+      - test_ros_gz_bridge
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_ign-release.git
+      version: 2.1.6-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebosim/ros_gz.git
+      version: ros2
+    status: developed
+  ros_image_to_qimage:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/ros_image_to_qimage.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
+      version: 0.4.1-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/ros_image_to_qimage.git
+      version: rolling
+    status: developed
+  ros_industrial_cmake_boilerplate:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
+      version: 0.5.4-1
+  ros_testing:
+    doc:
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: rolling
+    release:
+      packages:
+      - ros2test
+      - ros_testing
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_testing-release.git
+      version: 0.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/ros_testing.git
+      version: rolling
+    status: maintained
+  ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: rolling
+    release:
+      packages:
+      - turtlesim
+      - turtlesim_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_tutorials-release.git
+      version: 1.9.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: rolling
+    status: maintained
+  ros_workspace:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 1.0.3-6
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: maintained
+  rosbag2:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: rolling
+    release:
+      packages:
+      - liblz4_vendor
+      - mcap_vendor
+      - ros2bag
+      - rosbag2
+      - rosbag2_compression
+      - rosbag2_compression_zstd
+      - rosbag2_cpp
+      - rosbag2_examples_cpp
+      - rosbag2_examples_py
+      - rosbag2_interfaces
+      - rosbag2_performance_benchmarking
+      - rosbag2_performance_benchmarking_msgs
+      - rosbag2_py
+      - rosbag2_storage
+      - rosbag2_storage_default_plugins
+      - rosbag2_storage_mcap
+      - rosbag2_storage_sqlite3
+      - rosbag2_test_common
+      - rosbag2_test_msgdefs
+      - rosbag2_tests
+      - rosbag2_transport
+      - sqlite3_vendor
+      - zstd_vendor
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2-release.git
+      version: 0.32.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosbag2.git
+      version: rolling
+    status: developed
+  rosbag2_bag_v2:
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros2/rosbag2_bag_v2.git
+      version: master
+    status_description: Maintained in source form only since no ROS 1 packages available
+      in Rolling
+  rosbag2_broll:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/ros-tooling/rosbag2_broll.git
+      version: main
+    status: developed
+  rosbag2_to_video:
+    doc:
+      type: git
+      url: https://github.com/fictionlab/rosbag2_to_video.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_to_video-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/fictionlab/rosbag2_to_video.git
+      version: ros2
+    status: maintained
+  rosbridge_suite:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
+    release:
+      packages:
+      - rosapi
+      - rosapi_msgs
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      - rosbridge_test_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbridge_suite-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/RobotWebTools/rosbridge_suite.git
+      version: ros2
+    status: developed
+  rosidl:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_adapter
+      - rosidl_cli
+      - rosidl_cmake
+      - rosidl_generator_c
+      - rosidl_generator_cpp
+      - rosidl_generator_type_description
+      - rosidl_parser
+      - rosidl_pycommon
+      - rosidl_runtime_c
+      - rosidl_runtime_cpp
+      - rosidl_typesupport_interface
+      - rosidl_typesupport_introspection_c
+      - rosidl_typesupport_introspection_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl-release.git
+      version: 4.9.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl.git
+      version: rolling
+    status: maintained
+  rosidl_core:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_core.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_core_generators
+      - rosidl_core_runtime
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_core-release.git
+      version: 0.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_core.git
+      version: rolling
+    status: maintained
+  rosidl_dds:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_generator_dds_idl
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dds-release.git
+      version: 0.12.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dds.git
+      version: rolling
+    status: maintained
+  rosidl_defaults:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_default_generators
+      - rosidl_default_runtime
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_defaults-release.git
+      version: 1.7.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_defaults.git
+      version: rolling
+    status: maintained
+  rosidl_dynamic_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
+      version: 0.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+      version: rolling
+    status: maintained
+  rosidl_dynamic_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
+      version: 0.4.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
+      version: rolling
+    status: maintained
+  rosidl_python:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_generator_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_python-release.git
+      version: 0.24.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_python.git
+      version: rolling
+    status: maintained
+  rosidl_runtime_py:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
+      version: 0.14.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_runtime_py.git
+      version: rolling
+    status: maintained
+  rosidl_rust:
+    doc:
+      type: git
+      url: https://github.com/ros2-rust/rosidl_rust.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros2-rust/rosidl_rust.git
+      version: main
+    status: developed
+  rosidl_typesupport:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_typesupport_c
+      - rosidl_typesupport_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
+      version: 3.3.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport.git
+      version: rolling
+    status: maintained
+  rosidl_typesupport_fastrtps:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: rolling
+    release:
+      packages:
+      - rosidl_typesupport_fastrtps_c
+      - rosidl_typesupport_fastrtps_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
+      version: 3.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+      version: rolling
+    status: developed
+  rospy_message_converter:
+    doc:
+      type: git
+      url: https://github.com/DFKI-NI/rospy_message_converter.git
+      version: rolling
+    release:
+      packages:
+      - rclpy_message_converter
+      - rclpy_message_converter_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rospy_message_converter-release.git
+      version: 2.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DFKI-NI/rospy_message_converter.git
+      version: rolling
+    status: maintained
+  rosx_introspection:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/rosx_introspection.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosx_introspection-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/facontidavide/rosx_introspection.git
+      version: master
+    status: developed
+  rot_conv_lib:
+    release:
+      packages:
+      - rot_conv
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rot_conv_lib-release.git
+      version: 1.1.0-3
+    source:
+      type: git
+      url: https://github.com/AIS-Bonn/rot_conv_lib.git
+      version: master
+    status: maintained
+  rplidar_ros:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rplidar_ros-release.git
+      version: 2.1.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/allenh1/rplidar_ros.git
+      version: ros2
+    status: developed
+  rpyutils:
+    doc:
+      type: git
+      url: https://github.com/ros2/rpyutils.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rpyutils-release.git
+      version: 0.6.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rpyutils.git
+      version: rolling
+    status: developed
+  rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: rolling
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt-release.git
+      version: 1.9.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: rolling
+    status: maintained
+  rqt_action:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_action-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_action.git
+      version: rolling
+    status: maintained
+  rqt_bag:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: rolling
+    release:
+      packages:
+      - rqt_bag
+      - rqt_bag_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_bag-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_bag.git
+      version: rolling
+    status: maintained
+  rqt_common_plugins:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
+      version: 1.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_common_plugins.git
+      version: ros2
+    status: maintained
+  rqt_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_console-release.git
+      version: 2.3.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_console.git
+      version: rolling
+    status: maintained
+  rqt_dotgraph:
+    doc:
+      type: git
+      url: https://github.com/niwcpac/rqt_dotgraph.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_dotgraph-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/niwcpac/rqt_dotgraph.git
+      version: main
+    status: maintained
+  rqt_gauges:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_gauges-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    status: maintained
+  rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_graph-release.git
+      version: 1.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: rolling
+    status: maintained
+  rqt_image_overlay:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/rqt_image_overlay.git
+      version: rolling
+    release:
+      packages:
+      - rqt_image_overlay
+      - rqt_image_overlay_layer
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/rqt_image_overlay.git
+      version: rolling
+    status: developed
+  rqt_image_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_image_view-release.git
+      version: 1.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_image_view.git
+      version: rolling-devel
+    status: maintained
+  rqt_moveit:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_moveit-release.git
+      version: 1.0.1-4
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_moveit.git
+      version: ros2
+    status: maintained
+  rqt_msg:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_msg-release.git
+      version: 1.6.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_msg.git
+      version: rolling
+    status: maintained
+  rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_plot-release.git
+      version: 1.6.2-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: rolling
+    status: maintained
+  rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_publisher-release.git
+      version: 1.9.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: rolling
+    status: maintained
+  rqt_py_console:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_py_console-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_py_console.git
+      version: rolling
+    status: maintained
+  rqt_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
+      version: 1.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_reconfigure.git
+      version: rolling
+    status: maintained
+  rqt_robot_dashboard:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: ROS2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_dashboard-release.git
+      version: 0.6.1-4
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_dashboard.git
+      version: ROS2
+    status: maintained
+  rqt_robot_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_monitor.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
+      version: 1.0.6-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_monitor.git
+      version: dashing-devel
+    status: maintained
+  rqt_robot_steering:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: dashing-devel
+    status: maintained
+  rqt_runtime_monitor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
+      version: 1.0.0-4
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_runtime_monitor.git
+      version: rolling
+    status: maintained
+  rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_service_caller-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: rolling
+    status: maintained
+  rqt_shell:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_shell-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_shell.git
+      version: rolling
+    status: maintained
+  rqt_srv:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_srv-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_srv.git
+      version: rolling
+    status: maintained
+  rqt_tf_tree:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: humble
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/rqt_tf_tree.git
+      version: humble
+    status: maintained
+  rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_topic-release.git
+      version: 1.8.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: rolling
+    status: maintained
+  rsl:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/RSL.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/RSL-release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/RSL.git
+      version: main
+    status: developed
+  rt_manipulators_cpp:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    release:
+      packages:
+      - rt_manipulators_cpp
+      - rt_manipulators_examples
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/rt-net/rt_manipulators_cpp.git
+      version: ros2
+    status: maintained
+  rt_usb_9axisimu_driver:
+    doc:
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: jazzy
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rt-net/rt_usb_9axisimu_driver.git
+      version: jazzy
+    status: maintained
+  rtabmap:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: rolling-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rtabmap-release.git
+      version: 0.21.6-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap.git
+      version: rolling-devel
+    status: maintained
+  rtcm_msgs:
+    doc:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rtcm_msgs-release.git
+      version: 1.1.6-3
+    source:
+      type: git
+      url: https://github.com/tilk/rtcm_msgs.git
+      version: master
+    status: maintained
+  ruckig:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ruckig-release.git
+      version: 0.9.2-4
+    source:
+      type: git
+      url: https://github.com/pantor/ruckig.git
+      version: main
+    status: developed
+  rviz:
+    doc:
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: rolling
+    release:
+      packages:
+      - rviz2
+      - rviz_assimp_vendor
+      - rviz_common
+      - rviz_default_plugins
+      - rviz_ogre_vendor
+      - rviz_rendering
+      - rviz_rendering_tests
+      - rviz_visual_testing_framework
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz-release.git
+      version: 14.4.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rviz.git
+      version: rolling
+    status: maintained
+  rviz_2d_overlay_plugins:
+    doc:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    release:
+      packages:
+      - rviz_2d_overlay_msgs
+      - rviz_2d_overlay_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
+      version: 1.3.0-2
+    source:
+      type: git
+      url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
+      version: main
+    status: maintained
+  rviz_visual_tools:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_visual_tools-release.git
+      version: 4.1.4-3
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/rviz_visual_tools.git
+      version: ros2
+    status: maintained
+  sdformat_urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/sdformat_urdf.git
+      version: rolling
+    release:
+      packages:
+      - sdformat_test_files
+      - sdformat_urdf
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sdformat_urdf-release.git
+      version: 2.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/sdformat_urdf.git
+      version: rolling
+    status: maintained
+  sdformat_vendor:
+    doc:
+      type: git
+      url: https://github.com/gazebo-release/sdformat_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sdformat_vendor-release.git
+      version: 0.2.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/gazebo-release/sdformat_vendor.git
+      version: rolling
+    status: maintained
+  septentrio_gnss_driver:
+    doc:
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
+      version: 1.4.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
+      version: master
+    status: maintained
+  service_load_balancing:
+    doc:
+      type: git
+      url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/service_load_balancing-release.git
+      version: 0.1.1-2
+    source:
+      type: git
+      url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
+      version: main
+    status: developed
+  sick_safetyscanners2:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2.git
+      version: master
+    status: developed
+  sick_safetyscanners2_interfaces:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safetyscanners2_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
+      version: master
+    status: developed
+  sick_safetyscanners_base:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safetyscanners_base-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safetyscanners_base.git
+      version: ros2
+    status: developed
+  sick_safevisionary_base:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_base.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safevisionary_base-release.git
+      version: 1.0.1-2
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_base.git
+      version: main
+    status: developed
+  sick_safevisionary_ros2:
+    doc:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_ros2.git
+      version: main
+    release:
+      packages:
+      - sick_safevisionary_driver
+      - sick_safevisionary_interfaces
+      - sick_safevisionary_tests
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
+      version: 1.0.3-2
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_safevisionary_ros2.git
+      version: main
+    status: developed
+  sicks300_ros2:
+    doc:
+      type: git
+      url: https://github.com/ajtudela/sicks300_ros2.git
+      version: main
+    status: maintained
+  simple_actions:
+    doc:
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/simple_actions-release.git
+      version: 0.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/simple_actions.git
+      version: main
+    status: developed
+  simple_grasping:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/simple_grasping-release.git
+      version: 0.5.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/simple_grasping.git
+      version: ros2
+    status: developed
+  simple_launch:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: 1.0.2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/simple_launch-release.git
+      version: 1.11.0-1
+    source:
+      type: git
+      url: https://github.com/oKermorgant/simple_launch.git
+      version: devel
+    status: maintained
+  slg_msgs:
+    doc:
+      type: git
+      url: https://github.com/ajtudela/slg_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/slg_msgs-release.git
+      version: 3.9.1-1
+    source:
+      type: git
+      url: https://github.com/ajtudela/slg_msgs.git
+      version: main
+    status: maintained
+  slider_publisher:
+    doc:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/slider_publisher-release.git
+      version: 2.3.1-2
+    source:
+      type: git
+      url: https://github.com/oKermorgant/slider_publisher.git
+      version: ros2
+    status: maintained
+  smach:
+    doc:
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: ros2
+    release:
+      packages:
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/executive_smach-release.git
+      version: 3.0.3-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/executive_smach.git
+      version: ros2
+    status: maintained
+  snowbot_operating_system:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/snowbot_release.git
+      version: 0.1.2-4
+    source:
+      type: git
+      url: https://github.com/PickNikRobotics/snowbot_operating_system.git
+      version: ros2
+    status: maintained
+  soar_ros:
+    doc:
+      type: git
+      url: https://github.com/THA-Embedded-Systems-Lab/soar_ros.git
+      version: main
+    status: maintained
+  soccer_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/soccer_interfaces.git
+      version: rolling
+    release:
+      packages:
+      - soccer_geometry_msgs
+      - soccer_interfaces
+      - soccer_model_msgs
+      - soccer_vision_2d_msgs
+      - soccer_vision_3d_msgs
+      - soccer_vision_attribute_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/soccer_interfaces.git
+      version: rolling
+    status: developed
+  soccer_vision_3d_rviz_markers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
+      version: rolling
+    status: developed
+  sol_vendor:
+    doc:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sol_vendor-release.git
+      version: 0.0.3-4
+    source:
+      type: git
+      url: https://github.com/OUXT-Polaris/sol_vendor.git
+      version: main
+    status: developed
+  sophus:
+    doc:
+      type: git
+      url: https://github.com/clalancette/sophus.git
+      version: release/1.22.x
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sophus-release.git
+      version: 1.22.9102-2
+    source:
+      type: git
+      url: https://github.com/clalancette/sophus.git
+      version: release/1.22.x
+    status: maintained
+  spdlog_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/spdlog_vendor-release.git
+      version: 1.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/spdlog_vendor.git
+      version: rolling
+    status: maintained
+  srdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/srdfdom-release.git
+      version: 2.0.7-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/srdfdom.git
+      version: ros2
+    status: maintained
+  sros2:
+    doc:
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: rolling
+    release:
+      packages:
+      - sros2
+      - sros2_cmake
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/sros2-release.git
+      version: 0.15.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/sros2.git
+      version: rolling
+    status: developed
+  steering_functions:
+    doc:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/steering_functions-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/hbanzhaf/steering_functions.git
+      version: master
+    status: maintained
+  stomp:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/stomp.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/stomp-release.git
+      version: 0.1.2-3
+    source:
+      type: git
+      url: https://github.com/ros-industrial/stomp.git
+      version: main
+    status: maintained
+  swri_console:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/swri_console-release.git
+      version: 2.0.6-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/swri_console.git
+      version: ros2-devel
+    status: developed
+  synapticon_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/synapticon_ros2_control-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/synapticon/synapticon_ros2_control.git
+      version: main
+    status: maintained
+  system_fingerprint:
+    doc:
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
+      version: 0.7.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/MetroRobots/ros_system_fingerprint.git
+      version: ros2
+    status: developed
+  system_modes:
+    doc:
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
+    release:
+      packages:
+      - launch_system_modes
+      - system_modes
+      - system_modes_examples
+      - system_modes_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/system_modes-release.git
+      version: 0.9.0-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/micro-ROS/system_modes.git
+      version: master
+    status: developed
+  system_tests:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/system_tests.git
+      version: rolling
+    status: developed
+  tango_icons_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-visualization/tango_icons_vendor.git
+      version: rolling
+    status: maintained
+  teleop_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: master
+    release:
+      packages:
+      - joy_teleop
+      - key_teleop
+      - mouse_teleop
+      - teleop_tools
+      - teleop_tools_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_tools-release.git
+      version: 1.8.0-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/teleop_tools.git
+      version: master
+    status: maintained
+  teleop_twist_joy:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
+      version: 2.6.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_joy.git
+      version: rolling
+    status: maintained
+  teleop_twist_keyboard:
+    doc:
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
+      version: 2.4.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/teleop_twist_keyboard.git
+      version: dashing
+    status: maintained
+  tensorrt_cmake_module:
+    doc:
+      type: git
+      url: https://github.com/tier4/tensorrt_cmake_module.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
+      version: 0.0.4-2
+    source:
+      type: git
+      url: https://github.com/tier4/tensorrt_cmake_module.git
+      version: main
+    status: maintained
+  test_interface_files:
+    doc:
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/test_interface_files-release.git
+      version: 0.13.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/test_interface_files.git
+      version: rolling
+    status: maintained
+  tf2_2d:
+    doc:
+      type: git
+      url: https://github.com/locusrobotics/tf2_2d.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tf2_2d-release.git
+      version: 1.0.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/locusrobotics/tf2_2d.git
+      version: rolling
+    status: maintained
+  tf_transformations:
+    doc:
+      type: git
+      url: https://github.com/DLu/tf_transformations.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tf_transformations_release.git
+      version: 1.0.1-4
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/DLu/tf_transformations.git
+      version: main
+    status: maintained
+  tinyspline_vendor:
+    doc:
+      type: git
+      url: https://github.com/wep21/tinyspline_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
+      version: 0.6.1-1
+    source:
+      type: git
+      url: https://github.com/wep21/tinyspline_vendor.git
+      version: main
+    status: maintained
+  tinyxml2_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
+      version: 0.10.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml2_vendor.git
+      version: rolling
+    status: maintained
+  tinyxml_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
+      version: 0.10.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tinyxml_vendor.git
+      version: rolling
+    status: maintained
+  tlsf:
+    doc:
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tlsf-release.git
+      version: 0.10.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/tlsf.git
+      version: rolling
+    status: maintained
+  topic_based_ros2_control:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
+      version: 0.2.0-2
+  topic_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/topic_tools.git
+      version: rolling
+    release:
+      packages:
+      - topic_tools
+      - topic_tools_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_tools-release.git
+      version: 1.4.2-1
+    source:
+      type: git
+      url: https://github.com/ros-tooling/topic_tools.git
+      version: rolling
+    status: developed
+  trac_ik:
+    doc:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: rolling-devel
+    release:
+      packages:
+      - trac_ik
+      - trac_ik_kinematics_plugin
+      - trac_ik_lib
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/trac_ik-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://bitbucket.org/traclabs/trac_ik.git
+      version: rolling-devel
+    status: developed
+  tracetools_acceleration:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/tracetools_acceleration.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tracetools_acceleration-release.git
+      version: 0.4.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/tracetools_acceleration.git
+      version: rolling
+    status: developed
+  tracetools_analysis:
+    doc:
+      type: git
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: rolling
+    release:
+      packages:
+      - ros2trace_analysis
+      - tracetools_analysis
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tracetools_analysis-release.git
+      version: 3.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-tracing/tracetools_analysis.git
+      version: rolling
+    status: developed
+  transport_drivers:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/transport_drivers.git
+      version: main
+    release:
+      packages:
+      - asio_cmake_module
+      - io_context
+      - serial_driver
+      - udp_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/transport_drivers-release.git
+      version: 1.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/transport_drivers.git
+      version: main
+    status: developed
+  turbojpeg_compressed_image_transport:
+    doc:
+      type: git
+      url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
+      version: 0.2.1-4
+    source:
+      type: git
+      url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
+      version: rolling
+    status: maintained
+  turtle_nest:
+    doc:
+      type: git
+      url: https://github.com/Jannkar/turtle_nest.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/turtle_nest-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/Jannkar/turtle_nest.git
+      version: main
+    status: developed
+  turtlebot3:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3.git
+      version: main
+    status: developed
+  turtlebot3_autorace:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
+      version: main
+    status: developed
+  turtlebot3_manipulation:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
+      version: main
+    status: developed
+  turtlebot3_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_msgs-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
+      version: main
+    status: developed
+  turtlebot3_simulations:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: main
+    release:
+      packages:
+      - turtlebot3_fake_node
+      - turtlebot3_gazebo
+      - turtlebot3_simulations
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
+      version: 2.3.2-1
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+      version: main
+    status: developed
+  tuw_geometry:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tuw_geometry-release.git
+      version: 0.1.2-1
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_geometry.git
+      version: ros2
+    status: maintained
+  tuw_msgs:
+    doc:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_msgs.git
+      version: ros2
+    release:
+      packages:
+      - tuw_airskin_msgs
+      - tuw_geo_msgs
+      - tuw_geometry_msgs
+      - tuw_graph_msgs
+      - tuw_msgs
+      - tuw_multi_robot_msgs
+      - tuw_nav_msgs
+      - tuw_object_map_msgs
+      - tuw_object_msgs
+      - tuw_std_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tuw_msgs-release.git
+      version: 0.2.5-1
+    source:
+      type: git
+      url: https://github.com/tuw-robotics/tuw_msgs.git
+      version: ros2
+    status: developed
+  tvm_vendor:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/tvm_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/tvm_vendor-release.git
+      version: 0.9.1-3
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/tvm_vendor.git
+      version: main
+    status: maintained
+  twist_mux:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_mux-release.git
+      version: 4.4.0-1
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux.git
+      version: foxy-devel
+    status: maintained
+  twist_mux_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_mux_msgs-release.git
+      version: 3.0.1-2
+    source:
+      type: git
+      url: https://github.com/ros-teleop/twist_mux_msgs.git
+      version: master
+    status: maintained
+  twist_stamper:
+    doc:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/twist_stamper-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/joshnewans/twist_stamper.git
+      version: main
+    status: maintained
+  ublox:
+    doc:
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: ros2
+    release:
+      packages:
+      - ublox
+      - ublox_gps
+      - ublox_msgs
+      - ublox_serialization
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ublox-release.git
+      version: 2.3.0-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KumarRobotics/ublox.git
+      version: ros2
+    status: maintained
+  ublox_dgnss:
+    doc:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
+    release:
+      packages:
+      - ntrip_client_node
+      - ublox_dgnss
+      - ublox_dgnss_node
+      - ublox_nav_sat_fix_hp_node
+      - ublox_ubx_interfaces
+      - ublox_ubx_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ublox_dgnss-release.git
+      version: 0.5.5-4
+    source:
+      type: git
+      url: https://github.com/aussierobots/ublox_dgnss.git
+      version: main
+    status: maintained
+  udp_msgs:
+    doc:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/udp_msgs-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/flynneva/udp_msgs.git
+      version: main
+    status: maintained
+  uncrustify_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/ament/uncrustify_vendor.git
+      version: rolling
+    status: maintained
+  unique_identifier_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
+      version: 2.7.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/unique_identifier_msgs.git
+      version: rolling
+    status: maintained
+  ur_client_library:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
+      version: 1.9.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+      version: master
+    status: developed
+  ur_description:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_description-release.git
+      version: 3.1.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+      version: rolling
+    status: developed
+  ur_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: humble
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_msgs-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/ros-industrial/ur_msgs.git
+      version: humble-devel
+    status: developed
+  ur_robot_driver:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: main
+    release:
+      packages:
+      - ur
+      - ur_calibration
+      - ur_controllers
+      - ur_dashboard_msgs
+      - ur_moveit_config
+      - ur_robot_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
+      version: 3.2.1-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+      version: main
+    status: developed
+  ur_simulation_gz:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
+      version: 2.2.0-1
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
+      version: ros2
+    status: developed
+  urdf:
+    doc:
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: rolling
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf-release.git
+      version: 2.12.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/urdf.git
+      version: rolling
+    status: maintained
+  urdf_launch:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_launch.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf_launch-release.git
+      version: 0.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_launch.git
+      version: main
+    status: developed
+  urdf_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    release:
+      packages:
+      - urdfdom_py
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_py-release.git
+      version: 1.2.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    status: maintained
+  urdf_tutorial:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdf_tutorial-release.git
+      version: 1.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_tutorial.git
+      version: ros2
+    status: maintained
+  urdfdom:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom-release.git
+      version: 4.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdfdom.git
+      version: master
+    status: maintained
+  urdfdom_headers:
+    doc:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_headers-release.git
+      version: 1.1.1-2
+    source:
+      type: git
+      url: https://github.com/ros/urdfdom_headers.git
+      version: master
+    status: maintained
+  urg_c:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_c-release.git
+      version: 1.0.4001-5
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_c.git
+      version: ros2-devel
+    status: maintained
+  urg_node:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node-release.git
+      version: 1.1.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-drivers/urg_node.git
+      version: ros2-devel
+    status: maintained
+  urg_node_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/urg_node_msgs-release.git
+      version: 1.0.1-8
+    source:
+      type: git
+      url: https://github.com/ros-drivers/urg_node_msgs.git
+      version: master
+    status: maintained
+  usb_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/usb_cam-release.git
+      version: 0.8.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/usb_cam.git
+      version: ros2
+    status: maintained
+  v4l2_camera:
+    doc:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
+      version: 0.7.1-1
+    source:
+      type: git
+      url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
+      version: rolling
+    status: developed
+  variants:
+    doc:
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: rolling
+    release:
+      packages:
+      - desktop
+      - desktop_full
+      - perception
+      - ros_base
+      - ros_core
+      - simulation
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/variants-release.git
+      version: 0.12.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/variants.git
+      version: rolling
+    status: maintained
+  velodyne:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_laserscan
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/velodyne-release.git
+      version: 2.5.1-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/velodyne.git
+      version: ros2
+    status: developed
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_msgs.git
+      version: ros2
+    release:
+      packages:
+      - vision_msgs
+      - vision_msgs_rviz_plugins
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_msgs-release.git
+      version: 4.1.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_msgs.git
+      version: ros2
+    status: developed
+  vision_msgs_layers:
+    doc:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_msgs_layers-release.git
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/ros-sports/vision_msgs_layers.git
+      version: rolling
+    status: developed
+  vision_opencv:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: rolling
+    release:
+      packages:
+      - cv_bridge
+      - image_geometry
+      - vision_opencv
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vision_opencv-release.git
+      version: 4.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/vision_opencv.git
+      version: rolling
+    status: maintained
+  visp:
+    doc:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/visp-release.git
+      version: 3.5.0-3
+    source:
+      type: git
+      url: https://github.com/lagadic/visp.git
+      version: master
+    status: maintained
+  vitis_common:
+    doc:
+      type: git
+      url: https://github.com/ros-acceleration/vitis_common.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vitis_common-release.git
+      version: 0.4.2-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-acceleration/vitis_common.git
+      version: rolling
+    status: developed
+  vrpn:
+    doc:
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn-release.git
+      version: 7.35.0-20
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/vrpn/vrpn.git
+      version: master
+    status: maintained
+  vrpn_mocap:
+    doc:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/vrpn_mocap-release.git
+      version: 1.1.0-3
+    source:
+      type: git
+      url: https://github.com/alvinsunyixiao/vrpn_mocap.git
+      version: main
+    status: developed
+  warehouse_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/warehouse_ros-release.git
+      version: 2.0.5-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros.git
+      version: ros2
+    status: maintained
+  warehouse_ros_sqlite:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+      version: ros2
+    status: maintained
+  web_video_server:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/web_video_server-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/web_video_server.git
+      version: ros2
+    status: maintained
+  webots_ros2:
+    doc:
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: master
+    release:
+      packages:
+      - webots_ros2
+      - webots_ros2_control
+      - webots_ros2_crazyflie
+      - webots_ros2_driver
+      - webots_ros2_epuck
+      - webots_ros2_husarion
+      - webots_ros2_importer
+      - webots_ros2_mavic
+      - webots_ros2_msgs
+      - webots_ros2_tesla
+      - webots_ros2_tests
+      - webots_ros2_tiago
+      - webots_ros2_turtlebot
+      - webots_ros2_universal_robot
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/webots_ros2-release.git
+      version: 2025.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cyberbotics/webots_ros2.git
+      version: master
+    status: maintained
+  xacro:
+    doc:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/xacro-release.git
+      version: 2.0.13-1
+    source:
+      type: git
+      url: https://github.com/ros/xacro.git
+      version: ros2
+    status: maintained
+  yaml_cpp_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
+      version: 9.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/yaml_cpp_vendor.git
+      version: rolling
+    status: maintained
+  yasmin:
+    doc:
+      type: git
+      url: https://github.com/uleroboticsgroup/yasmin.git
+      version: main
+    release:
+      packages:
+      - yasmin
+      - yasmin_demos
+      - yasmin_msgs
+      - yasmin_ros
+      - yasmin_viewer
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/yasmin-release.git
+      version: 3.2.0-1
+    source:
+      type: git
+      url: https://github.com/uleroboticsgroup/yasmin.git
+      version: main
+    status: developed
+  zbar_ros:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: rolling
+    release:
+      packages:
+      - zbar_ros
+      - zbar_ros_interfaces
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/zbar_ros-release.git
+      version: 0.7.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/zbar_ros.git
+      version: rolling
+    status: maintained
+  zed-ros2-interfaces:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: master
+    release:
+      packages:
+      - zed_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
+      version: 5.0.0-1
+    source:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-interfaces.git
+      version: rolling
+    status: maintained
+  zenoh_bridge_dds:
+    doc:
+      type: git
+      url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/zenoh_bridge_dds-release.git
+      version: 0.5.0-4
+    source:
+      type: git
+      url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
+      version: master
+    status: developed
+  zmqpp_vendor:
+    doc:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/zmqpp_vendor-release.git
+      version: 0.0.2-3
+    source:
+      type: git
+      url: https://github.com/tier4/zmqpp_vendor.git
+      version: main
+    status: developed
 type: distribution
 version: 2

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -20,7 +20,7 @@ repositories:
       - smacc2
       - smacc2_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/SMACC2-release.git
     source:
       type: git
@@ -30,9 +30,9 @@ repositories:
   acado_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/acado_vendor-release.git
-      version: 1.0.0-6
+      version: 1.0.0-7
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/acado_vendor.git
@@ -41,9 +41,9 @@ repositories:
   ackermann_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ackermann_msgs-release.git
-      version: 2.0.2-5
+      version: 2.0.2-6
     source:
       type: git
       url: https://github.com/ros-drivers/ackermann_msgs.git
@@ -56,9 +56,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/actuator_msgs-release.git
-      version: 0.0.1-3
+      version: 0.0.1-4
     source:
       type: git
       url: https://github.com/rudislabs/actuator_msgs.git
@@ -71,9 +71,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/adaptive_component-release.git
-      version: 0.2.1-4
+      version: 0.2.1-5
     source:
       test_pull_requests: true
       type: git
@@ -107,9 +107,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_acceleration-release.git
-      version: 0.2.0-4
+      version: 0.2.0-5
     source:
       test_pull_requests: true
       type: git
@@ -122,9 +122,9 @@ repositories:
       - ament_black
       - ament_cmake_black
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
-      version: 0.2.6-1
+      version: 0.2.6-2
     source:
       type: git
       url: https://github.com/botsandus/ament_black.git
@@ -160,9 +160,9 @@ repositories:
       - ament_cmake_vendor_package
       - ament_cmake_version
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.7.3-1
+      version: 2.7.3-2
     source:
       test_pull_requests: true
       type: git
@@ -176,9 +176,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
@@ -197,9 +197,9 @@ repositories:
       - rmw_test_fixture
       - rmw_test_fixture_implementation
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.14.3-1
+      version: 0.14.3-2
     source:
       test_pull_requests: true
       type: git
@@ -213,9 +213,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_download-release.git
-      version: 0.0.5-5
+      version: 0.0.5-6
     source:
       type: git
       url: https://github.com/samsung-ros/ament_download.git
@@ -231,9 +231,9 @@ repositories:
       - ament_index_cpp
       - ament_index_python
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.10.2-1
+      version: 1.10.2-2
     source:
       test_pull_requests: true
       type: git
@@ -279,9 +279,9 @@ repositories:
       - ament_uncrustify
       - ament_xmllint
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.19.2-1
+      version: 0.19.2-2
     source:
       test_pull_requests: true
       type: git
@@ -291,9 +291,9 @@ repositories:
   ament_nodl:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_nodl-release.git
-      version: 0.1.0-6
+      version: 0.1.0-7
     source:
       type: git
       url: https://github.com/ubuntu-robotics/ament_nodl.git
@@ -306,9 +306,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.17.2-1
+      version: 0.17.2-2
     source:
       test_pull_requests: true
       type: git
@@ -322,9 +322,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_vitis-release.git
-      version: 0.10.1-4
+      version: 0.10.1-5
     source:
       test_pull_requests: true
       type: git
@@ -338,9 +338,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.16.0-4
+      version: 1.16.0-5
     source:
       test_pull_requests: true
       type: git
@@ -357,9 +357,9 @@ repositories:
       - apex_test_tools
       - test_apex_test_tools
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/apex_test_tools-release.git
-      version: 0.0.2-8
+      version: 0.0.2-9
     source:
       type: git
       url: https://gitlab.com/ApexAI/apex_test_tools.git
@@ -372,9 +372,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag-release.git
-      version: 3.4.3-1
+      version: 3.4.3-2
     source:
       type: git
       url: https://github.com/AprilRobotics/apriltag.git
@@ -393,9 +393,9 @@ repositories:
       - apriltag_draw
       - apriltag_tools
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 3.0.1-2
+      version: 3.0.1-3
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
@@ -408,9 +408,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_mit-release.git
-      version: 1.0.3-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_mit.git
@@ -419,9 +419,9 @@ repositories:
   apriltag_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_msgs-release.git
-      version: 2.0.1-4
+      version: 2.0.1-5
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_msgs.git
@@ -430,9 +430,9 @@ repositories:
   apriltag_ros:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_ros-release.git
-      version: 3.2.2-1
+      version: 3.2.2-2
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_ros.git
@@ -460,9 +460,9 @@ repositories:
       - aruco_opencv
       - aruco_opencv_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.0.1-1
+      version: 6.0.1-2
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git
@@ -479,9 +479,9 @@ repositories:
       - aruco_msgs
       - aruco_ros
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_ros-release.git
-      version: 5.0.5-1
+      version: 5.0.5-2
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git
@@ -503,9 +503,9 @@ repositories:
       - mobileye_560_660_msgs
       - neobotix_usboard_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/astuff_sensor_msgs-release.git
-      version: 4.0.0-3
+      version: 4.0.0-4
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
@@ -518,9 +518,9 @@ repositories:
       version: ros2-releases
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/async_web_server_cpp-release.git
-      version: 2.0.0-5
+      version: 2.0.0-6
     source:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git
@@ -543,9 +543,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.3.2-1
+      version: 0.3.2-2
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git
@@ -558,9 +558,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.9-1
+      version: 0.2.9-2
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git
@@ -577,9 +577,9 @@ repositories:
       - automotive_navigation_msgs
       - automotive_platform_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/automotive_autonomy_msgs-release.git
-      version: 3.0.4-5
+      version: 3.0.4-6
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git
@@ -591,9 +591,9 @@ repositories:
       - autoware_adapi_v1_msgs
       - autoware_adapi_version_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
@@ -606,9 +606,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_auto_msgs-release.git
-      version: 1.0.0-6
+      version: 1.0.0-7
     source:
       type: git
       url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
@@ -620,9 +620,9 @@ repositories:
       - autoware_cmake
       - autoware_lint_common
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git
@@ -637,9 +637,9 @@ repositories:
       - autoware_internal_perception_msgs
       - autoware_internal_planning_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.8.1-2
+      version: 1.8.1-3
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git
@@ -651,9 +651,9 @@ repositories:
       - autoware_lanelet2_extension
       - autoware_lanelet2_extension_python
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
@@ -674,9 +674,9 @@ repositories:
       - autoware_v2x_msgs
       - autoware_vehicle_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.6.0-1
+      version: 1.6.0-2
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -689,9 +689,9 @@ repositories:
       version: ros2_master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/avt_vimba_camera-release.git
-      version: 2001.1.0-5
+      version: 2001.1.0-6
     source:
       type: git
       url: https://github.com/astuff/avt_vimba_camera.git
@@ -706,7 +706,7 @@ repositories:
       packages:
       - aws_robomaker_small_warehouse_world
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/aws_robomaker_small_warehouse_world-release.git
     source:
       type: git
@@ -720,9 +720,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/aws_sdk_cpp_vendor-release.git
-      version: 0.2.1-2
+      version: 0.2.1-3
     source:
       type: git
       url: https://github.com/wep21/aws_sdk_cpp_vendor.git
@@ -735,9 +735,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
-      version: 1.14.0-1
+      version: 1.14.0-2
     source:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
@@ -750,9 +750,9 @@ repositories:
       version: foxy-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.7-1
+      version: 1.0.7-2
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git
@@ -765,9 +765,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/bag2_to_image-release.git
-      version: 0.1.0-4
+      version: 0.1.0-5
     source:
       type: git
       url: https://github.com/wep21/bag2_to_image.git
@@ -780,9 +780,9 @@ repositories:
       version: v3.8
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.6-2
+      version: 3.8.6-3
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
@@ -797,9 +797,9 @@ repositories:
       packages:
       - behaviortree_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.6.2-1
+      version: 4.6.2-2
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
@@ -812,9 +812,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/bno055-release.git
-      version: 0.5.0-2
+      version: 0.5.0-3
     source:
       type: git
       url: https://github.com/flynneva/bno055.git
@@ -833,9 +833,9 @@ repositories:
       - bondpy
       - smclib
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.2-1
+      version: 4.1.2-2
     source:
       test_pull_requests: true
       type: git
@@ -849,9 +849,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/boost_geometry_util-release.git
-      version: 0.0.1-4
+      version: 0.0.1-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/boost_geometry_util.git
@@ -869,9 +869,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/boost_sml_vendor-release.git
-      version: 1.1.11-1
+      version: 1.1.11-2
     source:
       type: git
       url: https://github.com/nobleo/boost_sml_vendor.git
@@ -884,9 +884,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/camera_ros-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/christianrauch/camera_ros.git
@@ -899,9 +899,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer-release.git
-      version: 2.0.9003-1
+      version: 2.0.9003-2
     source:
       test_pull_requests: true
       type: git
@@ -919,9 +919,9 @@ repositories:
       - cartographer_ros_msgs
       - cartographer_rviz
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 2.0.9003-1
+      version: 2.0.9003-2
     source:
       test_pull_requests: true
       type: git
@@ -938,9 +938,9 @@ repositories:
       - cascade_lifecycle_msgs
       - rclcpp_cascade_lifecycle
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git
@@ -953,9 +953,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/catch_ros2-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/ngmor/catch_ros2.git
@@ -968,9 +968,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.8.0-1
+      version: 2.8.0-2
     source:
       test_pull_requests: true
       type: git
@@ -984,9 +984,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/classic_bags-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1006,9 +1006,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     source:
       type: git
       url: https://github.com/coal-library/coal.git
@@ -1025,9 +1025,9 @@ repositories:
       - cob_msgs
       - cob_srvs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cob_common-release.git
-      version: 2.8.12-1
+      version: 2.8.12-2
     source:
       type: git
       url: https://github.com/4am-robotics/cob_common.git
@@ -1040,9 +1040,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/color_names-release.git
-      version: 0.0.3-5
+      version: 0.0.3-6
     source:
       type: git
       url: https://github.com/OUXT-Polaris/color_names-release.git
@@ -1055,9 +1055,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/color_util-release.git
-      version: 1.0.0-3
+      version: 1.0.0-4
     source:
       test_pull_requests: true
       type: git
@@ -1085,9 +1085,9 @@ repositories:
       - trajectory_msgs
       - visualization_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.5.0-1
+      version: 5.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1101,9 +1101,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
-      version: 1.8.0-1
+      version: 1.8.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1117,9 +1117,9 @@ repositories:
       version: foxy-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_box_rst-release.git
-      version: 0.0.7-5
+      version: 0.0.7-6
     source:
       test_pull_requests: true
       type: git
@@ -1133,9 +1133,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 6.0.0-1
+      version: 6.0.0-2
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
@@ -1148,9 +1148,9 @@ repositories:
       version: ros2-master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.2.0-1
+      version: 5.2.0-2
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
@@ -1162,9 +1162,9 @@ repositories:
       - tcb_span
       - tl_expected
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
-      version: 1.0.2-4
+      version: 1.0.2-5
     source:
       type: git
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
@@ -1177,9 +1177,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cudnn_cmake_module-release.git
-      version: 0.0.1-5
+      version: 0.0.1-6
     source:
       type: git
       url: https://github.com/tier4/cudnn_cmake_module.git
@@ -1188,9 +1188,9 @@ repositories:
   cyclonedds:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cyclonedds-release.git
-      version: 0.10.5-1
+      version: 0.10.5-2
     source:
       type: git
       url: https://github.com/eclipse-cyclonedds/cyclonedds.git
@@ -1206,9 +1206,9 @@ repositories:
       - data_tamer_cpp
       - data_tamer_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
-      version: 0.9.4-3
+      version: 0.9.4-4
     source:
       test_pull_requests: true
       type: git
@@ -1243,9 +1243,9 @@ repositories:
       - topic_monitor
       - topic_statistics_demo
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.35.1-1
+      version: 0.35.1-2
     source:
       test_pull_requests: true
       type: git
@@ -1259,9 +1259,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/depthimage_to_laserscan-release.git
-      version: 2.5.1-2
+      version: 2.5.1-3
     source:
       test_pull_requests: true
       type: git
@@ -1282,9 +1282,9 @@ repositories:
       - diagnostics
       - self_test
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.4.3-1
+      version: 4.4.3-2
     source:
       test_pull_requests: true
       type: git
@@ -1303,9 +1303,8 @@ repositories:
       - dolly_gazebo
       - dolly_ignition
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dolly-release.git
-      version: 0.4.0-5
     source:
       test_pull_requests: true
       type: git
@@ -1319,9 +1318,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/domain_bridge-release.git
-      version: 0.5.0-4
+      version: 0.5.0-5
     source:
       test_pull_requests: true
       type: git
@@ -1341,9 +1340,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dual_laser_merger-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/pradyum/dual_laser_merger.git
@@ -1356,9 +1355,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
-      version: 0.6.0-1
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
@@ -1367,9 +1366,9 @@ repositories:
   dynamixel_hardware_interface:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
-      version: 1.4.3-1
+      version: 1.4.3-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
@@ -1378,9 +1377,9 @@ repositories:
   dynamixel_interfaces:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_interfaces-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
@@ -1397,9 +1396,9 @@ repositories:
       - dynamixel_sdk_custom_interfaces
       - dynamixel_sdk_examples
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
-      version: 3.8.3-1
+      version: 3.8.3-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
@@ -1415,9 +1414,9 @@ repositories:
       - dynamixel_workbench
       - dynamixel_workbench_toolbox
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
-      version: 2.2.4-1
+      version: 2.2.4-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
@@ -1430,9 +1429,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench_msgs-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
@@ -1445,9 +1444,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ecal-release.git
-      version: 5.12.0-4
+      version: 5.12.0-5
     source:
       type: git
       url: https://github.com/eclipse-ecal/ecal.git
@@ -1486,9 +1485,9 @@ repositories:
       - ecl_type_traits
       - ecl_utilities
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_core-release.git
-      version: 1.2.1-4
+      version: 1.2.1-5
     source:
       test_pull_requests: true
       type: git
@@ -1511,9 +1510,9 @@ repositories:
       - ecl_sigslots_lite
       - ecl_time_lite
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_lite-release.git
-      version: 1.2.0-4
+      version: 1.2.0-5
     source:
       test_pull_requests: true
       type: git
@@ -1531,9 +1530,9 @@ repositories:
       - ecl_license
       - ecl_tools
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ecl_tools-release.git
-      version: 1.0.3-4
+      version: 1.0.3-5
     source:
       test_pull_requests: true
       type: git
@@ -1547,9 +1546,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
@@ -1562,9 +1561,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/eigen_stl_containers-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1578,9 +1577,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/eigenpy-release.git
-      version: 3.10.3-1
+      version: 3.10.3-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git
@@ -1593,9 +1592,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/eiquadprog-release.git
-      version: 1.2.9-1
+      version: 1.2.9-2
     source:
       type: git
       url: https://github.com/stack-of-tasks/eiquadprog.git
@@ -1608,9 +1607,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 1.0.5-1
+      version: 1.0.5-2
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
@@ -1623,9 +1622,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_msgs-release.git
-      version: 1.0.6-1
+      version: 1.0.6-2
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
@@ -1638,9 +1637,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
@@ -1653,9 +1652,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_renderer-release.git
-      version: 1.0.4-1
+      version: 1.0.4-2
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
@@ -1668,9 +1667,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.13.0-1
+      version: 0.13.0-2
     source:
       test_pull_requests: true
       type: git
@@ -1707,9 +1706,9 @@ repositories:
       - examples_rclpy_pointcloud_publisher
       - launch_testing_examples
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.20.4-1
+      version: 0.20.4-2
     source:
       test_pull_requests: true
       type: git
@@ -1719,9 +1718,9 @@ repositories:
   fastcdr:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fastcdr-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_commits: false
       test_pull_requests: false
@@ -1736,9 +1735,9 @@ repositories:
       version: 3.1.x
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fastdds-release.git
-      version: 3.2.1-1
+      version: 3.2.1-2
     source:
       test_commits: true
       test_pull_requests: false
@@ -1749,9 +1748,9 @@ repositories:
   feetech_ros2_driver:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
-      version: 0.1.0-2
+      version: 0.1.0-3
     source:
       type: git
       url: https://github.com/JafarAbdi/feetech_ros2_driver.git
@@ -1764,9 +1763,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
@@ -1779,9 +1778,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
@@ -1794,9 +1793,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
-      version: 1.0.2-2
+      version: 1.0.2-3
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
@@ -1809,9 +1808,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
-      version: 2.1.1-1
+      version: 2.1.1-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
@@ -1824,9 +1823,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fields2cover-release.git
-      version: 2.0.0-15
+      version: 2.0.0-16
     source:
       type: git
       url: https://github.com/Fields2Cover/fields2cover.git
@@ -1839,9 +1838,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.1.2-1
+      version: 2.1.2-2
     source:
       test_pull_requests: true
       type: git
@@ -1855,9 +1854,9 @@ repositories:
       version: rolling-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/find_object_2d-release.git
-      version: 0.7.1-1
+      version: 0.7.1-2
     source:
       type: git
       url: https://github.com/introlab/find-object.git
@@ -1870,9 +1869,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fkie_message_filters-release.git
-      version: 3.0.2-1
+      version: 3.0.2-2
     source:
       type: git
       url: https://github.com/fkie/message_filters.git
@@ -1891,9 +1890,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/flex_sync-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/flex_sync.git
@@ -1916,9 +1915,9 @@ repositories:
       - flexbe_testing
       - flexbe_widget
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
-      version: 3.0.3-1
+      version: 3.0.3-2
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git
@@ -1936,9 +1935,9 @@ repositories:
       - spinnaker_camera_driver
       - spinnaker_synchronized_camera_driver
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
-      version: 3.0.1-1
+      version: 3.0.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git
@@ -1951,9 +1950,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fluent_rviz-release.git
-      version: 0.0.3-4
+      version: 0.0.3-5
     source:
       type: git
       url: https://github.com/ForteFibre/FluentRviz.git
@@ -1969,9 +1968,9 @@ repositories:
       - fmi_adapter
       - fmi_adapter_examples
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fmi_adapter-release.git
-      version: 2.1.2-2
+      version: 2.1.2-3
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
@@ -1980,9 +1979,9 @@ repositories:
   fmilibrary_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fmilibrary_vendor-release.git
-      version: 1.0.1-4
+      version: 1.0.1-5
     source:
       type: git
       url: https://github.com/boschresearch/fmilibrary_vendor.git
@@ -1991,9 +1990,9 @@ repositories:
   foonathan_memory_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/foonathan_memory_vendor-release.git
-      version: 1.3.1-2
+      version: 1.3.1-3
     source:
       type: git
       url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -2002,9 +2001,9 @@ repositories:
   four_wheel_steering_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/four_wheel_steering_msgs-release.git
-      version: 2.0.1-5
+      version: 2.0.1-6
     source:
       type: git
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
@@ -2017,9 +2016,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.8.3-1
+      version: 0.8.3-2
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git
@@ -2032,9 +2031,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
@@ -2047,9 +2046,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       type: git
       url: https://github.com/foxglove/schemas.git
@@ -2076,9 +2075,9 @@ repositories:
       - fuse_variables
       - fuse_viz
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2095,9 +2094,8 @@ repositories:
       - game_controller_spl
       - game_controller_spl_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
-      version: 5.0.0-2
     source:
       type: git
       url: https://github.com/ros-sports/game_controller_spl.git
@@ -2118,9 +2116,9 @@ repositories:
       - generate_parameter_module_example
       - parameter_traits
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git
@@ -2137,9 +2135,9 @@ repositories:
       - geographic_info
       - geographic_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
-      version: 1.0.6-1
+      version: 1.0.6-2
     source:
       test_pull_requests: true
       type: git
@@ -2153,9 +2151,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.3.2-1
+      version: 2.3.2-2
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git
@@ -2183,9 +2181,9 @@ repositories:
       - tf2_sensor_msgs
       - tf2_tools
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.40.1-1
+      version: 0.40.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2203,9 +2201,9 @@ repositories:
       - turtle_tf2_cpp
       - turtle_tf2_py
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometry_tutorials-release.git
-      version: 0.6.3-1
+      version: 0.6.3-2
     source:
       type: git
       url: https://github.com/ros/geometry_tutorials.git
@@ -2218,9 +2216,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2233,9 +2231,9 @@ repositories:
       - gmock_vendor
       - gtest_vendor
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.15.1-1
+      version: 1.15.1-2
     source:
       type: git
       url: https://github.com/ament/googletest.git
@@ -2253,9 +2251,9 @@ repositories:
       - gps_umd
       - gpsd_client
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 2.0.4-1
+      version: 2.0.4-2
     source:
       test_pull_requests: true
       type: git
@@ -2279,9 +2277,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/graph_msgs-release.git
-      version: 0.2.0-5
+      version: 0.2.0-6
     source:
       type: git
       url: https://github.com/PickNikRobotics/graph_msgs.git
@@ -2294,9 +2292,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/grasping_msgs-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/mikeferguson/grasping_msgs.git
@@ -2309,9 +2307,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/grbl_msgs-release.git
-      version: 0.0.2-8
+      version: 0.0.2-9
     source:
       type: git
       url: https://github.com/flynneva/grbl_msgs.git
@@ -2324,9 +2322,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/grbl_ros-release.git
-      version: 0.0.16-6
+      version: 0.0.16-7
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
@@ -2339,9 +2337,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gscam-release.git
-      version: 2.0.2-4
+      version: 2.0.2-5
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git
@@ -2354,9 +2352,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
-      version: 4.2.0-6
+      version: 4.2.0-7
     source:
       type: git
       url: https://github.com/borglab/gtsam.git
@@ -2369,9 +2367,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -2385,9 +2383,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.2.3-1
+      version: 0.2.3-2
     source:
       test_pull_requests: true
       type: git
@@ -2401,9 +2399,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       test_pull_requests: true
       type: git
@@ -2417,9 +2415,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2433,9 +2431,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2449,9 +2447,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2465,9 +2463,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_math_vendor-release.git
-      version: 0.2.3-1
+      version: 0.2.3-2
     source:
       test_pull_requests: true
       type: git
@@ -2481,9 +2479,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -2497,9 +2495,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2513,9 +2511,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2529,9 +2527,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2545,9 +2543,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2564,9 +2562,9 @@ repositories:
       - gz_ros2_control
       - gz_ros2_control_demos
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.7-1
+      version: 2.0.7-2
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git
@@ -2579,9 +2577,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2595,9 +2593,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2611,9 +2609,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_tools_vendor-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       test_pull_requests: true
       type: git
@@ -2627,9 +2625,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -2643,9 +2641,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.2.2-1
+      version: 0.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -2659,9 +2657,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/hash_library_vendor-release.git
-      version: 0.1.1-6
+      version: 0.1.1-7
     source:
       type: git
       url: https://github.com/tier4/hash_library_vendor.git
@@ -2674,9 +2672,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/hatchbed_common-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/hatchbed/hatchbed_common.git
@@ -2689,9 +2687,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/heaphook-release.git
-      version: 0.1.1-2
+      version: 0.1.1-3
     source:
       type: git
       url: https://github.com/tier4/heaphook.git
@@ -2704,9 +2702,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
-      version: 3.12.3-1
+      version: 3.12.3-2
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
@@ -2719,9 +2717,9 @@ repositories:
       version: rolling-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/hls_lfcd_lds_driver-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
@@ -2734,9 +2732,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/hpp_fcl-release.git
-      version: 2.4.5-1
+      version: 2.4.5-2
     source:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
@@ -2762,9 +2760,9 @@ repositories:
       - iceoryx_introspection
       - iceoryx_posh
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
-      version: 2.0.5-5
+      version: 2.0.5-6
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git
@@ -2773,9 +2771,9 @@ repositories:
   ifm3d_core:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ifm3d-release.git
-      version: 0.18.0-9
+      version: 0.18.0-10
     status: developed
   ign_rviz:
     doc:
@@ -2788,7 +2786,7 @@ repositories:
       - ign_rviz_common
       - ign_rviz_plugins
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_rviz-release.git
     source:
       test_pull_requests: true
@@ -2810,9 +2808,9 @@ repositories:
       - image_transport
       - image_transport_py
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.1.0-1
+      version: 6.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2836,9 +2834,9 @@ repositories:
       - stereo_image_proc
       - tracetools_image_pipeline
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.10-1
+      version: 6.0.10-2
     source:
       test_pull_requests: true
       type: git
@@ -2858,9 +2856,9 @@ repositories:
       - theora_image_transport
       - zstd_image_transport
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 5.0.2-1
+      version: 5.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -2878,9 +2876,9 @@ repositories:
       - imu_processors
       - imu_transformer
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
-      version: 0.5.1-1
+      version: 0.5.1-2
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git
@@ -2898,9 +2896,9 @@ repositories:
       - imu_tools
       - rviz_imu_plugin
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2914,9 +2912,9 @@ repositories:
       version: humble-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_marker_twist_server-release.git
-      version: 2.1.0-2
+      version: 2.1.0-3
     source:
       type: git
       url: https://github.com/ros-visualization/interactive_marker_twist_server.git
@@ -2929,9 +2927,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -2941,9 +2939,9 @@ repositories:
   irobot_create_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/irobot_create_msgs-release.git
-      version: 2.1.0-3
+      version: 2.1.0-4
     source:
       type: git
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
@@ -2952,9 +2950,9 @@ repositories:
   jacro:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/jacro-release.git
-      version: 0.2.0-2
+      version: 0.2.0-3
     source:
       type: git
       url: https://github.com/JafarAbdi/jacro.git
@@ -2970,9 +2968,9 @@ repositories:
       - joint_state_publisher
       - joint_state_publisher_gui
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.4.0-2
+      version: 2.4.0-3
     source:
       test_pull_requests: true
       type: git
@@ -2986,9 +2984,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/joy_tester-release.git
-      version: 0.0.2-3
+      version: 0.0.2-4
     source:
       type: git
       url: https://github.com/joshnewans/joy_tester.git
@@ -3008,9 +3006,9 @@ repositories:
       - wiimote
       - wiimote_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/joystick_drivers-release.git
-      version: 3.3.0-2
+      version: 3.3.0-3
     source:
       test_pull_requests: true
       type: git
@@ -3024,9 +3022,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.12.1-1
+      version: 2.12.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3040,9 +3038,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3059,9 +3057,9 @@ repositories:
       - kinematics_interface
       - kinematics_interface_kdl
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git
@@ -3074,9 +3072,9 @@ repositories:
       version: ros-rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface_pinocchio-release.git
-      version: 0.0.1-1
+      version: 0.0.1-2
     source:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git
@@ -3089,9 +3087,9 @@ repositories:
       version: release/1.4.x
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_core-release.git
-      version: 1.4.0-3
+      version: 1.4.0-4
     source:
       test_pull_requests: true
       type: git
@@ -3105,9 +3103,9 @@ repositories:
       version: release/1.0.x
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_ros_interfaces-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       test_pull_requests: true
       type: git
@@ -3121,9 +3119,9 @@ repositories:
       version: release/0.15.x
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
-      version: 0.15.0-3
+      version: 0.15.0-4
     source:
       test_pull_requests: true
       type: git
@@ -3140,9 +3138,9 @@ repositories:
       - kompass
       - kompass_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git
@@ -3167,9 +3165,9 @@ repositories:
       - lanelet2_traffic_rules
       - lanelet2_validation
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
-      version: 1.2.1-6
+      version: 1.2.1-7
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
@@ -3178,9 +3176,9 @@ repositories:
   laser_filters:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.8-1
+      version: 2.0.8-2
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git
@@ -3193,9 +3191,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.10.0-1
+      version: 2.10.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3209,9 +3207,9 @@ repositories:
       version: ros2-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_proc-release.git
-      version: 1.0.2-6
+      version: 1.0.2-7
     source:
       test_pull_requests: true
       type: git
@@ -3225,9 +3223,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_segmentation-release.git
-      version: 3.0.2-1
+      version: 3.0.2-2
     source:
       type: git
       url: https://github.com/ajtudela/laser_segmentation.git
@@ -3247,9 +3245,9 @@ repositories:
       - launch_xml
       - launch_yaml
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.1-1
+      version: 3.8.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3263,9 +3261,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch_param_builder-release.git
-      version: 0.1.1-3
+      version: 0.1.1-4
     source:
       type: git
       url: https://github.com/PickNikRobotics/launch_param_builder.git
@@ -3282,9 +3280,9 @@ repositories:
       - launch_testing_ros
       - ros2launch
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.28.1-1
+      version: 0.28.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3294,9 +3292,9 @@ repositories:
   ld08_driver:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ld08_driver-release.git
-      version: 1.1.3-1
+      version: 1.1.3-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ld08_driver.git
@@ -3314,9 +3312,9 @@ repositories:
       - leo_msgs
       - leo_teleop
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git
@@ -3332,9 +3330,9 @@ repositories:
       - leo_desktop
       - leo_viz
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/leo_desktop-release.git
-      version: 3.0.0-2
+      version: 3.0.0-3
     source:
       type: git
       url: https://github.com/LeoRover/leo_desktop-ros2.git
@@ -3351,9 +3349,9 @@ repositories:
       - leo_fw
       - leo_robot
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git
@@ -3371,9 +3369,9 @@ repositories:
       - leo_gz_worlds
       - leo_simulator
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/leo_simulator-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/LeoRover/leo_simulator-ros2.git
@@ -3382,9 +3380,9 @@ repositories:
   lgsvl_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/lgsvl_msgs-release.git
-      version: 0.0.4-4
+      version: 0.0.4-5
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
@@ -3396,9 +3394,9 @@ repositories:
       version: ros_event_camera
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer-release.git
-      version: 1.0.2-2
+      version: 1.0.2-3
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git
@@ -3411,9 +3409,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
@@ -3426,9 +3424,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_vendor-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
@@ -3441,9 +3439,9 @@ repositories:
       version: v0.3.1
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
-      version: 0.5.0-3
+      version: 0.5.0-4
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git
@@ -3452,9 +3450,9 @@ repositories:
   libg2o:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libg2o-release.git
-      version: 2020.5.29-5
+      version: 2020.5.29-6
     status: maintained
   libnabo:
     doc:
@@ -3463,9 +3461,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libnabo-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ethz-asl/libnabo.git
@@ -3478,9 +3476,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libpointmatcher-release.git
-      version: 1.4.1-1
+      version: 1.4.1-2
     source:
       type: git
       url: https://github.com/norlab-ulaval/libpointmatcher.git
@@ -3493,9 +3491,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
@@ -3504,9 +3502,9 @@ repositories:
   libyaml_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.7.1-1
+      version: 1.7.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3526,9 +3524,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/linux_isolate_process-release.git
-      version: 0.0.2-2
+      version: 0.0.2-3
     source:
       type: git
       url: https://github.com/adityapande-1995/linux_isolate_process.git
@@ -3541,9 +3539,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/log_view-release.git
-      version: 0.2.5-1
+      version: 0.2.5-2
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git
@@ -3556,9 +3554,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/magic_enum-release.git
-      version: 0.9.6-1
+      version: 0.9.6-2
     source:
       type: git
       url: https://github.com/Neargye/magic_enum.git
@@ -3577,9 +3575,9 @@ repositories:
       - multires_image
       - tile_map
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.6-1
+      version: 2.4.6-2
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git
@@ -3595,9 +3593,9 @@ repositories:
       - marine_acoustic_msgs
       - marine_sensor_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marine_msgs-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/apl-ocean-engineering/marine_msgs.git
@@ -3610,9 +3608,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marker_msgs-release.git
-      version: 0.0.8-1
+      version: 0.0.8-2
     source:
       type: git
       url: https://github.com/tuw-robotics/marker_msgs.git
@@ -3638,9 +3636,9 @@ repositories:
       - swri_system_util
       - swri_transform_util
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.7.4-1
+      version: 3.7.4-2
     source:
       test_pull_requests: true
       type: git
@@ -3664,9 +3662,9 @@ repositories:
       - marti_status_msgs
       - marti_visualization_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.6.1-1
+      version: 1.6.1-2
     source:
       test_pull_requests: true
       type: git
@@ -3680,9 +3678,9 @@ repositories:
       version: release/rolling/mavlink
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2024.10.10-1
+      version: 2024.10.10-2
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git
@@ -3700,9 +3698,9 @@ repositories:
       - mavros_extras
       - mavros_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.9.0-1
+      version: 2.9.0-2
     source:
       type: git
       url: https://github.com/mavlink/mavros.git
@@ -3715,9 +3713,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
@@ -3730,9 +3728,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 7.1.0-1
+      version: 7.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3746,9 +3744,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
@@ -3761,9 +3759,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git
@@ -3779,9 +3777,9 @@ repositories:
       - micro_ros_diagnostic_bridge
       - micro_ros_diagnostic_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_diagnostics-release.git
-      version: 0.3.0-5
+      version: 0.3.0-6
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_diagnostics.git
@@ -3794,9 +3792,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/micro_ros_msgs-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
@@ -3815,9 +3813,9 @@ repositories:
       - microstrain_inertial_msgs
       - microstrain_inertial_rqt
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.6.0-1
+      version: 4.6.0-2
     source:
       test_pull_requests: true
       type: git
@@ -3831,9 +3829,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.8.1-1
+      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
@@ -3890,9 +3888,9 @@ repositories:
       - mola_viz
       - mola_yaml
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.6.3-1
+      version: 1.6.3-2
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git
@@ -3905,9 +3903,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_common-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git
@@ -3920,9 +3918,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_gnss_to_markers-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/MOLAorg/mola_gnss_to_markers.git
@@ -3935,9 +3933,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.7.1-1
+      version: 0.7.1-2
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git
@@ -3955,9 +3953,9 @@ repositories:
       - mola_state_estimation_simple
       - mola_state_estimation_smoother
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.8.0-1
+      version: 1.8.0-2
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git
@@ -3970,9 +3968,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_test_datasets-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git
@@ -3988,9 +3986,9 @@ repositories:
       - motion_capture_tracking
       - motion_capture_tracking_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
-      version: 1.0.3-2
+      version: 1.0.3-3
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git
@@ -4045,9 +4043,9 @@ repositories:
       - pilz_industrial_motion_planner
       - pilz_industrial_motion_planner_testutils
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.13.2-1
+      version: 2.13.2-2
     source:
       test_commits: false
       test_pull_requests: false
@@ -4062,9 +4060,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.6.0-1
+      version: 2.6.0-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git
@@ -4085,9 +4083,9 @@ repositories:
       - moveit_resources_panda_moveit_config
       - moveit_resources_pr2_description
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git
@@ -4100,9 +4098,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_visual_tools-release.git
-      version: 4.1.2-1
+      version: 4.1.2-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_visual_tools.git
@@ -4115,9 +4113,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.6.7-1
+      version: 1.6.7-2
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
@@ -4133,9 +4131,9 @@ repositories:
       - mqtt_client
       - mqtt_client_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
@@ -4148,9 +4146,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_msgs-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
@@ -4174,9 +4172,9 @@ repositories:
       - mrpt_tps_astar_planner
       - mrpt_tutorials
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.2.1-1
+      version: 2.2.1-2
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
@@ -4189,9 +4187,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.2.1-1
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git
@@ -4219,9 +4217,9 @@ repositories:
       - mrpt_libslam
       - mrpt_libtclap
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.14.7-1
+      version: 2.14.7-2
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git
@@ -4242,9 +4240,9 @@ repositories:
       - mrpt_sensorlib
       - mrpt_sensors
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.2.3-1
+      version: 0.2.3-2
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
@@ -4257,9 +4255,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrt_cmake_modules-release.git
-      version: 1.0.11-1
+      version: 1.0.11-2
     source:
       type: git
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
@@ -4272,9 +4270,9 @@ repositories:
       version: develop
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.13.2-1
+      version: 0.13.2-2
     source:
       test_pull_requests: true
       type: git
@@ -4288,9 +4286,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nao_button_sim-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/ijnek/nao_button_sim.git
@@ -4306,9 +4304,9 @@ repositories:
       - nao_command_msgs
       - nao_sensor_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nao_interfaces-release.git
-      version: 1.0.0-2
+      version: 1.0.0-3
     source:
       type: git
       url: https://github.com/ijnek/nao_interfaces.git
@@ -4326,9 +4324,9 @@ repositories:
       - nao_lola_command_msgs
       - nao_lola_sensor_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nao_lola-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros-sports/nao_lola.git
@@ -4345,9 +4343,9 @@ repositories:
       - nav2_minimal_tb4_description
       - nav2_minimal_tb4_sim
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
-      version: 1.1.0-2
+      version: 1.1.0-3
     source:
       type: git
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
@@ -4362,9 +4360,9 @@ repositories:
       packages:
       - map_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4378,9 +4376,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/neo_simulation2-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       type: git
       url: https://github.com/neobotix/neo_simulation2.git
@@ -4393,9 +4391,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
@@ -4408,9 +4406,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
-      version: 0.0.1-4
+      version: 0.0.1-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
@@ -4423,9 +4421,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_msgs-release.git
-      version: 2.1.0-2
+      version: 2.1.0-3
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_msgs.git
@@ -4438,9 +4436,9 @@ repositories:
       version: 2.0.1
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_navsat_driver-release.git
-      version: 2.0.1-2
+      version: 2.0.1-3
     source:
       test_pull_requests: true
       type: git
@@ -4451,9 +4449,9 @@ repositories:
   nobleo_socketcan_bridge:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/nobleo/nobleo_socketcan_bridge.git
@@ -4469,9 +4467,9 @@ repositories:
       - nodl_python
       - ros2nodl
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nodl-release.git
-      version: 0.3.1-4
+      version: 0.3.1-5
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git
@@ -4484,9 +4482,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nodl_to_policy-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       test_pull_requests: true
       type: git
@@ -4503,9 +4501,9 @@ repositories:
       - novatel_gps_driver
       - novatel_gps_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.2.0-1
+      version: 4.2.0-5
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
@@ -4518,9 +4516,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ntpd_driver-release.git
-      version: 2.2.0-3
+      version: 2.2.0-4
     source:
       type: git
       url: https://github.com/vooon/ntpd_driver.git
@@ -4533,9 +4531,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ntrip_client-release.git
-      version: 1.4.1-1
+      version: 1.4.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4545,9 +4543,9 @@ repositories:
   object_recognition_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/object_recognition_msgs-release.git
-      version: 2.0.0-4
+      version: 2.0.0-5
     source:
       type: git
       url: https://github.com/wg-perception/object_recognition_msgs.git
@@ -4563,9 +4561,9 @@ repositories:
       - octomap_mapping
       - octomap_server
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git
@@ -4578,9 +4576,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_msgs-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/octomap/octomap_msgs.git
@@ -4593,9 +4591,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_ros-release.git
-      version: 0.4.4-1
+      version: 0.4.4-2
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git
@@ -4608,9 +4606,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
-      version: 2.1.1-1
+      version: 2.1.1-2
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git
@@ -4623,9 +4621,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
-      version: 1.0.5-2
+      version: 1.0.5-3
     source:
       type: git
       url: https://github.com/gstavrinos/odom_to_tf_ros2.git
@@ -4640,9 +4638,9 @@ repositories:
       packages:
       - odri_master_board_sdk
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/odri_master_board_sdk-release.git
-      version: 1.0.7-2
+      version: 1.0.7-3
     source:
       type: git
       url: https://github.com/stack-of-tasks/odri_master_board_sdk_release.git
@@ -4655,9 +4653,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       type: git
       url: https://github.com/ompl/ompl.git
@@ -4681,9 +4679,9 @@ repositories:
       - open_manipulator_playground
       - open_manipulator_teleop
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.2.1-1
+      version: 3.2.1-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git
@@ -4696,9 +4694,9 @@ repositories:
       version: release
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/openeb_vendor-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git
@@ -4711,9 +4709,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.2.2-1
+      version: 2.2.2-2
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git
@@ -4745,9 +4743,9 @@ repositories:
       - orocos_kdl_vendor
       - python_orocos_kdl_vendor
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4757,9 +4755,9 @@ repositories:
   ortools_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
-      version: 9.9.0-9
+      version: 9.9.0-10
   osqp_vendor:
     doc:
       type: git
@@ -4767,9 +4765,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/osqp_vendor-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
     source:
       type: git
       url: https://github.com/tier4/osqp_vendor.git
@@ -4782,9 +4780,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 2.1.4-2
+      version: 2.1.4-3
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git
@@ -4797,9 +4795,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -4816,9 +4814,9 @@ repositories:
       - ouster_ros
       - ouster_sensor_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ouster-ros-release.git
-      version: 0.11.1-5
+      version: 0.11.1-6
     source:
       test_pull_requests: true
       type: git
@@ -4835,9 +4833,9 @@ repositories:
       - ouxt_common
       - ouxt_lint_common
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ouxt_common-release.git
-      version: 0.0.8-4
+      version: 0.0.8-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/ouxt_common.git
@@ -4853,9 +4851,9 @@ repositories:
       - pal_statistics
       - pal_statistics_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.6.2-1
+      version: 2.6.2-2
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git
@@ -4868,9 +4866,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Pangolin-release.git
-      version: 0.9.3-1
+      version: 0.9.3-2
     source:
       type: git
       url: https://github.com/stevenlovegrove/Pangolin.git
@@ -4879,9 +4877,9 @@ repositories:
   pcl_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pcl_msgs-release.git
-      version: 1.0.0-8
+      version: 1.0.0-9
     source:
       type: git
       url: https://github.com/ros-perception/pcl_msgs.git
@@ -4892,7 +4890,7 @@ repositories:
       packages:
       - open3d_conversions
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/perception_open3d-release.git
     source:
       test_commits: false
@@ -4912,9 +4910,9 @@ repositories:
       - pcl_ros
       - perception_pcl
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.6.3-1
+      version: 2.6.3-2
     source:
       test_pull_requests: true
       type: git
@@ -4928,9 +4926,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       type: git
       url: https://gitlab.com/ApexAI/performance_test.git
@@ -4939,9 +4937,9 @@ repositories:
   performance_test_fixture:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4972,9 +4970,9 @@ repositories:
       - phidgets_spatial
       - phidgets_temperature
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.3-1
+      version: 2.3.3-2
     source:
       test_pull_requests: true
       type: git
@@ -4988,9 +4986,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.1.1-1
+      version: 1.1.1-2
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git
@@ -4999,9 +4997,9 @@ repositories:
   picknik_ament_copyright:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_ament_copyright-release.git
-      version: 0.0.2-4
+      version: 0.0.2-5
   picknik_controllers:
     doc:
       type: git
@@ -5012,9 +5010,9 @@ repositories:
       - picknik_reset_fault_controller
       - picknik_twist_controller
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/picknik_controllers-release.git
-      version: 0.0.4-2
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/picknik_controllers.git
@@ -5027,9 +5025,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pinocchio-release.git
-      version: 3.4.0-3
+      version: 3.4.0-4
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git
@@ -5042,9 +5040,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.9.2-1
+      version: 3.9.2-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
@@ -5057,9 +5055,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler_msgs-release.git
-      version: 0.2.3-4
+      version: 0.2.3-5
     source:
       type: git
       url: https://github.com/facontidavide/plotjuggler_msgs.git
@@ -5072,9 +5070,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.1.3-1
+      version: 2.1.3-2
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
@@ -5087,9 +5085,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.6.0-1
+      version: 5.6.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5103,9 +5101,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_msg_wrapper-release.git
-      version: 1.0.7-4
+      version: 1.0.7-5
     source:
       type: git
       url: https://gitlab.com/ApexAI/point_cloud_msg_wrapper
@@ -5121,9 +5119,9 @@ repositories:
       - point_cloud_transport
       - point_cloud_transport_py
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.1.1-1
+      version: 5.1.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5143,9 +5141,9 @@ repositories:
       - zlib_point_cloud_transport
       - zstd_point_cloud_transport
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 5.0.1-1
+      version: 5.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5159,9 +5157,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
-      version: 0.0.2-1
+      version: 0.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -5175,9 +5173,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
-      version: 2.0.2-2
+      version: 2.0.2-3
     source:
       test_pull_requests: true
       type: git
@@ -5196,9 +5194,9 @@ repositories:
       - polygon_rviz_plugins
       - polygon_utils
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
-      version: 1.2.0-1
+      version: 1.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5212,9 +5210,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pose_cov_ops-release.git
-      version: 0.3.13-1
+      version: 0.3.13-2
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
@@ -5227,9 +5225,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/proxsuite-release.git
-      version: 0.6.5-1
+      version: 0.6.5-2
     source:
       type: git
       url: https://github.com/Simple-Robotics/proxsuite.git
@@ -5238,9 +5236,9 @@ repositories:
   py_binding_tools:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_binding_tools-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git
@@ -5253,9 +5251,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5269,9 +5267,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.6-1
+      version: 0.6.6-2
     source:
       test_pull_requests: true
       type: git
@@ -5285,9 +5283,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5301,9 +5299,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
-      version: 2.1.1-1
+      version: 2.1.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5317,9 +5315,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5333,9 +5331,9 @@ repositories:
       version: devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
-      version: 0.2.5-1
+      version: 0.2.5-2
     source:
       test_pull_requests: true
       type: git
@@ -5349,9 +5347,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
@@ -5364,9 +5362,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_vendor-release.git
-      version: 3.2.0-1
+      version: 3.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5380,9 +5378,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/python_cmake_module-release.git
-      version: 0.12.0-1
+      version: 0.12.0-2
     source:
       type: git
       url: https://github.com/ros2/python_cmake_module.git
@@ -5397,9 +5395,9 @@ repositories:
       packages:
       - python_mrpt
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/python_mrpt_ros-release.git
-      version: 2.14.7-1
+      version: 2.14.7-2
     source:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git
@@ -5412,9 +5410,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.3.1-1
+      version: 2.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5428,9 +5426,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
-      version: 2.25.2-2
+      version: 2.25.2-3
     source:
       type: git
       url: https://github.com/StefanFabian/qml_ros2_plugin.git
@@ -5439,9 +5437,9 @@ repositories:
   qpoases_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/qpoases_vendor-release.git
-      version: 3.2.3-4
+      version: 3.2.3-5
     source:
       type: git
       url: https://github.com/Autoware-AI/qpoases_vendor.git
@@ -5461,9 +5459,9 @@ repositories:
       - qt_gui_cpp
       - qt_gui_py_common
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.9.0-1
+      version: 2.9.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5477,9 +5475,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/quaternion_operation-release.git
-      version: 0.0.7-4
+      version: 0.0.7-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git
@@ -5496,9 +5494,9 @@ repositories:
       - splsm_7
       - splsm_7_conversion
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/r2r_spl-release.git
-      version: 3.0.1-3
+      version: 3.0.1-4
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git
@@ -5507,9 +5505,9 @@ repositories:
   radar_msgs:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/radar_msgs-release.git
-      version: 0.2.2-3
+      version: 0.2.2-4
     status: maintained
   random_numbers:
     doc:
@@ -5518,9 +5516,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/random_numbers-release.git
-      version: 2.0.1-4
+      version: 2.0.1-5
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git
@@ -5536,9 +5534,9 @@ repositories:
       - raspimouse
       - raspimouse_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/raspimouse2-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5552,9 +5550,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rc_common_msgs_ros2-release.git
-      version: 0.5.3-5
+      version: 0.5.3-6
     source:
       test_pull_requests: true
       type: git
@@ -5568,9 +5566,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rc_dynamics_api-release.git
-      version: 0.10.5-1
+      version: 0.10.5-2
     source:
       test_pull_requests: true
       type: git
@@ -5584,9 +5582,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.6.5-1
+      version: 2.6.5-2
     source:
       test_pull_requests: true
       type: git
@@ -5600,9 +5598,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -5619,9 +5617,9 @@ repositories:
       - rc_reason_clients
       - rc_reason_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
-      version: 0.4.0-2
+      version: 0.4.0-3
     source:
       test_pull_requests: true
       type: git
@@ -5635,9 +5633,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcdiscover-release.git
-      version: 1.1.7-1
+      version: 1.1.7-2
     source:
       test_pull_requests: true
       type: git
@@ -5656,9 +5654,9 @@ repositories:
       - rcl_lifecycle
       - rcl_yaml_param_parser
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.1.0-1
+      version: 10.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5683,9 +5681,9 @@ repositories:
       - test_msgs
       - type_description_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5703,9 +5701,9 @@ repositories:
       - rcl_logging_noop
       - rcl_logging_spdlog
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.2.2-1
+      version: 3.2.2-2
     source:
       test_pull_requests: true
       type: git
@@ -5735,9 +5733,9 @@ repositories:
       - rclc_lifecycle
       - rclc_parameter
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 6.2.0-1
+      version: 6.2.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5756,9 +5754,9 @@ repositories:
       - rclcpp_components
       - rclcpp_lifecycle
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.5.0-1
+      version: 29.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5772,9 +5770,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 9.1.0-1
+      version: 9.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5788,9 +5786,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.13.4-1
+      version: 2.13.4-2
     source:
       test_pull_requests: true
       type: git
@@ -5809,9 +5807,9 @@ repositories:
       - rcss3d_agent_msgs
       - rcss3d_agent_msgs_to_soccer_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_agent-release.git
-      version: 0.4.1-3
+      version: 0.4.1-4
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_agent.git
@@ -5824,9 +5822,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcss3d_nao-release.git
-      version: 1.2.0-2
+      version: 1.2.0-3
     source:
       type: git
       url: https://github.com/ros-sports/rcss3d_nao.git
@@ -5839,9 +5837,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.5-1
+      version: 6.9.5-2
     source:
       test_pull_requests: true
       type: git
@@ -5868,9 +5866,9 @@ repositories:
       - rttest
       - tlsf_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.18.2-1
+      version: 0.18.2-2
     source:
       test_pull_requests: true
       type: git
@@ -5884,9 +5882,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.2.0-1
+      version: 4.2.0-2
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
@@ -5902,9 +5900,9 @@ repositories:
       - libcurl_vendor
       - resource_retriever
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.6.0-1
+      version: 3.6.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5914,9 +5912,9 @@ repositories:
   rig_reconfigure:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       test_pull_requests: true
       type: git
@@ -5930,9 +5928,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
@@ -5945,9 +5943,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
@@ -5960,9 +5958,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
@@ -5975,9 +5973,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_cmake_uncrustify-release.git
-      version: 1.2.0-5
+      version: 1.2.0-6
     source:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
@@ -5998,9 +5996,9 @@ repositories:
       - rmf_demos_maps
       - rmf_demos_tasks
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.5.0-1
+      version: 2.5.0-3
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
@@ -6027,9 +6025,9 @@ repositories:
       - rmf_traffic_msgs
       - rmf_workcell_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.4.1-1
+      version: 3.4.1-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
@@ -6050,9 +6048,9 @@ repositories:
       - rmf_traffic_ros2
       - rmf_websocket
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.9.0-1
+      version: 2.9.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
@@ -6069,9 +6067,9 @@ repositories:
       - rmf_robot_sim_common
       - rmf_robot_sim_gz_plugins
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.4.1-1
+      version: 2.4.1-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
@@ -6087,9 +6085,9 @@ repositories:
       - rmf_task
       - rmf_task_sequence
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
@@ -6105,9 +6103,9 @@ repositories:
       - rmf_traffic
       - rmf_traffic_examples
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.4.0-1
+      version: 3.4.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
@@ -6125,9 +6123,9 @@ repositories:
       - rmf_traffic_editor_assets
       - rmf_traffic_editor_test_maps
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.11.0-1
+      version: 1.11.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
@@ -6140,9 +6138,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
@@ -6157,9 +6155,9 @@ repositories:
       packages:
       - rmf_dev
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_variants-release.git
-      version: 0.2.0-1
+      version: 0.2.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_variants.git
@@ -6181,9 +6179,9 @@ repositories:
       - rmf_visualization_rviz2_plugins
       - rmf_visualization_schedule
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.4.1-1
+      version: 2.4.1-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
@@ -6196,9 +6194,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
@@ -6215,9 +6213,9 @@ repositories:
       - rmw_implementation_cmake
       - rmw_security_common
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.8.2-1
+      version: 7.8.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6235,9 +6233,9 @@ repositories:
       - rmw_connextdds_common
       - rti_connext_dds_cmake_module
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
@@ -6252,9 +6250,9 @@ repositories:
       packages:
       - rmw_cyclonedds_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_cyclonedds-release.git
-      version: 4.0.2-1
+      version: 4.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6268,9 +6266,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 3.2.1-1
+      version: 3.2.1-2
     source:
       test_pull_requests: true
       type: git
@@ -6284,9 +6282,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_desert-release.git
-      version: 3.0.0-2
+      version: 3.0.0-3
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
@@ -6303,9 +6301,9 @@ repositories:
       - rmw_fastrtps_dynamic_cpp
       - rmw_fastrtps_shared_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.3.2-1
+      version: 9.3.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6322,9 +6320,9 @@ repositories:
       - gurumdds_cmake_module
       - rmw_gurumdds_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 5.0.0-3
+      version: 5.0.0-4
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git
@@ -6337,9 +6335,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 3.0.4-1
+      version: 3.0.4-2
     source:
       test_pull_requests: true
       type: git
@@ -6357,9 +6355,9 @@ repositories:
       - zenoh_cpp_vendor
       - zenoh_security_tools
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.0-1
+      version: 0.6.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git
@@ -6375,9 +6373,9 @@ repositories:
       - robot_calibration
       - robot_calibration_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.10.0-1
+      version: 0.10.0-2
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git
@@ -6386,9 +6384,9 @@ repositories:
   robot_localization:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.9.2-2
+      version: 3.9.2-3
     source:
       test_pull_requests: true
       type: git
@@ -6402,9 +6400,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.4.2-1
+      version: 3.4.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6414,9 +6412,9 @@ repositories:
   robotraconteur:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robotraconteur-release.git
-      version: 1.2.2-1
+      version: 1.2.2-2
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git
@@ -6451,9 +6449,9 @@ repositories:
       - canopen_utils
       - lely_core_libraries
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git
@@ -6478,9 +6476,9 @@ repositories:
       - rqt_controller_manager
       - transmission_interface
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.28.1-1
+      version: 4.28.1-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
@@ -6493,9 +6491,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
-      version: 0.1.1-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git
@@ -6535,9 +6533,9 @@ repositories:
       - tricycle_steering_controller
       - velocity_controllers
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.23.0-1
+      version: 4.23.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
@@ -6567,9 +6565,8 @@ repositories:
       - kortex_description
       - kortex_driver
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.2-2
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git
@@ -6585,9 +6582,9 @@ repositories:
       - robotiq_controllers
       - robotiq_description
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_robotiq_gripper-release.git
-      version: 0.0.1-2
+      version: 0.0.1-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
@@ -6603,9 +6600,9 @@ repositories:
       - ros2_socketcan
       - ros2_socketcan_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_socketcan-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/autowarefoundation/ros2_socketcan.git
@@ -6626,9 +6623,9 @@ repositories:
       - tracetools_test
       - tracetools_trace
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.6.0-1
+      version: 8.6.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6642,9 +6639,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2acceleration-release.git
-      version: 0.5.1-3
+      version: 0.5.1-4
     source:
       test_pull_requests: true
       type: git
@@ -6674,9 +6671,9 @@ repositories:
       - ros2service
       - ros2topic
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.37.0-1
+      version: 0.37.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6690,9 +6687,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
@@ -6708,9 +6705,9 @@ repositories:
       - ros2launch_security
       - ros2launch_security_examples
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2launch_security-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       test_pull_requests: true
       type: git
@@ -6727,9 +6724,9 @@ repositories:
       - ros_babel_fish
       - ros_babel_fish_test_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 3.25.2-1
+      version: 3.25.2-2
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
@@ -6745,9 +6742,9 @@ repositories:
       - battery_state_broadcaster
       - battery_state_rviz_overlay
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -6759,9 +6756,9 @@ repositories:
       packages:
       - can_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_canopen-release.git
-      version: 2.0.0-5
+      version: 2.0.0-6
     source:
       type: git
       url: https://github.com/ros-industrial/ros_canopen.git
@@ -6774,9 +6771,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_environment-release.git
-      version: 4.3.0-1
+      version: 4.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6798,9 +6795,9 @@ repositories:
       - ros_gz_sim_demos
       - test_ros_gz_bridge
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.6-1
+      version: 2.1.6-2
     source:
       test_pull_requests: true
       type: git
@@ -6814,9 +6811,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_image_to_qimage-release.git
-      version: 0.4.1-3
+      version: 0.4.1-4
     source:
       type: git
       url: https://github.com/ros-sports/ros_image_to_qimage.git
@@ -6825,9 +6822,9 @@ repositories:
   ros_industrial_cmake_boilerplate:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
-      version: 0.5.4-1
+      version: 0.5.4-2
   ros_testing:
     doc:
       type: git
@@ -6838,9 +6835,9 @@ repositories:
       - ros2test
       - ros_testing
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_testing-release.git
-      version: 0.8.0-1
+      version: 0.8.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6857,9 +6854,9 @@ repositories:
       - turtlesim
       - turtlesim_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.9.2-1
+      version: 1.9.2-2
     source:
       test_pull_requests: true
       type: git
@@ -6869,9 +6866,9 @@ repositories:
   ros_workspace:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_workspace-release.git
-      version: 1.0.3-6
+      version: 1.0.3-7
     source:
       type: git
       url: https://github.com/ros2/ros_workspace.git
@@ -6908,9 +6905,9 @@ repositories:
       - sqlite3_vendor
       - zstd_vendor
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.32.0-1
+      version: 0.32.0-2
     source:
       test_pull_requests: true
       type: git
@@ -6943,9 +6940,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2_to_video-release.git
-      version: 1.0.1-1
+      version: 1.0.1-2
     source:
       type: git
       url: https://github.com/fictionlab/rosbag2_to_video.git
@@ -6966,9 +6963,9 @@ repositories:
       - rosbridge_suite
       - rosbridge_test_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -6995,9 +6992,9 @@ repositories:
       - rosidl_typesupport_introspection_c
       - rosidl_typesupport_introspection_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.9.4-1
+      version: 4.9.4-2
     source:
       test_pull_requests: true
       type: git
@@ -7014,9 +7011,9 @@ repositories:
       - rosidl_core_generators
       - rosidl_core_runtime
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7032,9 +7029,9 @@ repositories:
       packages:
       - rosidl_generator_dds_idl
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dds-release.git
-      version: 0.12.0-1
+      version: 0.12.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7051,9 +7048,9 @@ repositories:
       - rosidl_default_generators
       - rosidl_default_runtime
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.7.1-1
+      version: 1.7.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7067,9 +7064,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport-release.git
-      version: 0.3.1-1
+      version: 0.3.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7083,9 +7080,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
-      version: 0.4.1-1
+      version: 0.4.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7101,9 +7098,9 @@ repositories:
       packages:
       - rosidl_generator_py
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.24.1-1
+      version: 0.24.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7117,9 +7114,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.14.1-1
+      version: 0.14.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7146,9 +7143,9 @@ repositories:
       - rosidl_typesupport_c
       - rosidl_typesupport_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 3.3.3-1
+      version: 3.3.3-2
     source:
       test_pull_requests: true
       type: git
@@ -7165,9 +7162,9 @@ repositories:
       - rosidl_typesupport_fastrtps_c
       - rosidl_typesupport_fastrtps_cpp
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.8.0-1
+      version: 3.8.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7184,9 +7181,9 @@ repositories:
       - rclpy_message_converter
       - rclpy_message_converter_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rospy_message_converter-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       test_pull_requests: true
       type: git
@@ -7200,9 +7197,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosx_introspection-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git
@@ -7213,9 +7210,9 @@ repositories:
       packages:
       - rot_conv
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rot_conv_lib-release.git
-      version: 1.1.0-3
+      version: 1.1.0-4
     source:
       type: git
       url: https://github.com/AIS-Bonn/rot_conv_lib.git
@@ -7224,9 +7221,9 @@ repositories:
   rplidar_ros:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_ros-release.git
-      version: 2.1.0-3
+      version: 2.1.0-4
     source:
       test_pull_requests: true
       type: git
@@ -7240,9 +7237,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.6.2-1
+      version: 0.6.2-2
     source:
       test_pull_requests: true
       type: git
@@ -7262,9 +7259,9 @@ repositories:
       - rqt_gui_py
       - rqt_py_common
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.9.0-1
+      version: 1.9.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7278,9 +7275,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
@@ -7296,9 +7293,9 @@ repositories:
       - rqt_bag
       - rqt_bag_plugins
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.0.2-1
+      version: 2.0.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
@@ -7311,9 +7308,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_common_plugins-release.git
-      version: 1.2.0-3
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_common_plugins.git
@@ -7326,9 +7323,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.3.1-1
+      version: 2.3.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
@@ -7341,9 +7338,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_dotgraph-release.git
-      version: 0.0.4-1
+      version: 0.0.4-2
     source:
       type: git
       url: https://github.com/niwcpac/rqt_dotgraph.git
@@ -7356,9 +7353,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_gauges-release.git
-      version: 0.0.3-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/ToyotaResearchInstitute/gauges2.git
@@ -7371,9 +7368,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7390,9 +7387,9 @@ repositories:
       - rqt_image_overlay
       - rqt_image_overlay_layer
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_overlay-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/ros-sports/rqt_image_overlay.git
@@ -7405,9 +7402,9 @@ repositories:
       version: rolling-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7421,9 +7418,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_moveit-release.git
-      version: 1.0.1-4
+      version: 1.0.1-5
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git
@@ -7436,9 +7433,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.6.0-1
+      version: 1.6.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
@@ -7451,9 +7448,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.6.2-1
+      version: 1.6.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
@@ -7466,9 +7463,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.9.0-1
+      version: 1.9.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
@@ -7481,9 +7478,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.4.0-1
+      version: 1.4.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
@@ -7496,9 +7493,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7512,9 +7509,9 @@ repositories:
       version: ROS2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_dashboard-release.git
-      version: 0.6.1-4
+      version: 0.6.1-5
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_dashboard.git
@@ -7527,9 +7524,9 @@ repositories:
       version: dashing-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_monitor-release.git
-      version: 1.0.6-1
+      version: 1.0.6-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_monitor.git
@@ -7542,9 +7539,9 @@ repositories:
       version: dashing-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
@@ -7557,9 +7554,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_runtime_monitor-release.git
-      version: 1.0.0-4
+      version: 1.0.0-5
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_runtime_monitor.git
@@ -7572,9 +7569,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.4.0-1
+      version: 1.4.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
@@ -7587,9 +7584,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.3.1-1
+      version: 1.3.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
@@ -7602,9 +7599,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_srv-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
@@ -7617,9 +7614,9 @@ repositories:
       version: humble
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.5-1
+      version: 1.0.5-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git
@@ -7632,9 +7629,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.8.0-1
+      version: 1.8.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7648,9 +7645,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 1.1.0-2
+      version: 1.1.0-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git
@@ -7666,9 +7663,9 @@ repositories:
       - rt_manipulators_cpp
       - rt_manipulators_examples
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rt_manipulators_cpp-release.git
-      version: 1.0.0-3
+      version: 1.0.0-4
     source:
       type: git
       url: https://github.com/rt-net/rt_manipulators_cpp.git
@@ -7681,9 +7678,9 @@ repositories:
       version: jazzy
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rt_usb_9axisimu_driver-release.git
-      version: 3.0.0-1
+      version: 3.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -7697,9 +7694,9 @@ repositories:
       version: rolling-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.6-1
+      version: 0.21.6-2
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
@@ -7712,9 +7709,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rtcm_msgs-release.git
-      version: 1.1.6-3
+      version: 1.1.6-4
     source:
       type: git
       url: https://github.com/tilk/rtcm_msgs.git
@@ -7723,9 +7720,9 @@ repositories:
   ruckig:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ruckig-release.git
-      version: 0.9.2-4
+      version: 0.9.2-5
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
@@ -7747,9 +7744,9 @@ repositories:
       - rviz_rendering_tests
       - rviz_visual_testing_framework
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.4-1
+      version: 14.4.4-2
     source:
       test_pull_requests: true
       type: git
@@ -7766,9 +7763,9 @@ repositories:
       - rviz_2d_overlay_msgs
       - rviz_2d_overlay_plugins
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.3.0-2
+      version: 1.3.0-3
     source:
       type: git
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
@@ -7781,9 +7778,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_visual_tools-release.git
-      version: 4.1.4-3
+      version: 4.1.4-4
     source:
       type: git
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
@@ -7799,9 +7796,9 @@ repositories:
       - sdformat_test_files
       - sdformat_urdf
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       test_pull_requests: true
       type: git
@@ -7815,9 +7812,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.2.4-1
+      version: 0.2.4-2
     source:
       test_pull_requests: true
       type: git
@@ -7831,9 +7828,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.2-1
+      version: 1.4.2-2
     source:
       test_pull_requests: true
       type: git
@@ -7847,9 +7844,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/service_load_balancing-release.git
-      version: 0.1.1-2
+      version: 0.1.1-3
     source:
       type: git
       url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
@@ -7862,9 +7859,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safetyscanners2-release.git
-      version: 1.0.4-1
+      version: 1.0.4-2
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2.git
@@ -7877,9 +7874,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safetyscanners2_interfaces-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
@@ -7892,9 +7889,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safetyscanners_base-release.git
-      version: 1.0.3-1
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners_base.git
@@ -7907,9 +7904,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_base-release.git
-      version: 1.0.1-2
+      version: 1.0.1-3
     source:
       type: git
       url: https://github.com/SICKAG/sick_safevisionary_base.git
@@ -7926,9 +7923,9 @@ repositories:
       - sick_safevisionary_interfaces
       - sick_safevisionary_tests
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
-      version: 1.0.3-2
+      version: 1.0.3-3
     source:
       type: git
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git
@@ -7947,9 +7944,8 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simple_actions-release.git
-      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git
@@ -7963,9 +7959,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simple_grasping-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       type: git
       url: https://github.com/mikeferguson/simple_grasping.git
@@ -7978,9 +7974,9 @@ repositories:
       version: 1.0.2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.11.0-1
+      version: 1.11.0-2
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git
@@ -7993,9 +7989,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/slg_msgs-release.git
-      version: 3.9.1-1
+      version: 3.9.1-2
     source:
       type: git
       url: https://github.com/ajtudela/slg_msgs.git
@@ -8008,9 +8004,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/slider_publisher-release.git
-      version: 2.3.1-2
+      version: 2.3.1-3
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git
@@ -8028,9 +8024,9 @@ repositories:
       - smach_msgs
       - smach_ros
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/executive_smach-release.git
-      version: 3.0.3-2
+      version: 3.0.3-3
     source:
       test_pull_requests: true
       type: git
@@ -8044,9 +8040,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/snowbot_release.git
-      version: 0.1.2-4
+      version: 0.1.2-5
     source:
       type: git
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
@@ -8072,9 +8068,9 @@ repositories:
       - soccer_vision_3d_msgs
       - soccer_vision_attribute_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_interfaces-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/ros-sports/soccer_interfaces.git
@@ -8087,9 +8083,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/soccer_vision_3d_rviz_markers-release.git
-      version: 1.0.0-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
@@ -8102,9 +8098,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sol_vendor-release.git
-      version: 0.0.3-4
+      version: 0.0.3-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/sol_vendor.git
@@ -8117,9 +8113,9 @@ repositories:
       version: release/1.22.x
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sophus-release.git
-      version: 1.22.9102-2
+      version: 1.22.9102-3
     source:
       type: git
       url: https://github.com/clalancette/sophus.git
@@ -8128,9 +8124,9 @@ repositories:
   spdlog_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -8144,9 +8140,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.7-1
+      version: 2.0.7-2
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git
@@ -8162,9 +8158,9 @@ repositories:
       - sros2
       - sros2_cmake
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.15.1-1
+      version: 0.15.1-2
     source:
       test_pull_requests: true
       type: git
@@ -8178,9 +8174,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/steering_functions-release.git
-      version: 0.3.0-1
+      version: 0.3.0-2
     source:
       type: git
       url: https://github.com/hbanzhaf/steering_functions.git
@@ -8193,9 +8189,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/stomp-release.git
-      version: 0.1.2-3
+      version: 0.1.2-4
     source:
       type: git
       url: https://github.com/ros-industrial/stomp.git
@@ -8208,9 +8204,9 @@ repositories:
       version: ros2-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.6-1
+      version: 2.0.6-4
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git
@@ -8223,9 +8219,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/synapticon_ros2_control-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
@@ -8238,9 +8234,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_system_fingerprint-release.git
-      version: 0.7.0-3
+      version: 0.7.0-4
     source:
       test_pull_requests: true
       type: git
@@ -8259,9 +8255,9 @@ repositories:
       - system_modes_examples
       - system_modes_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/system_modes-release.git
-      version: 0.9.0-5
+      version: 0.9.0-6
     source:
       test_pull_requests: true
       type: git
@@ -8278,9 +8274,9 @@ repositories:
   tango_icons_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git
@@ -8299,9 +8295,9 @@ repositories:
       - teleop_tools
       - teleop_tools_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_tools-release.git
-      version: 1.8.0-1
+      version: 1.8.0-2
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
@@ -8314,9 +8310,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.6.3-1
+      version: 2.6.3-2
     source:
       test_pull_requests: true
       type: git
@@ -8330,9 +8326,9 @@ repositories:
       version: dashing
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
-      version: 2.4.0-1
+      version: 2.4.0-2
     source:
       test_pull_requests: true
       type: git
@@ -8346,9 +8342,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
-      version: 0.0.4-2
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/tier4/tensorrt_cmake_module.git
@@ -8361,9 +8357,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.13.0-1
+      version: 0.13.0-2
     source:
       test_pull_requests: true
       type: git
@@ -8377,9 +8373,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tf2_2d-release.git
-      version: 1.0.1-3
+      version: 1.0.1-4
     source:
       test_pull_requests: true
       type: git
@@ -8393,9 +8389,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tf_transformations_release.git
-      version: 1.0.1-4
+      version: 1.0.1-5
     source:
       test_pull_requests: true
       type: git
@@ -8409,9 +8405,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tinyspline_vendor-release.git
-      version: 0.6.1-1
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/wep21/tinyspline_vendor.git
@@ -8424,9 +8420,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.10.0-1
+      version: 0.10.0-2
     source:
       test_pull_requests: true
       type: git
@@ -8436,9 +8432,9 @@ repositories:
   tinyxml_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml_vendor-release.git
-      version: 0.10.0-2
+      version: 0.10.0-3
     source:
       test_pull_requests: true
       type: git
@@ -8452,9 +8448,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tlsf-release.git
-      version: 0.10.1-1
+      version: 0.10.1-2
     source:
       test_pull_requests: true
       type: git
@@ -8464,9 +8460,9 @@ repositories:
   topic_based_ros2_control:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-2
+      version: 0.2.0-3
   topic_tools:
     doc:
       type: git
@@ -8477,9 +8473,9 @@ repositories:
       - topic_tools
       - topic_tools_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.2-1
+      version: 1.4.2-2
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
@@ -8496,9 +8492,9 @@ repositories:
       - trac_ik_kinematics_plugin
       - trac_ik_lib
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
-      version: 2.0.1-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
@@ -8511,9 +8507,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_acceleration-release.git
-      version: 0.4.1-3
+      version: 0.4.1-4
     source:
       test_pull_requests: true
       type: git
@@ -8530,9 +8526,9 @@ repositories:
       - ros2trace_analysis
       - tracetools_analysis
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tracetools_analysis-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -8551,9 +8547,9 @@ repositories:
       - serial_driver
       - udp_driver
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/transport_drivers-release.git
-      version: 1.2.0-3
+      version: 1.2.0-4
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
@@ -8566,9 +8562,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
-      version: 0.2.1-4
+      version: 0.2.1-5
     source:
       type: git
       url: https://github.com/wep21/turbojpeg_compressed_image_transport.git
@@ -8581,9 +8577,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/turtle_nest-release.git
-      version: 1.0.2-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/Jannkar/turtle_nest.git
@@ -8626,9 +8622,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_msgs-release.git
-      version: 2.3.0-1
+      version: 2.3.0-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
@@ -8645,9 +8641,9 @@ repositories:
       - turtlebot3_gazebo
       - turtlebot3_simulations
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
-      version: 2.3.2-1
+      version: 2.3.2-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
@@ -8660,9 +8656,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_geometry-release.git
-      version: 0.1.2-1
+      version: 0.1.2-2
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_geometry.git
@@ -8686,9 +8682,9 @@ repositories:
       - tuw_object_msgs
       - tuw_std_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tuw_msgs-release.git
-      version: 0.2.5-1
+      version: 0.2.5-2
     source:
       type: git
       url: https://github.com/tuw-robotics/tuw_msgs.git
@@ -8701,9 +8697,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tvm_vendor-release.git
-      version: 0.9.1-3
+      version: 0.9.1-4
     source:
       type: git
       url: https://github.com/autowarefoundation/tvm_vendor.git
@@ -8716,9 +8712,9 @@ repositories:
       version: foxy-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux-release.git
-      version: 4.4.0-1
+      version: 4.4.0-2
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
@@ -8731,9 +8727,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux_msgs-release.git
-      version: 3.0.1-2
+      version: 3.0.1-3
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux_msgs.git
@@ -8746,9 +8742,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/twist_stamper-release.git
-      version: 0.0.5-1
+      version: 0.0.5-2
     source:
       type: git
       url: https://github.com/joshnewans/twist_stamper.git
@@ -8766,9 +8762,9 @@ repositories:
       - ublox_msgs
       - ublox_serialization
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ublox-release.git
-      version: 2.3.0-3
+      version: 2.3.0-4
     source:
       test_pull_requests: true
       type: git
@@ -8789,9 +8785,9 @@ repositories:
       - ublox_ubx_interfaces
       - ublox_ubx_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.5.5-4
+      version: 0.5.5-5
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git
@@ -8804,9 +8800,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/udp_msgs-release.git
-      version: 0.0.5-1
+      version: 0.0.5-2
     source:
       type: git
       url: https://github.com/flynneva/udp_msgs.git
@@ -8815,9 +8811,9 @@ repositories:
   uncrustify_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/uncrustify_vendor-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
@@ -8830,9 +8826,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.7.0-1
+      version: 2.7.0-2
     source:
       test_pull_requests: true
       type: git
@@ -8846,9 +8842,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 1.9.0-1
+      version: 1.9.0-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
@@ -8861,9 +8857,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.1.0-1
+      version: 3.1.0-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
@@ -8876,9 +8872,9 @@ repositories:
       version: humble
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
@@ -8898,9 +8894,9 @@ repositories:
       - ur_moveit_config
       - ur_robot_driver
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.2.1-1
+      version: 3.2.1-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
@@ -8909,9 +8905,9 @@ repositories:
   ur_simulation_gz:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
-      version: 2.2.0-1
+      version: 2.2.0-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
@@ -8927,9 +8923,9 @@ repositories:
       - urdf
       - urdf_parser_plugin
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.12.2-1
+      version: 2.12.2-2
     source:
       test_pull_requests: true
       type: git
@@ -8943,9 +8939,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_launch-release.git
-      version: 0.1.1-2
+      version: 0.1.1-3
     source:
       test_pull_requests: true
       type: git
@@ -8961,9 +8957,9 @@ repositories:
       packages:
       - urdfdom_py
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_py-release.git
-      version: 1.2.1-2
+      version: 1.2.1-3
     source:
       test_pull_requests: true
       type: git
@@ -8977,9 +8973,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_tutorial-release.git
-      version: 1.1.0-2
+      version: 1.1.0-3
     source:
       test_pull_requests: true
       type: git
@@ -8993,9 +8989,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 4.0.0-2
+      version: 4.0.0-3
     source:
       test_pull_requests: true
       type: git
@@ -9009,9 +9005,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.1.1-2
+      version: 1.1.1-3
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git
@@ -9024,9 +9020,9 @@ repositories:
       version: ros2-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urg_c-release.git
-      version: 1.0.4001-5
+      version: 1.0.4001-6
     source:
       test_pull_requests: true
       type: git
@@ -9040,9 +9036,9 @@ repositories:
       version: ros2-devel
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.1.1-3
+      version: 1.1.1-4
     source:
       test_pull_requests: true
       type: git
@@ -9056,9 +9052,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node_msgs-release.git
-      version: 1.0.1-8
+      version: 1.0.1-9
     source:
       type: git
       url: https://github.com/ros-drivers/urg_node_msgs.git
@@ -9068,16 +9064,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/usb_cam-release.git
-      version: 0.8.1-1
+      version: 0.8.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     status: maintained
   v4l2_camera:
     doc:
@@ -9086,9 +9082,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_v4l2_camera-release.git
-      version: 0.7.1-1
+      version: 0.7.1-2
     source:
       type: git
       url: https://gitlab.com/boldhearts/ros2_v4l2_camera.git
@@ -9108,9 +9104,9 @@ repositories:
       - ros_core
       - simulation
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/variants-release.git
-      version: 0.12.0-1
+      version: 0.12.0-2
     source:
       test_pull_requests: true
       type: git
@@ -9130,9 +9126,9 @@ repositories:
       - velodyne_msgs
       - velodyne_pointcloud
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/velodyne-release.git
-      version: 2.5.1-1
+      version: 2.5.1-2
     source:
       type: git
       url: https://github.com/ros-drivers/velodyne.git
@@ -9148,9 +9144,9 @@ repositories:
       - vision_msgs
       - vision_msgs_rviz_plugins
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
-      version: 4.1.1-2
+      version: 4.1.1-3
     source:
       test_pull_requests: true
       type: git
@@ -9164,9 +9160,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs_layers-release.git
-      version: 0.2.0-3
+      version: 0.2.0-4
     source:
       type: git
       url: https://github.com/ros-sports/vision_msgs_layers.git
@@ -9183,9 +9179,9 @@ repositories:
       - image_geometry
       - vision_opencv
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 4.1.0-1
+      version: 4.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -9199,9 +9195,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/visp-release.git
-      version: 3.5.0-3
+      version: 3.5.0-4
     source:
       type: git
       url: https://github.com/lagadic/visp.git
@@ -9214,9 +9210,9 @@ repositories:
       version: rolling
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/vitis_common-release.git
-      version: 0.4.2-3
+      version: 0.4.2-4
     source:
       test_pull_requests: true
       type: git
@@ -9230,9 +9226,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn-release.git
-      version: 7.35.0-20
+      version: 7.35.0-21
     source:
       test_commits: false
       test_pull_requests: false
@@ -9247,9 +9243,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/vrpn_mocap-release.git
-      version: 1.1.0-3
+      version: 1.1.0-4
     source:
       type: git
       url: https://github.com/alvinsunyixiao/vrpn_mocap.git
@@ -9262,9 +9258,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.5-1
+      version: 2.0.5-2
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git
@@ -9277,9 +9273,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.5-1
+      version: 1.0.5-2
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git
@@ -9292,9 +9288,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/web_video_server-release.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -9323,9 +9319,9 @@ repositories:
       - webots_ros2_turtlebot
       - webots_ros2_universal_robot
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/webots_ros2-release.git
-      version: 2025.0.0-1
+      version: 2025.0.0-2
     source:
       test_pull_requests: true
       type: git
@@ -9339,9 +9335,9 @@ repositories:
       version: ros2
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.13-1
+      version: 2.0.13-2
     source:
       type: git
       url: https://github.com/ros/xacro.git
@@ -9350,9 +9346,9 @@ repositories:
   yaml_cpp_vendor:
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 9.1.0-1
+      version: 9.1.0-2
     source:
       test_pull_requests: true
       type: git
@@ -9372,9 +9368,9 @@ repositories:
       - yasmin_ros
       - yasmin_viewer
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 3.2.0-1
+      version: 3.2.0-2
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git
@@ -9390,9 +9386,9 @@ repositories:
       - zbar_ros
       - zbar_ros_interfaces
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/zbar_ros-release.git
-      version: 0.7.0-1
+      version: 0.7.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/zbar_ros.git
@@ -9407,9 +9403,9 @@ repositories:
       packages:
       - zed_msgs
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
-      version: 5.0.0-1
+      version: 5.0.0-2
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-interfaces.git
@@ -9422,9 +9418,9 @@ repositories:
       version: master
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/zenoh_bridge_dds-release.git
-      version: 0.5.0-4
+      version: 0.5.0-5
     source:
       type: git
       url: https://github.com/eclipse-zenoh/zenoh-plugin-dds.git
@@ -9437,9 +9433,9 @@ repositories:
       version: main
     release:
       tags:
-        release: release/rolling/{package}/{version}
+        release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/zmqpp_vendor-release.git
-      version: 0.0.2-3
+      version: 0.0.2-4
     source:
       type: git
       url: https://github.com/tier4/zmqpp_vendor.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+# ROS distribution file
+# see REP 143: http://ros.org/reps/rep-0143.html
+---
+release_platforms:
+  debian:
+  - bookworm
+  rhel:
+  - '9'
+  ubuntu:
+  - noble
+repositories: {}
+type: distribution
+version: 2


### PR DESCRIPTION
These changes add the new Kilted Kaiju distribution for ROS 2.

The initial state was taken from the commit 9cdeff6 and migration was performed with the following command: `python3 migration-tools/migrate-rosdistro.py --source rolling --dest kilted --source-ref 9cdeff677a1d1f475c75c863916758ab21088f99 --release-org ros2-gbp`

The following repositories did not migrate successfully:
- SMACC2
- aws-robomaker-small-warehouse-world
- dolly
- game_controller_spl
- ign_rviz
- perception_open3d
- ros2_kortex
- simple_actions

There will likely be CI failures here, as some packages may have changed their repository URLs or branch names since they were added to rolling. We'll open PRs to clean those up at a later date in all supported distributions.