### PR TITLE
mavlink: 2025.6.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4903,7 +4903,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2025.5.5-1
+      version: 2025.6.6-1
     source:
       type: git
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2025.6.6-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/ros2-gbp/mavlink-gbp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2025.5.5-1`
