### PR TITLE
add google-cloud-firestore to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1791,7 +1791,7 @@ python-google-cloud-bigquery-pip:
   ubuntu:
     pip:
       packages: [google-cloud-bigquery]
-python-google-cloud-firestore-pip:
+python3-google-cloud-firestore-pip:
   debian:
     pip:
       packages: [google-cloud-firestore]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1791,13 +1791,6 @@ python-google-cloud-bigquery-pip:
   ubuntu:
     pip:
       packages: [google-cloud-bigquery]
-python3-google-cloud-firestore-pip:
-  debian:
-    pip:
-      packages: [google-cloud-firestore]
-  ubuntu:
-    pip:
-      packages: [google-cloud-firestore]
 python-google-cloud-speech-pip:
   debian:
     pip:
@@ -6525,6 +6518,13 @@ python3-google-auth-oauthlib:
     '*': [python3-google-auth-oauthlib]
     bionic: null
     focal: null
+python3-google-cloud-firestore-pip:
+  debian:
+    pip:
+      packages: [google-cloud-firestore]
+  ubuntu:
+    pip:
+      packages: [google-cloud-firestore]
 python3-google-cloud-pubsub-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1791,6 +1791,13 @@ python-google-cloud-bigquery-pip:
   ubuntu:
     pip:
       packages: [google-cloud-bigquery]
+python-google-cloud-firestore-pip:
+  debian:
+    pip:
+      packages: [google-cloud-firestore]
+  ubuntu:
+    pip:
+      packages: [google-cloud-firestore]
 python-google-cloud-speech-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

google-cloud-firestore

## Package Upstream Source:

https://github.com/googleapis/python-firestore

## Purpose of using this:

To be able to access Firestore databases from python-based ROS packages.
