### PR TITLE
rviz: 14.1.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8896,7 +8896,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.11-1
+      version: 14.1.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.12-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.11-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Config::mapGetBool causes segmentation fault when value_out is nullptr (#1471 <https://github.com/ros2/rviz/issues/1471>) (#1480 <https://github.com/ros2/rviz/issues/1480>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Frame view controller: Removed warnings (#1470 <https://github.com/ros2/rviz/issues/1470>) (#1477 <https://github.com/ros2/rviz/issues/1477>)
* PointStampedDisplay: Ignore incoming messages if disabled (#1036 <https://github.com/ros2/rviz/issues/1036>) (#1466 <https://github.com/ros2/rviz/issues/1466>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
