### PR TITLE
openni2_camera: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4760,7 +4760,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/openni2_camera-release.git
-      version: 2.2.2-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-drivers/openni2_camera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni2_camera` to `2.3.0-1`:

- upstream repository: https://github.com/ros-drivers/openni2_camera.git
- release repository: https://github.com/ros2-gbp/openni2_camera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.2-1`

## openni2_camera

```
* Replace ament_target_dependencies with target_link_libraries (#145 <https://github.com/ros-drivers/openni2_camera/issues/145>)
  ament_target_dependencies is deprecated, it will require a release on
  rolling
* Contributors: Alejandro Hernández Cordero
```
