### PR TITLE
swri_console: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8364,7 +8364,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.6-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.1.0-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.6-1`

## swri_console

```
* Update README.md
* Updating for new build commands and constants in Kilted and later (#71 <https://github.com/swri-robotics/swri_console/issues/71>)
* Updating CI and readme to remove references to Iron
* Update industrial_ci.yml
  Updating to use ROS-I CI with support for new versions of Python.
* Contributors: David Anthony
```
