### PR TITLE
cascade_lifecycle: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -995,10 +995,11 @@ repositories:
       packages:
       - cascade_lifecycle_msgs
       - rclcpp_cascade_lifecycle
+      - rclpy_cascade_lifecycle
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 2.0.0-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `2.0.4-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Fix deprecation of ament_target_dependencies
* Contributors: Francisco Martín Ricoo, David Lu, Alejandro Hernández Cordero
```

## rclpy_cascade_lifecycle

- No changes
