### PR TITLE
frame_editor: 1.2.0-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3338,7 +3338,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
-      version: 1.1.1-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `1.2.0-1`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ipa320/rqt_frame_editor_plugin-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`

## frame_editor

```
* Bug fix: Deleted Frames not beeing able to be reused
* Feature: Clear Frame Buffer and Added loading animation for tf frame list when pressing either refresh button or deleting frames
* Feature: Automatically Update TF Frame List when adding/duplicating frames (without clearing the frame buffer)
* Chore: Moved from prints to rospy logging
* Feature: Added search bar for both tf and frame list (style: grey out or hide frames with argument --filter_style)
* Feature: Add Grouping Option for frames by setting the group attribute in the yaml file
* Feature: TF Frame list is automatically grouped by self-defined (Frames) and external frames (Other)
* Feature: Autosave Functionality
* Performance: Use Static Transform Publisher instead of Dynamic.
* Contributors: Jan Krieglstein, Daniel Bargmann
```
