### PR TITLE
kinematics_interface: 1.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3655,7 +3655,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.4.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## kinematics_interface

```
* [kilted] Update deprecated call to ament_target_dependencies (backport #138 <https://github.com/ros-controls/kinematics_interface/issues/138>) (#142 <https://github.com/ros-controls/kinematics_interface/issues/142>)
* Use ros2_control_cmake (backport #118 <https://github.com/ros-controls/kinematics_interface/issues/118>) (#119 <https://github.com/ros-controls/kinematics_interface/issues/119>)
* Contributors: mergify[bot]
```

## kinematics_interface_kdl

```
* [kilted] Update deprecated call to ament_target_dependencies (backport #138 <https://github.com/ros-controls/kinematics_interface/issues/138>) (#142 <https://github.com/ros-controls/kinematics_interface/issues/142>)
* Use ros2_control_cmake (backport #118 <https://github.com/ros-controls/kinematics_interface/issues/118>) (#119 <https://github.com/ros-controls/kinematics_interface/issues/119>)
* Contributors: mergify[bot]
```
