### PR TITLE
turtlebot3_applications: 1.3.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11139,7 +11139,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_applications-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `1.3.0-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ros2-gbp/turtlebot3_applications-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## turtlebot3_applications

```
* Added turtlebot3_yolo_object_detection pkg
* Added a Python script that runs the YOLO model on live camera images and publishes detection results with bounding boxes
* Contributors: YeonSoo Noh
```

## turtlebot3_aruco_tracker

```
* None
```

## turtlebot3_automatic_parking

```
* None
```

## turtlebot3_automatic_parking_vision

```
* None
```

## turtlebot3_follower

```
* None
```

## turtlebot3_panorama

```
* None
```

## turtlebot3_yolo_object_detection

```
* Added turtlebot3_yolo_object_detection pkg
* Added a Python script that runs the YOLO model on live camera images and publishes detection results with bounding boxes
* Contributors: YeonSoo Noh
```
