### PR TITLE
diagnostics: 4.4.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1337,7 +1337,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.4.4-1
+      version: 4.4.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.4.4-2`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.4.4-1`

## diagnostic_aggregator

```
* Kilted dep fix (#474 <https://github.com/ros/diagnostics/issues/474>)
* Contributors: David V. Lu, Christian Henkel
```

## diagnostic_common_diagnostics

- No changes

## diagnostic_remote_logging

```
* Kilted dep fix (#474 <https://github.com/ros/diagnostics/issues/474>)
* Contributors: David V. Lu, Christian Henkel
```

## diagnostic_updater

```
* Kilted dep fix (#474 <https://github.com/ros/diagnostics/issues/474>)
* Contributors: David V. Lu, Christian Henkel
```

## diagnostics

- No changes

## self_test

```
* Kilted dep fix (#474 <https://github.com/ros/diagnostics/issues/474>)
* Contributors: David V. Lu, Christian Henkel
```
