### PR TITLE
turtlebot3_simulations: 2.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11213,11 +11213,12 @@ repositories:
       packages:
       - turtlebot3_fake_node
       - turtlebot3_gazebo
+      - turtlebot3_manipulation_gazebo
       - turtlebot3_simulations
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
-      version: 2.3.0-1
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.3.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-1`

## turtlebot3_fake_node

```
* None
```

## turtlebot3_gazebo

```
* None
```

## turtlebot3_manipulation_gazebo

```
* Moved the TurtleBot3 Manipulation Gazebo simulation from the turtlebot3_manipulation_bringup package
* Contributors: ChanHyeong Lee
```

## turtlebot3_simulations

```
* Moved the TurtleBot3 Manipulation Gazebo simulation from the turtlebot3_manipulation_bringup package
* Contributors: ChanHyeong Lee
```
