### PR TITLE
ompl: 1.7.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4706,7 +4706,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.7.0-1
+      version: 1.7.0-2
     source:
       type: git
       url: https://github.com/ompl/ompl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `1.7.0-2`:

- upstream repository: https://github.com/ompl/ompl.git
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.0-1`
