### PR TITLE
ur_description: 3.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8959,7 +8959,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.1.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-1`

## ur_description

```
* Add kilted (#279 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/279>)
* Update ur3e's inertia values (#276 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/276>)
* Update documentation (#277 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/277>)
* Contributors: Felix Exner
```
