### PR TITLE
slam_toolbox: 2.9.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8006,6 +8006,21 @@ repositories:
       url: https://github.com/ros-simulation/simulation_interfaces.git
       version: main
     status: developed
+  slam_toolbox:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: kilted
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 2.9.0-1
+    source:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: kilted
+    status: maintained
   slg_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `2.9.0-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
