### PR TITLE
clearpath_ros2_socketcan_interface: 2.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1228,7 +1228,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
-      version: 2.1.1-2
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `2.1.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-2`

## clearpath_ros2_socketcan_interface

```
* Fix: Use script instead of OpaqueFunction (#12 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/12>)
  * Use script instead of OpaqueFunction
  * Add missing line
  * Add license header
  * Add EOF line
  * Add retry in the event lifecycle service is not up yet
* Use arguments instead of perform(context) (#11 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/11>)
* Reattempt transitions on failure (#10 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/10>)
  * Reattempt lifecycle transitions on failure
  * Unique activator node names
  * Removed namespace from node name
  * Linting
* Fix: Multiple IncludeLaunchDescription (#9 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/9>)
  * Use opaque function
  * Add import and context
  * Type performed context
* Contributors: Roni Kreinin, luis-camero
```
