### PR TITLE
Change branch name for old distro color_util

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/color_util.git
-      version: main
+      version: pre_kilted
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -1599,7 +1599,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/color_util.git
-      version: main
+      version: pre_kilted
     status: developed
   common_interfaces:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1336,7 +1336,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/color_util.git
-      version: main
+      version: pre_kilted
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -1346,7 +1346,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/color_util.git
-      version: main
+      version: pre_kilted
     status: developed
   common_interfaces:
     doc:


### PR DESCRIPTION
# Please change the branch for old distributions of color_util in the rosdistro

humble & jazzy

# The source is here:

https://github.com/MetroRobots/color_util

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
