### PR TITLE
geometry2: 0.42.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2272,7 +2272,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.42.0-1
+      version: 0.42.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.42.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.42.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Default initialize TransformStorage's frame_id_ and child_frame_id_ with UINT32_MAX (#783 <https://github.com/ros2/geometry2/issues/783>)
* Contributors: Andreas
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Add normals rotation in PointCloud2 doTransform (#792 <https://github.com/ros2/geometry2/issues/792>)
* Contributors: Patrick Roncagliolo
```

## tf2_tools

- No changes
