### PR TITLE
Add 'taskflow' rosdep rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6523,6 +6523,23 @@ libsystemd-dev:
   openembedded: [systemd@openembedded-core]
   ubuntu:
     '*': [libsystemd-dev]
+libtaskflow-cpp-dev:
+  debian:
+    '*': [libtaskflow-cpp-dev]
+    bookworm: null
+    bullseye: null
+  fedora: [taskflow-devel]
+  freebsd: [taskflow]
+  gentoo: [dev-cpp/taskflow]
+  nixos: [taskflow]
+  openembedded: [taskflow@meta-ros1-noetic]
+  osx:
+    homebrew:
+      packages: [taskflow]
+  ubuntu:
+    '*': [libtaskflow-cpp-dev]
+    focal: null
+    jammy: null
 libtclap-dev:
   arch: [tclap]
   debian: [libtclap-dev]
@@ -9222,23 +9239,6 @@ tar:
     '*': null
     '7': [libtar-devel]
   ubuntu: [libtar-dev]
-libtaskflow-cpp-dev:
-  debian:
-    '*': [libtaskflow-cpp-dev]
-    bookworm: null
-    bullseye: null
-  fedora: [taskflow-devel]
-  freebsd: [taskflow]
-  gentoo: [dev-cpp/taskflow]
-  nixos: [taskflow]
-  openembedded: [taskflow@meta-ros1-noetic]
-  osx:
-    homebrew:
-      packages: [taskflow]
-  ubuntu:
-    '*': [libtaskflow-cpp-dev]
-    focal: null
-    jammy: null
 tbb:
   arch: [intel-oneapi-tbb]
   debian: [libtbb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9224,7 +9224,9 @@ tar:
   ubuntu: [libtar-dev]
 taskflow:
   debian:
-    trixie: [libtaskflow-cpp-dev]
+    '*': [libtaskflow-cpp-dev]
+    bookworm: null
+    bullseye: null
   fedora: [taskflow-devel]
   freebsd: [taskflow]
   gentoo: [dev-cpp/taskflow]
@@ -9234,7 +9236,9 @@ taskflow:
     homebrew:
       packages: [taskflow]
   ubuntu:
-    noble: [libtaskflow-cpp-dev]
+    '*': [libtaskflow-cpp-dev]
+    focal: null
+    jammy: null
 tbb:
   arch: [intel-oneapi-tbb]
   debian: [libtbb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9222,7 +9222,7 @@ tar:
     '*': null
     '7': [libtar-devel]
   ubuntu: [libtar-dev]
-taskflow:
+libtaskflow-cpp-dev:
   debian:
     '*': [libtaskflow-cpp-dev]
     bookworm: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9222,6 +9222,19 @@ tar:
     '*': null
     '7': [libtar-devel]
   ubuntu: [libtar-dev]
+taskflow:
+  debian:
+    trixie: [libtaskflow-cpp-dev]
+  fedora: [taskflow-devel]
+  freebsd: [taskflow]
+  gentoo: [dev-cpp/taskflow]
+  nixos: [taskflow]
+  openembedded: [taskflow@meta-ros1-noetic]
+  osx:
+    homebrew:
+      packages: [taskflow]
+  ubuntu:
+    noble: [libtaskflow-cpp-dev]
 tbb:
   arch: [intel-oneapi-tbb]
   debian: [libtbb-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`taskflow`

## Package Upstream Source:

[Source repository](https://github.com/taskflow/taskflow).

## Purpose of using this:

This contains a header-only C++ library for parallel programming. It can be used to compose computational graphs declaring precedence dependencies between nodes and then executing them in parallel. More info in the [taskflow project's main page](https://taskflow.github.io/).

:warning:  Note that this was briefly [packaged and released by `ros-industrial` into ROS Noetic](https://github.com/ros-industrial-release/taskflow-release). I'm unsure of the implications of this (e.g. whether a different rosdep key should be used to avoid confusion or conflicts).

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libtaskflow-cpp-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libtaskflow-cpp-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/taskflow/taskflow-devel/
- Arch: https://www.archlinux.org/packages/
  - Not available ([only in AUR](https://aur.archlinux.org/packages/cpp-taskflow)).
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/taskflow
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/taskflow#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=24.11&show=taskflow&from=0&size=50&sort=relevance&type=packages&query=taskflow
- openSUSE: https://software.opensuse.org/package/
  - Not available
- rhel: https://rhel.pkgs.org/
  - Not available

Also:
- FreeBSD
  - https://ports.freebsd.org/cgi/ports.cgi?query=taskflow&stype=all&sektion=all
- OpenEmbedded
  - https://layers.openembedded.org/layerindex/recipe/419692/