### PR TITLE
imu_pipeline: 0.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2887,7 +2887,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
-      version: 0.5.1-2
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.6.0-1`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros2-gbp/imu_pipeline-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.1-2`

## imu_pipeline

- No changes

## imu_processors

```
* [kilted] Update deprecated call to ament_target_dependencies (#26 <https://github.com/ros-perception/imu_pipeline/issues/26>)
  As of the ROS 2 Kilted release [ament_target_dependencies is
  deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)
  This PR updates the syntax. Caution should be used to ensure that the
  target branch is not used for other ROS 2 distros.
  Note: This PR was generated by a bot script, but using the simple
  pattern matching of the
  [ros_glint](https://github.com/MetroRobots/ros_glint) library. No LLMs
  were used.
* Contributors: David V. Lu!!
```

## imu_transformer

```
* handle deprecations on rolling (#27 <https://github.com/ros-perception/imu_pipeline/issues/27>)
* [kilted] Update deprecated call to ament_target_dependencies (#26 <https://github.com/ros-perception/imu_pipeline/issues/26>)
  As of the ROS 2 Kilted release [ament_target_dependencies is
  deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)
  This PR updates the syntax. Caution should be used to ensure that the
  target branch is not used for other ROS 2 distros.
  Note: This PR was generated by a bot script, but using the simple
  pattern matching of the
  [ros_glint](https://github.com/MetroRobots/ros_glint) library. No LLMs
  were used.
* Contributors: David V. Lu!!, Michael Ferguson
```
