### PR TITLE
rmw_zenoh: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8405,10 +8405,11 @@ repositories:
       packages:
       - rmw_zenoh_cpp
       - zenoh_cpp_vendor
+      - zenoh_security_tools
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.1.2-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## rmw_zenoh_cpp

```
* Use data() to avoid potentially dereferencing an empty vector (#667 <https://github.com/ros2/rmw_zenoh/issues/667>) (#670 <https://github.com/ros2/rmw_zenoh/issues/670>)
* Bump Zenoh to 1.4.0 (#652 <https://github.com/ros2/rmw_zenoh/issues/652>) (#659 <https://github.com/ros2/rmw_zenoh/issues/659>)
* fix(comment): correct the QoS incompatibilities (#644 <https://github.com/ros2/rmw_zenoh/issues/644>) (#647 <https://github.com/ros2/rmw_zenoh/issues/647>)
* Change serialization format in attachment_helpers.cpp (backport #601 <https://github.com/ros2/rmw_zenoh/issues/601>) (#606 <https://github.com/ros2/rmw_zenoh/issues/606>)
* Fix the comment. (#597 <https://github.com/ros2/rmw_zenoh/issues/597>) (#599 <https://github.com/ros2/rmw_zenoh/issues/599>)
* Bump Zenoh to v1.3.2 and improve e2e reliability with HeartbeatSporadic (#591 <https://github.com/ros2/rmw_zenoh/issues/591>) (#594 <https://github.com/ros2/rmw_zenoh/issues/594>)
* Trigger qos event callback if there are changes before registration  (backport #587 <https://github.com/ros2/rmw_zenoh/issues/587>) (#590 <https://github.com/ros2/rmw_zenoh/issues/590>)
* Set wait_set->triggered flag to false (#575 <https://github.com/ros2/rmw_zenoh/issues/575>) (#585 <https://github.com/ros2/rmw_zenoh/issues/585>)
* Add space after id token in rmw_zenohd log string (#576 <https://github.com/ros2/rmw_zenoh/issues/576>) (#579 <https://github.com/ros2/rmw_zenoh/issues/579>)
* fix: use std::unique_lock to unlock correctly on Windows (#570 <https://github.com/ros2/rmw_zenoh/issues/570>) (#574 <https://github.com/ros2/rmw_zenoh/issues/574>)
* Switch to std::map for TopicTypeMap (backport #546 <https://github.com/ros2/rmw_zenoh/issues/546>) (#566 <https://github.com/ros2/rmw_zenoh/issues/566>)
* feat: support zenoh config override (backport #551 <https://github.com/ros2/rmw_zenoh/issues/551>) (#560 <https://github.com/ros2/rmw_zenoh/issues/560>)
* Enable Zenoh UDP transport (#486 <https://github.com/ros2/rmw_zenoh/issues/486>) (#489 <https://github.com/ros2/rmw_zenoh/issues/489>)
* feat: introduce the advanced publisher and subscriber (backport #368 <https://github.com/ros2/rmw_zenoh/issues/368>) (#470 <https://github.com/ros2/rmw_zenoh/issues/470>)
* Backport #294 <https://github.com/ros2/rmw_zenoh/issues/294> to humble  (backport #471 <https://github.com/ros2/rmw_zenoh/issues/471>) (#472 <https://github.com/ros2/rmw_zenoh/issues/472>)
* Align the config with the latest Zenoh. (#556 <https://github.com/ros2/rmw_zenoh/issues/556>) (#558 <https://github.com/ros2/rmw_zenoh/issues/558>)
* Bump zenoh-cpp to 2a127bb, zenoh-c to 3540a3c, and zenoh to f735bf5 (#503 <https://github.com/ros2/rmw_zenoh/issues/503>) (#512 <https://github.com/ros2/rmw_zenoh/issues/512>)
* Added documentation note in the code (#540 <https://github.com/ros2/rmw_zenoh/issues/540>) (#542 <https://github.com/ros2/rmw_zenoh/issues/542>)
* fix: unlock the mutex before making get (#537 <https://github.com/ros2/rmw_zenoh/issues/537>) (#538 <https://github.com/ros2/rmw_zenoh/issues/538>)
* Take wait_set_lock before condition_variable notification for subscriptions (#528 <https://github.com/ros2/rmw_zenoh/issues/528>) (#535 <https://github.com/ros2/rmw_zenoh/issues/535>)
* Switch default durability to volatile (#521 <https://github.com/ros2/rmw_zenoh/issues/521>) (#531 <https://github.com/ros2/rmw_zenoh/issues/531>)
* Honor ignore_local_publications in subscription options (backport #508 <https://github.com/ros2/rmw_zenoh/issues/508>) (#514 <https://github.com/ros2/rmw_zenoh/issues/514>)
* Fixed windows warning (#500 <https://github.com/ros2/rmw_zenoh/issues/500>) (#519 <https://github.com/ros2/rmw_zenoh/issues/519>)
* Config: tune some values for ROS use case, especially with large number of Nodes (>200) (#509 <https://github.com/ros2/rmw_zenoh/issues/509>) (#516 <https://github.com/ros2/rmw_zenoh/issues/516>)
* Fix calculation of current_count_change when event status is updated (#504 <https://github.com/ros2/rmw_zenoh/issues/504>) (#507 <https://github.com/ros2/rmw_zenoh/issues/507>)
* fix: use the default destructor that automatically drops the zenoh reply/query and hence sends the final signal (#473 <https://github.com/ros2/rmw_zenoh/issues/473>) (#475 <https://github.com/ros2/rmw_zenoh/issues/475>)
* Switch to debug log if topic_name not in topic_map (#454 <https://github.com/ros2/rmw_zenoh/issues/454>) (#465 <https://github.com/ros2/rmw_zenoh/issues/465>)
* Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits) (#456 <https://github.com/ros2/rmw_zenoh/issues/456>) (#462 <https://github.com/ros2/rmw_zenoh/issues/462>)
* Contributors: mergify[bot]
```

