### PR TITLE
Fix Fast-DDS branch for Rolling and Kilted

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1732,7 +1732,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 3.1.x
+      version: 3.2.x
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1743,7 +1743,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 3.1.x
+      version: 3.2.x
     status: maintained
   feetech_ros2_driver:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1784,7 +1784,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 3.1.x
+      version: 3.2.x
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1795,7 +1795,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-DDS.git
-      version: 3.1.x
+      version: 3.2.x
     status: maintained
   feetech_ros2_driver:
     release:


### PR DESCRIPTION
This aligns the 'source' and 'doc' builds with the currently released binaries and the state of 'ros2.repos'.