### PR TITLE
rmw_desert: 3.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6281,7 +6281,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_desert-release.git
-      version: 3.0.0-3
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_desert` to `3.0.1-1`:

- upstream repository: https://github.com/signetlabdei/rmw_desert.git
- release repository: https://github.com/ros2-gbp/rmw_desert-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-3`

## rmw_desert

```
* Switch to target_link_libraries for linking
* Updated documentation
* Changed RxStream dispatchment paradigm
* Solved segfault on rmw_wait
* Switch to ament_cmake_ros_core package
* Switch to ament_cmake_ros_core package
* Contributors: Scott K Logan, dcostan
```
