### PR TITLE
rig_reconfigure: 1.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6783,7 +6783,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.5.0-1
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rig_reconfigure` to `1.6.0-1`:

- upstream repository: https://github.com/teamspatzenhirn/rig_reconfigure.git
- release repository: https://github.com/ros2-gbp/rig_reconfigure-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.0-1`

## rig_reconfigure

```
* fix wrong bounds on one-sided numeric parameter bounds (#46 <https://github.com/teamspatzenhirn/rig_reconfigure/pull/46>)
* fix errors when exiting rig via sigint (#45 <https://github.com/teamspatzenhirn/rig_reconfigure/pull/45>)
* Add support for parameter ranges and disabling readonly parameters. (#42 <https://github.com/teamspatzenhirn/rig_reconfigure/pull/42>)
* Fix parameter input widget widths (#41 <https://github.com/teamspatzenhirn/rig_reconfigure/pull/41>)
* Contributors: Dominik, Jonas Otto, Marc Alban
```
