### PR TITLE
mola_state_estimation: 1.9.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3950,7 +3950,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.8.1-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.9.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.1-1`

## mola_imu_preintegration

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* State estimation interface is now raw data consumer too
* FIX: Error if sensor labels were provided in config yaml file
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* State estimation interface is now raw data consumer too
* FIX: Error if sensor labels were provided in config yaml file
* Contributors: Jose Luis Blanco-Claraco
```
