### PR TITLE
leo_robot: 2.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3361,7 +3361,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-1`

## leo_bringup

```
* Use services instead of topics for reboot and shutdown commands (#28 <https://github.com/LeoRover/leo_robot-ros2/issues/28>)
* Specify camera frame_id (#27 <https://github.com/LeoRover/leo_robot-ros2/issues/27>)
* Add publish_odom_tf argument to leo_bringup launch file (#26 <https://github.com/LeoRover/leo_robot-ros2/issues/26>)
* Contributors: Błażej Sowa
```

## leo_filters

```
* Don't use deprecated tf2 headers (#25 <https://github.com/LeoRover/leo_robot-ros2/issues/25>)
* Contributors: Błażej Sowa
```

## leo_fw

- No changes

## leo_robot

- No changes
