### PR TITLE
catkin: 0.8.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -892,7 +892,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.8.11-1
+      version: 0.8.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin` to `0.8.12-1`:

- upstream repository: git@github.com:ros/catkin.git
- release repository: https://github.com/ros-gbp/catkin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.8.11-1`

## catkin

```
* Ignore generator expressions used in PKG_CONFIG_LIBRARIES (#1181 <https://github.com/ros/catkin/issues/1181>)
* fix typo in user guide docs (#1183 <https://github.com/ros/catkin/issues/1183>)
* Use the newer unittest.mock from standard library on Python 3 (#1193 <https://github.com/ros/catkin/issues/1193>)
* Contributors: Alexandre Detiste, Paul Draghicescu, Robert Haschke
```
