### PR TITLE
Revert "ompl: 1.7.0-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5375,7 +5375,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.7.0-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ompl/ompl.git


### PR DESCRIPTION
Reverts ros/rosdistro#45248

This update broke the [package in Jazzy](https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__ompl__ubuntu_noble_amd64__binary/) and blocks a bunch of downstream ones. Reverting temporarily so we can get the [current patch sync]() out.

FYI: @JafarAbdi 