### PR TITLE
rcl: 9.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6505,7 +6505,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.2.5-1
+      version: 9.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.2.6-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.2.5-1`

## rcl

```
* remove rmw_connext from test. (#1226 <https://github.com/ros2/rcl/issues/1226>) (#1228 <https://github.com/ros2/rcl/issues/1228>)
  (cherry picked from commit 9c6da4d2f35097a43c2b287359c4657e3f652568)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Fix a dangling pointer discovered by a fresh Clang (#1222 <https://github.com/ros2/rcl/issues/1222>) (#1223 <https://github.com/ros2/rcl/issues/1223>)
  Fix a dangling pointer discovered by the -Wdangling Clang diagnostic:
  ```
  rcl/src/rcl/node_resolve_name.c:95:26: error: temporary whose address is used as value of local variable 'error' will be destroyed at the end of the full-expression [-Werror,-Wdangling]
  95 |     const char * error = rmw_get_error_string().str;
  ```
  (cherry picked from commit 57dc28e3c396f2a3ce1e2a1b065f298b8fdd49cc)
  Co-authored-by: Alexander Kornienko <mailto:alexfh@google.com>
* Contributors: mergify[bot]
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
