### PR TITLE
autoware_msgs: 1.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -722,7 +722,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.7.0-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.8.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.7.0-1`

## autoware_common_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_control_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_localization_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_map_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_perception_msgs

```
* feat(autoware_perception_msgs): update traffic light messages to include future states (#134 <https://github.com/autowarefoundation/autoware_msgs/issues/134>)
  * feat: add autoware_perception_msgs/FutureTrafficLightState message
  * feat: update autoware_perception_msgs/TrafficLightGroup to include predictions
  * fix: add inline comments to autoware_perception_msgs/FutureTrafficLightState message
  * fix: rename to PredictedTrafficLightState, update field names
  * fix: change CMakeLists.txt to alphabetical order
  * fix: add local_perception as predicted traffic light state information_source
  ---------
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt, Yu Asabe
```

## autoware_planning_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_sensing_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_system_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```

## autoware_v2x_msgs

- No changes

## autoware_vehicle_msgs

```
* chore: fix email domain (#133 <https://github.com/autowarefoundation/autoware_msgs/issues/133>)
* chore: update maintainers (#132 <https://github.com/autowarefoundation/autoware_msgs/issues/132>)
* Contributors: Mete Fatih Cırıt
```
