### PR TITLE
neo_nav2_bringup: 1.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5152,7 +5152,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.3.1-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## neo_nav2_bringup

```
* fixing sim time issue, which didn't allow costmap to spawn (#31 <https://github.com/neobotix/neo_nav2_bringup/issues/31>)
* Refactored rviz launch file (#28 <https://github.com/neobotix/neo_nav2_bringup/issues/28>)
  * Refactored rviz launch file
  * Removed contributor tag from package.xml
  * Added the start_rviz node to the navigation_neo.launch.py file and the necessary launch argument, removed changelog
  * Added the missing declare_use_rviz_cmd action in navigation_neo.launch.py
* Contributors: Adarsh Karan Kesavadas Prasanth, Pradheep Krishna
```
