### PR TITLE
fuse: 1.2.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2077,7 +2077,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.1-2
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.2.2-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-2`

## fuse

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Contributors: KB1110
```

## fuse_constraints

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* [RST-7809] Port fix for negative pi initial conditions from ROS1 to ROS2 (#335 <https://github.com/locusrobotics/fuse/issues/335>)
  * Add some unit tests for the 2D orientation constraints; Create getters/setters for the 2D orientation variable is preparation for a fix.
  * Force the 2D orientation value to be is minimum phase
* Contributors: KB1110, Stephen Williams
```

## fuse_core

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Fix build and linter warnings (#405 <https://github.com/locusrobotics/fuse/issues/405>)
* Update callback_wrapper.hpp (#397 <https://github.com/locusrobotics/fuse/issues/397>)
  Fix build failure on ROS 2 Rolling by adding a required override for get_timers() in CallbackAdapter.
  In ROS 2 Rolling, rclcpp::Waitable introduced a new pure virtual method get_timers() const. Since CallbackAdapter inherits from Waitable and did not implement this method, it remained abstract and could not be instantiated, causing the build to fail.
  This adds a simple override that returns an empty vector, as CallbackAdapter does not use timers. This resolves the abstract class instantiation error.
* Port fix for Issue 300 from ROS 1 into ROS 2 (#404 <https://github.com/locusrobotics/fuse/issues/404>)
  Handle prior on last stamp (#323 <https://github.com/locusrobotics/fuse/issues/323>)
  * Added unit test to illustrate the bug from Issue 300
  * Move where the input variables are updated to the motion model values to ensure that transactions that involve only a single timestamp are correctly handled
* Contributors: KB1110, Stephen Williams, Surabhi Gade
```

## fuse_doc

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Contributors: KB1110
```

## fuse_graphs

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Contributors: KB1110
```

## fuse_loss

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Contributors: KB1110
```

## fuse_models

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Port minor header fixes from ROS1 to ROS2 (#331 <https://github.com/locusrobotics/fuse/issues/331>)
  Port the minor header fixes PR (#266 <https://github.com/locusrobotics/fuse/issues/266> ) from ROS1 to ROS2
  Added missing header; reordered headers
* Port missing tf timeout from ROS1 to ROS2 (#333 <https://github.com/locusrobotics/fuse/issues/333>)
  Ported missing tf timeout in IMU and Odometry processing (#322 <https://github.com/locusrobotics/fuse/issues/322>) from ROS1 to ROS2
  * Add tf lookup timeout to IMU and Odometry processing
* [RST-7809] Port fix for negative pi initial conditions from ROS1 to ROS2 (#335 <https://github.com/locusrobotics/fuse/issues/335>)
  * Add some unit tests for the 2D orientation constraints; Create getters/setters for the 2D orientation variable is preparation for a fix.
  * Force the 2D orientation value to be is minimum phase
* Port patch #370 <https://github.com/locusrobotics/fuse/issues/370> into ROS 2 Rolling (#402 <https://github.com/locusrobotics/fuse/issues/402>)
  Cast nullptr to type for manifold support (#370 <https://github.com/locusrobotics/fuse/issues/370>)
  Co-authored-by: Jake McLaughlin <mailto:jmclaughlin@ottomotors.com>
* Port patch #395 <https://github.com/locusrobotics/fuse/issues/395> into ROS 2 Rolling (#400 <https://github.com/locusrobotics/fuse/issues/400>)
  Only instantiate tf_listeners if needed (#395 <https://github.com/locusrobotics/fuse/issues/395>)
* Port patch #394 <https://github.com/locusrobotics/fuse/issues/394> (imu2d-twist-transform-devel) into ROS2 Rolling (#399 <https://github.com/locusrobotics/fuse/issues/399>)
  Fix an error where we do not use the transformed_twist after computing it.
* Prevent optimizer thread from calling notify on stopped publishers (#393 <https://github.com/locusrobotics/fuse/issues/393>)
  * Prevent optimizer thread from calling notify on stopped publishers
  * Fix tests
  * Fix uncrustify issue
* Add missing parameter documentation (#382 <https://github.com/locusrobotics/fuse/issues/382>)
  * Add missing parameter documentation
  * Update fuse_models/include/fuse_models/unicycle_2d_ignition.hpp
  Co-authored-by: Stephen Williams <mailto:stephen.vincent.williams@gmail.com>
  * Update fuse_models/include/fuse_models/unicycle_2d_ignition.hpp
  Co-authored-by: Carlos Mendes <mailto:77983813+carlos-m159@users.noreply.github.com>
  ---------
  Co-authored-by: Stephen Williams <mailto:stephen.vincent.williams@gmail.com>
  Co-authored-by: Carlos Mendes <mailto:77983813+carlos-m159@users.noreply.github.com>
* Contributors: Carlos Mendes, KB1110, Patrick Roncagliolo, Stephen Williams
```

## fuse_msgs

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Contributors: KB1110
```

## fuse_optimizers

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Fix build and linter warnings (#405 <https://github.com/locusrobotics/fuse/issues/405>)
* Port graph printing on optimization failures from ROS1 to ROS2 (#332 <https://github.com/locusrobotics/fuse/issues/332>)
  Port the printing of the graph and transaction with an optimization failure occurs (#321 <https://github.com/locusrobotics/fuse/issues/321>) from ROS1 to ROS2
* Port the 'add reset to batch optimizer' patch from ROS 1 to ROS 2 (#361 <https://github.com/locusrobotics/fuse/issues/361>)
* Fix warning message (#389 <https://github.com/locusrobotics/fuse/issues/389>)
  * Fix timestamp format in warning messages
* Prevent optimizer thread from calling notify on stopped publishers (#393 <https://github.com/locusrobotics/fuse/issues/393>)
  * Prevent optimizer thread from calling notify on stopped publishers
  * Fix tests
  * Fix uncrustify issue
* Contributors: Carlos Mendes, KB1110, Patrick Roncagliolo, Stephen Williams
```

## fuse_publishers

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* [RST-7809] Port fix for negative pi initial conditions from ROS1 to ROS2 (#335 <https://github.com/locusrobotics/fuse/issues/335>)
  * Add some unit tests for the 2D orientation constraints; Create getters/setters for the 2D orientation variable is preparation for a fix.
  * Force the 2D orientation value to be is minimum phase
* Contributors: KB1110, Stephen Williams
```

## fuse_tutorials

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Contributors: KB1110
```

## fuse_variables

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* Port landmark cleanup from ROS1 to ROS2 (#330 <https://github.com/locusrobotics/fuse/issues/330>)
  Port landmark cleanup from ROS1 to ROS2 (#259 <https://github.com/locusrobotics/fuse/issues/259>)
* [RST-7809] Port fix for negative pi initial conditions from ROS1 to ROS2 (#335 <https://github.com/locusrobotics/fuse/issues/335>)
  * Add some unit tests for the 2D orientation constraints; Create getters/setters for the 2D orientation variable is preparation for a fix.
  * Force the 2D orientation value to be is minimum phase
* Port patch #385 <https://github.com/locusrobotics/fuse/issues/385> to ROS 2 Rolling (#403 <https://github.com/locusrobotics/fuse/issues/403>)
  Update orientation_3d_stamped.h (#385 <https://github.com/locusrobotics/fuse/issues/385>)
  * Update orientation_3d_stamped.h description of Orientation3DManifold
  authored-by: Jake McLaughlin <mailto:jmclaughlin@ottomotors.com>
* Contributors: KB1110, Stephen Williams
```

## fuse_viz

```
* 
  
    * Added dependencies in required CMakeLists.txt and package.xml files
    * Added ament_cmake_ros and gtest_vendor dependencies
    * Removed duplicate package depends, alphabetized lists
  See https://www.linkedin.com/posts/open-source-robotics-foundation_were-looking-for-half-a-dozen-new-open-activity-7317690134764605440-jm3h/
  Author: KB1110 <mailto:kartikbakshi10@gmail.com>
* [RST-7809] Port fix for negative pi initial conditions from ROS1 to ROS2 (#335 <https://github.com/locusrobotics/fuse/issues/335>)
  * Add some unit tests for the 2D orientation constraints; Create getters/setters for the 2D orientation variable is preparation for a fix.
  * Force the 2D orientation value to be is minimum phase
* Contributors: KB1110, Stephen Williams
```
