### PR TITLE
rmw_zenoh: 0.2.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7379,10 +7379,11 @@ repositories:
       packages:
       - rmw_zenoh_cpp
       - zenoh_cpp_vendor
+      - zenoh_security_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.3-1
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.5-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.3-1`

## rmw_zenoh_cpp

```
* Use data() to avoid potentially dereferencing an empty vector (#669 <https://github.com/ros2/rmw_zenoh/issues/669>)
* Bump Zenoh to 1.4.0 (#658 <https://github.com/ros2/rmw_zenoh/issues/658>)
* fix rmw_take_serialized_message. (#640 <https://github.com/ros2/rmw_zenoh/issues/640>)
* Contributors: Julien Enoch, Tomoya Fujita, Yuyuan Yuan, Øystein Sture
```

## zenoh_cpp_vendor

```
* Bump Zenoh to 1.4.0 (#658 <https://github.com/ros2/rmw_zenoh/issues/658>)
* fix: pin rust toolchain to v1.75.0 (#635 <https://github.com/ros2/rmw_zenoh/issues/635>)
* fix: use the right commit to bump zenoh to v1.3.2 (#632 <https://github.com/ros2/rmw_zenoh/issues/632>)
* Contributors: Julien Enoch, Yadunund, Yuyuan Yuan
```

## zenoh_security_tools

```
* Add zenoh_security_tools (#661 <https://github.com/ros2/rmw_zenoh/issues/661>)
* Contributors: Alejandro Hernández Cordero
```
