### PR TITLE
gps_umd: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3277,7 +3277,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 2.0.5-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `2.1.0-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.5-1`

## gps_msgs

- No changes

## gps_tools

```
* Update deprecated call to ament_target_dependencies (#110 <https://github.com/swri-robotics/gps_umd/issues/110>)
* Contributors: David V. Lu!!, David Anthony
```

## gps_umd

- No changes

## gpsd_client

```
* Update deprecated call to ament_target_dependencies (#110 <https://github.com/swri-robotics/gps_umd/issues/110>)
* Contributors: David V. Lu!!, David Anthony
```
