### PR TITLE
autoware_msgs: 1.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -676,7 +676,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.6.0-2
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.7.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.0-2`

## autoware_common_msgs

- No changes

## autoware_control_msgs

- No changes

## autoware_localization_msgs

- No changes

## autoware_map_msgs

- No changes

## autoware_msgs

- No changes

## autoware_perception_msgs

```
* feat(autoware_sensing_msgs): implement the proposed universal radar messages (#120 <https://github.com/autowarefoundation/autoware_msgs/issues/120>)
  Co-authored-by: Taekjin LEE <mailto:technolojin@gmail.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:xmfcx@users.noreply.github.com>
* Contributors: Kenzo Lobos Tsunekawa
```

## autoware_planning_msgs

- No changes

## autoware_sensing_msgs

```
* feat(autoware_sensing_msgs): implement the proposed universal radar messages (#120 <https://github.com/autowarefoundation/autoware_msgs/issues/120>)
  Co-authored-by: Taekjin LEE <mailto:technolojin@gmail.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:xmfcx@users.noreply.github.com>
* Contributors: Kenzo Lobos Tsunekawa
```

## autoware_system_msgs

- No changes

## autoware_v2x_msgs

- No changes

## autoware_vehicle_msgs

- No changes
