### PR TITLE
point_cloud_transport_tutorial: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5209,7 +5209,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_tutorial` to `0.0.3-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_tutorial
- release repository: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## point_cloud_transport_tutorial

```
* Fixed CI (#12 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/12>)
* Use target_link_libraries instead of ament_target_dependencies (#11 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/11>)
* Replaced deprecated rcpputils::path (#10 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/10>)
* Contributors: Alejandro Hernández Cordero
```
