### PR TITLE
Fix source branch for Fast-CDR in Kilted and Rolling

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1726,7 +1726,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: 2.2.x
+      version: 2.3.x
     status: maintained
   fastdds:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1778,7 +1778,7 @@ repositories:
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-CDR.git
-      version: 2.2.x
+      version: 2.3.x
     status: maintained
   fastdds:
     doc:


### PR DESCRIPTION
Like #45948, this makes rosdistro align with what we've tested and distributed.