### PR TITLE
rqt_shell: 0.4.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10980,7 +10980,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_shell-release.git
-      version: 0.4.11-1
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `0.4.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros-gbp/rqt_shell-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.11-1`

## rqt_shell

```
* Bump cmake_minimum_required to avoid deprecation (#25 <https://github.com/ros-visualization/rqt_shell/issues/25>)
* Contributors: Arne Hitzmann
```
