### PR TITLE
plotjuggler: 3.10.3-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6813,7 +6813,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.2-1
+      version: 3.10.3-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.10.3-2`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.10.2-1`

## plotjuggler

```
* cmake fixes (again)
* Cmake cleanups (#1076 <https://github.com/facontidavide/PlotJuggler/issues/1076>)
* Add missing find_package for plojuggler_qwt (#1064 <https://github.com/facontidavide/PlotJuggler/issues/1064>)
* improve MCAP loader
* fix issue in MCAP when one of the parsers fail
* Contributors: AlessandroCanossa, Davide Faconti
```
