### PR TITLE
ros_environment: 4.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6768,7 +6768,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_environment.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -6778,7 +6778,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_environment.git
-      version: rolling
+      version: kilted
     status: maintained
   ros_gz:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6773,7 +6773,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_environment-release.git
-      version: 4.3.0-2
+      version: 4.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_environment` to `4.3.1-1`:

- upstream repository: https://github.com/ros/ros_environment.git
- release repository: https://github.com/ros2-gbp/ros_environment-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-2`

## ros_environment

```
* Update ROS_DISTRO for Kilted Kaiju (#41 <https://github.com/ros/ros_environment/issues/41>)
* Remove CODEOWNERS. (#40 <https://github.com/ros/ros_environment/issues/40>)
* Contributors: Chris Lalancette, Scott K Logan
```
