### PR TITLE
navigation_msgs: 1.14.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6896,7 +6896,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation_msgs-release.git
-      version: 1.14.1-1
+      version: 1.14.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation_msgs` to `1.14.2-1`:

- upstream repository: https://github.com/ros-planning/navigation_msgs.git
- release repository: https://github.com/ros-gbp/navigation_msgs-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.14.1-1`
