### PR TITLE
plotjuggler_ros: 2.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5069,7 +5069,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.1.3-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `2.2.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.3-2`

## plotjuggler_ros

```
* jazzy+
* Fixing wstring ROS2 data type, and import rename for latest release build compatibility (#86 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/86>)
  Co-authored-by: Davide Faconti <mailto:davide.faconti@gmail.com>
* Update ros2_parser.cpp
* Fix detection of ROS 2 Humble (#82 <https://github.com/PlotJuggler/plotjuggler-ros-plugins/issues/82>)
  Detecting the ROS distribution based on the content of
  AMENT_PREFIX_PATH does not always work. For example, when using the
  Nix package manager, paths in AMENT_PREFIX_PATH could never match the
  currently used pattern. It's better to use ROS_DISTRO variable for
  this purpose. This should (I think) work everywhere.
* Contributors: Ben Cohen, Davide Faconti, Michal Sojka
```
