### PR TITLE
phidgets_drivers: 2.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6720,11 +6720,12 @@ repositories:
       - phidgets_motors
       - phidgets_msgs
       - phidgets_spatial
+      - phidgets_stepper
       - phidgets_temperature
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.3-1
+      version: 2.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.3.4-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.3-1`

## libphidget22

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_accelerometer

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_analog_inputs

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_analog_outputs

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_api

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Add stepper motor package for ROS2 (STC1005) (#186 <https://github.com/ros-drivers/phidgets_drivers/issues/186>)
* Contributors: Cedric Pradalier, Martin Günther
```

## phidgets_digital_inputs

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_digital_outputs

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_drivers

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_gyroscope

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_high_speed_encoder

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Add zeroing service to high_speed_encoders (#188 <https://github.com/ros-drivers/phidgets_drivers/issues/188>)
* Contributors: Cedric Pradalier, Martin Günther
```

## phidgets_ik

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_magnetometer

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_motors

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_msgs

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Add zeroing service to high_speed_encoders (#188 <https://github.com/ros-drivers/phidgets_drivers/issues/188>)
* Add stepper motor package for ROS2 (STC1005) (#186 <https://github.com/ros-drivers/phidgets_drivers/issues/186>)
* Contributors: Cedric Pradalier, Martin Günther
```

## phidgets_spatial

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```

## phidgets_stepper

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Add stepper motor package for ROS2 (STC1005) (#186 <https://github.com/ros-drivers/phidgets_drivers/issues/186>)
* Contributors: Cedric Pradalier, Martin Günther
```

## phidgets_temperature

```
* Upgrade to CMake 3.8, add file depend (#189 <https://github.com/ros-drivers/phidgets_drivers/issues/189>)
* Contributors: Martin Günther
```
