### PR TITLE
odom_to_tf_ros2: 1.0.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5430,7 +5430,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/gstavrinos/odom_to_tf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `odom_to_tf_ros2` to `1.0.6-1`:

- upstream repository: https://github.com/gstavrinos/odom_to_tf_ros2.git
- release repository: https://github.com/ros2-gbp/odom_to_tf_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.5-1`
