### PR TITLE
filters: 2.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2303,7 +2303,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.1.2-2
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.2.0-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.2-2`

## filters

```
* Handle dynamic reconfiguration of parameters
* Enable the use of a default for parameters
* Configure github action that runs tests
* Add Windows support
* Clean up filter chain parameter loading
* Make read only configurable
* Added parameter already declared check and allowed override
* Contributors: Dominik Moss, Jeanine van Bruggen, Jonathan Binney, Silvio Traversaro
```
