### PR TITLE
libyaml_vendor: 1.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3506,7 +3506,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.7.1-1
+      version: 1.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.8.0-1`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.1-1`

## libyaml_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#65 <https://github.com/ros2/libyaml_vendor/issues/65>)
* Contributors: Chris Lalancette
```
