### PR TITLE
event_camera_renderer: 2.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1654,7 +1654,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_renderer-release.git
-      version: 1.0.4-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_renderer` to `2.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_renderer.git
- release repository: https://github.com/ros2-gbp/event_camera_renderer-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.4-2`

## event_camera_renderer

- No changes
