### PR TITLE
slam_toolbox: 2.9.0-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8075,7 +8075,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/SteveMacenski/slam_toolbox-release.git
-      version: 2.9.0-1
+      version: 2.9.0-2
     source:
       type: git
       url: https://github.com/SteveMacenski/slam_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `2.9.0-2`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.9.0-1`
