### PR TITLE
popf: 0.0.18-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5199,6 +5199,21 @@ repositories:
       url: https://github.com/MetroRobots/polygon_ros.git
       version: main
     status: developed
+  popf:
+    doc:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: kilted-devel
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/popf-release.git
+      version: 0.0.18-1
+    source:
+      type: git
+      url: https://github.com/fmrico/popf.git
+      version: kilted-devel
+    status: maintained
   pose_cov_ops:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `0.0.18-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/ros2-gbp/popf-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## popf

```
* Update Changelog
* 0.0.17
* Update Changelog
* Contributors: Francisco Martín Rico
* 0.0.17
* Update Changelog
* Contributors: Francisco Martín Rico
```
