### PR TITLE
imu_tools: 1.2.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4394,7 +4394,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/imu_tools-release.git
-      version: 1.2.6-1
+      version: 1.2.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `1.2.7-1`:

- upstream repository: https://github.com/ccny-ros-pkg/imu_tools.git
- release repository: https://github.com/uos-gbp/imu_tools-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.6-1`

## imu_complementary_filter

- No changes

## imu_filter_madgwick

- No changes

## imu_tools

- No changes

## rviz_imu_plugin

```
* Fix Qt5 version requirement (#213 <https://github.com/CCNYRoboticsLab/imu_tools/issues/213>)
  - Use rviz_QT_VERSION
  - Drop OpenGL dependency
* Contributors: Robert Haschke
```
