### PR TITLE
frame_editor: re-index into jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2607,6 +2607,12 @@ repositories:
       url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     status: developed
+  frame_editor:
+    source:
+      type: git
+      url: https://github.com/ipa320/rqt_frame_editor_plugin.git
+      version: jazzy-devel
+    status: maintained
   fuse:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

frame_editor

## Package Upstream Source:

https://github.com/ipa320/rqt_frame_editor_plugin/tree/jazzy-devel

## Purpose of using this:

Frame-editor helps you creating and arranging tf-frames.

# Please Add This Package to be indexed in the rosdistro.

jazzy

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro


(This package was available in ros1 already and indexed in noetic)