### PR TITLE
mapviz: 2.5.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4236,7 +4236,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.5-1
+      version: 2.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.6-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.5-1`

## mapviz

```
* Adding libopencv as a depdendency (#849 <https://github.com/swri-robotics/mapviz/issues/849>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Adding libopencv as a depdendency (#849 <https://github.com/swri-robotics/mapviz/issues/849>)
* Contributors: David Anthony
```

## multires_image

- No changes

## tile_map

- No changes
