### PR TITLE
ardrone_ros: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -460,7 +460,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ardrone_ros-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/vtalpaert/ardrone-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_ros` to `1.1.0-1`:

- upstream repository: https://github.com/vtalpaert/ardrone-ros2.git
- release repository: https://github.com/ros2-gbp/ardrone_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## ardrone_sdk

```
* Compile ardrone_sdk without using the intermediate step of arsdk3 package
```

## ardrone_sumo

```
* [kilted] Update deprecated call to ament_target_dependencies (#1 <https://github.com/vtalpaert/ardrone-ros2/issues/1>)
* remove BUILD_TESTING CMake condition, since there are no tests
* Contributors: David V. Lu!!, Victor Talpaert
```
