### PR TITLE
Add turtlebot3_home_service_challenge to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8718,6 +8718,16 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/turtlebot3_autorace.git
       version: main
     status: developed
+  turtlebot3_home_service_challenge:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git
+      version: main
+    status: developed
   turtlebot3_manipulation:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
