### PR TITLE
mola_state_estimation: 1.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5278,7 +5278,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.8.0-1
+      version: 1.8.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.8.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.0-1`

## mola_imu_preintegration

```
* fixes for clang-tidy
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation

```
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_simple

```
* Feature: Implement basic twist covariance handling in the SimpleEstimator
* fixes for clang-tidy
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Update copyright year
* fixes for clang-tidy
* Contributors: Jose Luis Blanco-Claraco
```
