### PR TITLE
graph_monitor: 0.1.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2265,6 +2265,15 @@ repositories:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git
       version: main
+    release:
+      packages:
+      - rmw_stats_shim
+      - rosgraph_monitor
+      - rosgraph_monitor_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/graph_monitor-release.git
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_monitor` to `0.1.2-1`:

- upstream repository: https://github.com/ros-tooling/graph-monitor.git
- release repository: https://github.com/ros2-gbp/graph_monitor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rmw_stats_shim

- No changes

## rosgraph_monitor

```
* Kilted support (#6 <https://github.com/ros-tooling/graph-monitor/issues/6>)
* Contributors: Emerson Knapp
```

## rosgraph_monitor_msgs

- No changes
