### PR TITLE
mir_robot: 1.1.8-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6076,7 +6076,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/uos-gbp/mir_robot-release.git
-      version: 1.1.7-1
+      version: 1.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mir_robot` to `1.1.8-1`:

- upstream repository: https://github.com/dfki-ric/mir_robot.git
- release repository: https://github.com/uos-gbp/mir_robot-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.7-1`

## mir_actions

```
* package.xml: Use SPDX license declaration
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## mir_description

```
* package.xml: Use SPDX license declaration
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## mir_driver

```
* package.xml: Use SPDX license declaration
* Fix typo in license
* pre-commit: Update hook versions
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## mir_dwb_critics

```
* package.xml: Use SPDX license declaration
* Fix typo in license
* mir_dwb_critics: Fill in description
* Re-format C++ files using clang-format
* mir_dwb_critics: Fix URLs in package.xml
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## mir_gazebo

```
* package.xml: Use SPDX license declaration
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## mir_msgs

```
* package.xml: Use SPDX license declaration
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## mir_navigation

```
* package.xml: Use SPDX license declaration
* Fix typo in license
* Add Regulated Pure Pursuit local planner (experimental)
  requires https://github.com/JohnTGZ/regulated_pure_pursuit_controller
  known bugs:
  - ignores local costmap (will collide with dynamic obstacles)
  - oscillates near goal (https://github.com/JohnTGZ/regulated_pure_pursuit_controller/issues/8)
* Move repo to DFKI-NI
* Fix start_planner documentation
* Contributors: Martin Günther
```

## mir_robot

```
* package.xml: Use SPDX license declaration
* Move repo to DFKI-NI
* Contributors: Martin Günther
```

## sdc21x0

```
* package.xml: Use SPDX license declaration
* Move repo to DFKI-NI
* Contributors: Martin Günther
```
