### PR TITLE
googletest: 1.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2235,7 +2235,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/googletest-release.git
-      version: 1.15.1-1
+      version: 1.16.0-1
     source:
       type: git
       url: https://github.com/ament/googletest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `googletest` to `1.16.0-1`:

- upstream repository: https://github.com/ament/googletest.git
- release repository: https://github.com/ros2-gbp/googletest-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.15.1-1`

## gmock_vendor

- No changes

## gtest_vendor

- No changes
