### PR TITLE
tsid: 1.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10921,6 +10921,21 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  tsid:
+    doc:
+      type: git
+      url: https://github.com/stack-of-tasks/tsid.git
+      version: devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tsid-release.git
+      version: 1.8.0-1
+    source:
+      type: git
+      url: https://github.com/stack-of-tasks/tsid.git
+      version: devel
+    status: maintained
   turbojpeg_compressed_image_transport:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tsid` to `1.8.0-1`:

- upstream repository: https://github.com/stack-of-tasks/tsid
- release repository: https://github.com/ros2-gbp/tsid-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
