### PR TITLE
autoware_utils: 1.4.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -746,7 +746,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_utils-release.git
-      version: 1.4.1-1
+      version: 1.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_utils` to `1.4.2-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_utils.git
- release repository: https://github.com/ros2-gbp/autoware_utils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.1-1`

## autoware_utils

- No changes

## autoware_utils_debug

- No changes

## autoware_utils_diagnostics

- No changes

## autoware_utils_geometry

```
* fix: include tf2/convert.hpp instead of tf2/convert.h (#67 <https://github.com/autowarefoundation/autoware_utils/issues/67>)
* Contributors: Takagi, Isamu
```

## autoware_utils_logging

- No changes

## autoware_utils_math

- No changes

## autoware_utils_pcl

- No changes

## autoware_utils_rclcpp

- No changes

## autoware_utils_system

- No changes

## autoware_utils_tf

- No changes

## autoware_utils_uuid

- No changes

## autoware_utils_visualization

- No changes
