### PR TITLE
nobleo_socketcan_bridge: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4500,7 +4500,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/nobleo/nobleo_socketcan_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nobleo_socketcan_bridge` to `1.0.3-1`:

- upstream repository: https://github.com/nobleo/nobleo_socketcan_bridge.git
- release repository: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## nobleo_socketcan_bridge

```
* Remove deprecated call to ament_target_dependencies
* Bump minimum CMake version to avoid compatiility warning
* Contributors: Ramon Wijnands
```
