### PR TITLE
ros: 1.15.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9650,7 +9650,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.15.9-1
+      version: 1.15.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros` to `1.15.10-1`:

- upstream repository: https://github.com/ros/ros.git
- release repository: https://github.com/ros-gbp/ros-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.15.9-1`

## mk

- No changes

## ros

- No changes

## rosbash

```
* Call realpaths for roslaunch and rosbash. (#309 <https://github.com/ros/ros/issues/309>)
* Contributors: Ivor Wanders
```

## rosboost_cfg

- No changes

## rosbuild

- No changes

## rosclean

- No changes

## roscreate

- No changes

## roslang

- No changes

## roslib

```
* Call realpaths for roslaunch and rosbash. (#309 <https://github.com/ros/ros/issues/309>)
* Contributors: Ivor Wanders
```

## rosmake

- No changes

## rosunit

- No changes
