### PR TITLE
rmf_api_msgs: 0.5.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5927,7 +5927,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_api_msgs-release.git
-      version: 0.4.0-2
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_api_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_api_msgs` to `0.5.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_api_msgs
- release repository: https://github.com/ros2-gbp/rmf_api_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-2`

## rmf_api_msgs

```
* Task estimation schemas
* Document how labels should be formatted (#54 <https://github.com/open-rmf/rmf_api_msgs/issues/54>)
* Contributors: Teo Koon Peng, lkw303
```
