### PR TITLE
coin_d4_driver: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1588,6 +1588,11 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/coin_d4_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coin_d4_driver` to `1.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
- release repository: https://github.com/ros2-gbp/coin_d4_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## coin_d4_driver

```
* Added libraries that can use COIN D4 LIDAR (default handler, ROS NODE handler, LIFECYCLE NODE handler)
* Added example code (single lidar node, multi lidar node)
* Contributors: Hyeongjun Jeon, Pyo
```
