### PR TITLE
image_pipeline: 6.0.11-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2845,7 +2845,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.10-2
+      version: 6.0.11-1
     source:
       test_pull_requests: true
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2830,7 +2830,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: rolling
+      version: kilted
     release:
       packages:
       - camera_calibration
@@ -2850,7 +2850,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
-      version: rolling
+      version: kilted
     status: maintained
   image_transport_plugins:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.11-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.10-2`

## camera_calibration

```
* Replace OpenCV version string comparison with semver. (#1087 <https://github.com/ros-perception/image_pipeline/issues/1087>)
  When using the ChArUco markers with cameracalibrator, I found out that
  there's an issue with the last versions of OpenCV due to the fact that
  versions are compared as strings and the thing goes wrong for versions
  4.10 and above.
* Contributors: Filip Grčar
```

## depth_image_proc

```
* Fixed compilation error (#1096 <https://github.com/ros-perception/image_pipeline/issues/1096>)
  Related with this issue
  https://github.com/ros-perception/image_pipeline/issues/1095
* Contributors: Alejandro Hernández Cordero
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

```
* fix colour channel order for "rgb8" in image_view (#1093 <https://github.com/ros-perception/image_pipeline/issues/1093>)
  Previously, a rgb8 encoding was just visualised in RGB colour channel
  order via OpenCV, which expects colour channel order BGR. Fix this by
  converting from RGB to BGR.
* Contributors: Christian Rauch
```

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
