### PR TITLE
Add rtsp_image_transport to source index

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8816,6 +8816,12 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  rtsp_image_transport:
+    source:
+      type: git
+      url: https://github.com/fkie/rtsp_image_transport.git
+      version: ros2
+    status: maintained
   ruckig:
     release:
       tags:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8817,6 +8817,10 @@ repositories:
       version: master
     status: maintained
   rtsp_image_transport:
+    doc:
+      type: git
+      url: https://github.com/fkie/rtsp_image_transport.git
+      version: ros2
     source:
       type: git
       url: https://github.com/fkie/rtsp_image_transport.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7828,6 +7828,10 @@ repositories:
       version: master
     status: maintained
   rtsp_image_transport:
+    doc:
+      type: git
+      url: https://github.com/fkie/rtsp_image_transport.git
+      version: ros2
     source:
       type: git
       url: https://github.com/fkie/rtsp_image_transport.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7827,6 +7827,12 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  rtsp_image_transport:
+    source:
+      type: git
+      url: https://github.com/fkie/rtsp_image_transport.git
+      version: ros2
+    status: maintained
   ruckig:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO: jazzy, rolling

# The source is here:

https://github.com/fkie/rtsp_image_transport

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
