### PR TITLE
diagnostics: 4.4.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1341,7 +1341,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.4.4-2
+      version: 4.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.4.6-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.4.4-2`

## diagnostic_aggregator

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_common_diagnostics

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostic_remote_logging

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* fix: Missing link to libcurl (#505 <https://github.com/ros/diagnostics/issues/505>)
* Contributors: Christian Henkel, Moritz Schauer
```

## diagnostic_updater

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## diagnostics

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```

## self_test

```
* C++17 and cmake 3.20 everywhere (#510 <https://github.com/ros/diagnostics/issues/510>)
* Contributors: Christian Henkel
```
