### PR TITLE
pmb2_navigation: 4.17.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6912,7 +6912,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.15.0-1
+      version: 4.17.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.17.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/pal-gbp/pmb2_navigation-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.15.0-1`

## pmb2_2dnav

```
* support namespaces
* Contributors: antoniobrandi
```

## pmb2_laser_sensors

```
* support namespaces
* Contributors: antoniobrandi
```

## pmb2_navigation

- No changes

## pmb2_rgbd_sensors

```
* support namespaces
* Contributors: antoniobrandi
```
