### PR TITLE
kinematics_interface: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3121,7 +3121,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.1.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## kinematics_interface

```
* [kilted] Update deprecated call to ament_target_dependencies (#138 <https://github.com/ros-controls/kinematics_interface/issues/138>)
* Use ros2_control_cmake (#118 <https://github.com/ros-controls/kinematics_interface/issues/118>)
* Contributors: Christoph Fröhlich, David V. Lu!!
```

## kinematics_interface_kdl

```
* [kilted] Update deprecated call to ament_target_dependencies (#138 <https://github.com/ros-controls/kinematics_interface/issues/138>)
* Use ros2_control_cmake (#118 <https://github.com/ros-controls/kinematics_interface/issues/118>)
* Contributors: Christoph Fröhlich, David V. Lu!!
```
