### PR TITLE
phone_sensors and phone_sensors_examples to humble, jazzy, kilted and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6765,6 +6765,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: humble
     status: maintained
+  phone_sensors_bridge:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ros2-phone-sensors.git
+      version: main
+    status: developed
   pick_ik:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5842,6 +5842,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: jazzy
     status: maintained
+  phone_sensors_bridge:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ros2-phone-sensors.git
+      version: main
+    status: developed
   pick_ik:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5036,6 +5036,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: kilted
     status: maintained
+  phone_sensors_bridge:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ros2-phone-sensors.git
+      version: main
+    status: developed
   pick_ik:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5060,6 +5060,12 @@ repositories:
       url: https://github.com/ros-drivers/phidgets_drivers.git
       version: rolling
     status: maintained
+  phone_sensors_bridge:
+    source:
+      type: git
+      url: https://github.com/vtalpaert/ros2-phone-sensors.git
+      version: main
+    status: developed
   pick_ik:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

- phone_sensors
- phone_sensors_examples

## Package Upstream Source:

https://github.com/vtalpaert/ros2-phone-sensors

## Purpose of using this:

While many projects exist to control your robot from your phone, this project is the other way around; your phone is the robot' sensors ! Using a webpage hosted on a computer, the mobile client sends its camera feed, IMU and GPS so that you may integrate the phone onto a mobile base. 

Note: It is similar to https://github.com/VedantC2307/ros2-mobile-sensor-bridge but this one requires to install Node.js, in our case we have a minimalist version

# Please Add This Package to be indexed in the rosdistro.

- humble
- jazzy
- kilted
- rolling

# The source is here:

https://github.com/vtalpaert/ros2-phone-sensors

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
