### PR TITLE
pal_urdf_utils: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6610,7 +6610,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_urdf_utils-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_urdf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_urdf_utils` to `2.1.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_urdf_utils.git
- release repository: https://github.com/pal-gbp/pal_urdf_utils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## pal_urdf_utils

```
* Fix path for ft_sensor
* Fix camera gazebo
* Add cameras for talos
* Add talos ati and imu
* Add meshes folder in CMake
* Change path fro ft_sesnors
* Change path for both courier bases files
* Restructure meshes following urdf structure
* Reestructure urdf sensor
* Add pmb3 sensors
* Add sensor files for ari and specific bases
* Add imu urdf
* Update year
* Add imu sensor
* Add ft sensor files from pal_sea_arm_description
* Update path for tiago v1 ft sensor
* Change path for ftsensor ros2_control xacro
* Move sensors to pal_urdf_utils package
* Contributors: Aina
```
