### PR TITLE
yaml_cpp_vendor: 9.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9352,7 +9352,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 9.1.0-1
+      version: 9.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaml_cpp_vendor` to `9.2.0-1`:

- upstream repository: https://github.com/ros2/yaml_cpp_vendor.git
- release repository: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.1.0-1`

## yaml_cpp_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#52 <https://github.com/ros2/yaml_cpp_vendor/issues/52>)
* Contributors: Chris Lalancette
```
