### PR TITLE
point_cloud_transport: 5.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5192,7 +5192,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.2.0-1
+      version: 5.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.2.1-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.2.0-1`

## point_cloud_transport

```
* Feat/Add LifecycleNode Support (#109 <https://github.com/ros-perception/point_cloud_transport/issues/109>)
* Contributors: ElSayed ElSheikh
```

## point_cloud_transport_py

```
* Feat/Add LifecycleNode Support (#109 <https://github.com/ros-perception/point_cloud_transport/issues/109>)
* Contributors: ElSayed ElSheikh
```
