### PR TITLE
ros2_control: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6548,7 +6548,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.0-1`

## controller_interface

```
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>)
* Cleanup deprecations in ros_control  (#2258 <https://github.com/ros-controls/ros2_control/issues/2258>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>)
* Cleanup deprecations in ros_control  (#2258 <https://github.com/ros-controls/ros2_control/issues/2258>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

```
* Cleanup deprecations in ros_control  (#2258 <https://github.com/ros-controls/ros2_control/issues/2258>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface

```
* [RM] Isolate start and stop interfaces for each Hardware Component (#2120 <https://github.com/ros-controls/ros2_control/issues/2120>)
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>)
* Add new Handle constructor for easier initialization (#2253 <https://github.com/ros-controls/ros2_control/issues/2253>)
* Cleanup deprecations in ros_control  (#2258 <https://github.com/ros-controls/ros2_control/issues/2258>)
* Read data_type for all types of interfaces (#2235 <https://github.com/ros-controls/ros2_control/issues/2235>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface_testing

```
* [RM] Isolate start and stop interfaces for each Hardware Component (#2120 <https://github.com/ros-controls/ros2_control/issues/2120>)
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

```
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>)
* Contributors: Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Read data_type for all types of interfaces (#2235 <https://github.com/ros-controls/ros2_control/issues/2235>)
* Contributors: Sai Kishor Kothakota
```

## ros2controlcli

```
* Cleanup deprecations in ros_control  (#2258 <https://github.com/ros-controls/ros2_control/issues/2258>)
* Contributors: Sai Kishor Kothakota
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>)
* Contributors: Sai Kishor Kothakota
```
