### PR TITLE
movie_publisher: 3.0.3-1 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6458,7 +6458,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/peci1/movie_publisher-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/movie_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `movie_publisher` to `3.0.3-1`:

- upstream repository: https://github.com/peci1/movie_publisher.git
- release repository: https://github.com/peci1/movie_publisher-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.2-1`

## camera_info_manager_lib

- No changes

## camera_info_manager_metadata_extractor

```
* Fixed handling of movies where image rotation changes in the middle of the movie.
  Closes #9 <https://github.com/ctu-vras/movie_publisher/issues/9>.
* Contributors: Martin Pecka
```

## exiftool_metadata_extractor

```
* Fixed parsing camera model from GoPro videos.
  Closes #17 <https://github.com/ctu-vras/movie_publisher/issues/17>.
* Contributors: Martin Pecka
```

## exiv2_metadata_extractor

- No changes

## gpmf_metadata_extractor

```
* Fixed parsing of faces.
  Also fixed timestamps for timed metadata.
  Also fixed the order of some parsed vectors.
  Closes #12 <https://github.com/ctu-vras/movie_publisher/issues/12>.
* Fixed tests.
  Closes #11 <https://github.com/ctu-vras/movie_publisher/issues/11>.
* Contributors: Martin Pecka
```

## lensfun_metadata_extractor

- No changes

## libexif_metadata_extractor

- No changes

## movie_publisher

```
* Fixed swapped roll and pitch in RollPitchComposer.
  Closes #16 <https://github.com/ctu-vras/movie_publisher/issues/16>.
* Make timestamps of messages passed to MovieMetadataProcessors consistent.
  Closes #15 <https://github.com/ctu-vras/movie_publisher/issues/15>.
* Set inner frame_ids of detected faces.
  Closes #14 <https://github.com/ctu-vras/movie_publisher/issues/14>.
* Fixed creation of static TFs in movie_to_bag.
  Closes #13 <https://github.com/ctu-vras/movie_publisher/issues/13>.
* Fixed setting frame_id to latest metadata before they are updated from latest metadata.
  Closes #10 <https://github.com/ctu-vras/movie_publisher/issues/10>.
* Fixed handling of movies where image rotation changes in the middle of the movie.
  Closes #9 <https://github.com/ctu-vras/movie_publisher/issues/9>.
* Fixed doc comments.
* Update latest metadata from timed metadata.
  Closes #8 <https://github.com/ctu-vras/movie_publisher/issues/8>.
* Fixed OpticalFrameTFComposer producing too much output.
  Closes #7 <https://github.com/ctu-vras/movie_publisher/issues/7>.
* Fixed priority of composers.
  Closes #6 <https://github.com/ctu-vras/movie_publisher/issues/6>.
* Fixed exception when stream start_time is wrong and leads to negative stream time.
* Contributors: Martin Pecka
```

## movie_publisher_plugins

- No changes

## movie_publisher_plugins_copyleft

- No changes

## movie_publisher_plugins_nonfree

- No changes

## movie_publisher_plugins_permissive

- No changes
