### PR TITLE
clearpath_ros2_socketcan_interface: 2.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1228,7 +1228,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
-      version: 2.1.1-2
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `2.1.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-2`

## clearpath_ros2_socketcan_interface

```
* Fix: Spin Timeout (#13 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/13>)
  * Add timeout to spin to prevent script from waiting when node has failed
  * Update log to match appropriate action
* Contributors: luis-camero
```
