### PR TITLE
mp2p_icp: 1.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4110,7 +4110,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.6.7-2
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.7.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.6.7-2`

## mp2p_icp

```
* metric map data type: add new metadata YAML field
* Update broken link to ROS Index
* docs: change references to default branch master->develop
* Default generator: more details in debug traces when ignoring an observation
* Update package license tag to "BSD-3-Clause"
* Integrate vscode with colcon custom settings and clang-tidy
* Fix build unit tests with older gcc versions
* Drop apparently useless build dep
* Contributors: Jose Luis Blanco-Claraco
```
