### PR TITLE
mavros: 2.10.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3694,7 +3694,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.10.0-1
+      version: 2.10.1-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.10.1-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.0-1`

## libmavconn

- No changes

## mavros

```
* fix: display topic on service timeout error
* Fix incorrect macro usage
  RCLCPP_SMART_PTR_DEFINITIONS eventually is expanding to:
  #define __RCLCPP_MAKE_UNIQUE_DEFINITION(...) template<typename ... Args> static std::unique_ptr<__VA_ARGS__> make_unique(Args && ... args) { return std::unique_ptr<__VA_ARGS__>(new __VA_ARGS__(std::forward<Args>(args) ...)); }
  which is incorrect for abstract classes like Endpoint or Plugin
  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE is used instead excluding make_unique functionality
* Contributors: Emmanuel Ferdman, Mykhailo Kuznietsov
```

## mavros_extras

```
* Initialize last_pos_time with RCL_ROS_TIME
* extras: fix bitset error, lost during merge conflict resolution
* Contributors: Sergei Chashnikov, Vladimir Ermakov
```

## mavros_msgs

- No changes
