### PR TITLE
filters: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2652,7 +2652,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.1.0-3
+      version: 2.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.2.0-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-3`

## filters

```
* Handle dynamic reconfiguration of parameters
* Enable the use of a default for parameters
* Configure github action that runs tests
* Add Windows support
* Clean up filter chain parameter loading
* Make read only configurable
* Added parameter already declared check and allowed override
* Contributors: Dominik Moss, Jeanine van Bruggen, Jonathan Binney, Silvio Traversaro
```
