### PR TITLE
ros2_planning_system: 3.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6694,7 +6694,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_planning_system-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/PlanSys2/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `3.0.1-1`:

- upstream repository: https://github.com/PlanSys2/ros2_planning_system.git
- release repository: https://github.com/ros2-gbp/ros2_planning_system-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-1`

## plansys2

```
* remove dependency with nav2
* Contributors: Francisco Martín Rico
```

## plansys2_bringup

- No changes

## plansys2_bt_actions

- No changes

## plansys2_core

- No changes

## plansys2_domain_expert

- No changes

## plansys2_executor

- No changes

## plansys2_lifecycle_manager

- No changes

## plansys2_msgs

- No changes

## plansys2_pddl_parser

- No changes

## plansys2_planner

- No changes

## plansys2_popf_plan_solver

- No changes

## plansys2_problem_expert

- No changes

## plansys2_support_py

- No changes

## plansys2_terminal

- No changes

## plansys2_tests

- No changes

## plansys2_tools

- No changes
