### PR TITLE
realtime_tools: 4.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5881,7 +5881,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.2.0-2
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.3.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.2.0-2`

## realtime_tools

```
* Change default mutex of RealtimeThreadSafeBox and add more aliases (#342 <https://github.com/ros-controls/realtime_tools/issues/342>)
* Rename RealtimeBox to RealtimeThreadsafeBox and use prio_inherit_mutex (#318 <https://github.com/ros-controls/realtime_tools/issues/318>)
* export Boost dependency (#336 <https://github.com/ros-controls/realtime_tools/issues/336>)
* Use Boost::boost instead of ${Boost_LIBRARIES} (#333 <https://github.com/ros-controls/realtime_tools/issues/333>)
* Use target_link_libraries instead of ament_target_dependencies (#331 <https://github.com/ros-controls/realtime_tools/issues/331>)
* Cleanup deprecated constructor of RTPublisher (#330 <https://github.com/ros-controls/realtime_tools/issues/330>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
