### PR TITLE
gps_umd: 2.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3271,7 +3271,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `2.0.5-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.4-1`

## gps_msgs

```
* Added RTK fix/float enums (#94 <https://github.com/swri-robotics/gps_umd/issues/94>)
  Co-authored-by: Alex Youngs <mailto:alexyoungs@hatchbed.com>
* Contributors: agyoungs
```

## gps_tools

```
* Removing all ament_target_dependencies() calls (#111 <https://github.com/swri-robotics/gps_umd/issues/111>)
* Contributors: David Anthony
```

## gps_umd

- No changes

## gpsd_client

```
* Removing all ament_target_dependencies() calls (#111 <https://github.com/swri-robotics/gps_umd/issues/111>)
* Changing hard coded default port value and improving string allocation (#101 <https://github.com/swri-robotics/gps_umd/issues/101>)
* Updating package search (#99 <https://github.com/swri-robotics/gps_umd/issues/99>)
  * Updating package search
  * Removing pkg_check_modules call
* Check mode Field (#100 <https://github.com/swri-robotics/gps_umd/issues/100>)
  * Switching to use mode of fix instead of status to be more robust to changes in API
  * Making altitude NaN if in 2D fix mode
* Port of https://github.com/swri-robotics/gps_umd/pull/74 (#98 <https://github.com/swri-robotics/gps_umd/issues/98>)
* Contributors: David Anthony
```
