### PR TITLE
rmf_visualization: 2.4.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6178,7 +6178,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.4.1-2
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.4.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.1-2`

## rmf_visualization

- No changes

## rmf_visualization_building_systems

- No changes

## rmf_visualization_fleet_states

- No changes

## rmf_visualization_floorplans

- No changes

## rmf_visualization_navgraphs

- No changes

## rmf_visualization_obstacles

- No changes

## rmf_visualization_rviz2_plugins

- No changes

## rmf_visualization_schedule

```
* fix auth bypass (#79 <https://github.com/open-rmf/rmf_visualization/issues/79>)
* Contributors: Teo Koon Peng
```
