### PR TITLE
microstrain_inertial: 4.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5081,7 +5081,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.6.1-1
+      version: 4.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.7.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `4.6.1-1`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* Adds support for CV7-GNSS-INS (#389 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/389>)
* Contributors: Rob
```

## microstrain_inertial_examples

```
* Adds support for CV7-GNSS-INS (#389 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/389>)
* Contributors: Rob
```

## microstrain_inertial_msgs

- No changes

## microstrain_inertial_rqt

- No changes
