### PR TITLE
resource_retriever: 1.12.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9213,7 +9213,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.9-1
+      version: 1.12.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `1.12.10-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros-gbp/resource_retriever-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.9-1`

## resource_retriever

```
* fix build if no gtest is installed (#77 <https://github.com/ros/resource_retriever/issues/77>)
* Contributors: Daniel Reuter
```
