### PR TITLE
keyboard_handler: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3042,7 +3042,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.5.0-1`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/ros2-gbp/keyboard_handler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## keyboard_handler

- No changes
