### PR TITLE
ament_cmake: 2.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.8.1-1
+      version: 2.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.8.2-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.1-1`

## ament_cmake

- No changes

## ament_cmake_auto

- No changes

## ament_cmake_core

- No changes

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

```
* Revert "Removed deprecated function ament_cmake_target_dependencies" (#585 <https://github.com/ament/ament_cmake/issues/585>)
* Contributors: Shane Loretz
```

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

- No changes

## ament_cmake_version

- No changes
