### PR TITLE
ros2_controllers: 4.24.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6537,7 +6537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.23.0-1
+      version: 4.24.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.24.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.23.0-1`

## ackermann_steering_controller

```
* Rename ackermann msg to controller state msg type (#1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>)
* Remove front_steering from steering library (#1166 <https://github.com/ros-controls/ros2_controllers/issues/1166>)
* Fix preceeding->preceding typos (#1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>)
* Contributors: Christoph Fröhlich, Enrique Llorente Pastora, Mukunda Bharatheesha
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Rename ackermann msg to controller state msg type (#1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>)
* Remove front_steering from steering library (#1166 <https://github.com/ros-controls/ros2_controllers/issues/1166>)
* Fix preceeding->preceding typos (#1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>)
* Contributors: Christoph Fröhlich, Enrique Llorente Pastora, Mukunda Bharatheesha
```

## diff_drive_controller

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```

## effort_controllers

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

```
* [CI]  test_force_torque_sensor_broadcaster regularily times out (#1639 <https://github.com/ros-controls/ros2_controllers/issues/1639>)
* Contributors: Julia Jia
```

## forward_command_controller

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

```
* Use smart pointer of ctrl in GpsSensor and GpioCommandController tests (#1658 <https://github.com/ros-controls/ros2_controllers/issues/1658>)
* Contributors: Junius Santoso
```

## gps_sensor_broadcaster

```
* Use smart pointer of ctrl in GpsSensor and GpioCommandController tests (#1658 <https://github.com/ros-controls/ros2_controllers/issues/1658>)
* Fix wrong link in GPSBroadcaster doc (#1637 <https://github.com/ros-controls/ros2_controllers/issues/1637>)
* Contributors: Christoph Fröhlich, Junius Santoso
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Fix joint_state_broadcaster performance issues (#1640 <https://github.com/ros-controls/ros2_controllers/issues/1640>)
* Contributors: Christoph Fröhlich, Jordan Palacios
```

## joint_trajectory_controller

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```

## mecanum_drive_controller

```
* Fix preceeding->preceding typos (#1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>)
* Contributors: Christoph Fröhlich
```

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

```
* Deprecate tf.publish_rate parameter for pose_broadcaster (#1614 <https://github.com/ros-controls/ros2_controllers/issues/1614>)
* Contributors: Aarav Gupta
```

## position_controllers

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Rename ackermann msg to controller state msg type (#1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>)
* Remove front_steering from steering library (#1166 <https://github.com/ros-controls/ros2_controllers/issues/1166>)
* Fix preceeding->preceding typos (#1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>)
* Contributors: Christoph Fröhlich, Enrique Llorente Pastora, Mukunda Bharatheesha
```

## tricycle_controller

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

```
* Rename ackermann msg to controller state msg type (#1662 <https://github.com/ros-controls/ros2_controllers/issues/1662>)
* Remove front_steering from steering library (#1166 <https://github.com/ros-controls/ros2_controllers/issues/1166>)
* Fix preceeding->preceding typos (#1655 <https://github.com/ros-controls/ros2_controllers/issues/1655>)
* Contributors: Christoph Fröhlich, Enrique Llorente Pastora, Mukunda Bharatheesha
```

## velocity_controllers

```
* Call configure() of base class instead of node (#1659 <https://github.com/ros-controls/ros2_controllers/issues/1659>)
* Contributors: Christoph Fröhlich
```
