### PR TITLE
autoware_lanelet2_extension: 0.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -665,7 +665,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.7.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-1`

## autoware_lanelet2_extension

```
* ci(pre-commit): autoupdate (#55 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/55>)
  * ci(pre-commit): autoupdate
  * style(pre-commit): autofix
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Yutaka Kondo <mailto:yutaka.kondo@youtalk.jp>
* fix(autoware_lanelet2_extension): not use obsolete header (#63 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/63>)
  * Update query.cpp
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Yutaka Kondo, awf-autoware-bot[bot]
```

## autoware_lanelet2_extension_python

- No changes
