### PR TITLE
rqt_topic: 0.4.15-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11041,7 +11041,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_topic-release.git
-      version: 0.4.14-1
+      version: 0.4.15-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `0.4.15-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros-gbp/rqt_topic-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.14-1`

## rqt_topic

```
* Bump cmake_minimum_required to avoid deprecation (#56 <https://github.com/ros-visualization/rqt_topic/issues/56>)
* Contributors: Arne Hitzmann
```
