### PR TITLE
Add topic_based_hardware release

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9720,9 +9720,9 @@ repositories:
       version: 0.2.0-3
   topic_based_hardware_interfaces:
     doc:
-        type: git
-        url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
-        version: main
+      type: git
+      url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+      version: main
     source:
       type: git
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9719,11 +9719,15 @@ repositories:
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-3
   topic_based_hardware_interfaces:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_hardware_interfaces-release.git
-      version: 0.1.0-1
+    doc:
+        type: git
+        url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+        version: main
+    source:
+        type: git
+        url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+        version: main
+    status: developed
   topic_tools:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9724,9 +9724,9 @@ repositories:
         url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
         version: main
     source:
-        type: git
-        url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
-        version: main
+      type: git
+      url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+      version: main
     status: developed
   topic_tools:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9718,6 +9718,12 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-3
+  topic_based_hardware_interfaces:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_hardware_interfaces-release.git
+      version: 0.1.0-1
   topic_tools:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9712,12 +9712,6 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: jazzy
     status: maintained
-  topic_based_ros2_control:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-3
   topic_based_hardware_interfaces:
     doc:
       type: git
@@ -9728,6 +9722,12 @@ repositories:
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
     status: developed
+  topic_based_ros2_control:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
+      version: 0.2.0-3
   topic_tools:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8597,6 +8597,16 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-3
+  topic_based_hardware_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+      version: main
+    status: developed
   topic_tools:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8591,12 +8591,6 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: kilted
     status: maintained
-  topic_based_ros2_control:
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-3
   topic_based_hardware_interfaces:
     doc:
       type: git
@@ -8607,6 +8601,12 @@ repositories:
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
     status: developed
+  topic_based_ros2_control:
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
+      version: 0.2.0-3
   topic_tools:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8615,12 +8615,6 @@ repositories:
       url: https://github.com/ros2/tlsf.git
       version: rolling
     status: maintained
-  topic_based_ros2_control:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-2
   topic_based_hardware_interfaces:
     doc:
       type: git
@@ -8631,6 +8625,12 @@ repositories:
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
     status: developed
+  topic_based_ros2_control:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
+      version: 0.2.0-2
   topic_tools:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8621,6 +8621,12 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-2
+  topic_based_hardware_interfaces:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_hardware_interfaces-release.git
+      version: 0.1.0-1
   topic_tools:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8622,11 +8622,15 @@ repositories:
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
       version: 0.2.0-2
   topic_based_hardware_interfaces:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_hardware_interfaces-release.git
-      version: 0.1.0-1
+    doc:
+      type: git
+      url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+      version: main
+    status: developed
   topic_tools:
     doc:
       type: git


### PR DESCRIPTION
<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME: `joint_state_topic_hardware_interface`

# The source is here: 
https://github.com/ros-controls/topic_based_hardware_interfaces/tree/main

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
