### PR TITLE
libstatistics_collector: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3495,7 +3495,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `2.1.0-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## libstatistics_collector

```
* Bump ros-tooling/action-ros-ci from 0.3 to 0.4
* Bump codecov/codecov-action from 5.3.1 to 5.4.0
* Bump codecov/codecov-action from 5.1.2 to 5.3.1
* Bump codecov/codecov-action from 5.0.7 to 5.1.2
* Bump codecov/codecov-action from 4.6.0 to 5.0.7
* Contributors: dependabot[bot]
```
