### PR TITLE
Remove rai_interfaces from rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5511,12 +5511,6 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.2-3
     status: maintained
-  rai_interfaces:
-    source:
-      type: git
-      url: https://github.com/RobotecAI/rai_interfaces.git
-      version: main
-    status: maintained
   random_numbers:
     doc:
       type: git


### PR DESCRIPTION
Please remove rai_interfaces from the rolling distribution index. When creating the initial PR I meant to add it to Humble and Jazzy distributions only, but I also included rolling by mistake.
The package is giving build errors on rolling and we don't actually target this distribution with this package, so it can be removed.

Sorry for the inconvenience.