### PR TITLE
Added husarion_ugv_ros to humble and jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3651,6 +3651,12 @@ repositories:
       url: https://github.com/ros4hri/human_description.git
       version: humble-devel
     status: developed
+  husarion_ugv_ros:
+    source:
+      type: git
+      url: https://github.com/husarion/husarion_ugv_ros.git
+      version: humble
+    status: developed
   iceoryx:
     release:
       packages:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3295,6 +3295,12 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  husarion_ugv_ros:
+    source:
+      type: git
+      url: https://github.com/husarion/husarion_ugv_ros.git
+      version: ros2
+    status: developed
   hyveos_bridge:
     source:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

[husarion_ugv_ros](https://github.com/husarion/husarion_ugv_ros)

# The source is here:

[https://github.com/husarion/husarion_ugv_ros](https://github.com/husarion/husarion_ugv_ros)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
