### PR TITLE
ign_ros2_control: 0.7.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3727,7 +3727,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.14-1
+      version: 0.7.15-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.15-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.14-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Fix ackermann demo (backport #582 <https://github.com/ros-controls/gz_ros2_control/issues/582>) (#585 <https://github.com/ros-controls/gz_ros2_control/issues/585>)
* Fix quotes in launch files (#558 <https://github.com/ros-controls/gz_ros2_control/issues/558>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## gz_ros2_control_tests

- No changes

## ign_ros2_control

- No changes

## ign_ros2_control_demos

```
* Fix quotes in legacy launch files (#565 <https://github.com/ros-controls/gz_ros2_control/issues/565>)
* Contributors: Christoph Fröhlich
```
