### PR TITLE
cascade_lifecycle: 2.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -937,10 +937,11 @@ repositories:
       packages:
       - cascade_lifecycle_msgs
       - rclcpp_cascade_lifecycle
+      - rclpy_cascade_lifecycle
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 2.0.0-2
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `2.0.2-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-2`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Explicit removal of node from executor before destroy
* Allow to have pubs/sub with standard QoS
* Contributors: Francisco Martín Rico, Juan Carlos Manzanares Serrano
```

## rclpy_cascade_lifecycle

```
* Created rclpy_cascade_lifecycle
* Contributors: Francisco Martín Rico, Juan Carlos Manzanares Serrano
```
