### PR TITLE
gz_ros2_control: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2632,7 +2632,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.8-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `3.0.0-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.8-1`

## gz_ros2_control

```
* Use ros2_control_cmake (#588 <https://github.com/ros-controls/gz_ros2_control/issues/588>)
* Contributors: Christoph Fröhlich
```

## gz_ros2_control_demos

```
* Use ros2_control_cmake (#588 <https://github.com/ros-controls/gz_ros2_control/issues/588>)
* Contributors: Christoph Fröhlich
```
