### PR TITLE
rmf_ros2: 2.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6111,7 +6111,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.10.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.0-1`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Add a timer to log the size of planner caches (#427 <https://github.com/open-rmf/rmf_ros2/issues/427>)
* Fix goal orientation constraint (#426 <https://github.com/open-rmf/rmf_ros2/issues/426>)
* Log reason for rejecting dynamic event goals (#419 <https://github.com/open-rmf/rmf_ros2/issues/419>)
* Completely Excise Reservation Cancellation pathways (#416 <https://github.com/open-rmf/rmf_ros2/issues/416>)
* Reduce churn in lift supervisor (#418 <https://github.com/open-rmf/rmf_ros2/issues/418>)
* Dynamic Event Action Server (#410 <https://github.com/open-rmf/rmf_ros2/issues/410>)
* Improve arrival time predictions for lanes with speed limits (#400 <https://github.com/open-rmf/rmf_ros2/issues/400>)
* Ensure correct docking orientation (#414 <https://github.com/open-rmf/rmf_ros2/issues/414>)
* Direct robot task request estimation feature (#408 <https://github.com/open-rmf/rmf_ros2/issues/408>)
* Giving options to separate fire alarm by fleet names (#413 <https://github.com/open-rmf/rmf_ros2/issues/413>)
* Update documentation for RobotCommandHandle (#409 <https://github.com/open-rmf/rmf_ros2/issues/409>)
* Remove bad optional access (#406 <https://github.com/open-rmf/rmf_ros2/issues/406>)
* Fix potential issues around tasks starting (#403 <https://github.com/open-rmf/rmf_ros2/issues/403>)
* Fix the criteria for replanning (#405 <https://github.com/open-rmf/rmf_ros2/issues/405>)
* Do not update assignments if bid notice is for a dry run (#401 <https://github.com/open-rmf/rmf_ros2/issues/401>)
* Use unique name for exported targets and avoid exporting binary targets (#396 <https://github.com/open-rmf/rmf_ros2/issues/396>)
* Do not skip waypoint if orientation is not aligned (#398 <https://github.com/open-rmf/rmf_ros2/issues/398>)
* Contributors: Arjo Chakravarty, Chen Bainian, Cheng-Wei Chen, Grey, Jun, Luca Della Vedova, Xiyu, lkw303, yadunund
```

## rmf_fleet_adapter_python

```
* Add a timer to log the size of planner caches (#427 <https://github.com/open-rmf/rmf_ros2/issues/427>)
* Do not update assignments if bid notice is for a dry run (#401 <https://github.com/open-rmf/rmf_ros2/issues/401>)
* Contributors: Grey, yadunund
```

## rmf_reservation_node

```
* Completely Excise Reservation Cancellation pathways (#416 <https://github.com/open-rmf/rmf_ros2/issues/416>)
* Contributors: Arjo Chakravarty
```

## rmf_task_ros2

```
* Do not update assignments if bid notice is for a dry run (#401 <https://github.com/open-rmf/rmf_ros2/issues/401>)
* Use unique name for exported targets and avoid exporting binary targets (#396 <https://github.com/open-rmf/rmf_ros2/issues/396>)
* Contributors: Luca Della Vedova, yadunund
```

## rmf_traffic_ros2

```
* Giving options to separate fire alarm by fleet names (#413 <https://github.com/open-rmf/rmf_ros2/issues/413>)
* Use unique name for exported targets and avoid exporting binary targets (#396 <https://github.com/open-rmf/rmf_ros2/issues/396>)
* Contributors: Jun, Luca Della Vedova
```

## rmf_websocket

```
* Use unique name for exported targets and avoid exporting binary targets (#396 <https://github.com/open-rmf/rmf_ros2/issues/396>)
* Contributors: Luca Della Vedova
```
