### PR TITLE
mola_common: 0.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3901,7 +3901,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_common-release.git
-      version: 0.4.0-2
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_common` to `0.4.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_common.git
- release repository: https://github.com/ros2-gbp/mola_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.0-2`

## mola_common

```
* add mola_version_to_hexadecimal() to mola_cmake_functions (and fix tab formatting)
* Update package license to 'BSD-3-Clause'
* Silent warnings if built w/o any version of ROS
* Fix text references to license (correct one for this package is BSD-3)
* Contributors: Jose Luis Blanco-Claraco
```
