### PR TITLE
Add autoware_core package to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -899,6 +899,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: main
     status: developed
+  autoware_core:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_core.git
+      version: main
+    status: developed
   autoware_internal_msgs:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/autowarefoundation/autoware_core

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
