### PR TITLE
rosidl_python: 0.25.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7103,7 +7103,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.24.1-1
+      version: 0.25.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.25.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.24.1-1`

## rosidl_generator_py

- No changes
