### PR TITLE
control_toolbox: 4.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1449,7 +1449,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.3.0-1
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.4.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-1`

## control_toolbox

```
* Update deprecated call to ament_target_dependencies (#364 <https://github.com/ros-controls/control_toolbox/issues/364>) (#373 <https://github.com/ros-controls/control_toolbox/issues/373>)
* fix deprecated tf2 header (#361 <https://github.com/ros-controls/control_toolbox/issues/361>) (#363 <https://github.com/ros-controls/control_toolbox/issues/363>)
* Update clang_format (backport #347 <https://github.com/ros-controls/control_toolbox/issues/347>) (#348 <https://github.com/ros-controls/control_toolbox/issues/348>)
* Contributors: Christoph Fröhlich, mergify[bot],  David V. Lu!!
```
