### PR TITLE
septentrio_gnss_driver: 1.4.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8942,7 +8942,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.3-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.2-1`

## septentrio_gnss_driver

```
* Fixes
  
  Resolve issues with removed/renamed functionality in boost 1.87 (thanks to @oysstu)
  
  VSM data not being sent to the rx if configure_rx is false
  
  ROS 2 Rolling regression (thanks to @kevshin2002)
* Improvements
  
  IMU orientation sync
* Contributors:  @oysstu, @kevshin2002, Thomas Emter, Tibor Dome, septentrio-users
```
