### PR TITLE
fix broken source/doc for event_camera_py package

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2403,11 +2403,19 @@ repositories:
       version: humble
     status: developed
   event_camera_py:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
       version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_py.git
+      version: release
     status: developed
   event_camera_renderer:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2097,7 +2097,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2106,7 +2106,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: rolling
+      version: release
     status: developed
   event_camera_renderer:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1634,7 +1634,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1643,7 +1643,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: rolling
+      version: release
     status: developed
   event_camera_renderer:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1635,7 +1635,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1644,7 +1644,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git
-      version: rolling
+      version: release
     status: developed
   event_camera_renderer:
     doc:


### PR DESCRIPTION
The branches for event_camera_py have been renamed. Going forward the "release" branch is the only one to be maintained, so please approve this PR.

This relates to PR #45594 (https://github.com/ros/rosdistro/pull/45594).

This closes https://github.com/ros-event-camera/event_camera_py/issues/23
