### PR TITLE
turtlebot3_autorace: 1.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10980,6 +10980,16 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
       version: humble
+    release:
+      packages:
+      - turtlebot3_autorace
+      - turtlebot3_autorace_camera
+      - turtlebot3_autorace_detect
+      - turtlebot3_autorace_mission
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_autorace-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace` to `1.2.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
- release repository: https://github.com/ros2-gbp/turtlebot3_autorace-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot3_autorace

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```

## turtlebot3_autorace_camera

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```

## turtlebot3_autorace_detect

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```

## turtlebot3_autorace_mission

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```
