### PR TITLE
movie_publisher: 3.0.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6442,6 +6442,7 @@ repositories:
       - camera_info_manager_metadata_extractor
       - exiftool_metadata_extractor
       - exiv2_metadata_extractor
+      - gpmf_metadata_extractor
       - lensfun_metadata_extractor
       - libexif_metadata_extractor
       - movie_publisher
@@ -6452,7 +6453,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 2.0.3-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/movie_publisher.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6453,7 +6453,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `3.0.2-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## camera_info_manager_lib

- No changes

## camera_info_manager_metadata_extractor

- No changes

## exiftool_metadata_extractor

- No changes

## exiv2_metadata_extractor

- No changes

## gpmf_metadata_extractor

```
* Added GPMF reader (for GoPro cameras).
* Contributors: Martin Pecka
```

## lensfun_metadata_extractor

- No changes

## libexif_metadata_extractor

- No changes

## movie_publisher

- Added ROS parameters allowed_extractors and excluded_extractors.
- Finished the refactor for timed metadata support.
- Big refactoring towards better handling of timed metadata.
- Added more metadata: angular velocity, magnetic field and detected faces.

## movie_publisher_plugins

- No changes

## movie_publisher_plugins_copyleft

- No changes

## movie_publisher_plugins_nonfree

- No changes

## movie_publisher_plugins_permissive

- No changes
