### PR TITLE
orocos_kdl_vendor: 0.7.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4745,7 +4745,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.7.0-2
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-2`

## orocos_kdl_vendor

```
* Use the same cmake version (#36 <https://github.com/ros2/orocos_kdl_vendor/issues/36>)
* Resolve compatibility issue with newer cmake (#35 <https://github.com/ros2/orocos_kdl_vendor/issues/35>)
* Contributors: Alejandro Hernández Cordero, Øystein Sture
```

## python_orocos_kdl_vendor

- No changes
