### PR TITLE
py_binding_tools: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5284,11 +5284,15 @@ repositories:
       version: devel
     status: developed
   py_binding_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/py_binding_tools.git
+      version: ros2
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_binding_tools-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.0.2-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros2-gbp/py_binding_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## py_binding_tools

```
* Replace deprecated ament_target_dependencies()
* Add type caster for rclpy.Time <-> rclcpp::Time (#2 <https://github.com/ros-planning/py_binding_tools/issues/2>)
* Contributors: Robert Haschke
```
