### PR TITLE
geometric_shapes: 2.3.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2153,7 +2153,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.3.2-2
+      version: 2.3.3-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.3.3-1`:

- upstream repository: https://github.com/moveit/geometric_shapes.git
- release repository: https://github.com/ros2-gbp/geometric_shapes-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.2-2`

## geometric_shapes

```
* Replace deprecated MemoryResource -> ResourceSharedPtr (#263 <https://github.com/ros-planning/geometric_shapes/issues/263>)
* Fix dependencies (#262 <https://github.com/ros-planning/geometric_shapes/issues/262>)
* CI: Revert to custom cache action
* Contributors: Robert Haschke, David V. Lu
```
