### PR TITLE
image_pipeline: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2899,7 +2899,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.10-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `7.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.10-1`

## camera_calibration

```
* Replace OpenCV version string comparison with semver. (#1087 <https://github.com/ros-perception/image_pipeline/issues/1087>)
* Contributors: Filip Grčar
```

## depth_image_proc

```
* Fixed compilation error (#1096 <https://github.com/ros-perception/image_pipeline/issues/1096>)
  Related with this issue
  https://github.com/ros-perception/image_pipeline/issues/1095
* Contributors: Alejandro Hernández Cordero
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

```
* fix colour channel order for "rgb8" in image_view (#1093 <https://github.com/ros-perception/image_pipeline/issues/1093>)
  Previously, a rgb8 encoding was just visualised in RGB colour channel
  order via OpenCV, which expects colour channel order BGR. Fix this by
  converting from RGB to BGR.
* Contributors: Christian Rauch
```

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
