### PR TITLE
genpy: 0.6.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3604,7 +3604,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/genpy-release.git
-      version: 0.6.17-1
+      version: 0.6.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `genpy` to `0.6.18-1`:

- upstream repository: https://github.com/ros/genpy.git
- release repository: https://github.com/ros-gbp/genpy-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.17-1`

## genpy

```
* Use yaml.safe_load in test (#150 <https://github.com/ros/genpy/issues/150>)
* Replaced deprecated unit test aliases #145 <https://github.com/ros/genpy/issues/145> (#156 <https://github.com/ros/genpy/issues/156>)
* Contributors: Atsushi Watanabe, Tanveer Brar
```
