### PR TITLE
rviz: 15.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7821,7 +7821,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.2-1
+      version: 15.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.1.2-1`

## rviz2

```
* feat: support both qt5 and qt6 (#1187 <https://github.com/ros2/rviz/issues/1187>)
* Contributors: Daisuke Nishimatsu
```

## rviz_assimp_vendor

- No changes

## rviz_common

```
* feat: support both qt5 and qt6 (#1187 <https://github.com/ros2/rviz/issues/1187>)
* Contributors: Daisuke Nishimatsu
```

## rviz_default_plugins

```
* Removed unused headers from resouce retriever (#1463 <https://github.com/ros2/rviz/issues/1463>)
* feat: support both qt5 and qt6 (#1187 <https://github.com/ros2/rviz/issues/1187>)
* Contributors: Alejandro Hernández Cordero, Daisuke Nishimatsu
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed unused headers from resouce retriever (#1463 <https://github.com/ros2/rviz/issues/1463>)
* feat: support both qt5 and qt6 (#1187 <https://github.com/ros2/rviz/issues/1187>)
* Contributors: Alejandro Hernández Cordero, Daisuke Nishimatsu
```

## rviz_rendering_tests

```
* feat: support both qt5 and qt6 (#1187 <https://github.com/ros2/rviz/issues/1187>)
* Contributors: Daisuke Nishimatsu
```

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

```
* feat: support both qt5 and qt6 (#1187 <https://github.com/ros2/rviz/issues/1187>)
* Contributors: Daisuke Nishimatsu
```
