### PR TITLE
Add Fedora rules for qt5-quick and qt5-qml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6014,6 +6014,7 @@ libqt5-printsupport:
 libqt5-qml:
   arch: [qt5-declarative]
   debian: [libqt5qml5]
+  fedora: [qt5-qtdeclarative]
   gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt5]
@@ -6022,6 +6023,7 @@ libqt5-qml:
 libqt5-quick:
   arch: [qt5-declarative]
   debian: [libqt5quick5]
+  fedora: [qt5-qtdeclarative]
   gentoo: ['dev-qt/qtdeclarative:5']
   nixos: [qt5.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt5]


### PR DESCRIPTION
Same package as is used on RHEL: https://packages.fedoraproject.org/pkgs/qt5-qtdeclarative/qt5-qtdeclarative/