### PR TITLE
jsk_recognition: 1.2.18-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4922,6 +4922,7 @@ repositories:
       packages:
       - audio_to_spectrogram
       - checkerboard_detector
+      - depth_image_publisher
       - imagesift
       - jsk_pcl_ros
       - jsk_pcl_ros_utils
@@ -4934,7 +4935,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.17-2
+      version: 1.2.18-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jsk_recognition` to `1.2.18-1`:

- upstream repository: https://github.com/jsk-ros-pkg/jsk_recognition
- release repository: https://github.com/tork-a/jsk_recognition-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.17-2`

## audio_to_spectrogram

```
* [audio_to_spectrogram] Fix when to use catkin_install_python (#2859 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2859>)
  Conditional branch introduced by https://github.com/jsk-ros-pkg/jsk_recognition/pull/2743 is wrong
* Add missing ros_environment dependency to package.xml (#2837)
  
  Any package that evaluates ROS_VERSION, ROS_DISTRO or ROS_PYTHON_VERSION
  at build time should add ros_environment as a dependency.
* Contributors: Jeremy Kolb, Shingo Kitagawa, Shun Hasegawa, Yoshiki Obinata, Yuki Furuta
```

## checkerboard_detector

- No changes

## depth_image_publisher

```
* Merge branch 'master' into ccache-version
* Merge branch 'master' into invert-mask
* Merge pull request #2762 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2762> from knorth55/depth-image-publisher
  add depth_image_publisher package
* use CV_CAP_PROP_POS_FRAMES for CV_MAJOR_VERSION < 3, boost::placeholders::_1 -> _1 for back compatibility
* depth_image_publisher:CMakeLists.txt: use find_package(OpenCV 2) for indigo
* Revert "support opencv 2.4"
  This reverts commit 51b35843472637c6fb6d73152d6ed2fa9d9b8fd5.
* support opencv 2.4
* add depth_image_publisher package
* Contributors: Kei, Kei Okada, Shingo Kitagawa
* add depth_image_publisher package (#2762 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2762> )
* Contributors: Shingo Kitagawa, Kei Okada
```

## imagesift

```
* Set RULE_LAUNCH_COMPILE/LINK to ccache if CMAKE_VERSION < 3.4 (#2738 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2738>)
* Fix https://github.com/jsk-ros-pkg/jsk_recognition/issues/2860 (#2866 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2866> )
  * [imagesift] add test to load 2 imagesift node to the same nodelet manager
  * [imagesift] define static global mutex to make imagesift thread safe when more than 2 nodelets are loaded to the same nodelet manager
* Add missing ros_environment dependency to package.xml (#2837 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2837>)
* Contributors: Jeremy Kolb, Yoshiki Obinata, Yuki Furuta
```

## jsk_pcl_ros

```
* Set RULE_LAUNCH_COMPILE/LINK to ccache if CMAKE_VERSION < 3.4 (#2738 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2738>)
* support pointxyzi in octree_voxel_grid_nodelet (#2656 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2656>)
* fix uniform sampling nodelet (#2874 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2874>)
* add UniformSampling in nodelet xml (#2873 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2873>)
* [jsk_pcl/OrganizedStatisticalOutlierRemoval] support several pointcloud type (#2846 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2846>)
* [ROS-O] Add ParticleCuboid::weightedAverage method (#2863 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2863> )
* [ros-o] boost::make_shared -> std::make_shared, use .makeShared() (#2853 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2853>)
* Add missing ros_environment dependency to package.xml (#2837 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2837>)
* Add option 'synchronize' to hinted_plane_detector_nodelet (#2844 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2844>)
* use xyz instead of xyzrgb in ClusterPointIndicesDecomposer (#2839 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2839>)
* [jsk_pcl_ros] Fix errors on test_octomap_server_contact_pr2.test (#2821 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2821>)
* add test_octomap_server_contact_pr2.test for xacro or xacro.py, see #2817 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2817>
* Contributors: Jeremy Kolb, Shingo Kitagawa, Shun Hasegawa, Yoshiki Obinata, Yuki Furuta
```

## jsk_pcl_ros_utils

```
* do not publish when array_size is zero (#2878 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2878>)
* Set RULE_LAUNCH_COMPILE/LINK to ccache if CMAKE_VERSION < 3.4 (#2738 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2738>)
* fix build with PCL 1.13 (#2853 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2853>)
* Add missing ros_environment dependency to package.xml (#2837 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2837>)
* Contributors: Jeremy Kolb, Shingo Kitagawa, Yoshiki Obinata, Yuki Furuta, v4hn
```

## jsk_perception

