### PR TITLE
data_tamer: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1261,7 +1261,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer-release.git
-      version: 0.9.4-3
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer` to `1.0.2-1`:

- upstream repository: https://github.com/PickNikRobotics/data_tamer.git
- release repository: https://github.com/ros2-gbp/data_tamer-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.9.4-3`

## data_tamer_cpp

```
* Merge pull request #52 <https://github.com/PickNikRobotics/data_tamer/issues/52> from PickNikRobotics/fix_build_farm_3
  Try installing test deps no matter what
* try installing test deps no matter what
* Merge pull request #51 <https://github.com/PickNikRobotics/data_tamer/issues/51> from PickNikRobotics/fix_build_farm_2
  ignore build ros argument in test CMake
* ignore build ros argument in test
* Merge pull request #50 <https://github.com/PickNikRobotics/data_tamer/issues/50> from PickNikRobotics/fix_build_farm
  Fix ament GTest usage
* use ament add gtest
* Merge pull request #49 <https://github.com/PickNikRobotics/data_tamer/issues/49> from PickNikRobotics/fix_gtest_link
  Get gtest from vendor on ROS
* add myself to maintainer list, add package xml scheme
* get gtest from vendor on ROS
* Contributors: Henry Moore
```

## data_tamer_msgs

```
* Merge pull request #49 <https://github.com/PickNikRobotics/data_tamer/issues/49> from PickNikRobotics/fix_gtest_link
  Get gtest from vendor on ROS
* add myself to maintainer list, add package xml scheme
* Contributors: Henry Moore
```
