### PR TITLE
ffmpeg_image_transport_tools: 2.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2343,7 +2343,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_tools` to `2.1.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.1-1`

## ffmpeg_image_transport_tools

```
* avoid ament_target_dependencies
* Contributors: Bernd Pfrommer
```
