### PR TITLE
Update mp2p_icp dev branch name

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5429,7 +5429,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -5438,7 +5438,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     status: developed
   mqtt_client:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4747,7 +4747,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -4756,7 +4756,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     status: developed
   mqtt_client:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4106,7 +4106,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -4115,7 +4115,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     status: developed
   mqtt_client:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4165,7 +4165,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -4174,7 +4174,7 @@ repositories:
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git
-      version: master
+      version: develop
     status: developed
   mqtt_client:
     doc:


### PR DESCRIPTION
This is an update of the default branch name changed from the old "master" to the new "develop", for consistency with the rest of the org projects.
