### PR TITLE
marti_common: 3.8.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3632,7 +3632,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.8.1-1
+      version: 3.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.8.2-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.1-1`

## swri_cli_tools

- No changes

## swri_console_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_dbw_interface

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_geometry_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_image_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_math_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_opencv_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_roscpp

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_route_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_serial_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```

## swri_transform_util

```
* Dependency cleanup (#774 <https://github.com/swri-robotics/marti_common/issues/774>)
* Contributors: DangitBen
```
