### PR TITLE
mola_lidar_odometry: 0.7.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3931,7 +3931,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.7.2-1
+      version: 0.7.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.7.3-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.2-1`

## mola_lidar_odometry

```
* feature: new threshold to discard state estimation as invalid if uncertainty is too high
* Fixed unit tests in CI
* Prepare GUI for ortho camera option
* progress implementing init pitch/roll from IMU
* pipelines YAML files reformated with RedHat YAML formatter
* Update env var name to explicitly mention LO: MOLA_LO_INITIAL_LOCALIZATION_METHOD
* docs: on initial localization methods
* ROS2 launch: Add new mola_state_estimator_reference_frame argument.
  It should be used together with mola_lo_reference_frame to use an alternative reference map TF frame than the default map.
* Fix wrong namespace in class name (it worked anyway because of a fall-back mechanism using unqualified names)
* Expose env vars to change the reference frame_id for smoother (MOLA_TF_MAP)
* fix: potential missing publication of updated poses if there is no map subscriber
* lidar 3d pipeline: add rendering options for local map
* Contributors: Jose Luis Blanco-Claraco
```
