### PR TITLE
robot_navigation: 0.3.1-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9470,10 +9470,11 @@ repositories:
       - robot_nav_tools
       - robot_nav_viz_demos
       - robot_navigation
+      - rqt_dwb_plugin
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DLu/robot_navigation-release.git
-      version: 0.3.0-2
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_navigation` to `0.3.1-1`:

- upstream repository: https://github.com/locusrobotics/robot_navigation.git
- release repository: https://github.com/DLu/robot_navigation-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-2`
