### PR TITLE
crazyswarm2: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1545,6 +1545,27 @@ repositories:
       url: https://github.com/IMRCLab/crazyswarm2.git
       version: main
     status: developed
+  crazyswarm2:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/crazyswarm2.git
+      version: main
+    release:
+      packages:
+      - crazyflie
+      - crazyflie_examples
+      - crazyflie_interfaces
+      - crazyflie_py
+      - crazyflie_sim
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/crazyswarm2-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/IMRCLab/crazyswarm2.git
+      version: main
+    status: developed
   create3_examples:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `crazyswarm2` to `1.0.0-1`:

- upstream repository: https://github.com/IMRCLab/crazyswarm2.git
- release repository: https://github.com/ros2-gbp/crazyswarm2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## crazyflie

```
* First official release.
* Contributors: Christian Llanes, Julien Thevenoz, Khaled Wahba, Kimberly N. McGuire, Pablo, Wolfgang Hönig, Zach Williams, ben-jarvis, nan cai, phanfeld, torobo
```

## crazyflie_examples

```
* First official release.
* Contributors: Julien Thevenoz, Khaled Wahba, Kimberly N. McGuire, Pablo Robles, Wolfgang Hönig, phanfeld
```

## crazyflie_interfaces

```
* First official release.
* Contributors: Khaled Wahba, Kimberly McGuire, Wolfgang Hönig, phanfeld
```

## crazyflie_py

```
* First official release.
* Contributors: Julien Thevenoz, Kimberly McGuire, Kimberly N. McGuire, Wolfgang Hönig
```

## crazyflie_sim

```
* First official release.
* Contributors: HP99, Khaled Wahba, Kimberly N. McGuire, Pablo, Wolfgang Hönig, julienthevenoz, matthewoots, phanfeld
```
