### PR TITLE
launch: 3.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3346,7 +3346,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.0-1
+      version: 3.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.1-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.9.0-1`

## launch

```
* Make sure to install py.typed files (#886 <https://github.com/ros2/launch/issues/886>)
* use custom log_file name as per the user setting (#861 <https://github.com/ros2/launch/issues/861>)
* Using ``TimerAction`` with ``SetParameter`` from launch_ros causes crash (#879 <https://github.com/ros2/launch/issues/879>)
* Fix log_* warnings (#883 <https://github.com/ros2/launch/issues/883>)
* Updated launch typings (#831 <https://github.com/ros2/launch/issues/831>)
* Allow Path in substitutions, instead of requiring cast to str (#873 <https://github.com/ros2/launch/issues/873>)
* Add a / path join operator for PathJoinSubstitution (#868 <https://github.com/ros2/launch/issues/868>)
* Other Logging Implementations with getLevelNamesMapping fix (#866 <https://github.com/ros2/launch/issues/866>)
* Revert "Add Other Logging Implementations (#858 <https://github.com/ros2/launch/issues/858>)" (#865 <https://github.com/ros2/launch/issues/865>)
  This reverts commit b7b31c45b0eb350deedd282b88398d1ca0d5faf4.
* Add Other Logging Implementations (#858 <https://github.com/ros2/launch/issues/858>)
* Contributors: Christophe Bedard, Emerson Knapp, Kenji Brameld (TRACLabs), Michael Carlstrom, Tanishq Chaudhary
```

## launch_pytest

```
* Make sure to install py.typed files (#886 <https://github.com/ros2/launch/issues/886>)
* Add remaining py.typed (#884 <https://github.com/ros2/launch/issues/884>)
* Allow Path in substitutions, instead of requiring cast to str (#873 <https://github.com/ros2/launch/issues/873>)
* fix(launch_pytest): prevent re-wrapping test funtions on re-run (#855 <https://github.com/ros2/launch/issues/855>)
* Contributors: Christophe Bedard, David Revay, Emerson Knapp, Michael Carlstrom
```

## launch_testing

```
* Make sure to install py.typed files (#886 <https://github.com/ros2/launch/issues/886>)
* Add remaining py.typed (#884 <https://github.com/ros2/launch/issues/884>)
* Updated launch typings (#831 <https://github.com/ros2/launch/issues/831>)
* Contributors: Christophe Bedard, Michael Carlstrom
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Make sure to install py.typed files (#886 <https://github.com/ros2/launch/issues/886>)
* Add remaining py.typed (#884 <https://github.com/ros2/launch/issues/884>)
* Fix log_* warnings (#883 <https://github.com/ros2/launch/issues/883>)
* Allow Path in substitutions, instead of requiring cast to str (#873 <https://github.com/ros2/launch/issues/873>)
* Other Logging Implementations with getLevelNamesMapping fix (#866 <https://github.com/ros2/launch/issues/866>)
* Revert "Add Other Logging Implementations (#858 <https://github.com/ros2/launch/issues/858>)" (#865 <https://github.com/ros2/launch/issues/865>)
  This reverts commit b7b31c45b0eb350deedd282b88398d1ca0d5faf4.
* Add Other Logging Implementations (#858 <https://github.com/ros2/launch/issues/858>)
* Contributors: Christophe Bedard, Emerson Knapp, Michael Carlstrom
```

## launch_yaml

```
* Make sure to install py.typed files (#886 <https://github.com/ros2/launch/issues/886>)
* Add remaining py.typed (#884 <https://github.com/ros2/launch/issues/884>)
* Fix log_* warnings (#883 <https://github.com/ros2/launch/issues/883>)
* Other Logging Implementations with getLevelNamesMapping fix (#866 <https://github.com/ros2/launch/issues/866>)
* Revert "Add Other Logging Implementations (#858 <https://github.com/ros2/launch/issues/858>)" (#865 <https://github.com/ros2/launch/issues/865>)
  This reverts commit b7b31c45b0eb350deedd282b88398d1ca0d5faf4.
* Add Other Logging Implementations (#858 <https://github.com/ros2/launch/issues/858>)
* Contributors: Christophe Bedard, Michael Carlstrom
```
