### PR TITLE
septentrio_gnss_driver: 1.4.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11498,7 +11498,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.3-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
- release repository: https://github.com/septentrio-users/septentrio_gnss_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.2-1`

## septentrio_gnss_driver

```
* Fixes
  
  Resolve issues with removed/renamed functionality in boost 1.87 (thanks to @oysstu)
  
  VSM data not being sent to the rx if configure_rx is false
  
  ROS 2 Rolling regression (thanks to @kevshin2002)
* Improvements
  
  IMU orientation sync
* Contributors:  @oysstu, @kevshin2002, Thomas Emter, Tibor Dome, septentrio-users
```
