### PR TITLE
rmf_simulation: 2.5.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6066,7 +6066,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.4.1-2
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.1-2`

## rmf_building_sim_gz_plugins

```
* Recreate vel cmd components each cycle (#141 <https://github.com/open-rmf/rmf_simulation/issues/141>)
* Contributors: Grey
```

## rmf_robot_sim_common

```
* Remove unused code from slotcar / readonly (#140 <https://github.com/open-rmf/rmf_simulation/issues/140>)
* Port dispenser/ingestor common code to TeleportDispenser and TeleportIngestor (#139 <https://github.com/open-rmf/rmf_simulation/issues/139>)
* Contributors: Luca Della Vedova, Xiyu
```

## rmf_robot_sim_gz_plugins

```
* Recreate vel cmd components each cycle (#141 <https://github.com/open-rmf/rmf_simulation/issues/141>)
* Port dispenser/ingestor common code to TeleportDispenser and TeleportIngestor (#139 <https://github.com/open-rmf/rmf_simulation/issues/139>)
* Contributors: Grey, Xiyu
```
