### PR TITLE
common_interfaces: 5.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1124,7 +1124,6 @@ repositories:
       version: rolling
     release:
       packages:
-      - actionlib_msgs
       - common_interfaces
       - diagnostic_msgs
       - geometry_msgs
@@ -1140,7 +1139,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.5.0-1
+      version: 5.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.7.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.5.0-1`

## common_interfaces

```
* Removed deprecated actionlib_msgs (#280 <https://github.com/ros2/common_interfaces/issues/280>)
* Contributors: Alejandro Hernández Cordero
```

## diagnostic_msgs

- No changes

## geometry_msgs

- No changes

## nav_msgs

- No changes

## sensor_msgs

- No changes

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
