### PR TITLE
mapviz: 2.5.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3637,7 +3637,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.0-1
+      version: 2.5.3-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.3-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## mapviz

```
* Dependency cleanup (#845 <https://github.com/swri-robotics/mapviz/issues/845>)
* Contributors: DangitBen
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Dependency cleanup (#845 <https://github.com/swri-robotics/mapviz/issues/845>)
* Contributors: DangitBen
```

## multires_image

```
* Dependency cleanup (#845 <https://github.com/swri-robotics/mapviz/issues/845>)
* Contributors: DangitBen
```

## tile_map

```
* Dependency cleanup (#845 <https://github.com/swri-robotics/mapviz/issues/845>)
* Contributors: DangitBen
```
