### PR TITLE
rmw_zenoh: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6480,7 +6480,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.7.1-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.8.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.7.1-1`

## rmw_zenoh_cpp

```
* Use data() to avoid potentially dereferencing an empty vector (#667 <https://github.com/ros2/rmw_zenoh/issues/667>)
* Bump Zenoh to 1.4.0 (#652 <https://github.com/ros2/rmw_zenoh/issues/652>)
* Contributors: Julien Enoch, Øystein Sture
```

## zenoh_cpp_vendor

```
* Bump Zenoh to 1.4.0 (#652 <https://github.com/ros2/rmw_zenoh/issues/652>)
* Contributors: Julien Enoch
```

## zenoh_security_tools

- No changes
