### PR TITLE
Add RHEL 9 rule for 'opende'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7833,8 +7833,7 @@ opende:
   gentoo: [dev-games/ode]
   nixos: [ode]
   openembedded: [ode@meta-ros-common]
-  rhel:
-    '8': [ode-devel]
+  rhel: [ode-devel]
   ubuntu: [libode-dev]
 opengl:
   alpine: [mesa-dev]


### PR DESCRIPTION
This comes from EPEL for RHEL 8 and 9: https://packages.fedoraproject.org/pkgs/ode/ode-devel/