### PR TITLE
kinematics_interface: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4060,7 +4060,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.4.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## kinematics_interface

```
* Use CMake targets for eigen (backport #50 <https://github.com/ros-controls/kinematics_interface/issues/50>) (#55 <https://github.com/ros-controls/kinematics_interface/issues/55>)
* Contributors: mergify[bot]
```

## kinematics_interface_kdl

```
* Use CMake targets for eigen (backport #50 <https://github.com/ros-controls/kinematics_interface/issues/50>) (#55 <https://github.com/ros-controls/kinematics_interface/issues/55>)
* Contributors: mergify[bot]
```
