### PR TITLE
rviz: 15.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7747,7 +7747,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.0-1
+      version: 15.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.0.0-1`

## rviz2

- No changes

## rviz_assimp_vendor

```
* Clean ogre CMakeLists.txt (#1251 <https://github.com/ros2/rviz/issues/1251>) (#1445 <https://github.com/ros2/rviz/issues/1445>)
* Contributors: mergify[bot]
```

## rviz_common

```
* Fixed crash when a resource is not available (#1455 <https://github.com/ros2/rviz/issues/1455>) (#1456 <https://github.com/ros2/rviz/issues/1456>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Do not use ${Qt5Widgets_INCLUDE_DIRS} to avoid creating non-relocatable CMake config files (#1450 <https://github.com/ros2/rviz/issues/1450>) (#1451 <https://github.com/ros2/rviz/issues/1451>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* WrenchVisual::setForceColor and setTorqueColor clamp values (#1437 <https://github.com/ros2/rviz/issues/1437>) (#1447 <https://github.com/ros2/rviz/issues/1447>)
* Missing Null Pointer Check in TrianglePolygon Constructor Leads to Crash (#1434 <https://github.com/ros2/rviz/issues/1434>) (#1444 <https://github.com/ros2/rviz/issues/1444>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
