### PR TITLE
rqt_srv: 0.4.11-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10995,7 +10995,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_srv-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `0.4.11-1`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros-gbp/rqt_srv-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.10-1`

## rqt_srv

```
* Bump cmake_minimum_required to avoid deprecation (#15 <https://github.com/ros-visualization/rqt_srv/issues/15>)
* Contributors: Arne Hitzmann
```
