### PR TITLE
ur_robot_driver: 2.3.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12714,7 +12714,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
- release repository: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## ur_calibration

- No changes

## ur_dashboard_msgs

- No changes

## ur_robot_driver

```
* Add ROS param (robot_receive_timeout) to control reverse interface timeouts (#745 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/745>)
* Add launchfiles for ur7e and ur12e (#743 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/743>)
* Add support for ur7e and ur12e (#742 <https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/742>)
* Contributors: Felix Exner, cambel
```
