### PR TITLE
rosbridge_suite: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9079,7 +9079,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.0.1-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## rosapi

```
* Fix array-like parameter serialization in rosbridge get_param (#1019 <https://github.com/RobotWebTools/rosbridge_suite/issues/1019>)
* Add namespace to services names (#999 <https://github.com/RobotWebTools/rosbridge_suite/issues/999>)
* Prevent parameter retrieval crashes (#998 <https://github.com/RobotWebTools/rosbridge_suite/issues/998>)
* Add new service to retrieve the different interfaces in the ROS Network (#993 <https://github.com/RobotWebTools/rosbridge_suite/issues/993>)
* Contributors: Noah Wardlow, Matthias Rathauscher, Lebecque Florian, Błażej Sowa
```

## rosapi_msgs

```
* Add new service to retrieve the different interfaces in the ROS Network (#993 <https://github.com/RobotWebTools/rosbridge_suite/issues/993>)
* Contributors: Lebecque Florian
```

## rosbridge_library

```
* Default subscriber QOS to BestEffort, account for TRANSIENT_LOCAL (#1033 <https://github.com/RobotWebTools/rosbridge_suite/issues/1033>)
* Fix randomly failing subscribe unsubscribe test (#1015 <https://github.com/RobotWebTools/rosbridge_suite/issues/1015>)
* Fix action cancelling/aborting (#1014 <https://github.com/RobotWebTools/rosbridge_suite/issues/1014>)
* Add timeout option to call_service messages (#994 <https://github.com/RobotWebTools/rosbridge_suite/issues/994>)
* Fix infinite loop in QueueMessageHandler (#987 <https://github.com/RobotWebTools/rosbridge_suite/issues/987>)
* Use monotonic clock for time measuring (#986 <https://github.com/RobotWebTools/rosbridge_suite/issues/986>)
* Contributors: ewak, William Wedler, Mike Wake, Talha Işık, Daisuke Sato, Błażej Sowa
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* Add missing service timeout parameter to conditional launch (#1030 <https://github.com/RobotWebTools/rosbridge_suite/issues/1030>)
* fix: add url_path parameter in rosbridge_websocket_launch.xml (#1011 <https://github.com/RobotWebTools/rosbridge_suite/issues/1011>)
* Prevent parameter retrieval crashes (#998 <https://github.com/RobotWebTools/rosbridge_suite/issues/998>)
* Add warnings about default parameter values changes (#997 <https://github.com/RobotWebTools/rosbridge_suite/issues/997>)
* Add timeout option to call_service messages (#994 <https://github.com/RobotWebTools/rosbridge_suite/issues/994>)
* Contributors: Ana, Matthias Rathauscher, Lebecque Florian, Błażej Sowa, SeanPai
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
