### PR TITLE
open_manipulator: 3.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6332,7 +6332,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.0.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## open_manipulator

```
* Removed unnecessary dependencies
* Contributors: Wonho Yun
```

## open_manipulator_x_bringup

```
* None
```

## open_manipulator_x_description

```
* None
```

## open_manipulator_x_gui

```
* None
```

## open_manipulator_x_moveit_config

```
* Removed unnecessary dependencies
* Contributors: Wonho Yun
```

## open_manipulator_x_playground

```
* None
```

## open_manipulator_x_teleop

```
* None
```
