### PR TITLE
rosbag2_broll: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7835,6 +7835,14 @@ repositories:
       type: git
       url: https://github.com/ros-tooling/rosbag2_broll.git
       version: main
+    release:
+      packages:
+      - broll
+      - rosbag2_storage_broll
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_broll-release.git
+      version: 0.1.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_broll` to `0.1.0-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_broll.git
- release repository: https://github.com/ros2-gbp/rosbag2_broll-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## broll

```
* Hardware decoding of frames (#13 <https://github.com/ros-tooling/rosbag2_broll/issues/13>)
* Missed one bsf include :facepalm: (#12 <https://github.com/ros-tooling/rosbag2_broll/issues/12>)
* bsf.h doesn't exist in major versions below 60. (#11 <https://github.com/ros-tooling/rosbag2_broll/issues/11>)
* Fix ffmpeg 6 build and latest Rolling compatibility (#10 <https://github.com/ros-tooling/rosbag2_broll/issues/10>)
* Fix extended color range YUV pix format deprecation. (#7 <https://github.com/ros-tooling/rosbag2_broll/issues/7>)
* Detect and skip bad H265 P-Frames (#6 <https://github.com/ros-tooling/rosbag2_broll/issues/6>)
* Disable mcap (#4 <https://github.com/ros-tooling/rosbag2_broll/issues/4>)
* Lookup codec id name rather than switching (#3 <https://github.com/ros-tooling/rosbag2_broll/issues/3>)
* Add github action CI (#2 <https://github.com/ros-tooling/rosbag2_broll/issues/2>)
* Don't include bsf.h, for older versions of ffmpeg
* Fix build error
* Clean up bsfPacket_
* Annex-B streaming (plus code cleanup) (#1 <https://github.com/ros-tooling/rosbag2_broll/issues/1>)
* Export dependency, expose utility func as static
* End-to-end example workflow documentation and some small code touchups
* Initial functionality pass
* Contributors: Emerson Knapp, Henry Fuller
```

## rosbag2_storage_broll

```
* Hardware decoding of frames (#13 <https://github.com/ros-tooling/rosbag2_broll/issues/13>)
* Fix ffmpeg 6 build and latest Rolling compatibility (#10 <https://github.com/ros-tooling/rosbag2_broll/issues/10>)
* Disable mcap (#4 <https://github.com/ros-tooling/rosbag2_broll/issues/4>)
* Annex-B streaming (plus code cleanup) (#1 <https://github.com/ros-tooling/rosbag2_broll/issues/1>)
* End-to-end example workflow documentation and some small code touchups
* Initial functionality pass
* Contributors: Emerson Knapp
```
