### PR TITLE
turbojpeg_compressed_image_transport: 0.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8588,7 +8588,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
-      version: 0.2.1-5
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/wep21/turbojpeg_compressed_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turbojpeg_compressed_image_transport` to `0.3.0-1`:

- upstream repository: https://github.com/wep21/turbojpeg_compressed_image_transport.git
- release repository: https://github.com/ros2-gbp/turbojpeg_compressed_image_transport-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.1-5`

## turbojpeg_compressed_image_transport

```
* chore: remove deprecations (#1 <https://github.com/wep21/turbojpeg_compressed_image_transport/issues/1>)
* Contributors: Alejandro Hernández Cordero
```
