### PR TITLE
Update trac ik kilted branch

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8505,7 +8505,7 @@ repositories:
     doc:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
-      version: rolling
+      version: kilted
     release:
       packages:
       - trac_ik
@@ -8518,7 +8518,7 @@ repositories:
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git
-      version: rolling
+      version: kilted
     status: developed
   tracetools_acceleration:
     doc:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

This is a branch rename pull request.

## Package name:

trac_ik

## Package Upstream Source:

https://bitbucket.org/traclabs/trac_ik/src/rolling

## Purpose

A kilted branch was split off from the rolling branch.