### PR TITLE
bond_core: 1.8.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -678,7 +678,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/bond_core-release.git
-      version: 1.8.6-1
+      version: 1.8.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `1.8.7-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros-gbp/bond_core-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.6-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Use the first sister message as a Heartbeat (#93 <https://github.com/ros/bond_core/issues/93>)
* Contributors: Martin Pecka
```

## bondpy

- No changes

## smclib

- No changes
