### PR TITLE
grpc: 0.0.17-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -3924,10 +3924,13 @@ repositories:
       url: https://github.com/CogRob/catkin_grpc.git
       version: master
     release:
+      packages:
+      - grpc
+      - test_grpc
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/CogRobRelease/catkin_grpc-release.git
-      version: 0.0.16-2
+      version: 0.0.17-1
     source:
       type: git
       url: https://github.com/CogRob/catkin_grpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grpc` to `0.0.17-1`:

- upstream repository: https://github.com/CogRob/catkin_grpc.git
- release repository: https://github.com/CogRobRelease/catkin_grpc-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.16-2`

## grpc

```
* Allow users settings CXX standard (#63 <https://github.com/CogRob/catkin_grpc/issues/63>)
* Exclude unsecure library from exported libraries (#62 <https://github.com/CogRob/catkin_grpc/issues/62>)
* Reduce cmake warning (#60 <https://github.com/CogRob/catkin_grpc/issues/60>)
  * Remove -DBUILD_TESTING=OFF because it generates a warning message
  in cmake.
* Use submodule instead of ExternalProject_Add (#56 <https://github.com/CogRob/catkin_grpc/issues/56>)
  * Use submodule instead of ExternalProject_Add
* Mitigate access denial issue from github.com (#55 <https://github.com/CogRob/catkin_grpc/issues/55>)
  * Decrease the number of jobs to run git fetch to
  clone submodules in parallel.
* Contributors: Ryohei Ueda, Yuki Furuta
```

## test_grpc

```
* Allow users settings CXX standard (#63 <https://github.com/CogRob/catkin_grpc/issues/63>)
* Exclude unsecure library from exported libraries (#62 <https://github.com/CogRob/catkin_grpc/issues/62>)
* Fix bug in realpath (#61 <https://github.com/CogRob/catkin_grpc/issues/61>)
* Depend on roscpp (#59 <https://github.com/CogRob/catkin_grpc/issues/59>)
* Set the right version for test_grpc
* Add CHANGELOG.rst for test_grpc
* Add package to test grpc (#57 <https://github.com/CogRob/catkin_grpc/issues/57>)
  * Add package to test grpc
  * Enable Github Actions
  * support realpath on cmake <3.19
* Contributors: Ryohei Ueda, Yuki Furuta
* Add package to test grpc (#57 <https://github.com/CogRob/catkin_grpc/issues/57>)
  * Add package to test grpc
  * Enable Github Actions
  * support realpath on cmake <3.19
* Contributors: Yuki Furuta
```
