### PR TITLE
rmw_zenoh: 0.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6359,7 +6359,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.0-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.7.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-1`

## rmw_zenoh_cpp

- No changes

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

- No changes
