### PR TITLE
mod: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5192,7 +5192,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/OrebroUniversity/mod-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod` to `1.1.1-1`:

- upstream repository: https://bitbucket.org/mapsofdynamics/mod
- release repository: https://github.com/OrebroUniversity/mod-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.0-1`
