### PR TITLE
trac_ik: 1.6.7-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12340,7 +12340,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/traclabs/trac_ik-release.git
-      version: 1.6.6-1
+      version: 1.6.7-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `1.6.7-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik.git
- release repository: https://github.com/traclabs/trac_ik-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.6.6-1`

## trac_ik

- No changes

## trac_ik_examples

```
* drop requirement for obsolete c++ standard to support compiling on newer systems with log4cxx requiring c++17 (#39 <https://bitbucket.org/traclabs/trac_ik/pull-requests/39>)
* hotfix for init of solvers using non-thread-safe KDL::Chain (#32 <https://bitbucket.org/traclabs/trac_ik/pull-requests/32>)
* adding pr2_description dependency for trac_ik_examples (#32 <https://bitbucket.org/traclabs/trac_ik/pull-requests/32>)
* updating to use xacro instead of xacro.py (#32 <https://bitbucket.org/traclabs/trac_ik/pull-requests/32>)
* Contributors: Mike Lanighan, v4hn
```

## trac_ik_kinematics_plugin

```
* drop requirement for obsolete c++ standard to support compiling on newer systems with log4cxx requiring c++17 (#39 <https://bitbucket.org/traclabs/trac_ik/pull-requests/39>)
* Contributors: v4hn
```

## trac_ik_lib

```
* drop requirement for obsolete c++ standard to support compiling on newer systems with log4cxx requiring c++17 (#39 <https://bitbucket.org/traclabs/trac_ik/pull-requests/39>)
* added build_export_depends to tracik_lib for nlopt (#33 <https://bitbucket.org/traclabs/trac_ik/pull-requests/33>)
* hotfix for init of solvers using non-thread-safe KDL::Chain (#32 <https://bitbucket.org/traclabs/trac_ik/pull-requests/32>)
* adding pr2_description dependency for trac_ik_examples (#32 <https://bitbucket.org/traclabs/trac_ik/pull-requests/32>)
* updating to use xacro instead of xacro.py (#32 <https://bitbucket.org/traclabs/trac_ik/pull-requests/32>)
* Contributors: Mike Lanighan, Stephen Hart, v4hn
```

## trac_ik_python

```
* drop requirement for obsolete c++ standard to support compiling on newer systems with log4cxx requiring c++17 (#39 <https://bitbucket.org/traclabs/trac_ik/pull-requests/39>)
* Contributors: v4hn
```
