### PR TITLE
ros2_control: 2.51.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8572,7 +8572,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.50.0-1
+      version: 2.51.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.51.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.50.0-1`

## controller_interface

- No changes

## controller_manager

```
* Cleanup test name (#2295 <https://github.com/ros-controls/ros2_control/issues/2295>) (#2297 <https://github.com/ros-controls/ros2_control/issues/2297>)
* check_controllers_running: Make timeout a parameter  (#2278 <https://github.com/ros-controls/ros2_control/issues/2278>) (#2280 <https://github.com/ros-controls/ros2_control/issues/2280>)
* doc: Added explanation of preceding/following controllers (backport #2192 <https://github.com/ros-controls/ros2_control/issues/2192>) (#2193 <https://github.com/ros-controls/ros2_control/issues/2193>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix pre-commit (#2277 <https://github.com/ros-controls/ros2_control/issues/2277>) (#2284 <https://github.com/ros-controls/ros2_control/issues/2284>)
* Fix fourbarlinkage derivatives (#1837 <https://github.com/ros-controls/ros2_control/issues/1837>) (#2275 <https://github.com/ros-controls/ros2_control/issues/2275>)
* Contributors: mergify[bot]
```
