### PR TITLE
Added mcp sdk to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7240,6 +7240,10 @@ python3-mccabe:
   opensuse: [python3-mccabe]
   rhel: [python3-mccabe]
   ubuntu: [python3-mccabe]
+python3-mcp-pip:
+  '*':
+    pip:
+      packages: [mcp]
 python3-mechanize:
   debian:
     '*': [python3-mechanize]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

MCP Python SDK

## Package Upstream Source:

https://github.com/modelcontextprotocol/python-sdk

## Purpose of using this:

As more integration of AI and Robotics happens, MCPs will provide a great accessible interface for projects with support for AI. Additionally, my Auto MCP package also uses the MCP Python SDK.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available