### PR TITLE
imu_pipeline: 0.5.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3502,7 +3502,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
-      version: 0.5.0-3
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.5.2-1`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros2-gbp/imu_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-3`

## imu_pipeline

- No changes

## imu_processors

```
* Add use_stamped parameter to bias remover (backport #30 <https://github.com/ros-perception/imu_pipeline/issues/30>) (#31 <https://github.com/ros-perception/imu_pipeline/issues/31>)
  Adds use_stamped parameter (default is false) to bias remover node
  Co-authored-by: Tatsuro Sakaguchi <mailto:tacchan.mello.ioiq@gmail.com>
* Contributors: Michael Ferguson
```

## imu_transformer

- No changes
