### PR TITLE
rclcpp: 29.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5869,7 +5869,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.6.0-1
+      version: 29.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.6.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `29.6.0-1`

## rclcpp

```
* Fix for memory leaks in rclcpp::SerializedMessage (#2861 <https://github.com/ros2/rclcpp/issues/2861>)
* Removed warning test_qos (#2859 <https://github.com/ros2/rclcpp/issues/2859>)
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>)
* get_all_data_impl() does not handle null pointers properly, causing segmentation fault (#2840 <https://github.com/ros2/rclcpp/issues/2840>)
* QoSInitialization::from_rmw does not validate invalid history policy values, leading to silent failures (#2841 <https://github.com/ros2/rclcpp/issues/2841>)
* remove get_notify_guard_condition from NodeBaseInterface. (#2839 <https://github.com/ros2/rclcpp/issues/2839>)
* Removed deprecated StaticSingleThreadedExecutor (#2835 <https://github.com/ros2/rclcpp/issues/2835>)
* Removed deprecated rcpputils Path (#2834 <https://github.com/ros2/rclcpp/issues/2834>)
* Add range constraints for applicable array parameters (#2828 <https://github.com/ros2/rclcpp/issues/2828>)
* Update RingBufferImplementation to clear internal data. (#2837 <https://github.com/ros2/rclcpp/issues/2837>)
* Removed deprecated cancel_sleep_or_wait (#2836 <https://github.com/ros2/rclcpp/issues/2836>)
* Add missing 's' to 'NodeParametersInterface' in doc/comment (#2831 <https://github.com/ros2/rclcpp/issues/2831>)
* subordinate node consistent behavior and update docstring. (#2822 <https://github.com/ros2/rclcpp/issues/2822>)
* Contributors: Alejandro Hernández Cordero, Alex Youngs, Christophe Bedard, Michael Carlstrom, Michael Orlov, Tomoya Fujita
```

## rclcpp_action

```
* Replace std::default_random_engine with std::mt19937 (rolling) (#2843 <https://github.com/ros2/rclcpp/issues/2843>)
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>)
* Contributors: Alejandro Hernández Cordero, keeponoiro
```

## rclcpp_components

```
* set thread names by node in component container isolated (#2871 <https://github.com/ros2/rclcpp/issues/2871>)
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>)
* Contributors: Adam Aposhian, Alejandro Hernández Cordero
```

## rclcpp_lifecycle

```
* Added missing chrono includes (#2854 <https://github.com/ros2/rclcpp/issues/2854>)
* introduce rcl_lifecycle_get_transition_label_by_id(). (#2827 <https://github.com/ros2/rclcpp/issues/2827>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita
```
