### PR TITLE
clearpath_common: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1168,6 +1168,7 @@ repositories:
       - clearpath_control
       - clearpath_customization
       - clearpath_description
+      - clearpath_diagnostics
       - clearpath_generator_common
       - clearpath_manipulators
       - clearpath_manipulators_description
@@ -1177,7 +1178,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.3.2-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.5.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.2-1`

## clearpath_bt_joy

```
* Disable symlink rule to rely on DS4DRV instead
* Contributors: Luis Camero
```

## clearpath_common

- No changes

## clearpath_control

```
* Fix the velocity limits for Dingo-O using Logitech controllers (#207 <https://github.com/clearpathrobotics/clearpath_common/issues/207>)
* Increase A300 teleop normal speed to 0.4, reduce turbo speed to 1.5 (#206 <https://github.com/clearpathrobotics/clearpath_common/issues/206>)
* Contributors: Chris Iverach-Brereton
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

```
* Allow broad window of BMS message rates (#218 <https://github.com/clearpathrobotics/clearpath_common/issues/218>)
* Fix/fw version check (#217 <https://github.com/clearpathrobotics/clearpath_common/issues/217>)
  * Add condition for mcu firmware version newer than apt package
  * Clarify wording for checks that are evaluated on boot
* Fix: Foxglove Bridge Superclient (#214 <https://github.com/clearpathrobotics/clearpath_common/issues/214>)
* Feature: Foxglove Bridge (#213 <https://github.com/clearpathrobotics/clearpath_common/issues/213>)
  * Add foxglove bridge launch and parameter file
  * Add foxglove bridge parameter to generator
* Move clearpath_diagnostics to clearpath_common (#211 <https://github.com/clearpathrobotics/clearpath_common/issues/211>)
* Contributors: Hilary Luo, luis-camero
```

## clearpath_generator_common

```
* Feature: Foxglove Bridge (#213 <https://github.com/clearpathrobotics/clearpath_common/issues/213>)
  * Add foxglove bridge launch and parameter file
  * Add foxglove bridge parameter to generator
* Move clearpath_diagnostics to clearpath_common (#211 <https://github.com/clearpathrobotics/clearpath_common/issues/211>)
* Add cooling and ekf-node diagnostic settings conditionally (#209 <https://github.com/clearpathrobotics/clearpath_common/issues/209>)
  * Add cooling and ekf-node diagnostic settings conditionally
* Contributors: Hilary Luo, luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

```
* Fix: Post and Riser Leg Mounts (#216 <https://github.com/clearpathrobotics/clearpath_common/issues/216>)
* Contributors: luis-camero
```

## clearpath_platform_description

```
* Fix: PACS Limits (#215 <https://github.com/clearpathrobotics/clearpath_common/issues/215>)
* Contributors: luis-camero
```

## clearpath_sensors_description

- No changes
