### PR TITLE
Added touchlab-comm-py rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10458,6 +10458,10 @@ python3-tornado:
       packages: [tornado]
   rhel: ['python%{python3_pkgversion}-tornado']
   ubuntu: [python3-tornado]
+python3-touchlab-comm-py-pip:
+  '*':
+    pip:
+      packages: [touchlab-comm-py]
 python3-tqdm:
   alpine: [py3-tqdm]
   debian: [python3-tqdm]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

touchlab-comm-py

## Package Upstream Source:

[https://pypi.org/project/touchlab-comm-py/](https://pypi.org/project/touchlab-comm-py/)

## Purpose of using this:

This is a python wrapper for Touchlab tactile sensors.
