### PR TITLE
Add qt-material pip package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9275,6 +9275,10 @@ python3-pyxdg-pip:
   ubuntu:
     pip:
       packages: [pyxdg]
+python3-qt-material-pip:
+  '*':
+    pip:
+      packages: [qt-material]
 python3-qpsolvers-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9276,10 +9276,6 @@ python3-pyxdg-pip:
   ubuntu:
     pip:
       packages: [pyxdg]
-python3-qt-material-pip:
-  '*':
-    pip:
-      packages: [qt-material]
 python3-qpsolvers-pip:
   debian:
     pip:
@@ -9300,6 +9296,10 @@ python3-qrcode:
   rhel:
     '8': [python3-qrcode]
   ubuntu: [python3-qrcode]
+python3-qt-material-pip:
+  '*':
+    pip:
+      packages: [qt-material]
 python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`qt-material`

## Package Upstream Source:

https://github.com/dunderlab/qt-material
https://pypi.org/project/qt-material/

## Purpose of using this:

`qt-material` adds prepackaged stylesheets for Qt GUIs and on-the-fly theme switching (great for adapting to unexpected lighting/operating conditions).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

This is a Python package, so it's available for all platforms from PyPi.

- Debian: https://pypi.org/project/qt-material/
- Ubuntu: https://pypi.org/project/qt-material/
- Fedora: https://pypi.org/project/qt-material/
- Arch: https://pypi.org/project/qt-material/
- Gentoo: https://pypi.org/project/qt-material/
- macOS: https://pypi.org/project/qt-material/
- Alpine: https://pypi.org/project/qt-material/
- NixOS/nixpkgs: https://pypi.org/project/qt-material/
- openSUSE: https://pypi.org/project/qt-material/
- rhel: https://pypi.org/project/qt-material/
