### PR TITLE
rmf_traffic: 3.5.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6102,7 +6102,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.4.0-2
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `3.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.0-2`

## rmf_traffic

```
* Add an API for clearing the planner cache (#118 <https://github.com/open-rmf/rmf_traffic/issues/118>)
* Add a method to audit the size of planner caches (#117 <https://github.com/open-rmf/rmf_traffic/issues/117>)
* Fix build with Apple Clang (#98 <https://github.com/open-rmf/rmf_traffic/issues/98>)
* Reduce memory footprint of database (#116 <https://github.com/open-rmf/rmf_traffic/issues/116>)
* Use waypoint merge radius override when computing plan starts (#114 <https://github.com/open-rmf/rmf_traffic/issues/114>)
* Immediately mark dependencies as deprecated when the target plan was cleared (#115 <https://github.com/open-rmf/rmf_traffic/issues/115>)
* Fix negotiation route index bug (#113 <https://github.com/open-rmf/rmf_traffic/issues/113>)
* Insert in-place rotation waypoint if missing (#111 <https://github.com/open-rmf/rmf_traffic/issues/111>)
* Contributors: Grey, Xiyu, yadunund
```

## rmf_traffic_examples

- No changes
