### PR TITLE
robot_localization: 3.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6447,7 +6447,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.9.2-2
+      version: 3.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.9.3-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.9.2-2`

## robot_localization

```
* Fixing deprecated tf2 headers (#926 <https://github.com/cra-ros-pkg/robot_localization/issues/926>)
* Contributors: Tom Moore
```
