### PR TITLE
rqt_msg: 0.4.12-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10727,7 +10727,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_msg-release.git
-      version: 0.4.11-1
+      version: 0.4.12-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `0.4.12-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros-gbp/rqt_msg-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.11-1`

## rqt_msg

```
* Bump cmake_minimum_required to avoid deprecation (#22 <https://github.com/ros-visualization/rqt_msg/issues/22>)
* Contributors: Arne Hitzmann
```
