### PR TITLE
add python3-xlib

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10989,6 +10989,8 @@ python3-xlib:
   fedora: [python3-xlib]
   gentoo: [dev-python/python-xlib]
   ubuntu: [python3-xlib]
+  opensuse: [python3-python-xlib]
+  rhel: [python3-xlib]
 python3-xlsxwriter:
   debian: [python3-xlsxwriter]
   fedora: [python3-xlsxwriter]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10984,6 +10984,11 @@ python3-xdot:
   gentoo: [media-gfx/xdot]
   nixos: [xdot]
   ubuntu: [xdot]
+python3-xlib:
+  debian: [python3-xlib]
+  fedora: [python3-xlib]
+  gentoo: [dev-python/python-xlib]
+  ubuntu: [python3-xlib]
 python3-xlsxwriter:
   debian: [python3-xlsxwriter]
   fedora: [python3-xlsxwriter]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10988,9 +10988,9 @@ python3-xlib:
   debian: [python3-xlib]
   fedora: [python3-xlib]
   gentoo: [dev-python/python-xlib]
-  ubuntu: [python3-xlib]
   opensuse: [python3-python-xlib]
   rhel: [python3-xlib]
+  ubuntu: [python3-xlib]
 python3-xlsxwriter:
   debian: [python3-xlsxwriter]
   fedora: [python3-xlsxwriter]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-xlib

## Package Upstream Source:

https://github.com/python-xlib/python-xlib

## Purpose of using this:

This dependency is being used to interact with x11 through python3, e.g. for testing purposes. The python2 version is already in the rosdep database as `python-xlib`.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=python3-xlib
- Ubuntu: https://packages.ubuntu.com/python3-xlib
- Fedora: https://packages.fedoraproject.org/pkgs/python-xlib/python3-xlib/
- Gentoo: https://packages.gentoo.org/packages/dev-python/python-xlib
