### PR TITLE
pal_urdf_utils: 2.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6628,7 +6628,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_urdf_utils-release.git
-      version: 2.1.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_urdf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_urdf_utils` to `2.2.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_urdf_utils.git
- release repository: https://github.com/pal-gbp/pal_urdf_utils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## pal_urdf_utils

```
* Switch to gpu_ray due to an issue with the omni_base detecting its own collision boxes
* Contributors: thomaspeyrucain
```
