### PR TITLE
mvsim: 0.13.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5606,7 +5606,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.13.2-1
+      version: 0.13.3-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.13.3-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.13.2-1`

## mvsim

```
* Readme: add new demo video and add Kilted badges
* Format: space indentation in main cmake file
* Fix build after deprecation of ament_target_dependencies()
* Update broken link to ROS Index
* Contributors: Jose Luis Blanco-Claraco
```
