### PR TITLE
tf2_2d: 1.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8498,7 +8498,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tf2_2d-release.git
-      version: 1.0.1-3
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `1.3.2-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/ros2-gbp/tf2_2d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.1-3`

## tf2_2d

```
* Updated tf2 header extensions from .h to .hpp (#11 <https://github.com/locusrobotics/tf2_2d/issues/11>)
* Contributors: Stephen Williams, locus-services
```
