### PR TITLE
canboat_vendor: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1033,6 +1033,11 @@ repositories:
       version: main
     status: developed
   canboat_vendor:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/canboat_vendor-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/robotic-esp/canboat_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `canboat_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/robotic-esp/canboat_vendor.git
- release repository: https://github.com/ros2-gbp/canboat_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canboat_vendor

```
* Add "How to Use" section to README.md
* Bugfix: update ExternalProject_Add statement for compliance with older CMake versions
* Bugfix: swap to HTTPs URL so cloning possible w/o git SSH key
* Add the Makefile to .gitignore
* Remove the Makefile from git
* Switch to letting CMake download the Canboat repo at build time with ExternalProject_Add
* Contributors: Severn Lortie
```
