### PR TITLE
rmw_gurumdds: 6.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6319,7 +6319,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
-      version: 5.0.0-4
+      version: 6.0.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `6.0.1-1`:

 * upstream repository: https://github.com/ros2/rmw_gurumdds.git
 * release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
 * distro file: `rolling/distribution.yaml`
 * bloom version: `0.12.0`
 * previous version for package: `5.0.0-4`

# gurumdds_cmake_module
```

```

# rmw_gurumdds_cpp
```
6.0.1 (2025-05-20)
-----------
* Fix cpplint warnings
* Replace deprecated ament_target_dependencies
* Contributors: kumazuma

6.0.0 (2025-05-19)
-----------
* Update rmw event impl
  * Use RMW_EVENT_TYPE_MAX instead of RMW_EVENT_INVALID
  * Implement rmw_event_type_is_supported
* Fix a segfault on the dpf's initialization is failed
* Switch to ament_cmake_ros_core package
* Remove ament dependency of GurumDDS
* Improve performance of `rmw_wait`
* Reduce memcpy and memset
* Add read entity's qos from profile
  This allows changing DDS QoS, which is not supported in ROS2.
* Fix order of parameters in call initialize_node
* Remove additional member field for unused basic service support
* Instrument client/service for end-to-end request/response tracking
* Drop support for float128
* Add tracepoints to pub/sub
* Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT
* Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT
* Use rmw_namespace_validation_result_string() in rmw_create_node
* Remove rmw_localhost_only_t
* Contributors: gurum, kumazuma, Scott K Logan
```