### PR TITLE
generate_parameter_library: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2207,7 +2207,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.5.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## cmake_generate_parameter_module_example

```
* Add user callback python (#254 <https://github.com/PickNikRobotics/generate_parameter_library/issues/254>)
* Contributors: Nathan Brooks, Yannick de Hoop
```

## generate_parameter_library

```
* Fix generate_parameter_library macro on Windows (#242 <https://github.com/PickNikRobotics/generate_parameter_library/issues/242>)
* Contributors: Nathan Brooks, Silvio Traversaro
```

## generate_parameter_library_example

```
* Add try_update_params method (#260 <https://github.com/PickNikRobotics/generate_parameter_library/issues/260>)
* Add user callback (#250 <https://github.com/PickNikRobotics/generate_parameter_library/issues/250>)
* Contributors: Nathan Brooks, Sai Kishor Kothakota, Yannick de Hoop
```

## generate_parameter_library_example_external

```
* Add some new maintainers for ROS releases (#263 <https://github.com/PickNikRobotics/generate_parameter_library/issues/263>)
* Contributors: Nathan Brooks
```

## generate_parameter_library_py

```
* Add try_update_params method (#260 <https://github.com/PickNikRobotics/generate_parameter_library/issues/260>)
* Fix ros2_controllers issue`#1740 <https://github.com/PickNikRobotics/generate_parameter_library/issues/1740>`_ -Wreorder fix (#264 <https://github.com/PickNikRobotics/generate_parameter_library/issues/264>)
* No need to default-construct logger in the declaration (#252 <https://github.com/PickNikRobotics/generate_parameter_library/issues/252>)
* Add user callback python (#254 <https://github.com/PickNikRobotics/generate_parameter_library/issues/254>)
* Add user callback (#250 <https://github.com/PickNikRobotics/generate_parameter_library/issues/250>)
* Fix merge install for python packages (#241 <https://github.com/PickNikRobotics/generate_parameter_library/issues/241>)
* Contributors: Darren Tsai, Dimitri Decious, Nathan Brooks, Sai Kishor Kothakota, Tim Clephas, Yannick de Hoop
```

## generate_parameter_module_example

```
* Add some new maintainers for ROS releases (#263 <https://github.com/PickNikRobotics/generate_parameter_library/issues/263>)
* Contributors: Nathan Brooks
```

## parameter_traits

```
* Add some new maintainers for ROS releases (#263 <https://github.com/PickNikRobotics/generate_parameter_library/issues/263>)
* Contributors: Nathan Brooks
```
