### PR TITLE
rosbag2: 0.33.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6910,7 +6910,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.32.0-1
+      version: 0.33.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.33.0-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.32.0-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Contributors: Michael Orlov, Christophe Bedard
```

## rosbag2

- No changes

## rosbag2_compression

```
* Bugfix: ros2 bag convert dropping messages with compression mode message (#1975 <https://github.com/ros2/rosbag2/issues/1975>)
* Contributors: DangitBen, Michael Orlov
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Address clang warning in the TimeControllerClock::wakeup() (#1962 <https://github.com/ros2/rosbag2/issues/1962>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov, Christophe Bedard
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Add a simple example showing how to convert bags to the csv file (#1974 <https://github.com/ros2/rosbag2/issues/1974>)
* Contributors: Michael Orlov, Christophe Bedard
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Contributors: Michael Orlov, Christophe Bedard
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Bugfix: ros2 bag convert dropping messages with compression mode message (#1975 <https://github.com/ros2/rosbag2/issues/1975>)
* Contributors: DangitBen, Michael Orlov, Christophe Bedard
```

## rosbag2_storage

```
* Use DDS queue depth for subscriptions as a maximum value across publishers (#1960 <https://github.com/ros2/rosbag2/issues/1960>)
* Contributors: Michael Orlov
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Contributors: Michael Orlov, Christophe Bedard
```

## rosbag2_test_common

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Use DDS queue depth for subscriptions as a maximum value across publishers (#1960 <https://github.com/ros2/rosbag2/issues/1960>)
* Contributors: Michael Orlov, Christophe Bedard
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Contributors: Michael Orlov, Christophe Bedard
```

## rosbag2_transport

```
* Fix a maybe-uninitialized warning in player_action_client.cpp (#1969 <https://github.com/ros2/rosbag2/issues/1969>)
* Upstream quality changes from Apex.AI part-2 (#1924 <https://github.com/ros2/rosbag2/issues/1924>)
* Bugfix: ros2 bag convert dropping messages with compression mode message (#1975 <https://github.com/ros2/rosbag2/issues/1975>)
* Use DDS queue depth for subscriptions as a maximum value across publishers (#1960 <https://github.com/ros2/rosbag2/issues/1960>)
* Contributors: DangitBen, Michael Carroll, Michael Orlov, Christophe Bedard
```

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
