### PR TITLE
random_numbers: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5593,7 +5593,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/random_numbers-release.git
-      version: 2.0.2-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `2.0.4-1`:

- upstream repository: https://github.com/moveit/random_numbers.git
- release repository: https://github.com/ros2-gbp/random_numbers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## random_numbers

```
* Fix propagation of Boost::random dependency
* Contributors: Robert Haschke
```
