### PR TITLE
control_msgs: 5.4.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1453,7 +1453,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.4.0-1
+      version: 5.4.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.4.1-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.4.0-1`

## control_msgs

```
* Update CMake config (#212 <https://github.com/ros-controls/control_msgs/issues/212>) (#216 <https://github.com/ros-controls/control_msgs/issues/216>)
* Contributors: mergify[bot]
```
