### PR TITLE
rviz: 1.14.26-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11215,7 +11215,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rviz-release.git
-      version: 1.14.25-1
+      version: 1.14.26-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `1.14.26-1`:

- upstream repository: https://github.com/ros-visualization/rviz.git
- release repository: https://github.com/ros-gbp/rviz-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.14.25-1`

## rviz

```
* Warning Dialog for ROS 1 EOL (#1843 <https://github.com/ros-visualization/rviz/issues/1843>)
* Bump cmake_minimum_required to 3.5 (#1847 <https://github.com/ros-visualization/rviz/issues/1847>)
* Replace boost::filesystem::extension() (#1844 <https://github.com/ros-visualization/rviz/issues/1844>)
* Fix #1834 <https://github.com/ros-visualization/rviz/issues/1834>: segfault on addMaximizeButton
* Contributors: A K Azad, Arne Hitzmann, Katherine Scott, Robert Haschke
```
