### PR TITLE
control_toolbox: 5.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1231,7 +1231,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.4.0-1
+      version: 5.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.5.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.4.0-1`

## control_toolbox

```
* Use RealtimeThreadSafeBox for PID class (#387 <https://github.com/ros-controls/control_toolbox/issues/387>)
* Redefine the antiwindup strategy and their parameter interfacing (#400 <https://github.com/ros-controls/control_toolbox/issues/400>)
* Skip callback if saturation parameter is not declared (#397 <https://github.com/ros-controls/control_toolbox/issues/397>)
* Use new RT publisher API in PID class (#394 <https://github.com/ros-controls/control_toolbox/issues/394>)
* [PID] Cleanup saturation parameter in the methods and constructors (#390 <https://github.com/ros-controls/control_toolbox/issues/390>)
* Don't validate data_out if it is empty (#391 <https://github.com/ros-controls/control_toolbox/issues/391>)
* Update anti-windup techniques (#298 <https://github.com/ros-controls/control_toolbox/issues/298>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Victor Coutinho Vieira Santos
```
