### PR TITLE
image_pipeline: 5.0.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3426,7 +3426,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.10-1
+      version: 5.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.11-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.10-1`

## camera_calibration

- No changes

## depth_image_proc

- No changes

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

```
* fix colour channel order for "rgb8" in image_view (backport #1093 <https://github.com/ros-perception/image_pipeline/issues/1093>) (#1094 <https://github.com/ros-perception/image_pipeline/issues/1094>)
* Contributors: mergify[bot]
```

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
