### PR TITLE
system_fingerprint: 0.6.2-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12081,7 +12081,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/MetroRobots/ros_system_fingerprint-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_fingerprint` to `0.6.2-1`:

- upstream repository: https://github.com/MetroRobots/ros_system_fingerprint.git
- release repository: https://github.com/MetroRobots/ros_system_fingerprint-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.1-1`
