### PR TITLE
clearpath_config: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1192,7 +1192,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.5.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.0-1`

## clearpath_config

```
* Fix: PACS Limits (#171 <https://github.com/clearpathrobotics/clearpath_config/issues/171>)
* Add foxglove bridge enable to platform section (#169 <https://github.com/clearpathrobotics/clearpath_config/issues/169>)
* Add enable setting for wireless-watcher (#170 <https://github.com/clearpathrobotics/clearpath_config/issues/170>)
* Feature: CAN Bridge Parameters (#166 <https://github.com/clearpathrobotics/clearpath_config/issues/166>)
* Add cap_type parameter to the OS1 sample since it's supported (#163 <https://github.com/clearpathrobotics/clearpath_config/issues/163>)
* Fix/issue typos (#168 <https://github.com/clearpathrobotics/clearpath_config/issues/168>)
* Contributors: Chris Iverach-Brereton, Hilary Luo, luis-camero
```
