### PR TITLE
mola: 1.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3886,7 +3886,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.7.0-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.8.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.0-1`

## kitti_metrics_eval

```
* Update license tag to "BSD-3-Clause"
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola

```
* Update license tag to "BSD-3-Clause"
* Fix: "mola" metapackage warning if using CMAKE_EXPORT_COMPILE_COMMANDS
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* Update license tag to "BSD-3-Clause"
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* silent cmake warning when using CMAKE_EXPORT_COMPILE_COMMANDS
* Update license tag to "BSD-3-Clause"
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Update license tag to "BSD-3-Clause"
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* remove useless commented out dependency
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Update Viz interface: add methods to run arbitrary Scene manipulation and camera orthographic mode
* Update copyright year
* fix reversed logic
* clang-format fix
* Add mola::Synchronizer for grouping observations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Update license tag to "BSD-3-Clause"
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Implement new virtual Viz methods
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Update license tag to "BSD-3-Clause"
* Update copyright year
* Contributors: Jose Luis Blanco-Claraco
```
