### PR TITLE
Add turtlebot3_applications to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11072,6 +11072,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: humble
     status: developed
+  turtlebot3_applications:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
+      version: humble
+    status: developed
   turtlebot3_autorace:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/ROBOTIS-GIT/turtlebot3_applications

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
