### PR TITLE
scenario_execution: 1.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8930,14 +8930,13 @@ repositories:
       - scenario_execution_interfaces
       - scenario_execution_nav2
       - scenario_execution_os
-      - scenario_execution_py_trees_ros
       - scenario_execution_ros
       - scenario_execution_rviz
       - scenario_execution_x11
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
-      version: 1.2.0-5
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/IntelLabs/scenario_execution.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scenario_execution` to `1.3.0-1`:

- upstream repository: https://github.com/cps-test-lab/scenario-execution.git
- release repository: https://github.com/ros2-gbp/scenario_execution-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-5`

## scenario_execution

```
* add ros examples and new actions
* update run_process action to send signals to whole process group. add ros_run action
```

## scenario_execution_control

- No changes

## scenario_execution_coverage

- No changes

## scenario_execution_gazebo

- No changes

## scenario_execution_interfaces

- No changes

## scenario_execution_nav2

```
* example_nav2: use loopback navigation
```

## scenario_execution_os

- No changes

## scenario_execution_ros

```
* add ros examples and new actions
* update run_process action to send signals to whole process group
```

## scenario_execution_rviz

```
* Cleanup
```

## scenario_execution_x11

- No changes
