### PR TITLE
mola: 1.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5212,7 +5212,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `1.9.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.8.0-1`

## kitti_metrics_eval

- No changes

## mola

```
* Fix silent cmake warnings on unused variables
* Depend less on ament and more on pure cmake
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* fix clang-format
* Implement publishing of optional "metadata" map field too
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Fix silent cmake warnings on unused variables
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Depend less on ament and more on pure cmake
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* Fix usage of mola_version_to_hexadecimal()
* cmake: replace local mrpt_version_to_hex() with new mrpt_common mola_version_to_hexadecimal()
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

- No changes

## mola_kernel

```
* MapSourceBase: add a new optional field "metadata"
* NavStateFilter interface: Now is a RawDataConsumer too
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Depend less on ament and more on pure cmake
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

- No changes

## mola_msgs

```
* Depend less on ament and more on pure cmake
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
