### PR TITLE
mqtt_client: 2.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4130,7 +4130,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
-      version: 2.3.0-2
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.4.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ros2-gbp/mqtt_client-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.0-2`

## mqtt_client

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/mqtt_client/issues/83> from ika-rwth-aachen/codex/deprecate-ros-1-and-prepare-ros-2-for-kilted-release
  Drop ROS 1 support; add ROS 2 Kilted
* Merge branch 'main' into codex/deprecate-ros-1-and-prepare-ros-2-for-kilted-release
* Merge pull request #84 <https://github.com/ika-rwth-aachen/mqtt_client/issues/84> from ika-rwth-aachen/codex/finde-codeprobleme-und-verbesserungsvorschläge
  Fix typos and Int64 handling, add test
* Merge pull request #46 <https://github.com/ika-rwth-aachen/mqtt_client/issues/46> from prbelarmino/main
  Update CMakeLists file to run on a raspbian buster system
* Contributors: Lennart Reiher
```

## mqtt_client_interfaces

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/mqtt_client/issues/83> from ika-rwth-aachen/codex/deprecate-ros-1-and-prepare-ros-2-for-kilted-release
  Drop ROS 1 support; add ROS 2 Kilted
* Contributors: Lennart Reiher
```
