### PR TITLE
marti_common: 3.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3628,12 +3628,11 @@ repositories:
       - swri_roscpp
       - swri_route_util
       - swri_serial_util
-      - swri_system_util
       - swri_transform_util
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.7.5-1
+      version: 3.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.8.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.7.5-1`

## swri_cli_tools

- No changes

## swri_console_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_dbw_interface

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_geometry_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_image_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_math_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_opencv_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_roscpp

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_route_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_serial_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```

## swri_transform_util

```
* Updates for Rolling (#771 <https://github.com/swri-robotics/marti_common/issues/771>)
  * Removed obsolete ament macros
  * Removed boost in favor of standard library functionality
  * Deprecated swri_system_util
* Contributors: David Anthony
```
