### PR TITLE
cartographer: 2.0.9004-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1303,7 +1303,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer-release.git
-      version: 2.0.9003-1
+      version: 2.0.9004-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cartographer` to `2.0.9004-1`:

- upstream repository: https://github.com/ros2/cartographer.git
- release repository: https://github.com/ros2-gbp/cartographer-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.9003-1`
