### PR TITLE
Remove specific Python versions from NixOS rosdep entries

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5505,7 +5505,7 @@ python3-cvxopt:
   debian: [python3-cvxopt]
   fedora: [python-cvxopt]
   gentoo: [dev-python/cvxopt]
-  nixos: [python311Packages.cvxopt]
+  nixos: [python3Packages.cvxopt]
   ubuntu: [python3-cvxopt]
 python3-cvxpy-pip: *migrate_eol_2025_04_30_python3_cvxpy_pip
 python3-cycler:
@@ -7549,7 +7549,7 @@ python3-nest-asyncio:
   debian: [python3-nest-asyncio]
   fedora: [python3-nest-asyncio]
   gentoo: [dev-python/nest-asyncio]
-  nixos: [python312Packages.nest-asyncio]
+  nixos: [python3Packages.nest-asyncio]
   opensuse:
     '*': [python-nest-asyncio]
     '15.2': null
@@ -7931,7 +7931,7 @@ python3-owslib:
   debian: [python3-owslib]
   fedora: [python3-OWSLib]
   gentoo: [dev-python/owslib]
-  nixos: [python312Packages.owslib]
+  nixos: [python3Packages.owslib]
   rhel: [python3-OWSLib]
   ubuntu: [python3-owslib]
 python3-packaging:
@@ -9152,7 +9152,7 @@ python3-pytest-xvfb:
   debian: [python3-pytest-xvfb]
   fedora: [python3-pytest-xvfb]
   gentoo: [dev-python/pytest-xvfb]
-  nixos: [python312Packages.pytest-xvfb]
+  nixos: [python3Packages.pytest-xvfb]
   opensuse: [python3-pytest-xvfb]
   rhel:
     pip:
@@ -9339,7 +9339,7 @@ python3-regex:
   debian: [python3-regex]
   fedora: [python3-regex]
   gentoo: [dev-python/regex]
-  nixos: [python312Packages.regex]
+  nixos: [python3Packages.regex]
   opensuse: [python3-regex]
   rhel: [python3-regex]
   ubuntu: [python3-regex]
@@ -10174,7 +10174,7 @@ python3-svg.path:
   debian: [python3-svg.path]
   fedora: [python3-svg-path]
   gentoo: [dev-python/svg-path]
-  nixos: [python311Packages.svg-path]
+  nixos: [python3Packages.svg-path]
   ubuntu: [python3-svg.path]
 python3-sympy:
   debian: [python3-sympy]
@@ -10259,7 +10259,7 @@ python3-textual:
   arch: [python-textual]
   debian: [python3-textual]
   fedora: [python3-textual]
-  nixos: [python311Packages.textual]
+  nixos: [python3Packages.textual]
   ubuntu:
     '*': [python3-textual]
     focal: null
@@ -10734,7 +10734,7 @@ python3-wand:
   brew: [imagemagick]
   debian: [python3-wand]
   gentoo: [dev-python/wand]
-  nixos: [python311Packages.wand]
+  nixos: [python3Packages.wand]
   ubuntu: [python3-wand]
 python3-watchdog:
   debian: [python3-watchdog]


### PR DESCRIPTION
NixOS provides Python packages under names that include specific Python version (e.g. `python312Packages` for Python 3.12) as well as under unversioned names (`python3Packages`), which provide packages for the currently default Python version. rosdep entries should use the unversioned names to be future-proof.

This PR replaces all versioned names with unversioned. The majority of existing entries of already unversioned.