### PR TITLE
python_qt_binding: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5414,7 +5414,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.3.1-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.4.0-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.1-1`

## python_qt_binding

```
* Remove the mirror-rolling-to-main workflow (#145 <https://github.com/ros-visualization/python_qt_binding/issues/145>)
* Remove CODEOWNERS (#144 <https://github.com/ros-visualization/python_qt_binding/issues/144>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
