### PR TITLE
rqt_robot_steering: 0.5.14-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10919,7 +10919,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_robot_steering-release.git
-      version: 0.5.13-1
+      version: 0.5.14-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `0.5.14-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros-gbp/rqt_robot_steering-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.13-1`

## rqt_robot_steering

```
* Bump cmake_minimum_required to avoid deprecation (#24 <https://github.com/ros-visualization/rqt_robot_steering/issues/24>)
* Contributors: Arne Hitzmann
```
