### PR TITLE
ur_description: 3.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10241,7 +10241,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -10250,7 +10250,7 @@ repositories:
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-      version: rolling
+      version: jazzy
     status: developed
   ur_msgs:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10246,7 +10246,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.1.1-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.1-1`

## ur_description

```
* Add support for UR15 (#287 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/287>)
* Add documentation about the different base and base_link frames (backport of #286 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/286>) (#289 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/289>)
* Updated doc github_url entries for jazzy branch
* Delete dependabot and mergify configs
* Update branch for jazzy
* Remove unused workflow files
* Contributors: Felix Exner, mergify[bot]
```
