### PR TITLE
inuitive-camera-ros2: 2.10.14-6 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3948,7 +3948,7 @@ repositories:
       - inuros2
       tags:
         release: release/humble/{package}/{version}
-      url: git@bitbucket.org:inuitive/inuros2-release.git
+      url: https://bitbucket.org/inuitive/inuros2-release.git
       version: 2.10.14-6
     status: developed
   inverse_dynamics_solver:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3950,6 +3950,10 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://bitbucket.org/inuitive/inuros2-release.git
       version: 2.10.14-6
+    source:
+      type: git
+      url: https://bitbucket.org/inuitive/inuros2.git
+      version: master
     status: developed
   inverse_dynamics_solver:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3942,6 +3942,15 @@ repositories:
       url: https://github.com/ros-visualization/interactive_markers.git
       version: humble
     status: maintained
+  inuitive-camera-ros2:
+    release:
+      packages:
+      - inuros2
+      tags:
+        release: release/humble/{package}/{version}
+      url: git@bitbucket.org:inuitive/inuros2-release.git
+      version: 2.10.14-6
+    status: developed
   inverse_dynamics_solver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `inuitive-camera-ros2` to `2.10.14-6`:

- upstream repository: git@bitbucket.org:inuitive/inuros2.git
- release repository: git@bitbucket.org:inuitive/inuros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
