### PR TITLE
pal_gazebo_plugins: 4.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6455,7 +6455,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
-      version: 4.0.5-1
+      version: 4.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gazebo_plugins` to `4.0.6-1`:

- upstream repository: https://github.com/pal-robotics/pal_gazebo_plugins.git
- release repository: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.5-1`

## pal_gazebo_plugins

```
* Fix control_toolbox deprecation warnings
* Contributors: Noel Jimenez
```
