### PR TITLE
class_loader: 0.5.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -951,7 +951,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/class_loader-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `0.5.2-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros-gbp/class_loader-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.1-1`

## class_loader

```
* Fix shebang line for python3 (#158 <https://github.com/ros/class_loader/issues/158>)
* Suppress sanitizer warning about (expected) leak (#220 <https://github.com/ros/class_loader/issues/220>)
* Fix shebang for class_loader_headers_update.py (#180 <https://github.com/ros/class_loader/issues/180>) (#219 <https://github.com/ros/class_loader/issues/219>)
* Contributors: Mikael Arguedas, Shane Loretz
```
