### PR TITLE
rmw_zenoh: 0.6.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6354,7 +6354,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.0-2
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.1-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-2`

## rmw_zenoh_cpp

```
* fix(comment): correct the QoS incompatibilities (#645 <https://github.com/ros2/rmw_zenoh/issues/645>)
* fix rmw_take_serialized_message. (#639 <https://github.com/ros2/rmw_zenoh/issues/639>)
* Update CMakeLists.txt (#622 <https://github.com/ros2/rmw_zenoh/issues/622>)
* Contributors: Alejandro Hernández Cordero, mosfet80, Tomoya Fujita
```

## zenoh_cpp_vendor

```
* fix: pin rust toolchain to v1.75.0 (#634 <https://github.com/ros2/rmw_zenoh/issues/634>)
* fix: use the right commit to bump zenoh to v1.3.2 (#631 <https://github.com/ros2/rmw_zenoh/issues/631>)
* Contributors: Yadunund, Yuyuan Yuan
```

## zenoh_security_tools

```
* Update CMakeLists.txt (#622 <https://github.com/ros2/rmw_zenoh/issues/622>)
* Fix warning on Windows (#618 <https://github.com/ros2/rmw_zenoh/issues/618>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```
