### PR TITLE
add clips_executive to index of jazzy,kilted,rolling

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1308,6 +1308,12 @@ repositories:
       url: https://github.com/clearpathrobotics/clearpath_tests.git
       version: jazzy
     status: developed
+  clips_executive:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_executive.git
+      version: master
+    status: maintained
   clips_vendor:
     doc:
       type: git
@@ -6129,6 +6135,12 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  protobuf_comm:
+    source:
+      type: git
+      url: https://github.com/fawkesrobotics/protobuf_comm.git
+      version: main
+    status: developed
   proxsuite:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -994,6 +994,12 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clips_executive:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_executive.git
+      version: master
+    status: maintained
   clips_vendor:
     source:
       type: git
@@ -5305,6 +5311,12 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  protobuf_comm:
+    source:
+      type: git
+      url: https://github.com/fawkesrobotics/protobuf_comm.git
+      version: main
+    status: developed
   proxsuite:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1065,6 +1065,12 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clips_executive:
+    source:
+      type: git
+      url: https://github.com/carologistics/clips_executive.git
+      version: master
+    status: maintained
   clips_vendor:
     source:
       type: git
@@ -5321,6 +5327,12 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  protobuf_comm:
+    source:
+      type: git
+      url: https://github.com/fawkesrobotics/protobuf_comm.git
+      version: main
+    status: developed
   proxsuite:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy, kilted and rolling

# The source is here:

https://github.com/carologistics/clips_executive
https://github.com/fawkesrobotics/protobuf_comm


# Checks
 - [] All packages have a declared license in the package.xml
 - [] This repository has a LICENSE file
 - [] This package is expected to build on the submitted rosdistro

# Explanation
I would like to index the ROS2 CLIPS-Executive. It is a software stack for knowledge-based applications, written by myself.
It essentially allows to write CLIPS-based applications in the ROS ecosystem.
The CLIPS-Executive was originally a component of the [fawkes robotics framework](https://github.com/fawkesrobotics/fawkes). This project is a complete rewrite and modernization of that component, as we are planning to phase out fawkes in favor of ROS.

Almost all packages contained are licensed under Apache-2.0 license, aside from a protobuf extension, which utilizes `protobuf_comm`, a C++ wrapper for protobuf, licensed under GPLv2+. Hence, the `cx_protobuf_plugin` also needed to be licensed the same way.

the `clips_executive` package acts as a meta package, also containing documentation for the whole project, currently also[hosted on github](https://carologistics.github.io/clips_executive/clips_executive/index.html).
The rest of the packages are:
 - `cx_bringup`: containing a main launch file and some examples
 - `cx_clips_env_manager`: containing the ROS node running everything
 - `cx_msgs`: ROS interfaces of the ROS node
 - `cx_utils`: Some utility functions and definitions
 - `cx_tutorial_agents`: code used in the tutorials
 - `cx_plugin`: base interface for plugins loaded via pluginlib
 - `cx_ament_index_plugin`: CLIPS wrapper for `ament_index_cpp`
 - `cx_config_plugin`: CLIPS interface to translate YAML configuration files to facts
 - `cx_example_plugin`: Boilerplate plugin useful as starting point when writing custom plugins
 - `cx_executive_plugin`:  Plugin to continuously invokes the CLIPS inference engine
 - `cx_file_load_plugin`: Plugin for loading CLIPS code
 - `cx_protobuf_plugin`:  Communicate via protobuf using CLIPS (GPLv2+ license)
 - `cx_ros_msgs_plugin`: Communicate via ROS using CLIPS
 - `cx_tf2_pose_tracker_plugin`: track tf2 poses in CLIPS
 - `cx_ros_comm_gen`: generate plugins for ROS communication (only needed for actions and service providers due to limited generic support)
 
 The protobuf plugin needs `protobuf_comm`, which is a separate project. It is a plain CMake project, but I added a package.xml to accommodate for the usage with colcon. I could also wrap it as a vendor package if you prefer that.