### PR TITLE
Set plotjuggler packages to last building version.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5854,7 +5854,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.4-1
+      version: 3.9.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
@@ -5884,7 +5884,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.2.0-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Rolling back `plotjuggler` and `plotjuggler_ros` to last building versions.

It seems that [latest changes related to 3rd party dependencies](https://github.com/facontidavide/PlotJuggler/commit/63ced5aa2b20eacd5f90f93ea6f093cbe1dc9e31) don't go well with the buildfarm debian packaging. Rolling back to avoid regression in the [upcoming sync](https://discourse.ros.org/t/preparing-for-jazzy-sync-2025-05-23).

FYI: @facontidavide 