### PR TITLE
ur_robot_driver: 2.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11582,7 +11582,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.8.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.0-1`

## ur

- No changes

## ur_bringup

```
* Add support for launching a UR15 robot (#1359 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1359>)
* Contributors: Felix Exner
```

## ur_calibration

- No changes

## ur_controllers

```
* Added controller to enable and disable tool contact (backport of #940 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/940>) (#1337 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1337>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for launching a UR15 robot (#1359 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1359>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* [CI] Check links using lychee instead of a custom script (backport #1355 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1355>) (#1361 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1361>)
* Add support for launching a UR15 robot (#1359 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1359>)
* tool_contact_test: Check result status directly (backport of #1345 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1345>) (#1353 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1353>)
* Added controller to enable and disable tool contact (backport of #940 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/940>) (#1337 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1337>)
* Contributors: Felix Exner, mergify[bot]
```
