### PR TITLE
ros_comm: 1.17.4-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9738,7 +9738,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.17.3-1
+      version: 1.17.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_comm` to `1.17.4-1`:

- upstream repository: git@github.com:ros/ros_comm.git
- release repository: https://github.com/ros-gbp/ros_comm-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.17.3-1`

## message_filters

- No changes

## ros_comm

- No changes

## rosbag

- No changes

## rosbag_storage

- No changes

## roscpp

- No changes

## rosgraph

- No changes

## roslaunch

- No changes

## roslz4

- No changes

## rosmaster

- No changes

## rosmsg

- No changes

## rosnode

- No changes

## rosout

- No changes

## rosparam

- No changes

## rospy

- No changes

## rosservice

- No changes

## rostest

- No changes

## rostopic

- No changes

## roswtf

- No changes

## topic_tools

- No changes

## xmlrpcpp

```
* Revert "Maintain constness of accessed XmlRpcValue struct (#2315 <https://github.com/ros/ros_comm/issues/2315>)" (#2391 <https://github.com/ros/ros_comm/issues/2391>)
* Contributors: Shane Loretz
```
