### PR TITLE
ur_simulation_gz: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9083,7 +9083,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `2.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.0-1`

## ur_simulation_gz

```
* Add support for UR15 (#97 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/97>)
* Remove FTS broadcaster from list of controllers (#95 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/95>)
* [doc] Add github_url directives (#90 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/90>)
* Contributors: Felix Exner
```
