### PR TITLE
launch: 1.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4341,7 +4341,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.8-1
+      version: 1.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.9-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.8-1`

## launch

```
* Add conditional substitution (#734 <https://github.com/ros2/launch/issues/734>) (#870 <https://github.com/ros2/launch/issues/870>)
* Implement Any, All, Equals, and NotEquals substitutions (#649 <https://github.com/ros2/launch/issues/649>) (#871 <https://github.com/ros2/launch/issues/871>)
* Add a / path join operator for PathJoinSubstitution (#868 <https://github.com/ros2/launch/issues/868>) (#881 <https://github.com/ros2/launch/issues/881>)
* Add special cases to coerce "1" and "0" to bool when using bool coercion only (#651 <https://github.com/ros2/launch/issues/651>) (#872 <https://github.com/ros2/launch/issues/872>)
* Expose emulate_tty to xml and yaml launch (#669 <https://github.com/ros2/launch/issues/669>) (#869 <https://github.com/ros2/launch/issues/869>)
* Let XML executables/nodes be "required" (like in ROS 1) (#751 <https://github.com/ros2/launch/issues/751>) (#863 <https://github.com/ros2/launch/issues/863>)
* Fix ExecuteLocal output flushing (#860 <https://github.com/ros2/launch/issues/860>)
* Contributors: Emerson Knapp, mhidalgo-bdai
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Expose emulate_tty to xml and yaml launch (#669 <https://github.com/ros2/launch/issues/669>) (#869 <https://github.com/ros2/launch/issues/869>)
* Let XML executables/nodes be "required" (like in ROS 1) (#751 <https://github.com/ros2/launch/issues/751>) (#863 <https://github.com/ros2/launch/issues/863>)
* Contributors: Emerson Knapp
```

## launch_yaml

```
* Expose emulate_tty to xml and yaml launch (#669 <https://github.com/ros2/launch/issues/669>) (#869 <https://github.com/ros2/launch/issues/869>)
* Let XML executables/nodes be "required" (like in ROS 1) (#751 <https://github.com/ros2/launch/issues/751>) (#863 <https://github.com/ros2/launch/issues/863>)
* Contributors: Emerson Knapp
```
