### PR TITLE
talos_moveit_config: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10689,7 +10689,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_moveit_config-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/talos_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_moveit_config` to `2.0.2-1`:

- upstream repository: https://github.com/pal-robotics/talos_moveit_config.git
- release repository: https://github.com/pal-gbp/talos_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## talos_moveit_config

```
* Merge branch 'sim_time' into 'humble-devel'
  Fix use_sim_time
  See merge request control/talos_moveit_config!11
* Fix use_sim_time
* Contributors: Adrià Roig, Sai Kishor Kothakota
```
