### PR TITLE
ros2_control: 4.31.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7453,7 +7453,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.30.0-1
+      version: 4.31.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.31.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.30.0-1`

## controller_interface

```
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>) (#2271 <https://github.com/ros-controls/ros2_control/issues/2271>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Add data_type field to the HardwareInterfaces message (backport #2204 <https://github.com/ros-controls/ros2_control/issues/2204>) (#2232 <https://github.com/ros-controls/ros2_control/issues/2232>)
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>) (#2271 <https://github.com/ros-controls/ros2_control/issues/2271>)
* Add new strictness modes to SwitchController service (#2224 <https://github.com/ros-controls/ros2_control/issues/2224>) (#2231 <https://github.com/ros-controls/ros2_control/issues/2231>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

```
* Add data_type field to the HardwareInterfaces message (backport #2204 <https://github.com/ros-controls/ros2_control/issues/2204>) (#2232 <https://github.com/ros-controls/ros2_control/issues/2232>)
* Add new strictness modes to SwitchController service (#2224 <https://github.com/ros-controls/ros2_control/issues/2224>) (#2231 <https://github.com/ros-controls/ros2_control/issues/2231>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* [RM] Isolate start and stop interfaces for each Hardware Component (backport #2120 <https://github.com/ros-controls/ros2_control/issues/2120>) (#2273 <https://github.com/ros-controls/ros2_control/issues/2273>)
* Add data_type field to the HardwareInterfaces message (backport #2204 <https://github.com/ros-controls/ros2_control/issues/2204>) (#2232 <https://github.com/ros-controls/ros2_control/issues/2232>)
* Add new Handle constructor for easier initialization (#2253 <https://github.com/ros-controls/ros2_control/issues/2253>) (#2270 <https://github.com/ros-controls/ros2_control/issues/2270>)
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>) (#2271 <https://github.com/ros-controls/ros2_control/issues/2271>)
* Read data_type for all types of interfaces (#2235 <https://github.com/ros-controls/ros2_control/issues/2235>) (#2261 <https://github.com/ros-controls/ros2_control/issues/2261>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* [RM] Isolate start and stop interfaces for each Hardware Component (backport #2120 <https://github.com/ros-controls/ros2_control/issues/2120>) (#2273 <https://github.com/ros-controls/ros2_control/issues/2273>)
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>) (#2271 <https://github.com/ros-controls/ros2_control/issues/2271>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>) (#2271 <https://github.com/ros-controls/ros2_control/issues/2271>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Read data_type for all types of interfaces (#2235 <https://github.com/ros-controls/ros2_control/issues/2235>) (#2261 <https://github.com/ros-controls/ros2_control/issues/2261>)
* Contributors: mergify[bot]
```

## ros2controlcli

```
* Add data_type field to the HardwareInterfaces message (backport #2204 <https://github.com/ros-controls/ros2_control/issues/2204>) (#2232 <https://github.com/ros-controls/ros2_control/issues/2232>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix fourbarlinkage (#1837 <https://github.com/ros-controls/ros2_control/issues/1837>) (#2276 <https://github.com/ros-controls/ros2_control/issues/2276>)
* Use target_link_libraries instead of ament_target_dependencies (#2266 <https://github.com/ros-controls/ros2_control/issues/2266>) (#2271 <https://github.com/ros-controls/ros2_control/issues/2271>)
* Contributors: mergify[bot]
```
