### PR TITLE
rqt_plot: 0.4.16-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10766,7 +10766,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_plot-release.git
-      version: 0.4.15-1
+      version: 0.4.16-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `0.4.16-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros-gbp/rqt_plot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.15-1`

## rqt_plot

```
* Fix linalg error  (#84 <https://github.com/ros-visualization/rqt_plot/issues/84>)
* Bump cmake_minimum_required to avoid deprecation (#113 <https://github.com/ros-visualization/rqt_plot/issues/113>)
* Contributors: Arne Hitzmann, Karen Bodie
```
