### PR TITLE
sick_scan_xd: 3.7.0-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11617,7 +11617,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SICKAG/sick_scan_xd-release.git
-      version: 3.6.0-1
+      version: 3.7.0-2
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.7.0-2`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/SICKAG/sick_scan_xd-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.0-1`

## sick_scan_xd

```
* Release v3.7.0
  * fix: TiM7xx fieldset settings and services, #394, #408
  * update: README.md and cmake requirements
  * change: Publish lferec messages latched, #420
  * fix: TCP connection timeout, #424
  * add: Support for LRS-4xxx IMU and contamination data, #418
  * update: Improved TiM-7xx field evaluation status after start, #420
  * update: Dockertests for ROS-1, ROS-2 and API
  * fix: Timestamp handling (corrected system time estimation from transmit vs. generation timestamps), #428
  * fix: Disable UDP-Parsing during reinitialisation
  * fix: ParameterAlreadyDeclaredException on reinitialisation
  * add: LaserScan messages encode reflector detection through high intensity values
  * update: user level and user password can be freely specified in the launch file. For picoScan, multiScan and LRS4xxx, the default user level is 4.
```
