### PR TITLE
rosbridge_suite: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7034,7 +7034,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.3.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## rosapi

```
* Handle extra IDL slots when doing array introspection (#1031 <https://github.com/RobotWebTools/rosbridge_suite/issues/1031>)
* Add services to return Action interface details (#1021 <https://github.com/RobotWebTools/rosbridge_suite/issues/1021>)
* Fix array-like parameter serialization in rosbridge get_param (#1018 <https://github.com/RobotWebTools/rosbridge_suite/issues/1018>)
* Contributors: David Fernàndez López, Noah Wardlow, Scott Bell, Błażej Sowa
```

## rosapi_msgs

```
* Add services to return Action interface details (#1021 <https://github.com/RobotWebTools/rosbridge_suite/issues/1021>)
* Contributors: David Fernàndez López
```

## rosbridge_library

```
* Don't subscribe with Transient local QoS when there are volatile publishers (#1023 <https://github.com/RobotWebTools/rosbridge_suite/issues/1023>)
* Contributors: Talha Işık
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Add missing service timeout parameter to conditional launch (#1028 <https://github.com/RobotWebTools/rosbridge_suite/issues/1028>)
* Contributors: Ana
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
