### PR TITLE
tango_icons_vendor: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8280,7 +8280,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.5.0-1`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## tango_icons_vendor

```
* Remove the mirror-rolling-to-master workflow (#12 <https://github.com/ros-visualization/tango_icons_vendor/issues/12>)
* Remove CODEOWNERS (#11 <https://github.com/ros-visualization/tango_icons_vendor/issues/11>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
