### PR TITLE
rviz: 15.1.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7895,7 +7895,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.3-1
+      version: 15.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.1.3-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Config::mapGetBool causes segmentation fault when value_out is nullptr (#1471 <https://github.com/ros2/rviz/issues/1471>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Fix /rviz/get_resource (#1487 <https://github.com/ros2/rviz/issues/1487>)
* Removed point_cloud_transport deprecation (#1474 <https://github.com/ros2/rviz/issues/1474>)
* Frame view controller: Removed warnings (#1470 <https://github.com/ros2/rviz/issues/1470>)
* Fix compile with qt6 (#1475 <https://github.com/ros2/rviz/issues/1475>)
* Fix Issue with Quaternion Angular Distance (#1473 <https://github.com/ros2/rviz/issues/1473>)
* PointStampedDisplay: Ignore incoming messages if disabled (#1036 <https://github.com/ros2/rviz/issues/1036>)
* Contributors: Alejandro Hernández Cordero, Harrison Chen, mosfet80
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Handle glTF Y-Up frame convention on mesh load (#1482 <https://github.com/ros2/rviz/issues/1482>)
* Contributors: Michel Hidalgo
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
