### PR TITLE
ai_worker: 1.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -115,6 +115,20 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git
       version: jazzy
+    release:
+      packages:
+      - ffw
+      - ffw_bringup
+      - ffw_description
+      - ffw_joint_trajectory_command_broadcaster
+      - ffw_joystick_controller
+      - ffw_moveit_config
+      - ffw_spring_actuator_controller
+      - ffw_teleop
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ai_worker-release.git
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ai_worker` to `1.0.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ai_worker.git
- release repository: https://github.com/ros2-gbp/ai_worker-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## ffw

```
* Fixed Dockerfile
* Updated Camera URDF
* Contributors: Woojin Wie
```

## ffw_bringup

```
* None
```

## ffw_description

```
* Updated Camera URDF
* Contributors: Woojin Wie
```

## ffw_joint_trajectory_command_broadcaster

```
* None
```

## ffw_joystick_controller

```
* None
```

## ffw_moveit_config

```
* None
```

## ffw_spring_actuator_controller

```
* None
```

## ffw_teleop

```
* None
```