## zenoh_cpp_vendor

```
* Bump Zenoh to 1.4.0 (#652 <https://github.com/ros2/rmw_zenoh/issues/652>) (#659 <https://github.com/ros2/rmw_zenoh/issues/659>)
  (cherry picked from commit 4d066979d3cc1b1cf5ed48a806aa12206d0aab7f)
  Co-authored-by: Julien Enoch <mailto:julien.e@zettascale.tech>
* fix: pin rust toolchain to v1.75.0 (#602 <https://github.com/ros2/rmw_zenoh/issues/602>) (#636 <https://github.com/ros2/rmw_zenoh/issues/636>)
  * fix: pin rust toolchain to v1.75.0
  * Apply the suggested change
  ---------
  (cherry picked from commit 33b250e4541718977f35ea6d518a96f5af7465fd)
  Co-authored-by: Yuyuan Yuan <mailto:az6980522@gmail.com>
  Co-authored-by: yadunund <mailto:yadunund@gmail.com>
* fix: use the right commit to bump zenoh to v1.3.2 (#607 <https://github.com/ros2/rmw_zenoh/issues/607>) (#633 <https://github.com/ros2/rmw_zenoh/issues/633>)
  (cherry picked from commit 181c27de53da3f752dded1e6cd61d1ab2c3b19ab)
  Co-authored-by: Yuyuan Yuan <mailto:az6980522@gmail.com>
  Co-authored-by: Yadunund <mailto:yadunund@gmail.com>
* Bump Zenoh to v1.3.2 and improve e2e reliability with HeartbeatSporadic (#591 <https://github.com/ros2/rmw_zenoh/issues/591>) (#594 <https://github.com/ros2/rmw_zenoh/issues/594>)
  * Bump zenoh-c to ffa4bdd, zenoh-cpp to 868fdad and zenoh to 3f62ebc
  * Apply same config changes than eclipse-zenoh/zenoh#1825 <https://github.com/eclipse-zenoh/zenoh/issues/1825>
  * Apply same config changes than eclipse-zenoh/zenoh#1850 <https://github.com/eclipse-zenoh/zenoh/issues/1850>
  * For RELIABLE+TRANSIENT_LOCAL topics, enable sample_miss_detection and recovery for end-to-end reliability
  (cherry picked from commit a9ab960d57e1bb5eaa966e3dd90a5b32b5a14b61)
  Co-authored-by: Julien Enoch <mailto:julien.e@zettascale.tech>
* build(deps): bump zenoh-cpp from 2a127bb to 8ad67f6, zenoh-c from 3540a3c to e6a1971, and zenoh from f735bf5 to b661454 (#544 <https://github.com/ros2/rmw_zenoh/issues/544>) (#550 <https://github.com/ros2/rmw_zenoh/issues/550>)
  Co-authored-by: Yuyuan Yuan <mailto:az6980522@gmail.com>
* Enable Zenoh UDP transport (#486 <https://github.com/ros2/rmw_zenoh/issues/486>) (#489 <https://github.com/ros2/rmw_zenoh/issues/489>)
  Co-authored-by: Hugal31 <mailto:hugo.laloge@gmail.com>
* Bump zenoh-cpp to 2a127bb, zenoh-c to 3540a3c, and zenoh to f735bf5 (#503 <https://github.com/ros2/rmw_zenoh/issues/503>) (#512 <https://github.com/ros2/rmw_zenoh/issues/512>)
  (cherry picked from commit 19b7f7767917c1168ba081782ecde6b39d26262e)
  Co-authored-by: Luca Cominardi <mailto:luca.cominardi@gmail.com>
* Bump zenoh-c to 261493 and zenoh-cpp to 5dfb68c (#463 <https://github.com/ros2/rmw_zenoh/issues/463>) (#467 <https://github.com/ros2/rmw_zenoh/issues/467>)
  (cherry picked from commit baa4e875eca13dc16cebc61842cd6cf2600158fb)
  Co-authored-by: Julien Enoch <mailto:julien.e@zettascale.tech>
* Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits) (#456 <https://github.com/ros2/rmw_zenoh/issues/456>) (#462 <https://github.com/ros2/rmw_zenoh/issues/462>)
  * Bump Zenoh to 3bbf6af
  * Config: add new autoconnect_strategy setting
  (cherry picked from commit 1601a69622cd913d0f34e64f1840f3b159ca5e75)
  Co-authored-by: Julien Enoch <mailto:julien.e@zettascale.tech>
* Contributors: mergify[bot]
```

## zenoh_security_tools

```
* [backport jazzy] Add zenoh_security_tools (backport #661 <https://github.com/ros2/rmw_zenoh/issues/661>) (#673 <https://github.com/ros2/rmw_zenoh/issues/673>)
* Contributors: mergify[bot]
```
