### PR TITLE
Add qml6-module-qtqml-workerscript.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8378,6 +8378,16 @@ qml-module-qtquick2:
   nixos: [qt5.qtquickcontrols2]
   rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qtquick2]
+qml6-module-qtqml-workerscript:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtqml-workerscript]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtqml-workerscript]
+    'focal': null
 qml6-module-qtquick:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick]
@@ -8388,16 +8398,6 @@ qml6-module-qtquick:
     '8': null
   ubuntu:
     '*': [qml6-module-qtquick]
-    'focal': null
-qml6-module-qtqml-workerscript:
-  arch: [qt6-declarative]
-  debian: [qml6-module-qtqml-workerscript]
-  fedora: [qt6-qtdeclarative]
-  rhel:
-    '*': [qt6-qtdeclarative]
-    '8': null
-  ubuntu:
-    '*': [qml6-module-qtqml-workerscript]
     'focal': null
 qrencode:
   arch: [qrencode]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8389,6 +8389,16 @@ qml6-module-qtquick:
   ubuntu:
     '*': [qml6-module-qtquick]
     'focal': null
+qml6-module-qtqml-workerscript:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtqml-workerscript]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtqml-workerscript]
+    'focal': null
 qrencode:
   arch: [qrencode]
   debian: [qrencode]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
qml6-module-qtqml-workerscript

## Purpose of using this:

Qt6 version of QtQml.WorkerScript. Need it for the qml_ros_plugin in the Qt6 version.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtqml-workerscript
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtqml-workerscript
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/search/?q=qt6-qtdeclarative (Couldn't verify because I only get "Too many requests" for over a week now)