### PR TITLE
apriltag_detector: 3.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -426,7 +426,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `3.0.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## apriltag_detector

```
* no longer use ament_target_dependencies
* Contributors: Bernd Pfrommer
```

## apriltag_detector_mit

```
* no longer use ament_target_dependencies
* Contributors: Bernd Pfrommer
```

## apriltag_detector_umich

```
* no longer use ament_target_dependencies
* Contributors: Bernd Pfrommer
```

## apriltag_draw

```
* no longer use ament_target_dependencies
* Contributors: Bernd Pfrommer
```

## apriltag_tools

```
* no longer use ament_target_dependencies
* Contributors: Bernd Pfrommer
```
