### PR TITLE
fuse: 1.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2135,7 +2135,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.2.3-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.2-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

```
* Fix linter errors related to header ordering (#407 <https://github.com/locusrobotics/fuse/issues/407>)
* Removed deprecations warnings (#406 <https://github.com/locusrobotics/fuse/issues/406>)
* Contributors: Alejandro Hernández Cordero, Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

```
* Fix linter errors related to header ordering (#407 <https://github.com/locusrobotics/fuse/issues/407>)
* Removed deprecations warnings (#406 <https://github.com/locusrobotics/fuse/issues/406>)
* Contributors: Alejandro Hernández Cordero, Stephen Williams
```

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

```
* Fix linter errors related to header ordering (#407 <https://github.com/locusrobotics/fuse/issues/407>)
* Removed deprecations warnings (#406 <https://github.com/locusrobotics/fuse/issues/406>)
* Contributors: Alejandro Hernández Cordero, Stephen Williams
```
