### PR TITLE
rai_interfaces: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6353,6 +6353,11 @@ repositories:
       version: 0.2.2-4
     status: maintained
   rai_interfaces:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rai_interfaces-release.git
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/RobotecAI/rai_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rai_interfaces` to `0.2.2-1`:

- upstream repository: https://github.com/RobotecAI/rai_interfaces.git
- release repository: https://github.com/ros2-gbp/rai_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rai_interfaces

```
* Add action_msgs dependency for humble compatibility
* Add maintainers to package.xml
* Contributors: Kacper Dąbrowski
```
