### PR TITLE
visualization_tutorials: 0.11.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -13110,7 +13110,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/visualization_tutorials-release.git
-      version: 0.11.1-1
+      version: 0.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `visualization_tutorials` to `0.11.2-1`:

- upstream repository: https://github.com/ros-visualization/visualization_tutorials.git
- release repository: https://github.com/ros-gbp/visualization_tutorials-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.11.1-1`

## interactive_marker_tutorials

```
* Do not forward-declare Ogre types (#84 <https://github.com/ros-visualization/visualization_tutorials/issues/84>)
* Contributors: Michael Görner
```

## librviz_tutorial

```
* Eliminate Python 2 code (#88 <https://github.com/ros-visualization/visualization_tutorials/issues/88>)
* Contributors: vineet131
```

## rviz_plugin_tutorials

```
* Eliminate Python 2 code (#88 <https://github.com/ros-visualization/visualization_tutorials/issues/88>)
* Include class_list_macros.hpp instead of h (#91 <https://github.com/ros-visualization/visualization_tutorials/issues/91>)
* Do not forward-declare Ogre types (#84 <https://github.com/ros-visualization/visualization_tutorials/issues/84>)
* Contributors: Lucas Walter, Michael Görner, Robert Haschke, vineet131
```

## rviz_python_tutorial

```
* Eliminate Python 2 code (#88 <https://github.com/ros-visualization/visualization_tutorials/issues/88>)
* Contributors: vineet131
```

## visualization_marker_tutorials

```
* Remove '/' (forward slash) from '/my_frame', which frustratingly makes Rviz unable to show the markers. (#70 <https://github.com/ros-visualization/visualization_tutorials/issues/70>)
* Contributors: Phase Le
```

## visualization_tutorials

- No changes
