### PR TITLE
omni_base_robot: 2.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6285,7 +6285,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.10.1-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.12.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.1-1`

## omni_base_bringup

```
* configure joystick_relay with namespaces
* fix twist_mux with namespaces
* start twist mux with namespace
* init support to namespaces
* Contributors: antoniobrandi
```

## omni_base_controller_configuration

```
* fix twist_mux with namespaces
* missing launch argument
* support namespaces for control
* init support to namespaces
* Contributors: antoniobrandi
```

## omni_base_description

```
* uniform namespaces in URDF
* support namespaces for control
* init support to namespaces
* Contributors: antoniobrandi
```

## omni_base_robot

- No changes
