### PR TITLE
Revert release of rosidlcpp due to circular dependency

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7276,25 +7276,6 @@ repositories:
       type: git
       url: https://github.com/TonyWelte/rosidlcpp.git
       version: rolling
-    release:
-      packages:
-      - rosidlcpp
-      - rosidlcpp_generator_c
-      - rosidlcpp_generator_core
-      - rosidlcpp_generator_cpp
-      - rosidlcpp_generator_py
-      - rosidlcpp_generator_type_description
-      - rosidlcpp_parser
-      - rosidlcpp_typesupport_c
-      - rosidlcpp_typesupport_cpp
-      - rosidlcpp_typesupport_fastrtps_c
-      - rosidlcpp_typesupport_fastrtps_cpp
-      - rosidlcpp_typesupport_introspection_c
-      - rosidlcpp_typesupport_introspection_cpp
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/rosidlcpp-release.git
-      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Revert release of `rosidlcpp` introduced in https://github.com/ros/rosdistro/pull/46070.

The packages introduce a circular dependency which prevents the `Rrel_reconfigure` job from running on the buildfarm. This is hence causing several hundred regressions and blocking the [sync](https://discourse.ros.org/t/preparing-for-rolling-sync-2025-06-03/44024).

https://build.ros2.org/job/Rrel_reconfigure-jobs/4005/console

```
23:46:05 Traceback (most recent call last):
23:46:05   File "/tmp/ros_buildfarm/scripts/release/generate_release_jobs.py", line 21, in <module>
23:46:05     run_module('ros_buildfarm.scripts.release.generate_release_jobs', run_name='__main__')
23:46:05   File "/usr/lib/python3.8/runpy.py", line 210, in run_module
23:46:05     return _run_code(code, {}, init_globals, run_name, mod_spec)
23:46:05   File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
23:46:05     exec(code, run_globals)
23:46:05   File "/tmp/ros_buildfarm/ros_buildfarm/scripts/release/generate_release_jobs.py", line 45, in <module>
23:46:05     sys.exit(main())
23:46:05   File "/tmp/ros_buildfarm/ros_buildfarm/scripts/release/generate_release_jobs.py", line 38, in main
23:46:05     return configure_release_jobs(
23:46:05   File "/tmp/ros_buildfarm/ros_buildfarm/release_job.py", line 189, in configure_release_jobs
23:46:05     ordered_pkg_tuples = topological_order_packages(cached_pkgs)
23:46:05   File "/tmp/ros_buildfarm/ros_buildfarm/common.py", line 559, in topological_order_packages
23:46:05     raise RuntimeError('Circular dependency in: %s' % pkg)
23:46:06 RuntimeError: Circular dependency in: action_msgs, ament_cmake_ros, builtin_interfaces, rmw_connextdds, rmw_connextdds_common, rmw_cyclonedds_cpp, rmw_dds_common, rmw_desert, rmw_fastrtps_cpp, rmw_fastrtps_dynamic_cpp, rmw_fastrtps_shared_cpp, rmw_gurumdds_cpp, rmw_implementation, rmw_stats_shim, rmw_test_fixture_implementation, rosgraph_monitor_msgs, rosidl_core_generators, rosidl_default_runtime, rosidlcpp_generator_type_description, rosidlcpp_typesupport_c, rosidlcpp_typesupport_cpp, rosidlcpp_typesupport_fastrtps_c, rosidlcpp_typesupport_fastrtps_cpp, rosidlcpp_typesupport_introspection_c, rosidlcpp_typesupport_introspection_cpp, service_msgs, test_msgs, unique_identifier_msgs
```

cc @TonyWelte