### PR TITLE
naoqi_libqi: 3.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5055,6 +5055,22 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  naoqi_libqi:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 3.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: ros2
+    status: maintained
   nav2_minimal_turtlebot_simulation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `3.0.3-1`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## naoqi_libqi

```
* Update c++ to 14 for gtest compatability
* Support for Jazzy
* Update badges
* Contributors: Chris Birmingham, Victor Paléologue
```
