### PR TITLE
Add python3-posix-ipc-pip rule

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8228,6 +8228,10 @@ python3-polling2-pip:
   ubuntu:
     pip:
       packages: [polling2]
+python3-posix-ipc-pip:
+  '*':
+    pip:
+      packages: [posix-ipc]
 python3-pqdict-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8228,10 +8228,18 @@ python3-polling2-pip:
   ubuntu:
     pip:
       packages: [polling2]
-python3-posix-ipc-pip:
+python3-posix-ipc:
   '*':
     pip:
       packages: [posix-ipc]
+  fedora: [python3-posix-ipc]
+  rhel:
+    '9': [python3-posix-ipc]
+  ubuntu:
+    '*':
+      pip: [posix-ipc]
+    focal: [python3-posix-ipc]
+    jammy: [python3-posix-ipc]
 python3-pqdict-pip:
   debian:
     pip:


### PR DESCRIPTION
## Package name:

python3-posix-ipc-pip

## Package Upstream Source:

[Github](https://github.com/osvenskan/posix_ipc)

## Purpose of using this:
From the repo: "creation and manipulation of POSIX inter-process semaphores, shared memory and message queues"

## Links to Distribution Packages
pip: [pypi.org](https://pypi.org/project/posix-ipc/)
