### PR TITLE
rcutils: 6.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5899,7 +5899,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.10.0-1
+      version: 6.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.10.1-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.10.0-1`

## rcutils

```
* use getenv_s instead of getenv for Windows. (#499 <https://github.com/ros2/rcutils/issues/499>)
* Make linters happy
* Clean memory in test_process.cpp (#495 <https://github.com/ros2/rcutils/issues/495>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```
