### PR TITLE
flir_camera_driver: 3.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1937,7 +1937,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
-      version: 3.0.1-2
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `3.0.2-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros2-gbp/flir_camera_driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-2`

## flir_camera_description

- No changes

## flir_camera_msgs

- No changes

## spinnaker_camera_driver

```
* avoid ament_target_dependencies
* fixed doc formatting
* PTP support for spinnaker_camera_driver
* added reverse x/y for blackfly s
* Contributors: Bernd Pfrommer
```

## spinnaker_synchronized_camera_driver

```
* avoid ament_target_dependencies
* Contributors: Bernd Pfrommer
```
