### PR TITLE
rmf_traffic_editor: 1.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6186,7 +6186,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.11.0-1
+      version: 1.12.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.12.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.11.0-1`

## rmf_building_map_tools

```
* Remove redundant physics plugin (#530 <https://github.com/open-rmf/rmf_traffic_editor/issues/530>)
* Fix to Allow Numerically-Labelled Map (#528 <https://github.com/open-rmf/rmf_traffic_editor/issues/528>)
* Fix pit crew missing models and authorship logic (#522 <https://github.com/open-rmf/rmf_traffic_editor/issues/522>)
* Support robot types with organization namespaces (#521 <https://github.com/open-rmf/rmf_traffic_editor/issues/521>)
* Add flag to skip calculating and setting camera pose (#523 <https://github.com/open-rmf/rmf_traffic_editor/issues/523>)
* Add the ability to customize the base world file (#519 <https://github.com/open-rmf/rmf_traffic_editor/issues/519>)
* Contributors: Aaron Chong, Arjo Chakravarty, Gary Bey, Grey, Luca Della Vedova
```

## rmf_traffic_editor

```
* Add a conditional check for level transformation (#520 <https://github.com/open-rmf/rmf_traffic_editor/issues/520>)
* Allowing deletion of lift cabin vertices (#518 <https://github.com/open-rmf/rmf_traffic_editor/issues/518>)
* Contributors: Jun
```

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

- No changes
