### PR TITLE
realtime_tools: 4.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5975,7 +5975,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.3.0-1
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.4.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.3.0-1`

## realtime_tools

```
* Silence some deprecation warnings (#355 <https://github.com/ros-controls/realtime_tools/issues/355>)
* Add new API for the RealtimePublisher (#323 <https://github.com/ros-controls/realtime_tools/issues/323>)
* Add guidelines for realtimebox/queue (#347 <https://github.com/ros-controls/realtime_tools/issues/347>)
* Add docs for control.ros.org (#346 <https://github.com/ros-controls/realtime_tools/issues/346>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
