### PR TITLE
Fix perception_pcl CI on humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6655,7 +6655,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/perception_pcl.git
-      version: ros2
+      version: humble
     status: maintained
   performance_test:
     doc:


### PR DESCRIPTION
## Package name:

perception_pcl

## Purpose of using this:

On humble we should use the `humble` branch to do the CI.
