### PR TITLE
swri_console: 2.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9461,7 +9461,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9456,7 +9456,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/swri_console.git
-      version: ros2-devel
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -9465,7 +9465,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git
-      version: ros2-devel
+      version: jazzy
     status: developed
   synapticon_ros2_control:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.7-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.6-1`

## swri_console

```
* Update README.md
* Update industrial_ci.yml
* Updating CI and readme to remove references to Iron
* Update industrial_ci.yml
  Updating to use ROS-I CI with support for new versions of Python.
* Contributors: David Anthony
```
