### PR TITLE
trimble_driver: index into jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9754,6 +9754,12 @@ repositories:
       url: https://github.com/ros-drivers/transport_drivers.git
       version: main
     status: developed
+  trimble_driver:
+    source:
+      type: git
+      url: https://github.com/trimble-oss/trimble_driver_ros.git
+      version: jazzy
+    status: developed
   tsid:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

trimble_driver

## Package Upstream Source:

https://github.com/trimble-oss/trimble_driver_ros.git

## Purpose of using this:

Trimble customers can use this package to read data from various GNSS Receivers and INS products.

Distro packaging links:
 N/A