### PR TITLE
ardrone_ros: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -439,6 +439,18 @@ repositories:
       version: master
     status: developed
   ardrone_ros:
+    doc:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    release:
+      packages:
+      - ardrone_sdk
+      - ardrone_sumo
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ardrone_ros-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/vtalpaert/ardrone-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_ros` to `1.0.0-1`:

- upstream repository: https://github.com/vtalpaert/ardrone-ros2.git
- release repository: https://github.com/ros2-gbp/ardrone_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ardrone_sdk

```
* Export Parrot ARSDK3 as a library with all cmake confguration to use find_package
* Includes the headers, shared libraries (.so), native unix samples and Parrot licence as required
* Contributors: Victor Talpaert
```

## ardrone_sumo

```
* ROS2 node to control the Jumping Sumo Parrot drone
* Connect over private WiFi to retrieve the video feed, battery level and send motor commands
* No IMU data, no standard units for motor commands (currently in percentage of maximum value)
* Contributors: Victor Talpaert
```
