### PR TITLE
odom_to_tf_ros2: 1.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6201,7 +6201,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/gstavrinos/odom_to_tf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `odom_to_tf_ros2` to `1.0.6-1`:

- upstream repository: https://github.com/gstavrinos/odom_to_tf_ros2.git
- release repository: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.5-1`
