### PR TITLE
plotjuggler: 3.10.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5938,7 +5938,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.6-1
+      version: 3.10.7-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.10.7-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.10.6-1`

## plotjuggler

```
* fix mcap on ROS2
* update sol2
* Add button to delete custom timeseries (#1093 <https://github.com/facontidavide/PlotJuggler/issues/1093>)
  * Add button to delete custom timeseries
  * Remove tailing whitespace
* Contributors: Davide Faconti, Zach Davis
```
