### PR TITLE
mola_lidar_odometry: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3995,7 +3995,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.7.3-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.8.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.7.3-1`

## mola_lidar_odometry

```
* Publish mp2p_icp metric map metadata, if existing in loaded maps.
* state estimation config yaml file: expose IMU sensor name env var
* Update mola_lo_pipelines.rst: explicitly show an example of using the NDT pipeline
* ros2 launch: add new argument to control the scan validity filter based on minimum point count (now, enabled by default)
* Update broken link to ROS Index
* mola-lidar-odometry-cli: now also forward raw sensor data to state estimator
* Fix build against mola <1.8.0
* Docs: better explain existing variables to override sensor poses
* gui option: implement show as orthographic camera
* Contributors: Jose Luis Blanco-Claraco
```
