### PR TITLE
rqt_bag: 0.5.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10559,7 +10559,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_bag-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `0.5.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros-gbp/rqt_bag-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.2-1`

## rqt_bag

```
* floats need to be ints for many methods in python 3.10 (#131 <https://github.com/ros-visualization/rqt_bag/issues/131>)
* comment on message loaders notify (was message listeners before) (#112 <https://github.com/ros-visualization/rqt_bag/issues/112>)
* raw_view: fix display of array types (#152 <https://github.com/ros-visualization/rqt_bag/issues/152>)
* Bump cmake_minimum_required to avoid deprecation (#172 <https://github.com/ros-visualization/rqt_bag/issues/172>)
* Contributors: Arne Hitzmann, Lucas Walter, Paul Mathieu, fergian94
```

## rqt_bag_plugins

```
* Bump cmake_minimum_required to avoid deprecation (#172 <https://github.com/ros-visualization/rqt_bag/issues/172>)
* Contributors: Arne Hitzmann
```
