### PR TITLE
realtime_tools: 4.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5933,7 +5933,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.2.0-1
+      version: 4.2.1-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.2.1-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.0-1`

## realtime_tools

```
* Fix the deadlock in the destructor of RealtimePublisher (#320 <https://github.com/ros-controls/realtime_tools/issues/320>)
* Contributors: Sai Kishor Kothakota
```
