### PR TITLE
rviz_satellite: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7847,6 +7847,21 @@ repositories:
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
       version: main
     status: maintained
+  rviz_satellite:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/nobleo/rviz_satellite-release.git
+      version: 4.2.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: main
+    status: maintained
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.2.0-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rviz_satellite

```
* Fixed demo (install rviz file)
* Add libproj-dev as dependency at package.xml
* Add support for sub-region tile servers (local maps)
* fix: time conversion constant in publish_demo_data
* Contributors: Ahmad Kamal Nasir, Christian Geller, David Alejo Teissière, Tim Clephas, nmitropoulos
```
