### PR TITLE
Update source repo for scenario_execution

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8896,7 +8896,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/cps-test-lab/scenario-execution.git
-      version: jazzy
+      version: main
     release:
       packages:
       - scenario_execution

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8895,7 +8895,7 @@ repositories:
   scenario_execution:
     doc:
       type: git
-      url: https://github.com/IntelLabs/scenario_execution.git
+      url: https://github.com/cps-test-lab/scenario-execution.git
       version: jazzy
     release:
       packages:


### PR DESCRIPTION
Update source repo of scenario_execution


## Package name:

scenario_execution

## Package Upstream Source:

[link to source repository](https://github.com/cps-test-lab/scenario-execution)

## Purpose of using this:

Future development will happen in the new repository.


# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
