### PR TITLE
Added rtklib to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8561,6 +8561,11 @@ rti-connext-dds-7.3.0:
     '*': [rti-connext-dds-7.3.0-ros]
     focal: null
     jammy: null
+rtklib:
+  debian: [rtklib]
+  fedora: [rtklib]
+  opensuse: [rtklib]
+  ubuntu: [rtklib]
 rtmidi:
   arch: [rtmidi]
   debian: [librtmidi-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8564,7 +8564,9 @@ rti-connext-dds-7.3.0:
 rtklib:
   debian: [rtklib]
   fedora: [rtklib]
-  opensuse: [rtklib]
+  opensuse:
+    '*': [rtklib]
+    '15.2': null
   ubuntu: [rtklib]
 rtmidi:
   arch: [rtmidi]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rtklib

## Package Upstream Source:

https://www.rtklib.com/
https://github.com/tomojitakasu/RTKLIB

## Purpose of using this:

Taken from https://www.rtklib.com/:

> RTKLIB is an open source program package for standard and precise positioning with GNSS (global navigation satellite system). RTKLIB consists of a portable program library and several APs (application programs) utilizing the library. The features of RTKLIB are: 
> 
> 1. It supports standard and precise positioning algorithms with: GPS, GLONASS, Galileo, QZSS, BeiDou and SBAS
> 2. It supports various positioning modes with GNSS for both real-time and post-processing: Single, DGPS/DGNSS, Kinematic, Static, Moving-Baseline, Fixed, PPP-Kinematic, PPP-Staticand PPP-Fixed
> 3. It supports many standard formats and protocols for GNSS: RINEX 2.10, 2.11, 2.12 OBS/NAV/GNAV/HNAV/LNAV/QNAV, RINEX 3.00, 3.01, 3.02 OBS/NAV, RINEX 3.02 CLK, RTCM ver.2.3, RTCM ver.3.1 (with amendment 1-5), ver.3.2, BINEX, NTRIP 1.0, RTCA/DO-229C, NMEA 0183, SP3-c, ANTEX 1.4, IONEX 1.0, NGS PCV and EMS 2.0 (refer the Manual for details) 
> 4. It supports several GNSS receivers' proprietary messages: NovAtel: OEM4/V/6, OEM3, OEMStar, Superstar II, Hemisphere: Eclipse, Crescent, u-blox: LEA-4T/5T/6T, SkyTraq: S1315F, JAVAD: GRIL/GREIS, Furuno: GW-10 II/III and NVS NV08C BINR (refer the Manual for details)
> 5. It supports external communication via: Serial, TCP/IP, NTRIP, local log file (record and playback) and FTP/HTTP (automatic download)
> 6. It provides many library functions and APIs for GNSS data processing: Satellite and navigation system functions, matrix and vector functions, time and string functions, coordinates transformation, input and output functions, debug trace functions, platform dependent functions, positioning models, atmosphere models, antenna models, earth tides models, geoid models, datum transformation, RINEX functions, ephemeris and clock functions, precise ephemeris and clock functions, receiver raw data functions, RTCM functions, solution functions, Google Earth KML converter, SBAS functions, options functions, stream data input and output functions, integer ambiguity resolution, standard positioning, precise positioning, post-processing positioning, stream server functions, RTK server functions, downloader functions

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=rtklib&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=rtklib&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=rtklib
- Arch: https://www.archlinux.org/packages/
  - [Not available](https://archlinux.org/packages/?sort=&q=rtklib&maintainer=&flagged=)
- Gentoo: https://packages.gentoo.org/
  - [Not available](https://packages.gentoo.org/packages/search?q=rtklib)
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - [Not available](https://pkgs.alpinelinux.org/packages?name=rtklib&branch=edge&repo=&arch=&origin=&flagged=&maintainer=)
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/search?baseproject=ALL&q=rtklib
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE
