### PR TITLE
diagnostics: 4.3.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1284,7 +1284,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.3.4-1
+      version: 4.3.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.3.6-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.4-1`

## diagnostic_aggregator

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_common_diagnostics

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_remote_logging

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* fix: Missing link to libcurl (#505 <https://github.com/ros/diagnostics/issues/505>)
* Contributors: Christian Henkel, Moritz Schauer
```

## diagnostic_updater

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostics

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## self_test

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```
