### PR TITLE
mapviz: 2.4.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4767,7 +4767,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.7-1
+      version: 2.4.9-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.4.9-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.7-1`

## mapviz

- No changes

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

```
* Adding Mapviz to tile map include directories (#840 <https://github.com/swri-robotics/mapviz/issues/840>)
* Contributors: David Anthony
```
