### PR TITLE
ros2_control: 5.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6480,7 +6480,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.0-1`

## controller_interface

- No changes

## controller_manager

```
* Move enforce_command_limits parameter to GPL parameters (#2305 <https://github.com/ros-controls/ros2_control/issues/2305>)
* Cleanup test name (#2295 <https://github.com/ros-controls/ros2_control/issues/2295>)
* check_controllers_running: Make timeout a parameter  (#2278 <https://github.com/ros-controls/ros2_control/issues/2278>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* hardware_interface: optimise & rename find_common_hardware_interfaces (#2294 <https://github.com/ros-controls/ros2_control/issues/2294>)
* also use std::mutex on macOS (#2313 <https://github.com/ros-controls/ros2_control/issues/2313>)
* Use std::mutex on windows (#2311 <https://github.com/ros-controls/ros2_control/issues/2311>)
* Contributors: Christoph Fröhlich, Daisuke Nishimatsu, Eldgar
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* [Transmissions] Add absolute_position and torque interfaces (#2310 <https://github.com/ros-controls/ros2_control/issues/2310>)
* Fix pre-commit (#2277 <https://github.com/ros-controls/ros2_control/issues/2277>)
* Fix fourbarlinkage (#1837 <https://github.com/ros-controls/ros2_control/issues/1837>)
* Contributors: Bartłomiej Krajewski, Jordan Palacios, Sai Kishor Kothakota
```
