### PR TITLE
filters: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1894,7 +1894,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.2.1-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## filters

```
* Ignore unused parameter in FilterBase::reconfigureCB()
* Contributors: Christophe Bedard
```
