### PR TITLE
demos: 0.36.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1245,7 +1245,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.35.1-2
+      version: 0.36.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.36.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.35.1-2`

## action_tutorials_cpp

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
  demo_nodes_cpp/CMakeLists.txt require cmake min version 3.12 other modules cmake 3.5.
  It is proposed to standardize with version 3.12.
  This also fixes cmake <3.10 deprecation warnings
* Update action cpp demos to support setting introspection (#709 <https://github.com/ros2/demos/issues/709>)
  * Update action cpp demos to support setting introspection
  * Add the missing header file declaration
  ---------
* Contributors: Barry Xu, mosfet80
```

## action_tutorials_py

```
* Update action python demos to support setting introspection (#708 <https://github.com/ros2/demos/issues/708>)
  * Update action python demos to support setting introspection
  * Correct the errors in the document
  ---------
* Contributors: Barry Xu
```

## composition

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#711 <https://github.com/ros2/demos/issues/711>)
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz, mosfet80
```

## demo_nodes_cpp

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#711 <https://github.com/ros2/demos/issues/711>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## demo_nodes_cpp_native

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Shane Loretz, mosfet80
```

## demo_nodes_py

```
* Revert "Revert "fix loading parameter behavior from yaml file. (#656 <https://github.com/ros2/demos/issues/656>)" (#660 <https://github.com/ros2/demos/issues/660>)" (#661 <https://github.com/ros2/demos/issues/661>)
* Contributors: Tomoya Fujita
```

## dummy_map_server

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
  demo_nodes_cpp/CMakeLists.txt require cmake min version 3.12 other modules cmake 3.5.
  It is proposed to standardize with version 3.12.
  This also fixes cmake <3.10 deprecation warnings
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Shane Loretz, mosfet80
```

## dummy_robot_bringup

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
  demo_nodes_cpp/CMakeLists.txt require cmake min version 3.12 other modules cmake 3.5.
  It is proposed to standardize with version 3.12.
  This also fixes cmake <3.10 deprecation warnings
* Contributors: mosfet80
```

## dummy_sensors

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
  demo_nodes_cpp/CMakeLists.txt require cmake min version 3.12 other modules cmake 3.5.
  It is proposed to standardize with version 3.12.
  This also fixes cmake <3.10 deprecation warnings
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Shane Loretz, mosfet80
```

## image_tools

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Lint image_tools/CMakeLists.txt (#712 <https://github.com/ros2/demos/issues/712>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#711 <https://github.com/ros2/demos/issues/711>)
* Contributors: Alejandro Hernández Cordero, mosfet80, yadunund
```

## intra_process_demo

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#711 <https://github.com/ros2/demos/issues/711>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## lifecycle

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Shane Loretz, mosfet80
```

## lifecycle_py

- No changes

## logging_demo

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#711 <https://github.com/ros2/demos/issues/711>)
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz, mosfet80
```

## pendulum_control

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Set envars to run tests with rmw_zenoh_cpp with multicast discovery (#711 <https://github.com/ros2/demos/issues/711>)
* Use target_link_libraries instead of ament_target_dependencies (#707 <https://github.com/ros2/demos/issues/707>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz, mosfet80
```

## pendulum_msgs

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Contributors: mosfet80
```

## quality_of_service_demo_cpp

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
  demo_nodes_cpp/CMakeLists.txt require cmake min version 3.12 other modules cmake 3.5.
  It is proposed to standardize with version 3.12.
  This also fixes cmake <3.10 deprecation warnings
* Contributors: mosfet80
```

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

```
* Uniform CMAKE min VERSION (#714 <https://github.com/ros2/demos/issues/714>)
* Contributors: mosfet80
```
