### PR TITLE
dynamixel_workbench: 2.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2148,7 +2148,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_workbench-release.git
-      version: 2.2.4-1
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_workbench` to `2.2.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel-workbench.git
- release repository: https://github.com/ros2-gbp/dynamixel_workbench-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.4-1`

## dynamixel_workbench

```
* Remove unused rclcpp dependency
* Remove ament_target_dependencies (deprecated in ROS 2 kilted)
* Contributors: ijnek
```

## dynamixel_workbench_toolbox

```
* Remove unused rclcpp dependency
* Remove ament_target_dependencies (deprecated in ROS 2 kilted)
* Contributors: ijnek
```
