### PR TITLE
plotjuggler_ros: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6858,7 +6858,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.1.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler_ros` to `2.3.0-1`:

- upstream repository: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
- release repository: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`
