### PR TITLE
rosbag2_broll: 0.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6914,6 +6914,14 @@ repositories:
       type: git
       url: https://github.com/ros-tooling/rosbag2_broll.git
       version: main
+    release:
+      packages:
+      - broll
+      - rosbag2_storage_broll
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag2_broll-release.git
+      version: 0.1.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2_broll` to `0.1.1-1`:

- upstream repository: https://github.com/ros-tooling/rosbag2_broll.git
- release repository: https://github.com/ros2-gbp/rosbag2_broll-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## broll

- No changes

## rosbag2_storage_broll

```
* Support Kilted with CI and minor build fix (#6 <https://github.com/ros-tooling/rosbag2_broll/issues/6>)
* Contributors: Emerson Knapp
```
