### PR TITLE
trac_ik: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8586,7 +8586,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `2.1.0-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik
- release repository: https://github.com/ros2-gbp/trac_ik-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## trac_ik

- No changes

## trac_ik_kinematics_plugin

```
* Switch from ament_target_dependencies to target_link_libraries. (#43 <https://bitbucket.org/traclabs/trac_ik/pull-requests/43>)
* Clean up and format CMakeLists.txt. (#43 <https://bitbucket.org/traclabs/trac_ik/pull-requests/43>)
* Fix deprecated header warnings (#41 <https://bitbucket.org/traclabs/trac_ik/pull-requests/41>)
* Changes the trac_ik_kinematics plugin to relaunch the IK solver with a random seed when the solution callback fails. The same behavior is also done by KDL (see here) and leads to better solver integration when the callback is used for collision checking. (#38 <https://bitbucket.org/traclabs/trac_ik/pull-requests/38>)
* Contributors: Kenji Brameld, Timon Engelke, Roelof
```

## trac_ik_lib

```
* Switch from ament_target_dependencies to target_link_libraries. (#43 <https://bitbucket.org/traclabs/trac_ik/pull-requests/43>)
* Fix deprecated header warnings (#41 <https://bitbucket.org/traclabs/trac_ik/pull-requests/41>)
* Add a constructor TRAC_IK::TRAC_IK that does not require a rclcpp::Node as argument (#40 <https://bitbucket.org/traclabs/trac_ik/pull-requests/40>)
* Contributors: Kenji Brameld, Roelof
```
