### PR TITLE
urdfdom: 5.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9006,7 +9006,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/urdfdom.git
-      version: master
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -9016,7 +9016,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/urdfdom.git
-      version: master
+      version: kilted
     status: maintained
   urdfdom_headers:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9011,7 +9011,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 4.0.1-1
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `5.0.0-1`:

- upstream repository: https://github.com/ros/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-1`
