### PR TITLE
Point to kilted branch for tracetools_analysis @ Kilted

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8540,7 +8540,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tracing/tracetools_analysis.git
-      version: rolling
+      version: kilted
     release:
       packages:
       - ros2trace_analysis
@@ -8553,7 +8553,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-tracing/tracetools_analysis.git
-      version: rolling
+      version: kilted
     status: developed
   transport_drivers:
     doc:


### PR DESCRIPTION
See https://github.com/ros2/kilted_tutorial_party/issues/383#issuecomment-2877061117

I created a new `kilted` branch, so I'm changing this to point to it. I also updated the release repo: https://github.com/ros2-gbp/tracetools_analysis-release/blob/04f0dc78fd34b7189a1f1429b2668dac5de37ecb/tracks.yaml#L193.