### PR TITLE
common_msgs: 1.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1584,7 +1584,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/common_msgs-release.git
-      version: 1.13.1-1
+      version: 1.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_msgs` to `1.13.2-1`:

- upstream repository: git@github.com:ros/common_msgs.git
- release repository: https://github.com/ros-gbp/common_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.13.1-1`

## actionlib_msgs

- No changes

## common_msgs

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Remove additional spaces (#180 <https://github.com/ros/common_msgs/issues/180>)
* Contributors: Oskar
```

## nav_msgs

- No changes

## sensor_msgs

```
* Remove additional spaces (#180 <https://github.com/ros/common_msgs/issues/180>)
* sensor_msgs/CompressedImage: updated description of format field (#184 <https://github.com/ros/common_msgs/issues/184>)
* Fix STL assertion on recent libstdc++ when handling empty PointCloud2 (#192 <https://github.com/ros/common_msgs/issues/192>)
* Contributors: Atsushi Watanabe, Martin Pecka, Oskar
```

## shape_msgs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
