### PR TITLE
ros2_control: 4.32.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7477,7 +7477,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.31.0-1
+      version: 4.32.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.32.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.31.0-1`

## controller_interface

- No changes

## controller_manager

```
* Move enforce_command_limits parameter to GPL parameters (backport #2305 <https://github.com/ros-controls/ros2_control/issues/2305>) (#2316 <https://github.com/ros-controls/ros2_control/issues/2316>)
* Cleanup test name (#2295 <https://github.com/ros-controls/ros2_control/issues/2295>) (#2298 <https://github.com/ros-controls/ros2_control/issues/2298>)
* check_controllers_running: Make timeout a parameter  (#2278 <https://github.com/ros-controls/ros2_control/issues/2278>) (#2281 <https://github.com/ros-controls/ros2_control/issues/2281>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* also use std::mutex on macOS (#2313 <https://github.com/ros-controls/ros2_control/issues/2313>) (#2315 <https://github.com/ros-controls/ros2_control/issues/2315>)
* Use std::mutex on windows (#2311 <https://github.com/ros-controls/ros2_control/issues/2311>) (#2312 <https://github.com/ros-controls/ros2_control/issues/2312>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix pre-commit (#2277 <https://github.com/ros-controls/ros2_control/issues/2277>) (#2285 <https://github.com/ros-controls/ros2_control/issues/2285>)
* Contributors: mergify[bot]
```
