### PR TITLE
Index mola_vision source for rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4025,6 +4025,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_test_datasets.git
       version: develop
     status: developed
+  mola_vision:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_vision.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_vision.git
+      version: develop
+    status: developed
   motion_capture_tracking:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/MOLAorg/mola_vision

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
