### PR TITLE
play_motion2: 1.5.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6797,7 +6797,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.5.2-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.1-1`

## play_motion2

```
* Bump cmake_minimum_required to 3.8
* Fix: share client library for using it from other packages
* Fix deprecated generate_parameter_library header
* Revert "Merge branch 'fix/warn/generate_parameter_library' into 'humble-devel'"
  This reverts merge request !72
* Remove launch_pal dependency
* Contributors: Noel Jimenez
```

## play_motion2_msgs

```
* Bump cmake_minimum_required to 3.8
* Contributors: Noel Jimenez
```
