### PR TITLE
turtlebot4: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9967,7 +9967,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `2.1.0-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## turtlebot4_description

```
* Remove unnecessary comments
* Fix tag order
* Update package maintainers
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_msgs

```
* Fix tag order
* Update package maintainers
* Contributors: Chris Iverach-Brereton
```

## turtlebot4_navigation

```
* Change footprint from radius to octagon of similar size (#592 <https://github.com/turtlebot/turtlebot4/issues/592>)
* Nav2 changed how use_sim_time is set, should not be in yaml (#564 <https://github.com/turtlebot/turtlebot4/issues/564>)
* Fix tag order
* Update package maintainers
* Adds support for namespaces to TurtleBot4Navigator.
* Contributors: Chris Iverach-Brereton, Hilary Luo, Pbopbo, Pradyum Aadith
```

## turtlebot4_node

```
* Fix tag order
* Update package maintainers
* Contributors: Chris Iverach-Brereton
```
