### PR TITLE
libcaer_vendor: 2.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3421,7 +3421,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_vendor-release.git
-      version: 1.0.0-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_vendor` to `2.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_vendor.git
- release repository: https://github.com/ros2-gbp/libcaer_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-2`

## libcaer_vendor

- No changes
