### PR TITLE
ublox_dgnss: 0.5.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9003,7 +9003,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.5.5-4
+      version: 0.5.6-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.6-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.5-4`

## ntrip_client_node

```
* changed ament_target_dependencies to target_link_libraries
* Contributors: Nick Hortovanyi
```

## ublox_dgnss

- No changes

## ublox_dgnss_node

```
* changed ament_target_dependencies to target_link_libraries
* Merge pull request #45 <https://github.com/aussierobots/ublox_dgnss/issues/45> from ARK3r/main
  fix: show correct port_id
* now it shows reasonable port ids
* Merge pull request #43 <https://github.com/aussierobots/ublox_dgnss/issues/43> from bvsam/ubx-nav-svin-fix
  Fixing UBX-NAV-SVIN reading
* Merge pull request #40 <https://github.com/aussierobots/ublox_dgnss/issues/40> from mak22223/main
  Fixed U4, X4, I4 values interpretation
* Fixed U4, X4, I4 values interpretation
* Fixing UBX-NAV-SVIN reading
* Contributors: ARK3r, Benjamin Sam, Markin Maxim, Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

```
* changed ament_target_dependencies to target_link_libraries
* Merge pull request #36 <https://github.com/aussierobots/ublox_dgnss/issues/36> from ARK3r/add-qos-options-nav-sat-fix-node
  add qos options to nav sat fix hp node
* add qos options to nav sat fix hp node
* Contributors: ARK3r, Nick Hortovanyi
```

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
