### PR TITLE
simulation_interfaces: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10180,7 +10180,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.0.1-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## simulation_interfaces

```
* Add missing action_msgs dependency to package.xml #10 <https://github.com/ros-simulation/simulation_interfaces/issues/10>
* Added error code to SetEntityState.srv (#8 <https://github.com/ros-simulation/simulation_interfaces/issues/8>)
* Contributors: Adam Dąbrowski, Mateusz Żak, Michał Pełka
```
