### PR TITLE
Remove slic package

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4759,7 +4759,6 @@ repositories:
       - rosping
       - rostwitter
       - sesame_ros
-      - slic
       - switchbot_ros
       - voice_text
       - webrtcvad_ros


### PR DESCRIPTION
I noticed this package had no license when reviewing https://github.com/ros/rosdistro/pull/45685#pullrequestreview-2833872745

It seems like it comes from here https://github.com/PSMM/SLIC-Superpixels . Without a license it's not clear if the buildfarm can redistribute it in binary form. This PR removes the package from the buildfarm.

@k-okada FYI

https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/a3b5eb682efc0f0e0ad6ca43faae4ad5a96867f3/3rdparty/slic/package.xml#L15