### PR TITLE
digestible: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2036,6 +2036,21 @@ repositories:
       url: https://github.com/ros/diagnostics.git
       version: ros2-humble
     status: maintained
+  digestible:
+    doc:
+      type: git
+      url: https://github.com/tier4/digestible.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/tier4/digestible-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/tier4/digestible.git
+      version: main
+    status: maintained
   dolly:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `digestible` to `0.1.0-1`:

- upstream repository: https://github.com/tier4/digestible.git
- release repository: https://github.com/tier4/digestible-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
