### PR TITLE
mapviz: 2.4.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4194,7 +4194,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.6-1
+      version: 2.4.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.8-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.6-1`

## mapviz

```
* Fixing various dependencies (#839 <https://github.com/swri-robotics/mapviz/issues/839>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Fixing various dependencies (#839 <https://github.com/swri-robotics/mapviz/issues/839>)
* Contributors: David Anthony
```

## multires_image

```
* Fixing various dependencies (#839 <https://github.com/swri-robotics/mapviz/issues/839>)
* Contributors: David Anthony
```

## tile_map

```
* Fixing various dependencies (#839 <https://github.com/swri-robotics/mapviz/issues/839>)
* Contributors: David Anthony
```
