### PR TITLE
behaviortree_cpp_v4: 4.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -851,7 +851,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.7.1-1
+      version: 4.7.2-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.7.2-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.7.1-1`

## behaviortree_cpp

```
* Fix issue #978 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/978> : skipped was not working properly
* Added codespell as a pre-commit hook. (#977 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/977>)
* fix: Make impossible to accidentally copy JsonExporter singleton (#975 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/975>)
* Contributors: Davide Faconti, Leander Stephen D'Souza, tony-p
```
