### PR TITLE
dynamic_reconfigure: 1.7.6-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2385,7 +2385,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.7.5-1
+      version: 1.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamic_reconfigure` to `1.7.6-1`:

- upstream repository: https://github.com/ros/dynamic_reconfigure.git
- release repository: https://github.com/ros-gbp/dynamic_reconfigure-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.5-1`

## dynamic_reconfigure

```
* Revert "Fix unsafe yaml load on dynparam (#202 <https://github.com/ros/dynamic_reconfigure/issues/202>)" (#206 <https://github.com/ros/dynamic_reconfigure/issues/206>)
* Contributors: Shane Loretz
```
