### PR TITLE
ublox_dgnss: 0.5.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8811,7 +8811,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.5.5-5
+      version: 0.5.7-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.5.7-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.5-5`

## ntrip_client_node

- No changes

## ublox_dgnss

- No changes

## ublox_dgnss_node

```
* fixed whitespace comment
* Contributors: Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
