### PR TITLE
locator_ros_bridge: 1.0.14-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5553,7 +5553,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/locator_ros_bridge-release.git
-      version: 1.0.13-1
+      version: 1.0.14-2
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `1.0.14-2`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros-gbp/locator_ros_bridge-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.13-1`

## bosch_locator_bridge

```
* announced EOL noetic branch
* update to 1.11 #70 <https://github.com/boschglobal/locator_ros_bridge/issues/70> from boschglobal/noetic-v1.11
* Contributors: Sheung Ying Yuen-Wille
```
