### PR TITLE
nonpersistent_voxel_layer: 2.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4547,6 +4547,21 @@ repositories:
       url: https://github.com/osrf/nodl_to_policy.git
       version: master
     status: maintained
+  nonpersistent_voxel_layer:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: kilted
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
+      version: 2.6.0-1
+    source:
+      type: git
+      url: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
+      version: kilted
+    status: maintained
   novatel_gps_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nonpersistent_voxel_layer` to `2.6.0-1`:

- upstream repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer.git
- release repository: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
