### PR TITLE
mapviz: 2.5.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3572,7 +3572,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.4.8-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.8-1`

## mapviz

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## mapviz_interfaces

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## mapviz_plugins

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## multires_image

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```

## tile_map

```
* Correct CMake Export (#842 <https://github.com/swri-robotics/mapviz/issues/842>)
  * Removes Boost
  * Removes deprecated ament macro
  * General fixes to fix CMake exports and dependencies
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: David Anthony
```
