### PR TITLE
clearpath_nav2_demos: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1246,7 +1246,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `2.5.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.0-1`

## clearpath_nav2_demos

```
* Fix typos in issue templates (#27 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/27>)
* Add parameter files for Dingo (all variants), Ridgeback (#25 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/25>)
  * Add parameter files for Dingo (all variants), Ridgeback
  * Add trailing newlines to config files, add missing remap to launch file
* Fix the slam launch file to use the new lifecycle node (#24 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/24>)
* Contributors: Chris Iverach-Brereton, Hilary Luo
```
