### PR TITLE
ur_robot_driver: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9058,7 +9058,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.2.1-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.1-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Remove deprecated code from sjtc (#1362 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1362>)
* SJTC: Update to latest upstream JTC API (#1351 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1351>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for UR15 (#1358 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1358>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Add support for UR15 (#1358 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1358>)
* [CI] Check links using lychee instead of a custom script (#1355 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1355>)
* Make check_starting_point of test_move launch files configurable (#1354 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1354>)
* Add troubleshooting section about handling ABI breaks (#1350 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1350>)
* Only append to start_modes in prepare_switch (#1344 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1344>)
* tool_contact_test: Check result status directly (#1345 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1345>)
* Contributors: Felix Exner
```
