### PR TITLE
imu_pipeline: 0.6.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2887,7 +2887,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/imu_pipeline-release.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_pipeline` to `0.6.1-1`:

- upstream repository: https://github.com/ros-perception/imu_pipeline
- release repository: https://github.com/ros2-gbp/imu_pipeline-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.0-1`

## imu_pipeline

- No changes

## imu_processors

```
* set use_stamped to default true for kilted and later (#32 <https://github.com/ros-perception/imu_pipeline/issues/32>)
* Add use_stamped parameter to bias remover (#30 <https://github.com/ros-perception/imu_pipeline/issues/30>)
  Adds use_stamped parameter (default is false) to bias remover node
* Contributors: Michael Ferguson, Tatsuro Sakaguchi
```

## imu_transformer

```
* add depend on ament_cmake_gtest (#28 <https://github.com/ros-perception/imu_pipeline/issues/28>)
  Debian is building, but test job is still failing
* Contributors: Michael Ferguson
```
