### PR TITLE
cartographer: 2.0.9004-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -901,7 +901,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer-release.git
-      version: 2.0.9003-2
+      version: 2.0.9004-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `2.0.9004-1`:

- upstream repository: https://github.com/ros2/cartographer.git
- release repository: https://github.com/ros2-gbp/cartographer-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.9003-2`
