### PR TITLE
perception_pcl: 2.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4963,7 +4963,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.7.1-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.0-1`

## pcl_conversions

```
* Bump minimum cmake version to 3.20 (#496 <https://github.com/ros-perception/perception_pcl/issues/496>)
* Contributors: Ramon Wijnands
```

## pcl_ros

```
* Fix warning: 'subscribe<>' is deprecated: use rclcpp::QoS (#497 <https://github.com/ros-perception/perception_pcl/issues/497>)
* Bump minimum cmake version to 3.20 (#496 <https://github.com/ros-perception/perception_pcl/issues/496>)
* Contributors: Ramon Wijnands
```

## perception_pcl

```
* Bump minimum cmake version to 3.20 (#496 <https://github.com/ros-perception/perception_pcl/issues/496>)
* Contributors: Ramon Wijnands
```
