### PR TITLE
ros_gz: 2.1.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6863,7 +6863,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.8-1
+      version: 2.1.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.9-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.8-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Added easy way to configure bridge from XML launch files. (#735 <https://github.com/gazebosim/ros_gz/issues/735>) (#753 <https://github.com/gazebosim/ros_gz/issues/753>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* OS agnostic 'which' command (#762 <https://github.com/gazebosim/ros_gz/issues/762>) (#763 <https://github.com/gazebosim/ros_gz/issues/763>)
* ros_gz_sim: Added support for passing initial_sim_time to Gazebo. (#756 <https://github.com/gazebosim/ros_gz/issues/756>) (#758 <https://github.com/gazebosim/ros_gz/issues/758>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
