### PR TITLE
kinematics_interface: 2.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3068,7 +3068,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.0.0-2
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.1.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-2`

## kinematics_interface

```
* [kilted] Update deprecated call to ament_target_dependencies (#138 <https://github.com/ros-controls/kinematics_interface/issues/138>)
* Use ros2_control_cmake (#118 <https://github.com/ros-controls/kinematics_interface/issues/118>)
* Contributors: Christoph Fröhlich, David V. Lu!!
```

## kinematics_interface_kdl

```
* [kilted] Update deprecated call to ament_target_dependencies (#138 <https://github.com/ros-controls/kinematics_interface/issues/138>)
* Use ros2_control_cmake (#118 <https://github.com/ros-controls/kinematics_interface/issues/118>)
* Contributors: Christoph Fröhlich, David V. Lu!!
```
