### PR TITLE
pmb2_simulation: 4.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6916,7 +6916,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 4.3.0-1
+      version: 4.7.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.7.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/pal-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-1`

## pmb2_gazebo

```
* add use_sim_time to robot_info
* Contributors: antoniobrandi
```

## pmb2_simulation

- No changes
