### PR TITLE
Switch source and doc branches to kilted for open-rmf repos

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5966,7 +5966,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
-      version: kilted
+      version: rolling
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -5975,7 +5975,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
-      version: kilted
+      version: rolling
     status: developed
   rmf_demos:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -173,7 +173,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -182,7 +182,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git
-      version: main
+      version: kilted
     status: developed
   ament_cmake_ros:
     doc:
@@ -3705,7 +3705,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: master
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -3714,7 +3714,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git
-      version: master
+      version: kilted
     status: developed
   message_filters:
     doc:
@@ -4384,7 +4384,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -4393,7 +4393,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git
-      version: main
+      version: kilted
     status: developed
   nmea_hardware_interface:
     doc:
@@ -5340,7 +5340,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -5349,7 +5349,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
-      version: main
+      version: kilted
     status: developed
   pybind11_vendor:
     doc:
@@ -5921,7 +5921,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -5930,13 +5930,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git
-      version: main
+      version: kilted
     status: developed
   rmf_battery:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -5945,13 +5945,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git
-      version: main
+      version: kilted
     status: developed
   rmf_building_map_msgs:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -5960,13 +5960,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git
-      version: main
+      version: kilted
     status: developed
   rmf_cmake_uncrustify:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -5975,13 +5975,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_cmake_uncrustify.git
-      version: rolling
+      version: kilted
     status: developed
   rmf_demos:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_demos
@@ -5998,13 +5998,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
-      version: main
+      version: kilted
     status: developed
   rmf_internal_msgs:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_charger_msgs
@@ -6027,13 +6027,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git
-      version: main
+      version: kilted
     status: developed
   rmf_ros2:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_charging_schedule
@@ -6050,13 +6050,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git
-      version: main
+      version: kilted
     status: developed
   rmf_simulation:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_building_sim_gz_plugins
@@ -6069,13 +6069,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git
-      version: main
+      version: kilted
     status: developed
   rmf_task:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_task
@@ -6087,13 +6087,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git
-      version: main
+      version: kilted
     status: developed
   rmf_traffic:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_traffic
@@ -6105,13 +6105,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git
-      version: main
+      version: kilted
     status: developed
   rmf_traffic_editor:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_building_map_tools
@@ -6125,13 +6125,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git
-      version: main
+      version: kilted
     status: developed
   rmf_utils:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -6140,13 +6140,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git
-      version: main
+      version: kilted
     status: developed
   rmf_variants:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_variants.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_dev
@@ -6157,13 +6157,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_variants.git
-      version: main
+      version: kilted
     status: developed
   rmf_visualization:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
-      version: main
+      version: kilted
     release:
       packages:
       - rmf_visualization
@@ -6181,13 +6181,13 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git
-      version: main
+      version: kilted
     status: developed
   rmf_visualization_msgs:
     doc:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -6196,7 +6196,7 @@ repositories:
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git
-      version: main
+      version: kilted
     status: developed
   rmw:
     doc:


### PR DESCRIPTION
Sources branches for `kilted` now exist in open-rmf repos.