### PR TITLE
ffmpeg_encoder_decoder: 2.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1765,7 +1765,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_encoder_decoder` to `2.0.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
- release repository: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-2`

## ffmpeg_encoder_decoder

```
* avoid ament_target_dependencies
* When using CMake >= 3.24 use CMAKE_COMPILE_WARNING_AS_ERROR variable
* only build on most recent distros
* Fix deprecated libavcodec (#1 <https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder/issues/1>)
  * fix deprecated features for libav 7
  * fix formatting errors
* Contributors: Bernd Pfrommer, Silvio Traversaro
```
