### PR TITLE
service_load_balancing: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7953,7 +7953,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/service_load_balancing-release.git
-      version: 0.1.1-2
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `service_load_balancing` to `0.1.2-1`:

- upstream repository: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
- release repository: https://github.com/ros2-gbp/service_load_balancing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-2`

## service_load_balancing

```
* Add ament_cmake_gtest to package.xml
* Use target_link_libraries instead of ament_target_dependencies
```
