### PR TITLE
rmw_zenoh: 0.6.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6454,7 +6454,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.2-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.6.1-1`

## rmw_zenoh_cpp

```
* Use data() to avoid potentially dereferencing an empty vector (#668 <https://github.com/ros2/rmw_zenoh/issues/668>)
* Bump Zenoh to 1.4.0 (#657 <https://github.com/ros2/rmw_zenoh/issues/657>)
* Contributors: Julien Enoch, Øystein Sture
```

## zenoh_cpp_vendor

```
* Bump Zenoh to 1.4.0 (#657 <https://github.com/ros2/rmw_zenoh/issues/657>)
* Contributors: Julien Enoch
```

## zenoh_security_tools

- No changes
