### PR TITLE
sros2: 0.15.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8160,7 +8160,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.15.1-2
+      version: 0.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.15.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.1-2`

## sros2

```
* Switch to get_rmw_additional_env (#339 <https://github.com/ros2/sros2/issues/339>)
* Fix github-workflow mypy error (#336 <https://github.com/ros2/sros2/issues/336>)
* Contributors: Tomoya Fujita, yadunund
```

## sros2_cmake

- No changes
