### PR TITLE
locator_ros_bridge: 2.1.14-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4686,7 +4686,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.13-1
+      version: 2.1.14-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.14-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.13-1`

## bosch_locator_bridge

```
* Fix code formatting
* Update to ROKIT Locator version 1.11 #69 <https://github.com/boschglobal/locator_ros_bridge/issues/69> from boschglobal/humble-v1.11
* Contributors: Sheung Ying Yuen-Wille, Stefan Laible
```

## bosch_locator_bridge_utils

```
* Add bosch_locator_bridge_utils backward compatibility for galactic (#68 <https://github.com/boschglobal/locator_ros_bridge/issues/68>)
* Add hint that humble branch might also work for galactic
* Contributors: Fabian König
```
