### PR TITLE
rosidlcpp: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7332,7 +7332,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidlcpp-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.1.2-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

- No changes

## rosidlcpp_generator_core

```
* Fix missing fmt dependency in rosidlcpp_generator_core (#5 <https://github.com/TonyWelte/rosidlcpp/issues/5>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_cpp

- No changes

## rosidlcpp_generator_py

- No changes

## rosidlcpp_generator_type_description

```
* Fix missing fmt dependency in rosidlcpp_generator_core (#5 <https://github.com/TonyWelte/rosidlcpp/issues/5>)
* Contributors: Anthony Welte
```

## rosidlcpp_parser

- No changes

## rosidlcpp_typesupport_c

- No changes

## rosidlcpp_typesupport_cpp

- No changes

## rosidlcpp_typesupport_fastrtps_c

```
* Fix missing fmt dependency in rosidlcpp_generator_core (#5 <https://github.com/TonyWelte/rosidlcpp/issues/5>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_cpp

```
* Fix missing fmt dependency in rosidlcpp_generator_core (#5 <https://github.com/TonyWelte/rosidlcpp/issues/5>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_c

- No changes

## rosidlcpp_typesupport_introspection_cpp

- No changes
