### PR TITLE
mapviz: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4783,7 +4783,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.9-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.9-1`

## mapviz

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## mapviz_interfaces

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## mapviz_plugins

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## multires_image

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## tile_map

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```
