### PR TITLE
osrf_pycommon: 2.1.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4769,7 +4769,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_pycommon-release.git
-      version: 2.1.4-3
+      version: 2.1.6-1
     source:
       type: git
       url: https://github.com/osrf/osrf_pycommon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_pycommon` to `2.1.6-1`:

- upstream repository: https://github.com/osrf/osrf_pycommon.git
- release repository: https://github.com/ros2-gbp/osrf_pycommon-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.4-3`

## osrf_pycommon

```
* Merge pull request #103 <https://github.com/osrf/osrf_pycommon/issues/103> from christophebedard/christophebedard/fix-typo-on-each-verb
* Contributors: Christophe Bedard
```
