### PR TITLE
Revert "ompl: 1.7.0-2 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6265,7 +6265,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.7.0-2
+      version: 1.6.0-1
   open_manipulator:
     doc:
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#45249

This update broke the package in Humble and blocks many downstream ones

FYI: @JafarAbdi 