### PR TITLE
mrpt_navigation: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4229,7 +4229,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.2.2-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`

## mrpt_map_server

```
* FIX: remove usage of obsolete ament_target_dependencies()
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* FIX: remove usage of obsolete ament_target_dependencies()
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav_interfaces

- No changes

## mrpt_navigation

- No changes

## mrpt_pf_localization

```
* FIX: remove usage of obsolete ament_target_dependencies()
* Merge pull request #153 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/153> from dppp415/ros2
  Composable Nodes
* Shared libraries
* Some fixes and demo
* Copyright
* Deleted duplicated code
* Nodes mrpt_pointcloud_pipeline y mrpt_pf_localization are now composables
* Contributors: Jose Luis Blanco-Claraco, dppp415
```

## mrpt_pointcloud_pipeline

```
* FIX: remove usage of obsolete ament_target_dependencies()
* Merge pull request #153 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/153> from dppp415/ros2
  Composable Nodes
* Some fixes and demo
* Copyright
* Deleted duplicated code
* Nodes mrpt_pointcloud_pipeline y mrpt_pf_localization are now composables
* Contributors: Jose Luis Blanco-Claraco, dppp415
```

## mrpt_rawlog

```
* FIX: remove usage of obsolete ament_target_dependencies()
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* FIX: remove usage of obsolete ament_target_dependencies()
* remove special code to build against older mrpt_msgs
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tps_astar_planner

```
* FIX: remove usage of obsolete ament_target_dependencies()
* Merge pull request #156 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/156> from r-aguilera/ros2
  mrpt_tps_astar_planner_node: improves on obstacle points update
* astar_planner: limit excessive obstacle points ...
  logging
* astar_planner: prevent node from shutting down ...
  on missing tf info
* astar planner node: it will always return the best found path, even if success==false
* Merge pull request #155 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/155> from r-aguilera/ros2
  Fix MakePlanFromTo srv using robot pose as start
* Fix MakePlanFromTo srv using robot pose as start
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera
```

## mrpt_tutorials

```
* Fix tutorial demo launchs missing 'use_composable' argument
* Merge pull request #153 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/153> from dppp415/ros2
  Composable Nodes
* Fix
* Some fixes and demo
* Contributors: Jose Luis Blanco-Claraco, dppp415
```
