### PR TITLE
jsk_3rdparty: 2.1.30-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4735,6 +4735,7 @@ repositories:
       - collada_urdf_jsk_patch
       - dialogflow_task_executive
       - downward
+      - emotion_analyzer
       - ff
       - ffha
       - gdrive_ros
@@ -4762,13 +4763,14 @@ repositories:
       - slic
       - switchbot_ros
       - voice_text
+      - voicevox
       - webrtcvad_ros
       - zdepth
       - zdepth_image_transport
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.28-1
+      version: 2.1.30-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_3rdparty` to `2.1.30-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
- release repository: https://github.com/tork-a/jsk_3rdparty-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.28-1`

## aques_talk

```
* CI:aques_talk : run aques_talk only when download was succeeded (#534 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/534>)
* Add ROS-O 24.04 test (#521 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/521>)
* Contributors: Kei Okada, Yoshiki Obinata
```

## assimp_devel

- No changes

## bayesian_belief_networks

```
* bayesian_belief_networks: fix deb build (#525 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/525>) --single-version-externally-managed only available on ubuntu<20
  checked with 'git clean -xfd .; bloom-generate rosdebian --os-name=ubuntu --os-version=noble --ros-distro one  --skip-pip; dpkg-buildpackage -b -us -u'
* Add ROS-O 24.04 test (#521 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/521>)
* Contributors: Kei Okada
```

## chaplus_ros

- No changes

## collada_urdf_jsk_patch

```
* [ros-o] collada_urdf_jsk_patch: skip cmake/pkg config generation (#517 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/517>)
* Contributors: Kei Okada
```

## dialogflow_task_executive

```
* Add ROS-O 24.04 test (#521 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/521>)
* Contributors: Kei Okada
```

## downward

- No changes

## emotion_analyzer

```
* Add Emotion Analyzer (#527 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/527>)
* Contributors: Ayaha Nagata, Yoshiki Obinata
```

## ff

- No changes

## ffha

- No changes

## gdrive_ros

- No changes

## google_chat_ros

```
* google_chat_ros: enable to get therad_name message result (#516 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/516>)
* Add ROS-O 24.04 test (#521 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/521>)
* Contributors: Kei Okada, Yoshiki Obinata
```

## google_cloud_texttospeech

- No changes

## influxdb_store

- No changes

## jsk_3rdparty

- No changes

## julius

```
* [ros-o] julius: use system install julius, download dictation and grammer kit by script (#518 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/518>)
* Contributors: Kei Okada
```

## julius_ros

```
* [ros-o] julius: use system install julius (#518 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/518>)
* julius_ros/scripts/run_julius.sh: more information on how to install julius and grammer/dictation kit
* [ros-o] julius: use system install julius, download dictation and grammer kit by script
* Contributors: Kei Okada
```

## libcmt

- No changes

## libsiftfast

- No changes

## lpg_planner

- No changes

## mini_maxwell

- No changes

## nfc_ros

- No changes

## opt_camera

- No changes

## osqp

- No changes

## pgm_learner

- No changes

## respeaker_ros

- No changes

## ros_google_cloud_language

```
* Add ROS-O 24.04 test (#521 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/521>)
* Contributors: Kei Okada
```

## ros_speech_recognition

- No changes

## rospatlite

- No changes

## rosping

- No changes

## rostwitter

- No changes

## sesame_ros

```
* CI: add ROS-O testing on arm (#528 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/528>), fix sesame_ros on arm64
  * CI: add ROS-O testing on arm
  * CI: use ros-one-catkin-virtualenv
  * sesami_ros: add requirements.in.python3.12, for arm64 22.04/24.04
* Contributors: Kei Okada, Yoshiki Obinata
```

## slic

- No changes

## switchbot_ros

- No changes

## voice_text

- No changes

## voicevox

```
* Add voicevox (AI speech synthesis) package (#539 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/539> , #532 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/532> , #538 <https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/538> )
* Contributors: Aoi Nakane, Iori Yanokura, Kei Okada, Naoto Tsukamoto, Shingo Kitagawa, Yoshiki Obinata
```

## webrtcvad_ros

- No changes

## zdepth

- No changes

## zdepth_image_transport

- No changes
