### PR TITLE
omni_base_robot: 2.10.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6252,7 +6252,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.9.0-1
+      version: 2.10.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.10.1-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.0-1`

## omni_base_bringup

- No changes

## omni_base_controller_configuration

- No changes

## omni_base_description

```
* Merge branch 'tpe/imu_fix' into 'humble-devel'
  Pass the name to the IMU plugin in case we have several IMUs
  See merge request robots/omni_base_robot!63
* Pass the name to the IMU plugin in case we have several IMUs
* Contributors: thomas.peyrucain, thomaspeyrucain
```

## omni_base_robot

- No changes
