### PR TITLE
class_loader: 2.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -970,7 +970,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.8.0-1
+      version: 2.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.9.0-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.0-1`

## class_loader

```
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#215 <https://github.com/ros/class_loader/issues/215>)
* Contributors: Alejandro Hernández Cordero
```
