### PR TITLE
ros2_controllers: 2.45.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8539,7 +8539,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.44.0-1
+      version: 2.45.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.45.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.44.0-1`

## ackermann_steering_controller

```
* Rename ackermann msg to controller state msg type (backport #1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>) (#1663 <https://github.com/ros-controls/ros2_controllers/issues/1663>)
* Fix preceeding->preceding typos (backport #1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>) (#1657 <https://github.com/ros-controls/ros2_controllers/issues/1657>)
* Contributors: mergify[bot]
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Rename ackermann msg to controller state msg type (backport #1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>) (#1663 <https://github.com/ros-controls/ros2_controllers/issues/1663>)
* Fix preceeding->preceding typos (backport #1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>) (#1657 <https://github.com/ros-controls/ros2_controllers/issues/1657>)
* Contributors: mergify[bot]
```

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## mecanum_drive_controller

```
* Fix preceeding->preceding typos (backport #1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>) (#1657 <https://github.com/ros-controls/ros2_controllers/issues/1657>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Rename ackermann msg to controller state msg type (backport #1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>) (#1663 <https://github.com/ros-controls/ros2_controllers/issues/1663>)
* Fix preceeding->preceding typos (backport #1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>) (#1657 <https://github.com/ros-controls/ros2_controllers/issues/1657>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Rename ackermann msg to controller state msg type (backport #1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>) (#1663 <https://github.com/ros-controls/ros2_controllers/issues/1663>)
* Fix preceeding->preceding typos (backport #1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>) (#1657 <https://github.com/ros-controls/ros2_controllers/issues/1657>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
