### PR TITLE
rviz: 15.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7806,11 +7806,12 @@ repositories:
       - rviz_ogre_vendor
       - rviz_rendering
       - rviz_rendering_tests
+      - rviz_resource_interfaces
       - rviz_visual_testing_framework
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.4-1
+      version: 15.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.4.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Clean ogre CMakeLists.txt (#1251 <https://github.com/ros2/rviz/issues/1251>)
* Contributors: mosfet80
```

## rviz_common

```
* Fixed crash when a resource is not available (#1455 <https://github.com/ros2/rviz/issues/1455>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Changed Marker Displays to allow toggling visibility of namespaces (#1402 <https://github.com/ros2/rviz/issues/1402>)
* Do not use ${Qt5Widgets_INCLUDE_DIRS} to avoid creating non-relocatable CMake config files (#1450 <https://github.com/ros2/rviz/issues/1450>)
* Contributors: Silvio Traversaro, Stefan Fabian
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* WrenchVisual::setForceColor and setTorqueColor clamp values (#1437 <https://github.com/ros2/rviz/issues/1437>)
* Missing Null Pointer Check in TrianglePolygon Constructor Leads to Crash (#1434 <https://github.com/ros2/rviz/issues/1434>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
