### PR TITLE
urdf: 1.13.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12732,7 +12732,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/urdf-release.git
-      version: 1.13.3-1
+      version: 1.13.4-1
     source:
       type: git
       url: https://github.com/ros/urdf.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `1.13.4-1`:

- upstream repository: https://github.com/ros/urdf.git
- release repository: https://github.com/ros-gbp/urdf-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.13.3-1`

## urdf

```
* Migrate parser plugin from boost to std shared_ptr (#40 <https://github.com/ros/urdf/issues/40>)
* Contributors: Robert Haschke
```

## urdf_parser_plugin

- No changes
