### PR TITLE
rclcpp: 29.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5758,7 +5758,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.5.0-1
+      version: 29.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.6.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `29.5.0-1`

## rclcpp

```
* throws std::invalid_argument if ParameterEvent is NULL. (#2814 <https://github.com/ros2/rclcpp/issues/2814>)
* Removed clang warnings (#2823 <https://github.com/ros2/rclcpp/issues/2823>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
