### PR TITLE
Add openarm package to humble/distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6252,6 +6252,12 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.6.0-1
+  openarm:
+    source:
+      type: git
+      url: https://github.com/reazon-research/openarm_ros2.git
+      version: main
+    status: developed
   open_manipulator:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6274,12 +6274,6 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.7.0-2
-  openarm:
-    source:
-      type: git
-      url: https://github.com/reazon-research/openarm_ros2.git
-      version: main
-    status: developed
   open_manipulator:
     doc:
       type: git
@@ -6302,6 +6296,12 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git
       version: humble
+    status: developed
+  openarm:
+    source:
+      type: git
+      url: https://github.com/reazon-research/openarm_ros2.git
+      version: main
     status: developed
   openeb_vendor:
     doc:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`openarm`

## Package Upstream Source:

[reazon-research/openarm_ros2](https://github.com/reazon-research/openarm_ros2.git)

## Purpose of using this:

Enable quick bringup of OpenArm hardware.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
