### PR TITLE
event_camera_msgs: 2.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1624,7 +1624,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_msgs-release.git
-      version: 1.0.6-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_msgs` to `2.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_msgs.git
- release repository: https://github.com/ros2-gbp/event_camera_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.6-2`

## event_camera_msgs

- No changes
