### PR TITLE
phidgets_drivers: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5823,7 +5823,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/phidgets_drivers-release.git
-      version: 2.3.4-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `phidgets_drivers` to `2.4.0-1`:

- upstream repository: https://github.com/ros-drivers/phidgets_drivers.git
- release repository: https://github.com/ros2-gbp/phidgets_drivers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.4-1`

## libphidget22

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* libphidget22: Fix CMake warning (DOWNLOAD_EXTRACT_TIMESTAMP)
* Contributors: Martin Günther
```

## phidgets_accelerometer

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_analog_inputs

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_analog_outputs

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_api

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* phidgets_api: Switch to modern CMake target-based dependency handling
* phidgets_api: Reformat CMakeLists for better readability
* Contributors: Martin Günther
```

## phidgets_digital_inputs

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_digital_outputs

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_drivers

- No changes

## phidgets_gyroscope

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_high_speed_encoder

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_ik

- No changes

## phidgets_magnetometer

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_motors

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_msgs

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* Contributors: Martin Günther
```

## phidgets_spatial

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_stepper

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```

## phidgets_temperature

```
* Merge pull request #191 <https://github.com/ros-drivers/phidgets_drivers/issues/191> from mintar/remove-ament-target-dependencies
  [kilted] Update deprecated call to ament_target_dependencies
* Update to C++ standard 17
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: Martin Günther
```
