### PR TITLE
so_arm_100_hardware: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9238,7 +9238,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/brukg/so_arm_100_hardware-release.git
-      version: 0.1.0-3
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/brukg/so_arm_100_hardware.git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

so_arm_100_hardware

## Package Upstream Source:

https://github.com/brukg/so_arm_100_hardware

## Purpose of using this:

merge with minor changes and version update

Distro packaging links:

## Links to Distribution Packages

https://github.com/brukg/so_arm_100_hardware


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
