### PR TITLE
autoware_lanelet2_extension: 0.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -681,7 +681,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.7.2-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.1-1`

## autoware_lanelet2_extension

```
* fix(autoware_lanelet2_extension): point on the edge of a triangle was  not treated as inside the triangle (#66 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/66>)
  fix(autoware_lanelet2_extension): point on the edge of a triangle was not treated as inside the triangle
  Co-authored-by: Marek Piechula <mailto:mpiechula@autonomous-systems.pl>
* Contributors: Marek Piechula
```

## autoware_lanelet2_extension_python

- No changes
