### PR TITLE
rmw_gurumdds: jazzy in 'jazzy/distribution.yaml'

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7250,7 +7250,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git
-      version: rolling
+      version: jazzy
     release:
       packages:
       - gurumdds_cmake_module
@@ -7262,7 +7262,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git
-      version: rolling
+      version: jazzy
     status: developed
   rmw_implementation:
     doc:


### PR DESCRIPTION
Changing source version of package in repository `rmw_gurumdds`
* upstream repository: https://github.com/ros2/rmw_gurumdds.git
* release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
* distro file: jazzy/distribution.yaml