### PR TITLE
turtlebot3_autorace: 1.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8604,6 +8604,16 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
       version: main
+    release:
+      packages:
+      - turtlebot3_autorace
+      - turtlebot3_autorace_camera
+      - turtlebot3_autorace_detect
+      - turtlebot3_autorace_mission
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_autorace-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_autorace` to `1.2.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
- release repository: https://github.com/ros2-gbp/turtlebot3_autorace-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot3_autorace

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```

## turtlebot3_autorace_camera

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```

## turtlebot3_autorace_detect

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```

## turtlebot3_autorace_mission

```
* Fixed incorrect entries in package.xml
* Contributors: Hyungyu Kim
```
