### PR TITLE
simulation_interfaces: 1.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7970,6 +7970,21 @@ repositories:
       url: https://github.com/oKermorgant/simple_launch.git
       version: devel
     status: maintained
+  simulation_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-simulation/simulation_interfaces.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/simulation_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-simulation/simulation_interfaces.git
+      version: main
+    status: developed
   slg_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## simulation_interfaces

```
Initial release of the simulation_interfaces package - a new Standard ROS 2 interfaces for interacting with simulators.
The standard defines highly useful features such as spawning robots and other objects, moving things around for testing, stepping through simulation and querying the virtual world for ground truth data. It is supportive of automation and scenario-based testing.
* Contributors: Adam Dąbrowski <mailto:adam.dabrowski@robotec.ai>, Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Co-authored-by: Steve Peters <mailto:computersthatmove@gmail.com>
* Co-authored-by: David V. Lu!! <mailto:davidvlu@gmail.com>
* Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Co-authored-by: Tully Foote <mailto:tully.foote@gmail.com>
* Co-authored-by: Sebastian Castro <mailto:4603398+sea-bass@users.noreply.github.com>
* Co-authored-by: Michał Pełka <mailto:michal.pelka@robotec.ai>
* Co-authored-by: Paweł Liberadzki <mailto:pawel.liberadzki@gmail.com>
```
