### PR TITLE
realtime_tools: 3.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.5.1-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.6.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.5.1-1`

## realtime_tools

```
* Rename RealtimeBox to RealtimeThreadsafeBox and use prio_inherit_mutex (backport #318 <https://github.com/ros-controls/realtime_tools/issues/318>) (#341 <https://github.com/ros-controls/realtime_tools/issues/341>)
* Use Boost::boost instead of ${Boost_LIBRARIES} and export it (backport #333 <https://github.com/ros-controls/realtime_tools/issues/333>, #336 <https://github.com/ros-controls/realtime_tools/issues/336>) (#334 <https://github.com/ros-controls/realtime_tools/issues/334>)
* Use target_link_libraries instead of ament_target_dependencies (backport #331 <https://github.com/ros-controls/realtime_tools/issues/331>) (#332 <https://github.com/ros-controls/realtime_tools/issues/332>)
* Contributors: mergify[bot]
```
