### PR TITLE
turtlebot3_applications: 1.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9923,6 +9923,19 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
       version: jazzy
+    release:
+      packages:
+      - turtlebot3_applications
+      - turtlebot3_aruco_tracker
+      - turtlebot3_automatic_parking
+      - turtlebot3_automatic_parking_vision
+      - turtlebot3_follower
+      - turtlebot3_panorama
+      - turtlebot3_yolo_object_detection
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_applications-release.git
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_applications` to `1.3.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_applications.git
- release repository: https://github.com/ros2-gbp/turtlebot3_applications-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## turtlebot3_applications

```
* Fix cmake error in turtlebot3_panorama
* Contributors: Hyungyu Kim
```

## turtlebot3_aruco_tracker

```
* None
```

## turtlebot3_automatic_parking

```
* None
```

## turtlebot3_automatic_parking_vision

```
* None
```

## turtlebot3_follower

```
* None
```

## turtlebot3_panorama

```
* Fix cmake error in turtlebot3_panorama
* Contributors: Hyungyu Kim
```

## turtlebot3_yolo_object_detection

```
* None
```
