### PR TITLE
open_manipulator: 3.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5512,7 +5512,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.2.2-1
+      version: 3.2.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.2.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.2-1`

## om_gravity_compensation_controller

```
* Modified ROS2 controller package dependencies
* Fixed stderr output handling
* Deprecate ament_include_dependency usage in CMakeLists.txt
* Contributors: Wonho Yun
```

## om_joint_trajectory_command_broadcaster

```
* Modified ROS2 controller package dependencies
* Fixed stderr output handling
* Deprecate ament_include_dependency usage in CMakeLists.txt
* Contributors: Wonho Yun
```

## om_spring_actuator_controller

```
* Modified ROS2 controller package dependencies
* Fixed stderr output handling
* Deprecate ament_include_dependency usage in CMakeLists.txt
* Contributors: Wonho Yun
```

## open_manipulator

```
* Modified ROS2 controller package dependencies
* Fixed stderr output handling
* Deprecate ament_include_dependency usage in CMakeLists.txt
* Contributors: Wonho Yun
```

## open_manipulator_bringup

```
* None
```

## open_manipulator_description

```
* None
```

## open_manipulator_gui

```
* Deprecate ament_include_dependency usage in CMakeLists.txt
* Contributors: Wonho Yun
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* Deprecate ament_include_dependency usage in CMakeLists.txt
* Contributors: Wonho Yun
```

## open_manipulator_teleop

```
* None
```
