### PR TITLE
resource_retriever: 3.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5904,7 +5904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.6.0-1
+      version: 3.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.8.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.0-1`

## libcurl_vendor

- No changes

## resource_retriever

- No changes
