### PR TITLE
docs: add laser_scan_merger description to distribution.yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3848,13 +3848,8 @@ repositories:
   laser_scan_merger:
     doc:
       type: git
-      url: https://github.com/BruceChanJianLe/laser_scan_merger
-      version: jazzy
-    source:
-      type: git
       url: https://github.com/BruceChanJianLe/laser_scan_merger.git
       version: jazzy
-    status: developed
   laser_segmentation:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3845,6 +3845,16 @@ repositories:
       url: https://github.com/ros-perception/laser_proc.git
       version: ros2-devel
     status: maintained
+  laser_scan_merger:
+    doc:
+      type: git
+      url: https://github.com/BruceChanJianLe/laser_scan_merger
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/BruceChanJianLe/laser_scan_merger.git
+      version: jazzy
+    status: developed
   laser_segmentation:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3850,6 +3850,11 @@ repositories:
       type: git
       url: https://github.com/BruceChanJianLe/laser_scan_merger.git
       version: jazzy
+    source:
+      type: git
+      url: https://github.com/BruceChanJianLe/laser_scan_merger.git
+      version: jazzy
+    status: developed
   laser_segmentation:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

I have seen a couple of opensource laser scan merger, but they only merged up to 2 laser scan, I would like to contribute a merge that uses the approximate time filter which can merge up to 9 laser scans.

ROSDISTRO NAME: jazzy

# The source is here:

https://github.com/BruceChanJianLe/laser_scan_merger

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
