### PR TITLE
Add turtlebot3_applications_msgs to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9798,6 +9798,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git
       version: jazzy
     status: developed
+  turtlebot3_applications_msgs:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
+      version: jazzy
+    status: developed
   turtlebot3_autorace:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
