### PR TITLE
mavros: 2.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3749,7 +3749,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.10.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.0-1`

## libmavconn

```
* Merge branch 'master' into ros2
  * master:
  1.20.1
  update changelog
  1.20.0
  update changelog
  update mavlink dep branch
  Add missing std_srvs dependency
  add param to odom plugin
  add frame_id parameter
  Fix compile error when compiling with gcc 13
* 1.20.1
* update changelog
* 1.20.0
* update changelog
* Contributors: Vladimir Ermakov
```

## mavros

```
* extras: fix odid build
* extras: re-generate all cog scripts
* mavros: fix indentation
* Merge branch 'master' into ros2
  * master:
  1.20.1
  update changelog
  1.20.0
  update changelog
  update mavlink dep branch
  Add missing std_srvs dependency
  add param to odom plugin
  add frame_id parameter
  Fix compile error when compiling with gcc 13
* 1.20.1
* update changelog
* fix spelling error
* add new flag
* if
* Address Warnings
* cpplint
* built successfully
* 1.20.0
* update changelog
* add param to odom plugin
* add frame_id parameter
* Contributors: EnderMandS, Michael Carlstrom, Vladimir Ermakov
```

## mavros_extras

```
* extras: fix format
* extras: fix build of odom
* extras: fix odid build
* extras: re-generate all cog scripts
* extras: fix odid messages
* extras: fix indent
* Adding OpenDroneID plugin and messages (#3 <https://github.com/mavlink/mavros/issues/3>)
* mavros: fix indentation
* Merge branch 'master' into ros2
  * master:
  1.20.1
  update changelog
  1.20.0
  update changelog
  update mavlink dep branch
  Add missing std_srvs dependency
  add param to odom plugin
  add frame_id parameter
  Fix compile error when compiling with gcc 13
* 1.20.1
* update changelog
* Fix code style: remove trailing whitespace and tabs (Rolling distribution)
* Fix: Corrected compass calibration result report to match mavlink documentation (MAG_CAL_REPORT (192))
* Address Warnings
* re-run ci
* re-run ci
* ament_uncrustify
* Fix cpplint errors
* typo
* Added support for MAV_FRAME::BODY_FRD to landing_target
* 1.20.0
* update changelog
* Add missing std_srvs dependency
* add param to odom plugin
* add frame_id parameter
* Fix compile error when compiling with gcc 13
  The error is:
  src/plugins/mag_calibration_status.cpp:64:22: error: ‘bitset’ is not a member of ‘std’
* Contributors: EnderMandS, Gus Meyer, Kye Morton, Michael Carlstrom, Michal Sojka, Roland Arsenault, Vladimir Ermakov, denis
```

## mavros_msgs

```
* extras: re-generate all cog scripts
* extras: fix odid messages
* msgs: generate ODID constants from mavlink
* msgs: fix message names for ODID
* Adding OpenDroneID plugin and messages (#3 <https://github.com/mavlink/mavros/issues/3>)
* Merge branch 'master' into ros2
  * master:
  1.20.1
  update changelog
  1.20.0
  update changelog
  update mavlink dep branch
  Add missing std_srvs dependency
  add param to odom plugin
  add frame_id parameter
  Fix compile error when compiling with gcc 13
* 1.20.1
* update changelog
* Fix: Corrected compass calibration result report to match mavlink documentation (MAG_CAL_REPORT (192))
* built successfully
* 1.20.0
* update changelog
* Contributors: Gus Meyer, Michael Carlstrom, Vladimir Ermakov, denis
```
