### PR TITLE
rviz: 11.2.18-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9870,7 +9870,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.17-1
+      version: 11.2.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.18-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `11.2.17-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Config::mapGetBool causes segmentation fault when value_out is nullptr (#1471 <https://github.com/ros2/rviz/issues/1471>) (#1481 <https://github.com/ros2/rviz/issues/1481>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Frame view controller: Removed warnings (#1470 <https://github.com/ros2/rviz/issues/1470>) (#1478 <https://github.com/ros2/rviz/issues/1478>)
* PointStampedDisplay: Ignore incoming messages if disabled (#1036 <https://github.com/ros2/rviz/issues/1036>) (#1467 <https://github.com/ros2/rviz/issues/1467>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
