### PR TITLE
canboat_vendor: 0.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -892,6 +892,12 @@ repositories:
       url: https://github.com/christianrauch/camera_ros.git
       version: main
     status: developed
+  canboat_vendor:
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/canboat_vendor-release.git
+      version: 0.0.2-1
   cartographer:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -898,6 +898,10 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/canboat_vendor-release.git
       version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/robotic-esp/canboat_vendor.git
+      version: master
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canboat_vendor` to `0.0.2-1`:

- upstream repository: https://github.com/robotic-esp/canboat_vendor.git
- release repository: https://github.com/ros2-gbp/canboat_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## canboat_vendor

```
* Add "How to Use" section to README.md
* Bugfix: update ExternalProject_Add statement for compliance with older CMake versions
* Bugfix: swap to HTTPs URL so cloning possible w/o git SSH key
* Add the Makefile to .gitignore
* Remove the Makefile from git
* Switch to letting CMake download the Canboat repo at build time with ExternalProject_Add
* Contributors: Severn Lortie
```
