### PR TITLE
Revert "rmw_zenoh: 0.2.4-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7204,7 +7204,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.4-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Reverts ros/rosdistro#45285

This year's [Perception Challenge for Bin-Picking](https://bpc.opencv.org/) organized by `opencv` relies on `rmw_zenoh` running in docker images that participants submit. 

The `0.2.4` bump includes a wire breaking change, namely
- Change serialization format in attachment_helpers.cpp (`#605 <https://github.com/ros2/rmw_zenoh/issues/605>`_)

If the sync goes out with this change, there is risk of `rmw_zenoh` protocol mismatch between images on the evaluation side and those submitted by participants. Requiring all participants to rebuild their submitted images is a challenge (the Dockerfile used to create these images relies on apt installed `rmw_zenoh` binary and does not build a pinned version from source). 

In light of this, the organizers have requested to keep the version of `rmw_zenoh` binary at `0.2.3` for the next two weeks. 

I am inclined to honoring this request as they are some of the first users of the `rmw_zenoh` binaries but I also understand how this gatekeeps latest binaries from the community for another couple weeks.  
  