### PR TITLE
swri_console: 2.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10598,7 +10598,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/swri_console.git
-      version: ros2-devel
+      version: jazzy
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -10607,7 +10607,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git
-      version: ros2-devel
+      version: jazzy
     status: developed
   synapticon_ros2_control:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10603,7 +10603,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.7-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.6-1`

## swri_console

```
* Update README.md
* Update industrial_ci.yml
* Updating CI and readme to remove references to Iron
* Update industrial_ci.yml
  Updating to use ROS-I CI with support for new versions of Python.
* Contributors: David Anthony
```
