### PR TITLE
pmb2_robot: 5.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6932,7 +6932,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.8.2-1
+      version: 5.9.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.9.0-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.8.2-1`

## pmb2_bringup

```
* add support to namespaces
* Contributors: antoniobrandi
```

## pmb2_controller_configuration

```
* add support to namespaces
* Contributors: antoniobrandi
```

## pmb2_description

```
* add support to namespaces
* Contributors: antoniobrandi
```

## pmb2_robot

- No changes
