### PR TITLE
rmf_ros2: 2.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6111,7 +6111,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.10.0-1
+      version: 2.10.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.10.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.0-1`

## rmf_charging_schedule

```
* Remove icecream as a dependency entirely (#432 <https://github.com/open-rmf/rmf_ros2/issues/432>)
```

## rmf_fleet_adapter

```
* Add dependency on rclcpp_action (#431 <https://github.com/open-rmf/rmf_ros2/issues/431>)
```

## rmf_fleet_adapter_python

- No changes

## rmf_reservation_node

- No changes

## rmf_task_ros2

- No changes

## rmf_traffic_ros2

- No changes

## rmf_websocket

- No changes
