### PR TITLE
Add rtest to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8816,6 +8816,16 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  rtest:
+    release:
+      packages:
+      - rtest
+    source:
+      type: git
+      url: https://github.com/Beam-and-Spyrosoft/rtest.git
+      version: jazzy
+    status: developed
+    status_description: Rtest is work-in-progress. Help wanted!
   ruckig:
     release:
       tags:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7724,6 +7724,16 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  rtest:
+    release:
+      packages:
+      - rtest
+    source:
+      type: git
+      url: https://github.com/Beam-and-Spyrosoft/rtest.git
+      version: kilted
+    status: developed
+    status_description: Rtest is work-in-progress. Help wanted!
   ruckig:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy, kilted

# The source is here:

https://github.com/Beam-and-Spyrosoft/rtest

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
