### PR TITLE
Bump catkin_virtualenv

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -915,7 +915,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.6.1-2
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Tested against a clean noetic install.

Include https://github.com/locusrobotics/catkin_virtualenv/pull/114 and other fixes