### PR TITLE
remove 'libopen3d-dev' and 'python3-open3d' from Ubuntu noble

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5011,6 +5011,7 @@ libopen3d-dev:
     '*': [libopen3d-dev]
     bionic: null
     focal: null
+    noble: null
 libopenal-dev:
   arch: [openal]
   debian: [libopenal-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7831,6 +7831,7 @@ python3-open3d:
     '*': [python3-open3d]
     bionic: null
     focal: null
+    noble: null
 python3-open3d-pip:
   debian:
     pip:


### PR DESCRIPTION
The packages `libopen3d-dev` and `python3-open3d` do not exist on Ubuntu 24.04.

See:
- https://launchpad.net/ubuntu/noble/amd64/libopen3d-dev
- https://github.com/isl-org/Open3D/issues/6730

Trying to resolve them with rosdep causes an apt failure.