### PR TITLE
rqt_nav_view: 0.5.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10751,7 +10751,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_nav_view-release.git
-      version: 0.5.7-1
+      version: 0.5.8-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_nav_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_nav_view` to `0.5.8-1`:

- upstream repository: https://github.com/ros-visualization/rqt_nav_view.git
- release repository: https://github.com/ros-gbp/rqt_nav_view-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.7-1`

## rqt_nav_view

```
* Bump cmake_minimum_required to avoid deprecation (#11 <https://github.com/ros-visualization/rqt_nav_view/issues/11>)
* Add missing dep on setuptools (#10 <https://github.com/ros-visualization/rqt_nav_view/issues/10>)
* Add myself as maintainer (#9 <https://github.com/ros-visualization/rqt_nav_view/issues/9>)
* Add myself as maintainer (#8 <https://github.com/ros-visualization/rqt_nav_view/issues/8>)
* Fix and major update (#7 <https://github.com/ros-visualization/rqt_nav_view/issues/7>)
* fix shebang line for python3
* Contributors: Arne Hitzmann, Matthijs van der Burgh, Mikael Arguedas, Srishti Dhamija
```
