### PR TITLE
Delete event_camera_py doc and source entries

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2403,19 +2403,19 @@ repositories:
       version: humble
     status: developed
   event_camera_py:
-    doc:
-      type: git
-      url: https://github.com/ros-event-camera/event_camera_py.git
-      version: humble
+    #doc:
+    #  type: git
+    #  url: https://github.com/ros-event-camera/event_camera_py.git
+    #  version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
       version: 2.0.0-1
-    source:
-      type: git
-      url: https://github.com/ros-event-camera/event_camera_py.git
-      version: humble
+    #source:
+    #  type: git
+    #  url: https://github.com/ros-event-camera/event_camera_py.git
+    #  version: humble
     status: developed
   event_camera_renderer:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2403,19 +2403,19 @@ repositories:
       version: humble
     status: developed
   event_camera_py:
-    #doc:
-    #  type: git
-    #  url: https://github.com/ros-event-camera/event_camera_py.git
-    #  version: humble
+    # doc:
+    #   type: git
+    #   url: https://github.com/ros-event-camera/event_camera_py.git
+    #   version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
       version: 2.0.0-1
-    #source:
-    #  type: git
-    #  url: https://github.com/ros-event-camera/event_camera_py.git
-    #  version: humble
+    # source:
+    #   type: git
+    #   url: https://github.com/ros-event-camera/event_camera_py.git
+    #   version: humble
     status: developed
   event_camera_renderer:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2403,19 +2403,11 @@ repositories:
       version: humble
     status: developed
   event_camera_py:
-    # doc:
-    #   type: git
-    #   url: https://github.com/ros-event-camera/event_camera_py.git
-    #   version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
       version: 2.0.0-1
-    # source:
-    #   type: git
-    #   url: https://github.com/ros-event-camera/event_camera_py.git
-    #   version: humble
     status: developed
   event_camera_renderer:
     doc:


### PR DESCRIPTION
I'm seen CI failures on other PRs because the humble branch has gone missing

https://github.com/ros-event-camera/event_camera_py/issues/23

I still see [`humble` mentioned in the release track](https://github.com/ros2-gbp/event_camera_py-release/blob/bd5558160ba24000408fb2b63a13a3307d161a15/tracks.yaml#L24), so I think the fix is to restore the humble branch rather than switch to a different one.

This PR deletes the doc and source stanzas to try to get the CI jobs to pass again.
