### PR TITLE
aruco_markers: 0.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -477,7 +477,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/namo-robotics/aruco_markers-release.git
-      version: 0.0.2-1
+      version: 0.0.0-1
     source:
       type: git
       url: https://github.com/namo-robotics/aruco_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_markers` to `0.0.0-1`:

- upstream repository: https://github.com/namo-robotics/aruco_markers.git
- release repository: https://github.com/namo-robotics/aruco_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`
