### PR TITLE
vision_msgs: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9362,7 +9362,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/vision_msgs-release.git
-      version: 4.1.1-2
+      version: 4.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vision_msgs` to `4.2.0-1`:

- upstream repository: https://github.com/ros-perception/vision_msgs.git
- release repository: https://github.com/ros2-gbp/vision_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.1.1-2`
