### PR TITLE
ros2_canopen: 0.2.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8585,7 +8585,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.2.11-2
+      version: 0.2.13-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.2.13-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.11-2`

## canopen

```
* Add namespacing support
* Implement configurable position offsets.
* Remove set heartbeat service from master documentation (#294 <https://github.com/ros-industrial/ros2_canopen/issues/294>)
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
* Add cyclic torque mode to cia402 driver and robot system controller (#293 <https://github.com/ros-industrial/ros2_canopen/issues/293>)
  * Add base functions for switching to cyclic torque mode
  * Add cyclic torque mode as effort interface to robot_system controller
  * Add documentation about cyclic torque mode.
  ---------
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
* Contributors: Christoph Hellmann Santos, Vishnuprasad Prachandabhanu
```

## canopen_base_driver

```
* Add boot timeout and retry
* Boot Timeout: Add parameter to base driver to pass to wait as timeout
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_core

```
* Add namespacing support
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_fake_slaves

```
* Add boot timeout and retry
* Add suported modes to canopen_fake_slaves README (#337 <https://github.com/ros-industrial/ros2_canopen/issues/337>)
* [FakeSlave] Extend slaves to provide period data for properly testing PDOs
* Fix loop timer for run_profile_velocity_mode in fake slave
* Contributors: Patrick Roncagliolo, Vishnuprasad Prachandabhanu
```

## canopen_interfaces

- No changes

## canopen_utils

- No changes

## lely_core_libraries

```
* Do not export deprecated Lely IO library (#318 <https://github.com/ros-industrial/ros2_canopen/issues/318>)
* Stop SYNC timer and receiver in co_sync_stop()
  Docker - adding back support for building docker images for old GCC
* Add yaml dependency to package.xml of lely_core_libraries (#290 <https://github.com/ros-industrial/ros2_canopen/issues/290>)
* Contributors: Grvzard, Patrick Roncagliolo, mosfet80
```
