### PR TITLE
open_manipulator: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4783,7 +4783,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.3.0-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.0-1`

## om_gravity_compensation_controller

```
* Fix the velocity unit issue to match the new dynamixel_hardware_interface version
* Contributors: Woojin Wie
```

## om_joint_trajectory_command_broadcaster

```
* None
```

## om_spring_actuator_controller

```
* Fix the velocity unit issue to match the new dynamixel_hardware_interface version
* Contributors: Woojin Wie
```

## open_manipulator

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```

## open_manipulator_bringup

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```

## open_manipulator_collision

```
* None
```

## open_manipulator_description

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```

## open_manipulator_gui

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```

## open_manipulator_moveit_config

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```

## open_manipulator_playground

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```

## open_manipulator_teleop

```
* Refactored the package to support the new OMY-3M, OMY-F3M, OMY-L100
* Contributors: Woojin Wie, Wonho Yun
```
