### PR TITLE
rqt_rviz: 0.7.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10949,7 +10949,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_rviz-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_rviz` to `0.7.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_rviz.git
- release repository: https://github.com/ros-gbp/rqt_rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.1-1`

## rqt_rviz

```
* Bump cmake_minimum_required to avoid deprecation (#21 <https://github.com/ros-visualization/rqt_rviz/issues/21>)
* Contributors: Arne Hitzmann
```
