### PR TITLE
ros2_controllers: 4.25.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7494,7 +7494,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.24.0-1
+      version: 4.25.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7462,7 +7462,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: jazzy
     release:
       packages:
       - ackermann_steering_controller
@@ -7498,7 +7498,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: jazzy
     status: developed
   ros2_kortex:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.25.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.24.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Simplify on_set_chained_mode avoiding cpplint warnings (backport #1564 <https://github.com/ros-controls/ros2_controllers/issues/1564>) (#1688 <https://github.com/ros-controls/ros2_controllers/issues/1688>)
* Deprecating tf2 C Headers (#1325 <https://github.com/ros-controls/ros2_controllers/issues/1325>)
* Contributors: Lucas Wendland, mergify[bot], Bhagyesh Agresar
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Add multiplier support to ForceTorqueSensorBroadcaster (backport #1647 <https://github.com/ros-controls/ros2_controllers/issues/1647>) (#1686 <https://github.com/ros-controls/ros2_controllers/issues/1686>)
* Contributors: mergify[bot], edward.ix
```

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

- No changes

## mecanum_drive_controller

```
* Simplify on_set_chained_mode avoiding cpplint warnings (backport #1564 <https://github.com/ros-controls/ros2_controllers/issues/1564>) (#1688 <https://github.com/ros-controls/ros2_controllers/issues/1688>)
* Deprecating tf2 C Headers (#1325 <https://github.com/ros-controls/ros2_controllers/issues/1325>)
* Contributors: Lucas Wendland, mergify[bot], Bhagyesh Agresar
```

## parallel_gripper_controller

- No changes

## pid_controller

```
* [Pid] Add enable_feedforward parameter (backport #1553 <https://github.com/ros-controls/ros2_controllers/issues/1553>) (#1689 <https://github.com/ros-controls/ros2_controllers/issues/1689>)
* Simplify on_set_chained_mode avoiding cpplint warnings (backport #1564 <https://github.com/ros-controls/ros2_controllers/issues/1564>) (#1688 <https://github.com/ros-controls/ros2_controllers/issues/1688>)
* Contributors: mergify[bot], Pascal Auf der Maur, hagyesh Agresar
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Use warning  attribute of RcutilsLogger (backport #1690 <https://github.com/ros-controls/ros2_controllers/issues/1690>) (#1691 <https://github.com/ros-controls/ros2_controllers/issues/1691>)
* Contributors: mergify[bot], Sai Kishor Kothakota
```

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Simplify on_set_chained_mode avoiding cpplint warnings (backport #1564 <https://github.com/ros-controls/ros2_controllers/issues/1564>) (#1688 <https://github.com/ros-controls/ros2_controllers/issues/1688>)
* Contributors: mergify[bot], Bhagyesh Agresar
```

## tricycle_controller

```
* Deprecating tf2 C Headers (#1325 <https://github.com/ros-controls/ros2_controllers/issues/1325>)
* Contributors: Lucas Wendland
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
