### PR TITLE
fkie_message_filters: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1872,7 +1872,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fkie_message_filters-release.git
-      version: 3.0.2-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/fkie/message_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `3.2.0-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/ros2-gbp/fkie_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.2-1`

## fkie_message_filters

```
* Add Publisher/Subscriber support for custom allocators
* Add tests with rclcpp_lifecycle nodes
* Fix overzealous noexcept declarations
* REUSE 3.3 compliance
* Migrate to ROS manifest version 3 (REP-149)
* Contributors: Timo Röhling
```
