### PR TITLE
ament_cmake: 2.5.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -172,7 +172,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.5.3-1
+      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.5.4-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.3-1`

## ament_cmake

- No changes

## ament_cmake_auto

```
* Add USE_SCOPED_HEADER_INSTALL_DIR option to ament_auto_package (backport #540 <https://github.com/ament/ament_cmake/issues/540>) (#578 <https://github.com/ament/ament_cmake/issues/578>)
  * Add USE_SCOPED_HEADER_INSTALL_DIR option to ament_auto_package
  * Add warning message to ament_auto_package related to USE_SCOPED_HEADER_INSTALL_DIR option
  * Add missing endif to ament_auto_package
  * Use no mode instead of WARNING in message in ament_auto_package.cmake
  ---------
* Contributors: Kotaro Yoshimoto
```

## ament_cmake_core

- No changes

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

- No changes

## ament_cmake_version

- No changes
