### PR TITLE
rqt: 0.5.5-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10526,7 +10526,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.5.4-1
+      version: 0.5.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `0.5.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros-gbp/rqt-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.4-1`

## rqt

```
* Bump cmake_minimum_required to avoid deprecation (#320 <https://github.com/ros-visualization/rqt/issues/320>)
* Contributors: Arne Hitzmann
```

## rqt_gui

```
* Bump cmake_minimum_required to avoid deprecation (#320 <https://github.com/ros-visualization/rqt/issues/320>)
* Contributors: Arne Hitzmann
```

## rqt_gui_cpp

```
* Bump cmake_minimum_required to avoid deprecation (#320 <https://github.com/ros-visualization/rqt/issues/320>)
* Contributors: Arne Hitzmann
```

## rqt_gui_py

```
* Bump cmake_minimum_required to avoid deprecation (#320 <https://github.com/ros-visualization/rqt/issues/320>)
  * Update CMakeLists.txt
  * Update CMakeLists.txt
  * Update CMakeLists.txt
  * Update CMakeLists.txt
  * Update CMakeLists.txt
* Contributors: Arne Hitzmann
```

## rqt_py_common

```
* Bump cmake_minimum_required to avoid deprecation (#320 <https://github.com/ros-visualization/rqt/issues/320>)
* Contributors: Arne Hitzmann
```
