### PR TITLE
rosidlcpp: 0.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7314,6 +7314,25 @@ repositories:
       type: git
       url: https://github.com/TonyWelte/rosidlcpp.git
       version: rolling
+    release:
+      packages:
+      - rosidlcpp
+      - rosidlcpp_generator_c
+      - rosidlcpp_generator_core
+      - rosidlcpp_generator_cpp
+      - rosidlcpp_generator_py
+      - rosidlcpp_generator_type_description
+      - rosidlcpp_parser
+      - rosidlcpp_typesupport_c
+      - rosidlcpp_typesupport_cpp
+      - rosidlcpp_typesupport_fastrtps_c
+      - rosidlcpp_typesupport_fastrtps_cpp
+      - rosidlcpp_typesupport_introspection_c
+      - rosidlcpp_typesupport_introspection_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidlcpp-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.1.1-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_core

- No changes

## rosidlcpp_generator_cpp

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_py

- No changes

## rosidlcpp_generator_type_description

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_parser

- No changes

## rosidlcpp_typesupport_c

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_cpp

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_c

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_cpp

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_c

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_cpp

```
* Fix circular dependency caused by ament_cmake_ros dependency (#4 <https://github.com/TonyWelte/rosidlcpp/issues/4>)
* Contributors: Anthony Welte
```
