### PR TITLE
Add live555_vendor to source index

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4134,6 +4134,12 @@ repositories:
       url: https://github.com/adityapande-1995/linux_isolate_process.git
       version: main
     status: maintained
+  live555_vendor:
+    source:
+      type: git
+      url: https://github.com/fkie/live555_vendor.git
+      version: main
+    status: maintained
   log_view:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3582,6 +3582,12 @@ repositories:
       url: https://github.com/adityapande-1995/linux_isolate_process.git
       version: main
     status: maintained
+  live555_vendor:
+    source:
+      type: git
+      url: https://github.com/fkie/live555_vendor.git
+      version: main
+    status: maintained
   log_view:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy, rolling

# The source is here:

https://github.com/fkie/live555_vendor
http://live555.com/liveMedia/

This is a vendoring-friendly copy of the live555 multimedia library which has been augmented with a CMake configuration for convenient use in ROS packages. The library itself has been taken unmodified from upstream.

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
