### PR TITLE
ros2_control: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6538,7 +6538,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.29.0-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.29.0-1`

## controller_interface

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>)
* Contributors: mini-1235
```

## controller_manager

```
* [CM] Add option to avoid shutting down on hardware initial state failure (#2230 <https://github.com/ros-controls/ros2_control/issues/2230>)
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>)
* Use warning attribute of RcutilsLogger (#2244 <https://github.com/ros-controls/ros2_control/issues/2244>)
* [CM] Set default strictness of switch_controllers using parameters (#2168 <https://github.com/ros-controls/ros2_control/issues/2168>)
* Add data_type field to the HardwareInterfaces message (#2204 <https://github.com/ros-controls/ros2_control/issues/2204>)
* Add new strictness modes to SwitchController service (#2224 <https://github.com/ros-controls/ros2_control/issues/2224>)
* Contributors: Marq Rasmussen, Sai Kishor Kothakota, mini-1235
```

## controller_manager_msgs

```
* Add data_type field to the HardwareInterfaces message (#2204 <https://github.com/ros-controls/ros2_control/issues/2204>)
* Add new strictness modes to SwitchController service (#2224 <https://github.com/ros-controls/ros2_control/issues/2224>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>)
* Add data_type field to the HardwareInterfaces message (#2204 <https://github.com/ros-controls/ros2_control/issues/2204>)
* Contributors: Sai Kishor Kothakota, mini-1235
```

## hardware_interface_testing

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>)
* Contributors: Sai Kishor Kothakota, mini-1235
```

## joint_limits

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>)
* Contributors: mini-1235
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* [CM] Set default strictness of switch_controllers using parameters (#2168 <https://github.com/ros-controls/ros2_control/issues/2168>)
* Add data_type field to the HardwareInterfaces message (#2204 <https://github.com/ros-controls/ros2_control/issues/2204>)
* Contributors: Sai Kishor Kothakota
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Statically allocate string concatenations using FMT formatting (#2205 <https://github.com/ros-controls/ros2_control/issues/2205>)
* Suppress the deprecation warnings of the hardware_interface API (#2223 <https://github.com/ros-controls/ros2_control/issues/2223>)
* Contributors: Sai Kishor Kothakota, mini-1235
```
