### PR TITLE
rviz: 15.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7912,7 +7912,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.2-1
+      version: 15.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.0.2-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Config::mapGetBool causes segmentation fault when value_out is nullptr (#1471 <https://github.com/ros2/rviz/issues/1471>) (#1479 <https://github.com/ros2/rviz/issues/1479>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fix /rviz/get_resource (#1487 <https://github.com/ros2/rviz/issues/1487>) (#1490 <https://github.com/ros2/rviz/issues/1490>)
* Frame view controller: Removed warnings (#1470 <https://github.com/ros2/rviz/issues/1470>) (#1476 <https://github.com/ros2/rviz/issues/1476>)
* Removed unused headers from resouce retriever (#1463 <https://github.com/ros2/rviz/issues/1463>) (#1464 <https://github.com/ros2/rviz/issues/1464>)
* PointStampedDisplay: Ignore incoming messages if disabled (#1036 <https://github.com/ros2/rviz/issues/1036>) (#1465 <https://github.com/ros2/rviz/issues/1465>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed unused headers from resouce retriever (#1463 <https://github.com/ros2/rviz/issues/1463>) (#1464 <https://github.com/ros2/rviz/issues/1464>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
