### PR TITLE
coin_d4_driver: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1110,6 +1110,11 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/coin_d4_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coin_d4_driver` to `1.0.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
- release repository: https://github.com/ros2-gbp/coin_d4_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## coin_d4_driver

```
* Added libraries that can use COIN D4 LIDAR (default handler, ROS NODE handler, LIFECYCLE NODE handler)
* Added example code (single lidar node, multi lidar node)
* Contributors: Hyeongjun Jeon, Pyo
```
