### PR TITLE
moveit_resources: 3.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4082,7 +4082,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 3.1.0-2
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `3.1.1-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.1.0-2`

## dual_arm_panda_moveit_config

- No changes

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

- No changes

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Remove dependency to gripper_controllers (#206 <https://github.com/ros-planning/moveit_resources/issues/206>)
* Contributors: Felix Exner
```

## moveit_resources_pr2_description

- No changes
