### PR TITLE
laser_filters: 2.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3187,7 +3187,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.8-2
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.2.0-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.8-2`

## laser_filters

```
* Updated deprecated calls to message_filters
* Added heartbeat diagnostics
* Window size check to prevent segfault in speckle filter
* Added params_prefix to reconfigure callback
* Remove use of boost from polygon_filter
* Contributors: Alejandro Hernandez Cordero, Alejandro Hernández Cordero, Jeanine van Bruggen, Silvio Traversaro
```
