### PR TITLE
Added opengen to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7855,17 +7855,8 @@ python3-opencv:
     '7': null
     '8': null
   ubuntu: [python3-opencv]
-python3-opengen:
-  debian:
-    pip:
-      packages: [opengen]
-  fedora:
-    pip:
-      packages: [opengen]
-  rhel:
-    pip:
-      packages: [opengen]
-  ubuntu:
+python3-opengen-pip:
+  '*':
     pip:
       packages: [opengen]
 python3-opengl:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7855,6 +7855,19 @@ python3-opencv:
     '7': null
     '8': null
   ubuntu: [python3-opencv]
+python3-opengen:
+  debian:
+    pip:
+      packages: [opengen]
+  fedora:
+    pip:
+      packages: [opengen]
+  rhel:
+    pip:
+      packages: [opengen]
+  ubuntu:
+    pip:
+      packages: [opengen]
 python3-opengl:
   debian: [python3-opengl]
   fedora: [python3-pyopengl]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

Opengen

## Package Upstream Source:

https://github.com/alphaville/optimization-engine.git

## Purpose of using this:

Opengen is the python interface to Optimization Engine, a nonlinear optimization tool. I use it for problems in nonlinear control and state estimation for various robotics projects. 
