### PR TITLE
image_common: 5.1.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3445,7 +3445,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.6-1
+      version: 5.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.7-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.6-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

```
* Fix CameraInfo distortion coefficients and logger (#360 <https://github.com/ros-perception/image_common/issues/360>) (#362 <https://github.com/ros-perception/image_common/issues/362>)
* Contributors: mergify[bot]
```

## image_common

- No changes

## image_transport

- No changes