```
* Set RULE_LAUNCH_COMPILE/LINK to ccache if CMAKE_VERSION < 3.4 (#2738 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2738>)
* [jsk_perception/sample/apply_mask] Add clip and negative option for users (#2707 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2707>)
* fix tile image (#2875 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2875>)
* collections.abc.Sequence does not work on python2 (#2872 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2872>)
* use cv2.putText if font is not found (#2868 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2868>)
* add use_mask param in solidity_rag_merge (#2855 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2855>)
* publish compressed tile image (#2857 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2857>)
* Add missing ros_environment dependency to package.xml (#2837 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2837>)
* Contributors: Jeremy Kolb, Shingo Kitagawa, Yoshiki Obinata, Yuki Furuta, Iori Yanokura
```

## jsk_recognition

- No changes

## jsk_recognition_msgs

```
* Fixup 6ac62fef5caba52cbfa71c093b242a1f0b5a1b88 (#2853 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2853>)
  Drop unused catkin_python_setup().
  The call and setup.py are only required when defining python modules,
  but jsk_recognition_msgs does not expose a python package (aside from
  the autogenerated package for the messages).
  This got noticed because Debian's python setuptools complains about
  missing package list in setup.py:
  ---
  error: Multiple top-level packages discovered in a flat-layout: ['srv', 'msg', 'debian', 'action', 'sample'].
  To avoid accidental inclusion of unwanted files or directories,
  setuptools will not proceed with this build.
  If you are trying to create a single distribution with multiple packages
  on purpose, you should not rely on automatic discovery.
  Instead, consider the following options:
  1. set up custom discovery (find directive with include or exclude)
  2. use a src-layout
  3. explicitly set py_modules or packages with a list of names
  To find more information, look for "package discovery" on setuptools docs.
  CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):
  execute_process(/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/catkin_generated/python_distutils_install.sh)
  returned error code
  Call Stack (most recent call first):
  cmake_install.cmake:46 (include)
  ---
* Add ros_environment (#2836 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2836>)
* Contributors: Jeremy Kolb, v4hn
```

## jsk_recognition_utils

```
* Set RULE_LAUNCH_COMPILE/LINK to ccache if CMAKE_VERSION < 3.4 (#2738 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2738>)
* use cv2.putText if font is not found (#2868 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2868>)
* filter None image in jsk_recognition_utils/visualize.py (#2856 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2856>)
* CI: update ROS-O config rules (#2870 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2870>)
* Delete copy constructor of TfListenerSingleton (#2862 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2862>)
* Add missing ros_environment dependency to package.xml (#2837 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2837>)
* [jsk_recognition_utils] add OpenCV to catkin_depends (#2823 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2823>)
* Contributors: Jeremy Kolb, Kei, Shingo Kitagawa, Yoshiki Obinata, Yuki Furuta
```

## resized_image_transport

```
* Set RULE_LAUNCH_COMPILE/LINK to ccache if CMAKE_VERSION < 3.4 (#2738 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2738> )
* Contributors: Yuki Furuta
```

## sound_classification

```
* fix for ROS-O (#2861 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2861>)
* add std_mgs build_depends, to fix obase-build (maybe and others)
  ```
  2025-01-03T00:50:28.1527201Z -- BUILD_SHARED_LIBS is on
  2025-01-03T00:50:28.2543412Z -- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
  2025-01-03T00:50:28.2568008Z -- Could NOT find std_msgs (missing: std_msgs_DIR)
  2025-01-03T00:50:28.2569369Z -- Could not find the required component 'std_msgs'. The following CMake error indicates that you\
  either need to install the package with the same name or change your environment so that it can be found.
  2025-01-03T00:50:28.2584407Z CMake Error at /usr/share/catkin/cmake/catkinConfig.cmake:82 (find_package):
  2025-01-03T00:50:28.2585511Z   Could not find a package configuration file provided by "std_msgs" with any
  2025-01-03T00:50:28.2586306Z   of the following names:
  2025-01-03T00:50:28.2586595Z
  2025-01-03T00:50:28.2586761Z     std_msgsConfig.cmake
  2025-01-03T00:50:28.2587107Z     std_msgs-config.cmake
  2025-01-03T00:50:28.2587292Z
  2025-01-03T00:50:28.2587515Z   Add the installation prefix of "std_msgs" to CMAKE_PREFIX_PATH or set
  2025-01-03T00:50:28.2588032Z   "std_msgs_DIR" to a directory containing one of the above files.  If
  2025-01-03T00:50:28.2588533Z   "std_msgs" provides a separate development package or SDK, be sure it has
  2025-01-03T00:50:28.2588941Z   been installed.
  2025-01-03T00:50:28.2589180Z Call Stack (most recent call first):
  2025-01-03T00:50:28.2589472Z   CMakeLists.txt:4 (find_package)
  2025-01-03T00:50:28.2589660Z
  ```
* [ros-o] sound_classification: use Python3 and requirements.in.obase (#2853 <https://github.com/jsk-ros-pkg/jsk_recognition/issues/2853>)
* Contributors: Kei Okada, Shingo Kitagawa, Yoshiki Obinata, Yuki Furuta
```
