### PR TITLE
rviz: 11.2.17-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9830,7 +9830,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.16-1
+      version: 11.2.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.17-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `11.2.16-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* addTrackedObject Function Fails to Handle Null Pointer, Causing Crash When nullptr is Passed (#1375 <https://github.com/ros2/rviz/issues/1375>) (#1379 <https://github.com/ros2/rviz/issues/1379>)
* Fix Potential Null Pointer Dereference in VisualizerApp::getRenderWindow() to Prevent Crashes (#1359 <https://github.com/ros2/rviz/issues/1359>) (#1366 <https://github.com/ros2/rviz/issues/1366>)
* UniformStringStream::parseFloat Fails to Handle Invalid Float Formats Correctly (#1360 <https://github.com/ros2/rviz/issues/1360>) (#1368 <https://github.com/ros2/rviz/issues/1368>)
* Add test to check mapGetString when key is missing (#1361 <https://github.com/ros2/rviz/issues/1361>) (#1370 <https://github.com/ros2/rviz/issues/1370>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Backported FrameAligned camera (backport #1453 <https://github.com/ros2/rviz/issues/1453>) (#1460 <https://github.com/ros2/rviz/issues/1460>)
* PointCloudDisplay: Fix decay time 0 keeping more than the last message. (#1400 <https://github.com/ros2/rviz/issues/1400>) (#1433 <https://github.com/ros2/rviz/issues/1433>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

```
* Use official freetype github mirror instead of savannah mirror (backport #1348 <https://github.com/ros2/rviz/issues/1348>) (#1431 <https://github.com/ros2/rviz/issues/1431>)
* Add missing glew dependency for ogre vendor package. (backport #1350 <https://github.com/ros2/rviz/issues/1350>) (#1352 <https://github.com/ros2/rviz/issues/1352>)
* Contributors: mergify[bot]
```

## rviz_rendering

```
* BillboardLine::addPoint() does not throw an exception when exceeding max_points_per_line limit (backport #1436 <https://github.com/ros2/rviz/issues/1436>) (#1441 <https://github.com/ros2/rviz/issues/1441>)
* Constructor ScrewVisual::ScrewVisual does not handle null pointers, leading to crashes (#1435 <https://github.com/ros2/rviz/issues/1435>) (#1440 <https://github.com/ros2/rviz/issues/1440>)
* Removed Windows warnings (#1413 <https://github.com/ros2/rviz/issues/1413>) (#1415 <https://github.com/ros2/rviz/issues/1415>)
* MovableText constructor does not validate invalid character height, default fallback missing (#1398 <https://github.com/ros2/rviz/issues/1398>) (#1425 <https://github.com/ros2/rviz/issues/1425>)
* Memory Access Error When Handling Empty Strings in splitStringIntoTrimmedItems Function (backport #1412 <https://github.com/ros2/rviz/issues/1412>) (#1429 <https://github.com/ros2/rviz/issues/1429>)
* Invalid Parameter Handling in CovarianceVisual::CovarianceVisual Constructor (backport #1396 <https://github.com/ros2/rviz/issues/1396>) (#1417 <https://github.com/ros2/rviz/issues/1417>)
* Crash due to Unhandled Null Pointer in ParameterEventsFilter Constructor (backport #1411 <https://github.com/ros2/rviz/issues/1411>) (#1427 <https://github.com/ros2/rviz/issues/1427>)
* Grid Class Constructor Does Not Handle Null Pointer, Leading to Program Crash (backport #1394 <https://github.com/ros2/rviz/issues/1394>) (#1423 <https://github.com/ros2/rviz/issues/1423>)
* Lack of Validity Check for Invalid Parameters in EffortVisual::Effort Visual Constructor (backport #1395 <https://github.com/ros2/rviz/issues/1395>) (#1419 <https://github.com/ros2/rviz/issues/1419>)
* Crash in MovableText::update() when caption is an empty string due to uninitialized resource usage (#1393 <https://github.com/ros2/rviz/issues/1393>) (#1421 <https://github.com/ros2/rviz/issues/1421>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
