### PR TITLE
add python-duckdb for ubuntu and debian

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1385,7 +1385,7 @@ python-dt-apriltags-pip:
     pip: [dt-apriltags]
   ubuntu:
     pip: [dt-apriltags]
-python-duckdb:
+python-duckdb-pip:
   alpine:
     pip: [duckdb]
   arch:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1386,19 +1386,7 @@ python-dt-apriltags-pip:
   ubuntu:
     pip: [dt-apriltags]
 python-duckdb-pip:
-  alpine:
-    pip: [duckdb]
-  arch:
-    pip: [duckdb]
-  debian:
-    pip: [duckdb]
-  fedora:
-    pip: [duckdb]
-  opensuse:
-    pip: [duckdb]
-  rhel:
-    pip: [duckdb]
-  ubuntu:
+  '*':
     pip: [duckdb]
 python-dxfgrabber-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1385,6 +1385,21 @@ python-dt-apriltags-pip:
     pip: [dt-apriltags]
   ubuntu:
     pip: [dt-apriltags]
+python-duckdb:
+  alpine:
+    pip: [duckdb]
+  arch:
+    pip: [duckdb]
+  debian:
+    pip: [duckdb]
+  fedora:
+    pip: [duckdb]
+  opensuse:
+    pip: [duckdb]
+  rhel:
+    pip: [duckdb]
+  ubuntu:
+    pip: [duckdb]
 python-dxfgrabber-pip:
   ubuntu:
     pip: [dxfgrabber]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python-duckdb-pip

## Package Upstream Source:

https://github.com/duckdb/duckdb/

## Purpose of using this:

This package is another alternative to sqlite as an embeddable database. This change allow for installation using rosdep.

