### PR TITLE
talos_robot: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10707,7 +10707,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/talos_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `2.1.0-1`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.2-1`

## talos_bringup

```
* Adapt to changes in play_motion2
* Contributors: davidfernandez
```

## talos_controller_configuration

- No changes

## talos_description

- No changes

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes

## talos_robot

- No changes
