### PR TITLE
pluginlib: 1.13.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -8053,7 +8053,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/pluginlib-release.git
-      version: 1.13.1-1
+      version: 1.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `1.13.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros-gbp/pluginlib-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.13.1-1`

## pluginlib

```
* fix shebang line for python3 (#197 <https://github.com/ros/pluginlib/issues/197>)
* Fix warnings reported by Wformat. Printouts with format '%p' should be void pointers. Add static_cast's. (#179 <https://github.com/ros/pluginlib/issues/179>)
* Fix runtime dependencies (#257 <https://github.com/ros/pluginlib/issues/257>)
* Contributors: Atsushi Watanabe, Gabriel Hottiger, Mikael Arguedas
```
