### PR TITLE
ros_gz: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6867,7 +6867,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.1-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Fix debug_env (#747 <https://github.com/gazebosim/ros_gz/issues/747>)
* Log environment variables with which gazebo was launched (#680 <https://github.com/gazebosim/ros_gz/issues/680>)
  * Log environment variables with which gazebo was launched
  This can be useful for debugging scenarios where we want to debug why a simulation is not loading the correct files.
  * Add confg
  * Minor refactor
  * make linters happy
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero, Arjo Chakravarty
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
