### PR TITLE
mapviz: 2.5.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3637,7 +3637,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.0-1
+      version: 2.5.5-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.5-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## mapviz

```
* Updating headers with new names (#848 <https://github.com/swri-robotics/mapviz/issues/848>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Updating headers with new names (#848 <https://github.com/swri-robotics/mapviz/issues/848>)
* Contributors: David Anthony
```

## multires_image

```
* Updating headers with new names (#848 <https://github.com/swri-robotics/mapviz/issues/848>)
* Contributors: David Anthony
```

## tile_map

```
* Updating headers with new names (#848 <https://github.com/swri-robotics/mapviz/issues/848>)
* Contributors: David Anthony
```
