### PR TITLE
Revert "jsk_3rdparty: 2.1.31-3 in 'noetic/distribution.yaml' [bloom] …

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4738,7 +4738,6 @@ repositories:
       - collada_urdf_jsk_patch
       - dialogflow_task_executive
       - downward
-      - emotion_analyzer
       - ff
       - ffha
       - gdrive_ros
@@ -4764,14 +4763,14 @@ repositories:
       - rostwitter
       - sesame_ros
       - switchbot_ros
-      - voicevox
+      - voice_text
       - webrtcvad_ros
       - zdepth
       - zdepth_image_transport
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_3rdparty-release.git
-      version: 2.1.31-3
+      version: 2.1.28-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git


### PR DESCRIPTION
…(#45761)"

This reverts commit 74f44d9a1dda86c52411092f01e15b80f340f8cc.

This appears to have caused a regression in jsk_3rdparty on amd64 https://repositories.ros.org/status_page/ros_noetic_default.html?q=REGRESSION

The root cause is voicevox fails to build https://build.ros.org/job/Nbin_uF64__voicevox__ubuntu_focal_amd64__binary/

This would remove `emotion_analyzer`, which would be unfortunate. @k-okada Think you can fix the voicevox regression?