### PR TITLE
behaviortree_cpp_v4: 4.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -852,7 +852,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.7.0-1
+      version: 4.7.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.7.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.7.0-1`

## behaviortree_cpp

```
* fix ROS CI
* Add action to publish Doxygen documentation as GH Page (#972 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/972>)
* Update Doxyfile
* Make BT::Any::copyInto const (#970 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/970>)
* more changes related to TestNode
* Contributors: David Sobek, Davide Faconti, Marcus Ebner von Eschenbach
```
