### PR TITLE
(jazzy) update branch name for imu_pipeline

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3472,7 +3472,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git
-      version: ros2
+      version: jazzy
     status: maintained
   imu_tools:
     doc:


### PR DESCRIPTION
We've had to branch for Kilted and later - humble/jazzy will continue to share a branch.
