### PR TITLE
Fedora 40 is EOL, long live Fedora 42

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -66,8 +66,8 @@ supported_versions:
   debian:
   - bookworm
   fedora:
-  - '40'
   - '41'
+  - '42'
   opensuse:
   - '15.2'
   openembedded:
@@ -100,9 +100,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '40':
-      '%{__isa_name}': 'x86'
     '41':
+      '%{__isa_name}': 'x86'
+    '42':
       '%{__isa_name}': 'x86'
   openembedded:
     master:


### PR DESCRIPTION
https://docs.fedoraproject.org/en-US/releases/eol/