### PR TITLE
replace libcamera URL

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4557,7 +4557,7 @@ repositories:
   libcamera:
     doc:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: v0.1.0
     release:
       tags:
@@ -4566,7 +4566,7 @@ repositories:
       version: 0.1.0-3
     source:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: master
     status: developed
   libcreate:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4091,7 +4091,7 @@ repositories:
   libcamera:
     doc:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: v0.3.1
     release:
       tags:
@@ -4100,7 +4100,7 @@ repositories:
       version: 0.5.0-1
     source:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: master
     status: maintained
   libg2o:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3432,7 +3432,7 @@ repositories:
   libcamera:
     doc:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: v0.3.1
     release:
       tags:
@@ -3441,7 +3441,7 @@ repositories:
       version: 0.5.0-4
     source:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: master
     status: maintained
   libg2o:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3520,7 +3520,7 @@ repositories:
   libcamera:
     doc:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: v0.3.1
     release:
       tags:
@@ -3529,7 +3529,7 @@ repositories:
       version: 0.5.0-3
     source:
       type: git
-      url: https://git.libcamera.org/libcamera/libcamera.git
+      url: https://gitlab.freedesktop.org/camera/libcamera.git
       version: master
     status: maintained
   libg2o:


### PR DESCRIPTION
The libcamera repo moved to https://gitlab.freedesktop.org/camera/libcamera.git. The original repo (https://git.libcamera.org/libcamera/libcamera.git) is not reachable any more.