### PR TITLE
Add index for ReductStore Agent

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6878,6 +6878,16 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: jazzy
     status: maintained
+  reductstore_agent:
+    doc:
+      type: git
+      url: https://github.com/reductstore/reductstore_agent.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/reductstore/reductstore_agent.git
+      version: main
+    status: developed
   replay_testing:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5965,6 +5965,16 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: master
     status: maintained
+  reductstore_agent:
+    doc:
+      type: git
+      url: https://github.com/reductstore/reductstore_agent.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/reductstore/reductstore_agent.git
+      version: main
+    status: developed
   replay_testing:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling and jazzy

# The source is here:

https://github.com/reductstore/reductstore_agent

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
