### PR TITLE
marti_common: 3.8.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4845,7 +4845,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.8.3-1
+      version: 3.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.8.4-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.8.3-1`

## swri_cli_tools

```
* Updating setup.py to remove deprecated features (#779 <https://github.com/swri-robotics/marti_common/issues/779>)
* Contributors: David Anthony
```

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

```
* Add dependency on libopencv-dev for pkgs directly using OpenCV (#781 <https://github.com/swri-robotics/marti_common/issues/781>)
* Contributors: Christophe Bedard
```

## swri_image_util

```
* Add dependency on libopencv-dev for pkgs directly using OpenCV (#781 <https://github.com/swri-robotics/marti_common/issues/781>)
* Contributors: Christophe Bedard
```

## swri_math_util

- No changes

## swri_opencv_util

```
* Add dependency on libopencv-dev for pkgs directly using OpenCV (#781 <https://github.com/swri-robotics/marti_common/issues/781>)
* Contributors: Christophe Bedard
```

## swri_roscpp

```
* Fix swri roscpp srv to topic (#776 <https://github.com/swri-robotics/marti_common/issues/776>)
  * Change generate_topic_service_files install location to match ROS 2 conventions
  * update generate_topic_service_files to match ROS 2 conventions (snake_case and .hpp)
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
* Contributors: DangitBen
```

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_transform_util

```
* Add dependency on libopencv-dev for pkgs directly using OpenCV (#781 <https://github.com/swri-robotics/marti_common/issues/781>)
* Updating setup.py to remove deprecated features (#779 <https://github.com/swri-robotics/marti_common/issues/779>)
* Contributors: Christophe Bedard, David Anthony
```
