### PR TITLE
rai_interfaces: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6391,7 +6391,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rai_interfaces-release.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/RobotecAI/rai_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rai_interfaces` to `0.3.0-1`:

- upstream repository: https://github.com/RobotecAI/rai_interfaces.git
- release repository: https://github.com/ros2-gbp/rai_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.2-1`

## rai_interfaces

```
* Add EmbodimentInfo service
  Co-authored-by: Maciej Majek <mailto:maciej.majek@robotec.ai>
* Contributors: Bartłomiej Boczek, Kacper Dąbrowski, Maciej Majek
```
