### PR TITLE
ros_gz: 1.0.15-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7856,7 +7856,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.14-1
+      version: 1.0.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.15-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.14-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Added easy way to configure bridge from XML launch files. (backport #735 <https://github.com/gazebosim/ros_gz/issues/735>) (#754 <https://github.com/gazebosim/ros_gz/issues/754>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* OS agnostic 'which' command (#762 <https://github.com/gazebosim/ros_gz/issues/762>)
* ros_gz_sim: Added support for passing initial_sim_time to Gazebo. (backport #756 <https://github.com/gazebosim/ros_gz/issues/756>) (#759 <https://github.com/gazebosim/ros_gz/issues/759>)
* Contributors: Griffin Tabor, mergify[bot]
```

## ros_gz_sim_demos

- No changes

## test_ros_gz_bridge

- No changes
