### PR TITLE
image_common: 6.1.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2820,7 +2820,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.1.1-1
+      version: 6.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.1.2-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.1.1-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

```
* Fix CameraInfo distortion coefficients and logger (#360 <https://github.com/ros-perception/image_common/issues/360>) (#361 <https://github.com/ros-perception/image_common/issues/361>)
* Contributors: mergify[bot]
```

## image_common

- No changes

## image_transport

- No changes

## image_transport_py

- No changes
