### PR TITLE
aruco_opencv: 6.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -462,7 +462,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.0.1-2
+      version: 6.0.2-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `6.0.2-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.1-2`

## aruco_opencv

```
* Don't use deprecated tf2 headers (#53 <https://github.com/fictionlab/ros_aruco_opencv/issues/53>)
* Update deprecated call to ament_target_dependencies (#51 <https://github.com/fictionlab/ros_aruco_opencv/issues/51>)
* Contributors: Błażej Sowa, David V. Lu!!
```

## aruco_opencv_msgs

- No changes
