### PR TITLE
rcl: 10.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5716,7 +5716,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.2.0-1
+      version: 10.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.2.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `10.2.0-1`

## rcl

```
* remove unnecessary test_with_localhost_only. (#1238 <https://github.com/ros2/rcl/issues/1238>)
* Address memory leaks in rcl test_timer_init_state (#1236 <https://github.com/ros2/rcl/issues/1236>)
* Removed unused nondefault_qos_profile (#1233 <https://github.com/ros2/rcl/issues/1233>)
* Removed unused functions (#1230 <https://github.com/ros2/rcl/issues/1230>)
* remove rcl_qos_profile_rosout_default. (#1225 <https://github.com/ros2/rcl/issues/1225>)
* remove rmw_connext from test. (#1226 <https://github.com/ros2/rcl/issues/1226>)
* Contributors: Alejandro Hernández Cordero, Michael Orlov, Tomoya Fujita
```

## rcl_action

- No changes

## rcl_lifecycle

```
* introduce rcl_lifecycle_get_transition_label_by_id(). (#1229 <https://github.com/ros2/rcl/issues/1229>)
* Contributors: Tomoya Fujita
```

## rcl_yaml_param_parser

- No changes
