### PR TITLE
Fix wxGTK package name for Fedora and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9668,13 +9668,13 @@ workrave:
 wx-common:
   arch: [wxwidgets-gtk3]
   debian: [wx-common]
-  fedora: [wxGTK3-devel]
+  fedora: [wxGTK-devel]
   gentoo: [x11-libs/wxGTK]
   nixos: [wxGTK32]
   openembedded: [wxwidgets@meta-ros-common]
   rhel:
-    '*': [wxGTK3-devel]
-    '7': [wxGTK-devel]
+    '*': [wxGTK-devel]
+    '8': [wxGTK3-devel]
   ubuntu: [wx-common]
 wxwidgets:
   arch: [wxwidgets-gtk3]
@@ -9682,7 +9682,7 @@ wxwidgets:
     '*': [libwxgtk3.2-dev]
     bullseye: [libwxgtk3.0-gtk3-dev]
     buster: [libwxgtk3.0-dev]
-  fedora: [wxGTK3-devel]
+  fedora: [wxGTK-devel]
   freebsd: [wxgtk2]
   gentoo: [x11-libs/wxGTK]
   macports: [wxWidgets-python]
@@ -9690,8 +9690,8 @@ wxwidgets:
   openembedded: [wxwidgets@meta-ros-common]
   opensuse: [wxGTK-devel]
   rhel:
-    '*': [wxGTK3-devel]
-    '7': [wxGTK-devel]
+    '*': [wxGTK-devel]
+    '8': [wxGTK3-devel]
   ubuntu:
     '*': [libwxgtk3.2-dev]
     bionic: [libwxgtk3.0-dev]


### PR DESCRIPTION
When wxGTK v3 was introduced in Fedora, there was an attempt to switch the package name from wxGTK to wxGTK3. I'm fuzzy on the details, but it appears that we've reverted back to wxGTK moving forward.

For RHEL 9 both packages are available, but the 'wxGTK' package appears more up-to-date. This leaves only RHEL 8 using the older package name.

https://packages.fedoraproject.org/pkgs/wxGTK/wxGTK-devel/
https://packages.fedoraproject.org/pkgs/wxGTK3/wxGTK3-devel/