### PR TITLE
rosidl_python: 0.22.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8008,7 +8008,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.22.0-2
+      version: 0.22.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.22.1-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.22.0-2`

## rosidl_generator_py

```
* fix (#224 <https://github.com/ros2/rosidl_python/issues/224>) (#227 <https://github.com/ros2/rosidl_python/issues/227>)
  (cherry picked from commit 8aefd489b840d46c138245095402fcc50d3559f4)
  Co-authored-by: Michael Carlstrom <mailto:rmc@carlstrom.com>
* Contributors: mergify[bot]
```
