### PR TITLE
rviz_satellite: 4.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8840,7 +8840,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/nobleo/rviz_satellite-release.git
-      version: 4.1.0-2
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.2.0-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.0-2`

## rviz_satellite

```
* Fixed demo (install rviz file)
* Add libproj-dev as dependency at package.xml
* Add support for sub-region tile servers (local maps)
* fix: time conversion constant in publish_demo_data
* Contributors: Ahmad Kamal Nasir, Christian Geller, David Alejo Teissière, Tim Clephas, nmitropoulos
```
