### PR TITLE
wireless: 1.1.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10568,7 +10568,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.1.5-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.4-1`

## wireless_msgs

```
* Added Github codeowners, issue template, CI.  Also, fixed linting. (#24 <https://github.com/clearpathrobotics/wireless/issues/24>)
* Contributors: Tony Baltovski
```

## wireless_watcher

```
* Added Github codeowners, issue template, CI.  Also, fixed linting. (#24 <https://github.com/clearpathrobotics/wireless/issues/24>)
* Contributors: Tony Baltovski
```
