### PR TITLE
ur_robot_driver: 4.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9030,7 +9030,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.0.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.0.1-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Ignore deprecation warning for set_gains for now (#1392 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1392>)
* Use std_atomic<bool> in SJTC (#1385 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1385>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Remove unnecessary arguments. (#1389 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1389>)
* Contributors: Dr. Denis
```
