### PR TITLE
rmw_zenoh: 0.7.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6418,7 +6418,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.7.1-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.0-1`

## rmw_zenoh_cpp

```
* fix(comment): correct the QoS incompatibilities (#644 <https://github.com/ros2/rmw_zenoh/issues/644>)
* fix rmw_take_serialized_message. (#638 <https://github.com/ros2/rmw_zenoh/issues/638>)
* Update CMakeLists.txt (#617 <https://github.com/ros2/rmw_zenoh/issues/617>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita, Yuyuan Yuan, mosfet80
```

## zenoh_cpp_vendor

```
* fix: pin rust toolchain to v1.75.0 (#602 <https://github.com/ros2/rmw_zenoh/issues/602>)
* fix: use the right commit to bump zenoh to v1.3.2 (#607 <https://github.com/ros2/rmw_zenoh/issues/607>)
* Contributors: Yadunund, Yuyuan Yuan
```

## zenoh_security_tools

```
* Update CMakeLists.txt (#617 <https://github.com/ros2/rmw_zenoh/issues/617>)
* Fix warning on Windows (#615 <https://github.com/ros2/rmw_zenoh/issues/615>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```
