### PR TITLE
turtlebot3_msgs: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9721,7 +9721,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_msgs-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_msgs` to `2.4.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
- release repository: https://github.com/ros2-gbp/turtlebot3_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## turtlebot3_msgs

```
* Updated Goal.srv for turtlebot3_machine_learning
* Contributors: ChanHyeong Lee
```
