### PR TITLE
rviz_2d_overlay_plugins: 1.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7773,7 +7773,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.3.0-3
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.3.1-1`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-3`

## rviz_2d_overlay_msgs

- No changes

## rviz_2d_overlay_plugins

```
* Replace ament_target_dependencies with target_link_libraries ([#22](https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/22))
* use less custom package docs with sphinx instead of doxygen ([#19](https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/19))
* Contributors: Alejandro Hernandez Cordero, Jonas Otto
```
