### PR TITLE
realtime_tools: 3.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6888,7 +6888,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.7.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.6.0-1`

## realtime_tools

```
* Silence some warnings (backport #355 <https://github.com/ros-controls/realtime_tools/issues/355>) (#357 <https://github.com/ros-controls/realtime_tools/issues/357>)
* Add new API for the RealtimePublisher (backport #323 <https://github.com/ros-controls/realtime_tools/issues/323>) (#352 <https://github.com/ros-controls/realtime_tools/issues/352>)
* Add guidelines for realtimebox/queue (backport #347 <https://github.com/ros-controls/realtime_tools/issues/347>) (#354 <https://github.com/ros-controls/realtime_tools/issues/354>)
* Add docs for control.ros.org (backport #346 <https://github.com/ros-controls/realtime_tools/issues/346>) (#353 <https://github.com/ros-controls/realtime_tools/issues/353>)
* Contributors: Christoph Froehlich, Sai Kishor Kothakota, mergify[bot]
```
