### PR TITLE
ros2cli: 0.32.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7571,7 +7571,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.3-1
+      version: 0.32.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.4-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.32.3-1`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* Custom Completion Finder for fetching topic prototype. (backport #995 <https://github.com/ros2/ros2cli/issues/995>) (#1012 <https://github.com/ros2/ros2cli/issues/1012>)
  * Custom Completion Finder for fetching topic prototype. (#995 <https://github.com/ros2/ros2cli/issues/995>)
  * Double yaml encoding for fetching topic prototype.
  * Use a custom completer for yaml strings.
  ---------
  (cherry picked from commit 526401b42107014f56f9d77dcf3df005f360bc91)
  # Conflicts:
  #     ros2topic/ros2topic/verb/pub.py
  * resolve conflicts for backport.
  * Remove whitespace on blank lines
  ---------
  Co-authored-by: Leander Stephen D'Souza <mailto:leanderdsouza1234@gmail.com>
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Shane Loretz <mailto:shane.loretz@gmail.com>
* ros2topic: Documented now and auto keywords (#1008 <https://github.com/ros2/ros2cli/issues/1008>) (#1011 <https://github.com/ros2/ros2cli/issues/1011>)
  (cherry picked from commit 1a0dcf22b61534c9a391a7d60fbc95a972d23d06)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Conditional deserialization of message for ros2 topic hz (backport #1005 <https://github.com/ros2/ros2cli/issues/1005>) (#1006 <https://github.com/ros2/ros2cli/issues/1006>)
  (cherry picked from commit bfc52454d07a1554226b56b64dfdbf5bcb6b3f6b)
  Co-authored-by: Kostubh Khandelwal <mailto:123073764+exMachina316@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Revert "jazzy: Backport Patch CVE-2024-42002 (#998 <https://github.com/ros2/ros2cli/issues/998>)" (#1004 <https://github.com/ros2/ros2cli/issues/1004>)
  This reverts commit f037c1961f2b108be734d20c8f770c5e9d523856.
* jazzy: Backport Patch CVE-2024-42002 (#998 <https://github.com/ros2/ros2cli/issues/998>)
* Contributors: Christophe Bedard, Michael Carroll, mergify[bot]
```
