### PR TITLE
Add turtlebot3_machine_learning to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9818,6 +9818,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
       version: jazzy
     status: developed
+  turtlebot3_machine_learning:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_machine_learning.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_machine_learning.git
+      version: jazzy
+    status: developed
   turtlebot3_manipulation:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

https://github.com/ROBOTIS-GIT/turtlebot3_machine_learning

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
