### PR TITLE
add nanoeigenpy on rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4330,6 +4330,12 @@ repositories:
       url: https://github.com/MRPT/mvsim.git
       version: develop
     status: developed
+  nanoeigenpy:
+    source:
+      type: git
+      url: https://github.com/Simple-Robotics/nanoeigenpy.git
+      version: main
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

nanoeigenpy

This is the successor of eigenpy, rewritten from Boost::Python to nanobind

# The source is here:

https://github.com/Simple-Robotics/nanoeigenpy

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x]This package is expected to build on the submitted rosdistro
