### PR TITLE
Add coin_d4_driver to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1352,6 +1352,16 @@ repositories:
       url: https://github.com/4am-robotics/cob_common.git
       version: foxy
     status: maintained
+  coin_d4_driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
+      version: jazzy
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

https://github.com/ROBOTIS-GIT/coin_d4_driver

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
