### PR TITLE
turtlebot3_applications_msgs: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8718,6 +8718,11 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_applications_msgs-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications_msgs` to `1.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications_msgs.git
- release repository: https://github.com/ros2-gbp/turtlebot3_applications_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot3_applications_msgs

```
* Added Git action CI and lint
* Contributors: Hyungyu Kim
```
