### PR TITLE
rqt_common_plugins: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10574,7 +10574,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_common_plugins-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_common_plugins` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_common_plugins.git
- release repository: https://github.com/ros-gbp/rqt_common_plugins-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.10-1`

## rqt_common_plugins

```
* Bump cmake_minimum_required to avoid deprecation (#468 <https://github.com/ros-visualization/rqt_common_plugins/issues/468>)
* Contributors: Arne Hitzmann, Shane Loretz
```
