### PR TITLE
open_manipulator: 3.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5516,6 +5516,7 @@ repositories:
       - om_spring_actuator_controller
       - open_manipulator
       - open_manipulator_bringup
+      - open_manipulator_collision
       - open_manipulator_description
       - open_manipulator_gui
       - open_manipulator_moveit_config
@@ -5524,7 +5525,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.2.4-1
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.3.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.4-1`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* Added self-collision functionality to OMY Follower
* Contributors: Sungho Woo
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Added self-collision functionality to OMY Follower
* Contributors: Sungho Woo
```

## open_manipulator_bringup

```
* Added self-collision functionality to OMY Follower
* Contributors: Sungho Woo
```

## open_manipulator_collision

```
* Added self-collision functionality to OMY Follower
* Contributors: Sungho Woo
```

## open_manipulator_description

```
* Added self-collision functionality to OMY Follower
* Contributors: Sungho Woo
```

## open_manipulator_gui

```
* None
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* None
```
