### PR TITLE
urg_node: 1.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9058,7 +9058,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urg_node-release.git
-      version: 1.1.1-4
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urg_node` to `1.2.0-1`:

- upstream repository: https://github.com/ros-drivers/urg_node.git
- release repository: https://github.com/ros2-gbp/urg_node-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-4`

## urg_node

```
* replace ament_target_dependencies (#120 <https://github.com/ros-drivers/urg_node/issues/120>)
* Contributors: Michael Ferguson
```
