### PR TITLE
image_common: 6.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2810,7 +2810,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.1.0-2
+      version: 6.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.1.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.1.0-2`

## camera_calibration_parsers

```
* Use target_link_libraries instead of ament_target_dependencies (#345 <https://github.com/ros-perception/image_common/issues/345>)
* Contributors: Shane Loretz
```

## camera_info_manager

- No changes

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Remove windows warnings (#350 <https://github.com/ros-perception/image_common/issues/350>)
* Add rclcpp::shutdown (#347 <https://github.com/ros-perception/image_common/issues/347>)
* Use target_link_libraries instead of ament_target_dependencies (#345 <https://github.com/ros-perception/image_common/issues/345>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz, Yuyuan Yuan
```

## image_transport_py

- No changes
