### PR TITLE
urdf_tutorial: 0.5.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12775,7 +12775,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/urdf_tutorial-release.git
-      version: 0.5.0-1
+      version: 0.5.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_tutorial` to `0.5.0-2`:

- upstream repository: https://github.com/ros/urdf_tutorial.git
- release repository: https://github.com/ros-gbp/urdf_tutorial-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-1`
