### PR TITLE
perception_pcl: 2.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4963,7 +4963,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.6.3-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.7.0-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.3-1`

## pcl_conversions

```
* Modern CMake (#489 <https://github.com/ros-perception/perception_pcl/issues/489>)
* Contributors: Patrick Roncagliolo
```

## pcl_ros

```
* Fix downstream CMake error: rosbag2_transport not found (#494 <https://github.com/ros-perception/perception_pcl/issues/494>)
* Port bag_to_pcd to ROS 2 (#486 <https://github.com/ros-perception/perception_pcl/issues/486>)
* Add CombinedPointCloudToPCD Node for Accumulating Multiple Point Clouds into a Single PCD (#479 <https://github.com/ros-perception/perception_pcl/issues/479>)
* Fix deprecation of .h files in message_filters (#493 <https://github.com/ros-perception/perception_pcl/issues/493>)
* Improve pointcloud_to_pcd by keeping all field available in sensor_msgs (#491 <https://github.com/ros-perception/perception_pcl/issues/491>)
* Added crop box marker publisher (#488 <https://github.com/ros-perception/perception_pcl/issues/488>)
* Properly order the header includes for cpplint (#490 <https://github.com/ros-perception/perception_pcl/issues/490>)
* Contributors: Adraub, Alireza Moayyedi, Ramon Wijnands, Tim Clephas, Valerio Passamano, vladimirjendrol
```

## perception_pcl

- No changes
