### PR TITLE
automatika_ros_sugar: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -611,7 +611,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.9-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.3.0-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.9-1`

## automatika_ros_sugar

```
* (chore) Updates installation instructions and CI
* (fix) Removes NoneType from types for compatibility with python < 3.10
* (fix) Add missing pyyaml dependency
* (feature) Adds config parsing from toml, json and yaml and removes Omegaconf dependency
* (fix) Add missing action decorator to methods
* (docs) Updates img names
* (docs) Updates readme
* (chore) Adds a sweeter name for ROS Sugar .. Sugarcoat
* (docs) Minor edits
* (docs) Adds documentation for creating systemd services with scripts
* (docs) Fixes size of logo
* (docs) Fixes warnings in docs
* (docs) Minor fix
* (docs) Updates supported types docs
* (fix) Fixes minor typo
* (fix) Fixes logging level parsing
* (feature) Adds node logging level and rclpy logging level to component config
* (fix) Adds BGR2RGB tranformation for yuv422_yuy2 encoding
* (docs) Removes unused extension
* (docs) Adds docs for components services and pkg advantages
* Merge branch 'feature/system_management' of github.com:automatika-robotics/ros-sugar into feature/system_management
* (fix) Fixes transformation quaternion parsing
* (feature) Adds utility method for processing all ROS image encodings
* (feature) Adds transformation/rotation propertires to TFListener
* (fix) Fixes lifecycle transitioin callback in component
* (chore) Adds msgpack-numpy and attrs as deb package dependencies
* (fix) Handles lifecycle actions start/stop/restart from the launcher
* (fix) Adds action goal lock to handle aborting ongoing goals and executing new incoming goals
* Contributors: ahr, mkabtoul
```
