### PR TITLE
console_bridge_vendor: 1.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1103,7 +1103,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/console_bridge_vendor-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `console_bridge_vendor` to `1.9.0-1`:

- upstream repository: https://github.com/ros2/console_bridge_vendor.git
- release repository: https://github.com/ros2-gbp/console_bridge_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`

## console_bridge_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#42 <https://github.com/ros2/console_bridge_vendor/issues/42>)
* Contributors: Chris Lalancette
```
