### PR TITLE
aruco_markers: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -481,6 +481,18 @@ repositories:
       version: main
     status: developed
   aruco_markers:
+    doc:
+      type: git
+      url: https://github.com/namo-robotics/aruco_markers.git
+      version: jazzy
+    release:
+      packages:
+      - aruco_markers
+      - aruco_markers_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/namo-robotics/aruco_markers-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/namo-robotics/aruco_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_markers` to `0.0.2-1`:

- upstream repository: https://github.com/namo-robotics/aruco_markers.git
- release repository: https://github.com/namo-robotics/aruco_markers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
