### PR TITLE
ros2_canopen: 0.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7559,7 +7559,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.1-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## canopen

```
* Sync upstream 'master' into homing_timeout_pr.
  Fix homing info message to include both offset
  and homing timeout information.
* Add namespacing support
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_402_driver

```
* Homing timeout
* Add services to disable/enable motor so that brake is usable.
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_base_driver

```
* Add boot timeout and retry
* Include driver exception when boot failed
* Boot Timeout: Add parameter to base driver to pass to wait as timeout
* Contributors: Gerry Salinas, Luis Camero, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_core

```
* Add namespacing support
* Contributors: Christoph Hellmann Santos, Gerry Salinas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_fake_slaves

```
* Add boot timeout and retry
* Add suported modes to canopen_fake_slaves README (#337 <https://github.com/ros-industrial/ros2_canopen/issues/337>)
* Contributors: Gerry Salinas, Patrick Roncagliolo, Vishnuprasad Prachandabhanu
```

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

- No changes

## canopen_ros2_control

```
* Fixing ID type in storage of ros2_control system.
* Contributors: Dr. Denis, Gerry Salinas, Vishnuprasad Prachandabhanu
```

## canopen_ros2_controllers

```
* Add boot timeout and retry
* Fix command interfaces value missmatch.
* Fix realtime-tools include header file
* Include upstream changes from 'master'.
* Contributors: Gerry Salinas, Marco A. Gutierrez, Vishnuprasad Prachandabhanu
```

## canopen_tests

- No changes

## canopen_utils

- No changes

## lely_core_libraries

```
* Do not export deprecated Lely IO library (#318 <https://github.com/ros-industrial/ros2_canopen/issues/318>)
* Contributors: Gerry Salinas, Patrick Roncagliolo
```
