### PR TITLE
rosidl_rust: 0.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7206,6 +7206,13 @@ repositories:
       type: git
       url: https://github.com/ros2-rust/rosidl_rust.git
       version: main
+    release:
+      packages:
+      - rosidl_generator_rs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_rust-release.git
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/ros2-rust/rosidl_rust.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_rust` to `0.4.5-1`:

- upstream repository: https://github.com/ros2-rust/rosidl_rust.git
- release repository: https://github.com/ros2-gbp/rosidl_rust-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rosidl_generator_rs

```
* clean up changelog. Removed rosidl_runtime_rs as a dependency
* Contributors: Esteve Fernandez
```
