### PR TITLE
septentrio_gnss_driver: 1.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7956,7 +7956,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.3-1
+      version: 1.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.4-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.3-1`

## septentrio_gnss_driver

```
* Fixes
  
  Readme on PVT messages for INS
  
  Deprecation of ament_target_dependencies in Rolling
* Contributors:  Thomas Emter, Tibor Dome, septentrio-users
```
