### PR TITLE
rviz: 14.1.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8704,7 +8704,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.8-1
+      version: 14.1.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.9-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.8-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* addTrackedObject Function Fails to Handle Null Pointer, Causing Crash When nullptr is Passed (#1375 <https://github.com/ros2/rviz/issues/1375>) (#1378 <https://github.com/ros2/rviz/issues/1378>)
  (cherry picked from commit a657981d9fc816900688663bfcb6e7f3c50a0acc)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Fix Potential Null Pointer Dereference in VisualizerApp::getRenderWindow() to Prevent Crashes (#1359 <https://github.com/ros2/rviz/issues/1359>) (#1365 <https://github.com/ros2/rviz/issues/1365>)
  (cherry picked from commit c2118276a21db73752cbe468ea9a0c052f6a3502)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* UniformStringStream::parseFloat Fails to Handle Invalid Float Formats Correctly (#1360 <https://github.com/ros2/rviz/issues/1360>) (#1367 <https://github.com/ros2/rviz/issues/1367>)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit 2e6fd001b25b02314c5785b5e74e68fcc193e1d8)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Add test to check mapGetString when key is missing (#1361 <https://github.com/ros2/rviz/issues/1361>) (#1369 <https://github.com/ros2/rviz/issues/1369>)
  (cherry picked from commit 98225aaaf5be04a35cc30b275c38c43cf1baede9)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

```
* Use official freetype github mirror instead of savannah mirror (backport #1348 <https://github.com/ros2/rviz/issues/1348>) (#1430 <https://github.com/ros2/rviz/issues/1430>)
  * Use official freetype github mirror instead of savannah (#1348 <https://github.com/ros2/rviz/issues/1348>)
  (cherry picked from commit fbe9254e5eb11000877f8332f634eb2f7d6d4c4e)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rviz_rendering

```
* Removed Windows warnings (#1413 <https://github.com/ros2/rviz/issues/1413>) (#1414 <https://github.com/ros2/rviz/issues/1414>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* MovableText constructor does not validate invalid character height, default fallback missing (#1398 <https://github.com/ros2/rviz/issues/1398>) (#1424 <https://github.com/ros2/rviz/issues/1424>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Invalid Parameter Handling in CovarianceVisual::CovarianceVisual Constructor (#1396 <https://github.com/ros2/rviz/issues/1396>) (#1416 <https://github.com/ros2/rviz/issues/1416>)
  (cherry picked from commit 6870dc2d5538570a0d04ee30b242a6446ebea4b4)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Memory Access Error When Handling Empty Strings in splitStringIntoTrimmedItems Function (#1412 <https://github.com/ros2/rviz/issues/1412>) (#1428 <https://github.com/ros2/rviz/issues/1428>)
  (cherry picked from commit d87b5a514fe5ebd5028ceb8fdee36b3c7fb2fb50)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Crash due to Unhandled Null Pointer in ParameterEventsFilter Constructor (#1411 <https://github.com/ros2/rviz/issues/1411>) (#1426 <https://github.com/ros2/rviz/issues/1426>)
  (cherry picked from commit b64a03c0c43f07feada7bcdf809d11dfc8d753d1)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Grid Class Constructor Does Not Handle Null Pointer, Leading to Program Crash (#1394 <https://github.com/ros2/rviz/issues/1394>) (#1422 <https://github.com/ros2/rviz/issues/1422>)
  (cherry picked from commit 30ffc518cc5472e91c026ba075d3328d1f983548)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Crash in MovableText::update() when caption is an empty string due to uninitialized resource usage (#1393 <https://github.com/ros2/rviz/issues/1393>) (#1420 <https://github.com/ros2/rviz/issues/1420>)
  (cherry picked from commit d6f13b7cda10b6f27dca4466ac9b25f404b6bd2c)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Lack of Validity Check for Invalid Parameters in EffortVisual::EffortVisual Constructor (#1395 <https://github.com/ros2/rviz/issues/1395>) (#1418 <https://github.com/ros2/rviz/issues/1418>)
  (cherry picked from commit 157fabdde99dd7e6bfb4a8ab61de6c445fdcb851)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
