### PR TITLE
Revert "Revert "rmw_zenoh: 0.2.4-1 in 'jazzy/distribution.yaml' [bloom]""

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7331,7 +7331,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Reverts ros/rosdistro#45556 after https://bpc.opencv.org/