### PR TITLE
ament_lint: 0.20.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -290,7 +290,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.20.0-1
+      version: 0.20.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.20.1-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.20.0-1`

## ament_clang_format

- No changes

## ament_clang_tidy

- No changes

## ament_cmake_clang_format

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Allow overriding clang-format version via CMake (#536 <https://github.com/ament/ament_lint/issues/536>)
* Contributors: Nathan Wiebe Neufeldt, mosfet80
```

## ament_cmake_clang_tidy

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_copyright

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_cppcheck

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_cpplint

```
* cpplint: update link to upstream cpplint repo (#538 <https://github.com/ament/ament_lint/issues/538>)
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: Romain Reignier, mosfet80
```

## ament_cmake_flake8

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_lint_cmake

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_mypy

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_pclint

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_pep257

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_pycodestyle

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_pyflakes

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_uncrustify

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_cmake_xmllint

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_copyright

- No changes

## ament_cppcheck

- No changes

## ament_cpplint

```
* cpplint: update link to upstream cpplint repo (#538 <https://github.com/ament/ament_lint/issues/538>)
* Contributors: Romain Reignier
```

## ament_flake8

- No changes

## ament_lint

- No changes

## ament_lint_auto

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_lint_cmake

- No changes

## ament_lint_common

```
* Fix cmake deprecation (#539 <https://github.com/ament/ament_lint/issues/539>)
* Contributors: mosfet80
```

## ament_mypy

- No changes

## ament_pclint

- No changes

## ament_pep257

- No changes

## ament_pycodestyle

- No changes

## ament_pyflakes

- No changes

## ament_uncrustify

- No changes

## ament_xmllint

- No changes
