### PR TITLE
mvsim: 0.13.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4268,7 +4268,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.13.2-2
+      version: 0.13.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.13.3-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.13.2-2`

## mvsim

```
* Readme: add new demo video and add Kilted badges
* Format: space indentation in main cmake file
* Fix build after deprecation of ament_target_dependencies()
* Update broken link to ROS Index
* Contributors: Jose Luis Blanco-Claraco
```
