### PR TITLE
omni_base_navigation: 2.15.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6232,7 +6232,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_navigation-release.git
-      version: 2.12.1-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_navigation` to `2.15.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_navigation.git
- release repository: https://github.com/pal-gbp/omni_base_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.12.1-1`

## omni_base_2dnav

- No changes

## omni_base_laser_sensors

```
* fix laser sim
* Contributors: antoniobrandi
```

## omni_base_navigation

- No changes

## omni_base_rgbd_sensors

- No changes
