### PR TITLE
libcaer_driver: 1.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3459,7 +3459,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.5.1-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.0-1`

## libcaer_driver

```
* stop using ament_target_dependencies
* Contributors: Bernd Pfrommer
```
