### PR TITLE
leo_robot: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3873,12 +3873,13 @@ repositories:
     release:
       packages:
       - leo_bringup
+      - leo_filters
       - leo_fw
       - leo_robot
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## leo_bringup

```
* Improve ov5647 compression quality
* Add leo_filters package (#17 <https://github.com/LeoRover/leo_robot-ros2/issues/17>)
* Fix camera config file path
* Add parameter handling based on rover's model (#19 <https://github.com/LeoRover/leo_robot-ros2/issues/19>)
* New camera implementation (#16 <https://github.com/LeoRover/leo_robot-ros2/issues/16>)
* Contributors: Aleksander Szymański, Błażej Sowa, Jan Hernas
```

## leo_filters

```
* Add leo_filters package (#17 <https://github.com/LeoRover/leo_robot-ros2/issues/17>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_fw

```
* Include leocore firmware version 2.0.0 (#20 <https://github.com/LeoRover/leo_robot-ros2/issues/20>)
* Add leo_filters package (#17 <https://github.com/LeoRover/leo_robot-ros2/issues/17>)
* Add parameter handling based on rover's model (#19 <https://github.com/LeoRover/leo_robot-ros2/issues/19>)
* Add missing type annotations in leo_fw package nodes (#18 <https://github.com/LeoRover/leo_robot-ros2/issues/18>)
* Contributors: Aleksander Szymański, Błażej Sowa, Jan Hernas
```

## leo_robot

- No changes
