### PR TITLE
Update distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5192,7 +5192,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/OrebroUniversity/mod-release.git
-      version: 1.1.0-4
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5192,7 +5192,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/OrebroUniversity/mod-release.git
-      version: 1.1.0-1
+      version: 1.1.0-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Update version of package MoD to 1.1.0-4 from 1.1.0-1

Minor update fixed OMPL Includes not being found. Fixes [this issue](https://github.com/OrebroUniversity/mod/issues/1) 
