### PR TITLE
nav2_minimal_turtlebot_simulation: 1.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4341,7 +4341,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
-      version: 1.1.0-3
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nav2_minimal_turtlebot_simulation` to `1.2.0-1`:

- upstream repository: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
- release repository: https://github.com/ros2-gbp/nav2_minimal_turtlebot_simulation-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-3`
