### PR TITLE
mola: 1.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3864,6 +3864,7 @@ repositories:
       - mola_input_paris_luco_dataset
       - mola_input_rawlog
       - mola_input_rosbag2
+      - mola_input_video
       - mola_kernel
       - mola_launcher
       - mola_metric_maps
@@ -3876,7 +3877,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.6.4-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.7.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.4-1`

## kitti_metrics_eval

- No changes

## mola

```
* Merge pull request #85 <https://github.com/MOLAorg/mola/issues/85> from MOLAorg/feat/video-input-module
  Feature: new video input MOLA module
* Feature: new video input MOLA module. For now, implements "image directory" input.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

- No changes

## mola_demos

```
* Implement live camera mode too
* video input from video files also implemented now
* Merge pull request #85 <https://github.com/MOLAorg/mola/issues/85> from MOLAorg/feat/video-input-module
  Feature: new video input MOLA module
* Feature: new video input MOLA module. For now, implements "image directory" input.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

```
* code clean up: remove useless dtors, and mark the required copy ctors as deleted
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

- No changes

## mola_input_video

```
* Implement live camera mode too
* video input from video files also implemented now
* Merge pull request #85 <https://github.com/MOLAorg/mola/issues/85> from MOLAorg/feat/video-input-module
  Feature: new video input MOLA module
* Feature: new video input MOLA module. For now, implements "image directory" input.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* code clean up: remove useless dtors, and mark the required copy ctors as deleted
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* code clean up: remove useless dtors, and mark the required copy ctors as deleted
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* fix clang-format
* Metric maps can now be rendered as semitransparent pointclouds
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* Metric maps can now be rendered as semitransparent pointclouds
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
