### PR TITLE
Update distribution.yaml for 1.12.1 diagnotics packages noetic

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2183,7 +2183,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/diagnostics-release.git
-      version: 1.11.0-1
+      version: 1.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Given a token issue during the last PR opening step with bloom, I am opening this PR manually

Increasing version of package(s) in repository diagnostics to 1.12.1-1:

upstream repository: https://github.com/ros/diagnostics.git
release repository: https://github.com/ros-gbp/diagnostics-release.git
distro file: noetic/distribution.yaml
previous version for package: 1.12.1-1