### PR TITLE
ur_description: 2.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11544,7 +11544,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.6.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## ur_description

```
* Add support for UR15 (#288 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/288>)
* Humble update distro branches (#285 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/285>)
* Update ur3e's inertia values (backport #276 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/276>) (#278 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/278>)
* Add ros2_control interfaces for tool_contact (#275 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/275>)
* Contributors: Felix Exner, mergify[bot]
```
