### PR TITLE
marti_common: 3.7.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4838,7 +4838,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.7.5-1
+      version: 3.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.7.6-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.5-1`

## swri_cli_tools

- No changes

## swri_console_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_image_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_math_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_opencv_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_roscpp

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_route_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_serial_util

- No changes

## swri_system_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```

## swri_transform_util

```
* Reverting changes back to 3.7.4 (#770 <https://github.com/swri-robotics/marti_common/issues/770>)
* Contributors: David Anthony
```
