### PR TITLE
topic_tools: 1.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8585,7 +8585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.4.3-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.4.2-1`

## topic_tools

```
* Replace ament_target_dependencies with target_link_libraries (#127 <https://github.com/ros-tooling/topic_tools/issues/127>)
* Add missing exec_depend on ros2topic (#126 <https://github.com/ros-tooling/topic_tools/issues/126>)
* Contributors: Alejandro Hernández Cordero, Christophe Bedard
```

## topic_tools_interfaces

- No changes
