### PR TITLE
ros2cli: 0.38.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6673,7 +6673,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.37.0-2
+      version: 0.38.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.38.0-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.37.0-2`

## ros2action

```
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Support 'ros2 action echo' (#978 <https://github.com/ros2/ros2cli/issues/978>)
* Correct the license content (#979 <https://github.com/ros2/ros2cli/issues/979>)
* Contributors: Barry Xu, Michael Carroll
```

## ros2cli

```
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Contributors: Michael Carroll
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Skip QoS compatibility test on Zenoh (#985 <https://github.com/ros2/ros2cli/issues/985>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```

## ros2interface

- No changes

## ros2lifecycle

```
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Contributors: Michael Carroll
```

## ros2lifecycle_test_fixtures

```
* Use target_link_libraries instead of ament_target_dependencies (#973 <https://github.com/ros2/ros2cli/issues/973>)
* Contributors: Shane Loretz
```

## ros2multicast

- No changes

## ros2node

```
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Contributors: Michael Carroll
```

## ros2param

```
* Fix loading parameter behavior from yaml file (#864 <https://github.com/ros2/ros2cli/issues/864>)
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Contributors: Michael Carroll, Tomoya Fujita
```

## ros2pkg

```
* Use modern C++17 syntax. (#982 <https://github.com/ros2/ros2cli/issues/982>)
* Use target_link_libraries instead of ament_target_dependencies (#973 <https://github.com/ros2/ros2cli/issues/973>)
* Try to use the git global user.name for maintainer-name (#968 <https://github.com/ros2/ros2cli/issues/968>)
* Update minimum CMake version CMakeLists.txt.em (#969 <https://github.com/ros2/ros2cli/issues/969>)
* Contributors: Larry Gezelius, Sebastian Castro, Shane Loretz, Shynur
```

## ros2run

```
* Add signal handler SIGIN/SIGTERM to ros2run (#899 <https://github.com/ros2/ros2cli/issues/899>)
* Contributors: Tomoya Fujita
```

## ros2service

```
* Use get_service in ros2service call (#994 <https://github.com/ros2/ros2cli/issues/994>)
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Support QoS options for ros2 service call (#966 <https://github.com/ros2/ros2cli/issues/966>)
* Contributors: Michael Carlstrom, Michael Carroll, Tomoya Fujita
```

## ros2topic

```
* Custom Completion Finder for fetching topic prototype (#995 <https://github.com/ros2/ros2cli/issues/995>)
* Documented now and auto keywords (#1008 <https://github.com/ros2/ros2cli/issues/1008>)
* Conditional deserialization of message for ros2 topic hz (#1005 <https://github.com/ros2/ros2cli/issues/1005>)
* Enable ros2 topic echo with entries of array fields (#996 <https://github.com/ros2/ros2cli/issues/996>)
* Allow zenoh tests to run with multicast (#992 <https://github.com/ros2/ros2cli/issues/992>)
* Adapt tests to Zenoh (#988 <https://github.com/ros2/ros2cli/issues/988>)
* Adjust topic hz and bw command description (#987 <https://github.com/ros2/ros2cli/issues/987>)
* Add support for topic QOS for ros2topic bw, delay and hz (#935 <https://github.com/ros2/ros2cli/issues/935>)
* Start the simulation from 1 second for the test (#975 <https://github.com/ros2/ros2cli/issues/975>)
* Support QoS options for ros2 service call (#966 <https://github.com/ros2/ros2cli/issues/966>)
* Support ros2 topic pub yaml file input (#925 <https://github.com/ros2/ros2cli/issues/925>)
* Contributors: Alejandro Hernández Cordero, Anthony Welte, Fabian Thomsen, Florencia, Kostubh Khandelwal, Leander Stephen D'Souza, Martin Pecka, Michael Carroll, Tomoya Fujita
```
