### PR TITLE
ros2_controllers: 2.47.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8614,7 +8614,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.46.0-1
+      version: 2.47.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.47.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.46.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

```
* Add missing github_url to rst files (backport #1717 <https://github.com/ros-controls/ros2_controllers/issues/1717>) (#1718 <https://github.com/ros-controls/ros2_controllers/issues/1718>)
* Contributors: mergify[bot]
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* JTC: Use std::atomic<bool> (backport #1720 <https://github.com/ros-controls/ros2_controllers/issues/1720>) (#1722 <https://github.com/ros-controls/ros2_controllers/issues/1722>)
* Reset both sec and nanosec in time_from_start (backport #1709 <https://github.com/ros-controls/ros2_controllers/issues/1709>) (#1710 <https://github.com/ros-controls/ros2_controllers/issues/1710>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Add missing github_url to rst files (backport #1717 <https://github.com/ros-controls/ros2_controllers/issues/1717>) (#1718 <https://github.com/ros-controls/ros2_controllers/issues/1718>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Fix steering_controllers_library docs (backport #1734 <https://github.com/ros-controls/ros2_controllers/issues/1734>) (#1735 <https://github.com/ros-controls/ros2_controllers/issues/1735>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
