### PR TITLE
control_toolbox: 5.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.3.1-1
+      version: 5.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.4.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.1-1`

## control_toolbox

```
* Update deprecated call to ament_target_dependencies (#364 <https://github.com/ros-controls/control_toolbox/issues/364>)
* Make member variables of LowPassFilter class generic (#351 <https://github.com/ros-controls/control_toolbox/issues/351>)
* Contributors: David V. Lu!!, Pedro de Azeredo
```
