### PR TITLE
ur_description: 4.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8879,7 +8879,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.1.1-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `4.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.1-1`

## ur_description

```
* Add support for UR15 (#290 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/290>)
* Add documentation about the different base and base_link frames (#286 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/286>)
* [BREAKING] changes for Kilted (#280 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/280>)
* Branch jazzy (#284 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/284>)
* Contributors: Felix Exner
```
