### PR TITLE
turtlebot3_applications: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11127,6 +11127,19 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
       version: humble
+    release:
+      packages:
+      - turtlebot3_applications
+      - turtlebot3_aruco_tracker
+      - turtlebot3_automatic_parking
+      - turtlebot3_automatic_parking_vision
+      - turtlebot3_follower
+      - turtlebot3_panorama
+      - turtlebot3_yolo_object_detection
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_applications-release.git
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `1.3.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ros2-gbp/turtlebot3_applications-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot3_applications

```
* Added turtlebot3_yolo_object_detection pkg
* Added a Python script that runs the YOLO model on live camera images and publishes detection results with bounding boxes
* Contributors: YeonSoo Noh
```

## turtlebot3_aruco_tracker

```
* None
```

## turtlebot3_automatic_parking

```
* None
```

## turtlebot3_automatic_parking_vision

```
* None
```

## turtlebot3_follower

```
* None
```

## turtlebot3_panorama

```
* None
```

## turtlebot3_yolo_object_detection

```
* Added turtlebot3_yolo_object_detection pkg
* Added a Python script that runs the YOLO model on live camera images and publishes detection results with bounding boxes
* Contributors: YeonSoo Noh
```
