### PR TITLE
ros2_controllers: 5.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6601,7 +6601,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.0.2-1
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.2-1`

## ackermann_steering_controller

```
* Remove deprecated parameters from steering_controllers_library (#1684 <https://github.com/ros-controls/ros2_controllers/issues/1684>)
* Fix steering_controllers_library docs and msg field (#1733 <https://github.com/ros-controls/ros2_controllers/issues/1733>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Remove deprecated parameters from steering_controllers_library (#1684 <https://github.com/ros-controls/ros2_controllers/issues/1684>)
* Fix steering_controllers_library docs and msg field (#1733 <https://github.com/ros-controls/ros2_controllers/issues/1733>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* Fix DiffDrive claiming state when open_loop is set (#1731 <https://github.com/ros-controls/ros2_controllers/issues/1731>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Revert temporary logging changes added for CI timeout investigation (#1741 <https://github.com/ros-controls/ros2_controllers/issues/1741>)
* Contributors: Julia Jia
```

## forward_command_controller

- No changes

## gpio_controllers

```
* Add missing github_url to rst files (#1717 <https://github.com/ros-controls/ros2_controllers/issues/1717>)
* Contributors: Christoph Fröhlich
```

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Added frame_id to Joint State Broadcaster (#1746 <https://github.com/ros-controls/ros2_controllers/issues/1746>)
* Fix RST syntax (#1715 <https://github.com/ros-controls/ros2_controllers/issues/1715>)
* Contributors: Christoph Fröhlich, Jakub "Deli" Delicat
```

## joint_trajectory_controller

```
* [JTC] [Doc] Update PID documentation for effort related command interface support (#1748 <https://github.com/ros-controls/ros2_controllers/issues/1748>)
* JTC: Use std::atomic<bool> (#1720 <https://github.com/ros-controls/ros2_controllers/issues/1720>)
* Reset both sec and nanosec in time_from_start (#1709 <https://github.com/ros-controls/ros2_controllers/issues/1709>)
* Contributors: Arnav Kapoor, Christoph Fröhlich, Julia Jia
```

## mecanum_drive_controller

```
* Add tf_frame_prefix parameters to mecanum_drive_controller (#1680 <https://github.com/ros-controls/ros2_controllers/issues/1680>)
* Add missing github_url to rst files (#1717 <https://github.com/ros-controls/ros2_controllers/issues/1717>)
* Contributors: Christoph Fröhlich, Dawid Kmak
```

## parallel_gripper_controller

- No changes

## pid_controller

```
* Remove deprecated feedforward parameter+service (#1753 <https://github.com/ros-controls/ros2_controllers/issues/1753>)
  Co-authored-by: pascalau <pascalau>
* Set enable_feedforward parameter in the respective tests (#1743 <https://github.com/ros-controls/ros2_controllers/issues/1743>)
* Contributors: Pascal Auf der Maur, Sai Kishor Kothakota
```

## pose_broadcaster

```
* Remove deprecated parameter from pose_broadcaster (#1685 <https://github.com/ros-controls/ros2_controllers/issues/1685>)
* Contributors: Christoph Fröhlich
```

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Remove deprecated parameters from steering_controllers_library (#1684 <https://github.com/ros-controls/ros2_controllers/issues/1684>)
* Fix steering_controllers_library docs and msg field (#1733 <https://github.com/ros-controls/ros2_controllers/issues/1733>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Remove deprecated parameters from steering_controllers_library (#1684 <https://github.com/ros-controls/ros2_controllers/issues/1684>)
* Fix steering_controllers_library docs and msg field (#1733 <https://github.com/ros-controls/ros2_controllers/issues/1733>)
* Contributors: Christoph Fröhlich
```

## velocity_controllers

- No changes
