### PR TITLE
dynamic_reconfigure: 1.7.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2385,7 +2385,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.7.4-1
+      version: 1.7.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.7.5-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.4-1`

## dynamic_reconfigure

```
* check group name validity to avoid compilation error later (#97 <https://github.com/ros/dynamic_reconfigure/issues/97>)
* Explicit use sys.exit (#159 <https://github.com/ros/dynamic_reconfigure/issues/159>)
* Fix flaky multipleClients test (#167 <https://github.com/ros/dynamic_reconfigure/issues/167>)
* Changed variable to size_t for consistency (#196 <https://github.com/ros/dynamic_reconfigure/issues/196>)
* Contributors: Atsushi Watanabe, Mikael Arguedas, Sean Yen, karina-ranadive
```
