### PR TITLE
mrpt_ros: 2.14.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6613,7 +6613,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/mrpt-ros-pkg-release/mrpt_ros-release.git
-      version: 2.14.7-1
+      version: 2.14.8-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.14.8-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/mrpt-ros-pkg-release/mrpt_ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.7-1`

## mrpt_apps

```
* Fix RawLogViewer ICP module.
```

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

```
* CCameraSensor would crash at the end of the video file.
```

## mrpt_libmaps

- No changes

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libros_bridge

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
