### PR TITLE
Add python3-regex.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9334,6 +9334,15 @@ python3-rdflib:
   rhel:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
+python3-regex:
+  arch: [python-regex]
+  debian: [python3-regex]
+  fedora: [python3-regex]
+  gentoo: [dev-python/regex]
+  nixos: [python3Packages.regex]
+  opensuse: [python3-regex]
+  rhel: [python3-regex]
+  ubuntu: [python3-regex]
 python3-reportlab:
   arch: [python-reportlab]
   debian: [python3-reportlab]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9339,7 +9339,7 @@ python3-regex:
   debian: [python3-regex]
   fedora: [python3-regex]
   gentoo: [dev-python/regex]
-  nixos: [python3Packages.regex]
+  nixos: [python312Packages.regex]
   opensuse: [python3-regex]
   rhel: [python3-regex]
   ubuntu: [python3-regex]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-regex

## Purpose of using this:

Commonly used regex library for python. Usually pre-installed but not necessarily on CI servers.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-regex
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-regex
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-regex/python3-regex/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/python-regex/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-python/regex
- macOS: https://formulae.brew.sh/
  - NOT FOUND
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT FOUND
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.11&show=python312Packages.regex&from=0&size=50&sort=relevance&type=packages&query=python312Packages.regex
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-regex
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/epel-aarch64/python3-regex-2024.11.6-1.el8.aarch64.rpm.html