### PR TITLE
ros_gz: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6898,7 +6898,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.2-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* ros_gz_bridge: Allow setting QoS profile from YAML files and launch action. (#761 <https://github.com/gazebosim/ros_gz/issues/761>)
* Added easy way to configure bridge from XML launch files. (#735 <https://github.com/gazebosim/ros_gz/issues/735>)
* Contributors: Martin Pecka
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* OS agnostic 'which' command (#762 <https://github.com/gazebosim/ros_gz/issues/762>) (#765 <https://github.com/gazebosim/ros_gz/issues/765>)
* ros_gz_sim: Added support for passing initial_sim_time to Gazebo. (#756 <https://github.com/gazebosim/ros_gz/issues/756>)
* Contributors: Alejandro Hernandez Cordero, Martin Pecka, mergify[bot]
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
