### PR TITLE
rqt_pose_view: 0.5.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10781,7 +10781,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_pose_view-release.git
-      version: 0.5.12-1
+      version: 0.5.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_pose_view` to `0.5.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_pose_view.git
- release repository: https://github.com/ros-gbp/rqt_pose_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.12-1`

## rqt_pose_view

```
* Bump cmake_minimum_required to avoid deprecation (#10 <https://github.com/ros-visualization/rqt_pose_view/issues/10>)
* Contributors: Arne Hitzmann
```
