### PR TITLE
mapviz: 2.4.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3625,7 +3625,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.6-1
+      version: 2.4.7-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.7-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.6-1`

## mapviz

```
* [kilted] Update deprecated call to ament_target_dependencies (#838 <https://github.com/swri-robotics/mapviz/issues/838>)
  * Removing deprecated ament calls while building.
* Contributors: David V. Lu!!
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* [kilted] Update deprecated call to ament_target_dependencies (#838 <https://github.com/swri-robotics/mapviz/issues/838>)
  * Removing deprecated ament calls while building.
* Contributors: David V. Lu!!
```

## multires_image

```
* [kilted] Update deprecated call to ament_target_dependencies (#838 <https://github.com/swri-robotics/mapviz/issues/838>)
  * Removing deprecated ament calls while building.
* Contributors: David V. Lu!!
```

## tile_map

```
* [kilted] Update deprecated call to ament_target_dependencies (#838 <https://github.com/swri-robotics/mapviz/issues/838>)
  * Removing deprecated ament calls while building.
* Contributors: David V. Lu!!
```
