### PR TITLE
Rename usb_cam development branch: ros2 -> main

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11629,7 +11629,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -11638,7 +11638,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     status: maintained
   v4l2_camera:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10249,7 +10249,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -10258,7 +10258,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     status: maintained
   v4l2_camera:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9068,7 +9068,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -9077,7 +9077,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/usb_cam.git
-      version: ros2
+      version: main
     status: maintained
   v4l2_camera:
     doc:


### PR DESCRIPTION
It appears that this repository started using the `main` branch and deleted the `ros2` branch.

@flynneva to confirm.

Should resolve the CI failures uncovered during the Kilted migration.