### PR TITLE
interactive_markers: 1.12.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4487,7 +4487,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/interactive_markers-release.git
-      version: 1.12.1-1
+      version: 1.12.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `1.12.2-1`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros-gbp/interactive_markers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.1-1`

## interactive_markers

```
* Update CMakeLists.txt (#112 <https://github.com/ros-visualization/interactive_markers/issues/112>)
* Contributors: Arne Hitzmann
```
