### PR TITLE
rtabmap_ros: 0.22.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7770,6 +7770,35 @@ repositories:
       url: https://github.com/introlab/rtabmap.git
       version: rolling-devel
     status: maintained
+  rtabmap_ros:
+    doc:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: kilted-devel
+    release:
+      packages:
+      - rtabmap_conversions
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.22.0-1
+    source:
+      type: git
+      url: https://github.com/introlab/rtabmap_ros.git
+      version: kilted-devel
+    status: maintained
   rtcm_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.22.0-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
