### PR TITLE
ros2_control: 4.30.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7438,7 +7438,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.29.0-1
+      version: 4.30.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7421,7 +7421,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: jazzy
     release:
       packages:
       - controller_interface
@@ -7442,7 +7442,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: jazzy
     status: developed
   ros2_control_cmake:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.30.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.29.0-1`

## controller_interface

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>) (#2249 <https://github.com/ros-controls/ros2_control/issues/2249>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Keep current shutdown behaviour in Jazzy (#2254 <https://github.com/ros-controls/ros2_control/issues/2254>)
* [CM] Add option to avoid shutting down on hardware initial state failure (#2230 <https://github.com/ros-controls/ros2_control/issues/2230>) (#2251 <https://github.com/ros-controls/ros2_control/issues/2251>)
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>) (#2249 <https://github.com/ros-controls/ros2_control/issues/2249>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>) (#2247 <https://github.com/ros-controls/ros2_control/issues/2247>)
* Use warning attribute of RcutilsLogger (#2244 <https://github.com/ros-controls/ros2_control/issues/2244>) (#2245 <https://github.com/ros-controls/ros2_control/issues/2245>)
* [CM] Set default strictness of switch_controllers using parameters (#2168 <https://github.com/ros-controls/ros2_control/issues/2168>) (#2233 <https://github.com/ros-controls/ros2_control/issues/2233>)
* Contributors: Bence Magyar, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>) (#2249 <https://github.com/ros-controls/ros2_control/issues/2249>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>) (#2247 <https://github.com/ros-controls/ros2_control/issues/2247>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>) (#2249 <https://github.com/ros-controls/ros2_control/issues/2249>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>) (#2247 <https://github.com/ros-controls/ros2_control/issues/2247>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>) (#2249 <https://github.com/ros-controls/ros2_control/issues/2249>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [CM] Set default strictness of switch_controllers using parameters (#2168 <https://github.com/ros-controls/ros2_control/issues/2168>) (#2233 <https://github.com/ros-controls/ros2_control/issues/2233>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Add deprecated get_optional to Transmission Handle (#2255 <https://github.com/ros-controls/ros2_control/issues/2255>)
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>) (#2249 <https://github.com/ros-controls/ros2_control/issues/2249>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>) (#2247 <https://github.com/ros-controls/ros2_control/issues/2247>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```
