### PR TITLE
phidgets_drivers: 1.0.10-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7844,6 +7844,7 @@ repositories:
       - phidgets_analog_inputs
       - phidgets_analog_outputs
       - phidgets_api
+      - phidgets_current_inputs
       - phidgets_digital_inputs
       - phidgets_digital_outputs
       - phidgets_drivers
@@ -7859,7 +7860,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
-      version: 1.0.9-1
+      version: 1.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `1.0.10-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros-drivers-gbp/phidgets_drivers-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.9-1`

## libphidget22

- No changes

## phidgets_accelerometer

- No changes

## phidgets_analog_inputs

- No changes

## phidgets_analog_outputs

- No changes

## phidgets_api

```
* Contributors: Martin Günther, Ben Schattinger
```

## phidgets_current_inputs

```
* Add support for Phidgets Current sensors (#148 <https://github.com/ros-drivers/phidgets_drivers/issues/148>)
* Contributors: Martin Günther, Ben Schattinger
```

## phidgets_digital_inputs

- No changes

## phidgets_digital_outputs

- No changes

## phidgets_drivers

- No changes

## phidgets_gyroscope

- No changes

## phidgets_high_speed_encoder

- No changes

## phidgets_humidity

- No changes

## phidgets_ik

- No changes

## phidgets_magnetometer

- No changes

## phidgets_motors

- No changes

## phidgets_msgs

- No changes

## phidgets_spatial

- No changes

## phidgets_temperature

- No changes
