### PR TITLE
rqt_moveit: 0.5.13-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10713,7 +10713,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_moveit-release.git
-      version: 0.5.11-1
+      version: 0.5.13-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_moveit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_moveit` to `0.5.13-1`:

- upstream repository: https://github.com/ros-visualization/rqt_moveit.git
- release repository: https://github.com/ros-gbp/rqt_moveit-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.11-1`

## rqt_moveit

```
* Potetially final release for ROS1 Noetic https://github.com/ros-visualization/rqt_moveit/issues/12
```
