### PR TITLE
play_motion2: 1.5.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6831,7 +6831,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.5.2-1
+      version: 1.5.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.5.3-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.2-1`

## play_motion2

```
* Fix motion starting on the current position of the robot
  The joints were compared with the approach positions size, which always
  will match. Then if the approach was not needed, the motion was not
  performed
* Contributors: Noel Jimenez
```

## play_motion2_msgs

- No changes
