### PR TITLE
geometry2: 0.25.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3201,7 +3201,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.12-1
+      version: 0.25.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.25.13-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.25.12-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Overflow Issue in durationFromSec() Function when Handling Extremely Large or Small Values (#785 <https://github.com/ros2/geometry2/issues/785>) (#787 <https://github.com/ros2/geometry2/issues/787>)
* Backport: Do not clobber callback handles when cancelling pending transformable requests (#781 <https://github.com/ros2/geometry2/issues/781>)
* Contributors: Timo Röhling, mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Backport: "Port point cloud transformation to numpy" (#507 <https://github.com/ros2/geometry2/issues/507>, #520 <https://github.com/ros2/geometry2/issues/520>) (#778 <https://github.com/ros2/geometry2/issues/778>)
* Contributors: Gilbert Tanner
```

## tf2_tools

- No changes
