### PR TITLE
Update trac to kilted branch

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6276,7 +6276,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
-      version: main
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -6285,7 +6285,7 @@ repositories:
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git
-      version: main
+      version: kilted
     status: maintained
   rmw_fastrtps:
     doc:


### PR DESCRIPTION
This is a branch rename pull request.

## Package name:

rmw_desert

## Package Upstream Source:

https://github.com/signetlabdei/rmw_desert

## Purpose:

A kilted branch was split off from the rolling branch.