### PR TITLE
add crazyflie* packages to jazzy and rolling

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1511,6 +1511,12 @@ repositories:
       url: https://github.com/rt-net/crane_plus.git
       version: master
     status: maintained
+  crazyflie:
+    source:
+      type: git
+      url: https://github.com/IMRCLab/crazyswarm2.git
+      version: main
+    status: developed
   create3_examples:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1227,6 +1227,12 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  crazyflie:
+    source:
+      type: git
+      url: https://github.com/IMRCLab/crazyswarm2.git
+      version: main
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy, rolling

# The source is here:

https://github.com/IMRCLab/crazyswarm2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

Adding @knmcguire for visibility.

