### PR TITLE
rqt_logger_level: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10697,7 +10697,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_logger_level-release.git
-      version: 0.4.12-1
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_logger_level` to `0.4.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_logger_level.git
- release repository: https://github.com/ros-gbp/rqt_logger_level-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.12-1`

## rqt_logger_level

```
* Handle setting logger level of non-present nodes (#7 <https://github.com/ros-visualization/rqt_logger_level/issues/7>)
* Bump cmake_minimum_required to avoid deprecation (#13 <https://github.com/ros-visualization/rqt_logger_level/issues/13>)
* Contributors: Arne Hitzmann, Simon Tegelid
```
