### PR TITLE
ros2cli: 0.39.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6796,7 +6796,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.39.0-1
+      version: 0.39.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.39.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.39.0-1`

## ros2action

```
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>)
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* move QoS methods from ros2topic.api to ros2cli.qos. (#1053 <https://github.com/ros2/ros2cli/issues/1053>)
* remove unnecessary '/' from ros2 action info. (#1049 <https://github.com/ros2/ros2cli/issues/1049>)
* add QoS option to ros2service/ros2action echo commands. (#1036 <https://github.com/ros2/ros2cli/issues/1036>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```

## ros2cli

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* move QoS methods from ros2topic.api to ros2cli.qos. (#1053 <https://github.com/ros2/ros2cli/issues/1053>)
* Assert HistoryQoS in test_ros2cli_daemon (#1040 <https://github.com/ros2/ros2cli/issues/1040>)
* remove add_subparsers from ros2cli. (#1032 <https://github.com/ros2/ros2cli/issues/1032>)
* Contributors: Mario Domínguez López, Michael Carlstrom, Tomoya Fujita
```

## ros2cli_test_interfaces

- No changes

## ros2component

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom
```

## ros2doctor

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Fix stringifying InterfaceFlags when the flags are empty. (#1026 <https://github.com/ros2/ros2cli/issues/1026>)
* Contributors: Chris Lalancette, Michael Carlstrom
```

## ros2interface

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom
```

## ros2lifecycle

```
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>)
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom
```

## ros2node

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom
```

## ros2param

```
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>)
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* fix misspelling. (#1035 <https://github.com/ros2/ros2cli/issues/1035>)
* catch ConnectionRefusedError, so that it can fall back to DirectNode. (#1014 <https://github.com/ros2/ros2cli/issues/1014>)
* fails the test properly to avoid TypeError exception. (#1016 <https://github.com/ros2/ros2cli/issues/1016>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```

## ros2pkg

```
* Reduce boilerplate in install(TARGETS for library (#1056 <https://github.com/ros2/ros2cli/issues/1056>)
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom, Silvio Traversaro
```

## ros2run

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* Contributors: Michael Carlstrom
```

## ros2service

```
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>)
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* move QoS methods from ros2topic.api to ros2cli.qos. (#1053 <https://github.com/ros2/ros2cli/issues/1053>)
* add QoS option to ros2service/ros2action echo commands. (#1036 <https://github.com/ros2/ros2cli/issues/1036>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```

## ros2topic

```
* Export Typing information (#1041 <https://github.com/ros2/ros2cli/issues/1041>)
* move QoS methods from ros2topic.api to ros2cli.qos. (#1053 <https://github.com/ros2/ros2cli/issues/1053>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```
