### PR TITLE
turtlebot3_manipulation: 2.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9939,6 +9939,20 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
       version: jazzy
+    release:
+      packages:
+      - turtlebot3_manipulation
+      - turtlebot3_manipulation_bringup
+      - turtlebot3_manipulation_cartographer
+      - turtlebot3_manipulation_description
+      - turtlebot3_manipulation_hardware
+      - turtlebot3_manipulation_moveit_config
+      - turtlebot3_manipulation_navigation2
+      - turtlebot3_manipulation_teleop
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_manipulation` to `2.2.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_manipulation.git
- release repository: https://github.com/ros2-gbp/turtlebot3_manipulation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot3_manipulation

```
* Removed the TurtleBot3 Manipulation Gazebo simulation
* Contributors: ChanHyeong Lee
```

## turtlebot3_manipulation_bringup

```
* Removed the TurtleBot3 Manipulation Gazebo simulation
* Contributors: ChanHyeong Lee
```

## turtlebot3_manipulation_cartographer

```
* None
```

## turtlebot3_manipulation_description

```
* Removed the TurtleBot3 Manipulation Gazebo simulation
* Contributors: ChanHyeong Lee
```

## turtlebot3_manipulation_hardware

```
* None
```

## turtlebot3_manipulation_moveit_config

```
* None
```

## turtlebot3_manipulation_navigation2

```
* None
```

## turtlebot3_manipulation_teleop

```
* None
```
