### PR TITLE
ur_client_library: 2.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9054,7 +9054,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.0-1`

## ur_client_library

```
* Minimal support for building on macOS (#341 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/341>)
* Install endian.h and add that to the target include directories on Windows and MacOS (#345 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/345>)
* Add ScriptReader for script template parsing (#343 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/343>)
* Add more tests for VersionInformation (#344 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/344>)
* Fix driver branch for Jazzy downstream build (#339 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/339>)
* Stop control, when UrDriver object is destroyed (#338 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/338>)
* Add new robot types to URSim startup script (#331 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/331>)
* Fix robot message type POPUP (#335 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/335>)
* Disable checking links for two broken ones (#333 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/333>)
* readme: load ROSin imgs from press_kit repository (#334 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/334>)
* Added configuration data to packages parsed from the primary interface (#327 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/327>)
* Correct message sum in test_tool_contact (#324 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/324>)
* Fix the image sizes in architecture section (#321 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/321>)
* Check links using lychee (#319 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/319>)
* Update ROS distributions for industrial_ci (#317 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/317>)
* Support PolyScopeX simulator for 10.8.0 (#315 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/315>)
* Add an API reference page to the docs (#314 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/314>)
* Update documentation (#309 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/309>)
* Contributors: Andrew C. Morrow, Felix Exner, G.A. vd. Hoorn, Mads Holm Peters
```
