### PR TITLE
rclcpp: 16.0.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7812,7 +7812,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.12-1
+      version: 16.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.13-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `16.0.12-1`

## rclcpp

```
* Fix for memory leaks in rclcpp::SerializedMessage (#2861 <https://github.com/ros2/rclcpp/issues/2861>) (#2865 <https://github.com/ros2/rclcpp/issues/2865>)
* Added missing chrono includes (backport #2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2857 <https://github.com/ros2/rclcpp/issues/2857>)
* QoSInitialization::from_rmw does not validate invalid history policy … (backport #2841 <https://github.com/ros2/rclcpp/issues/2841>) (#2844 <https://github.com/ros2/rclcpp/issues/2844>)
* throws std::invalid_argument if ParameterEvent is NULL. (#2814 <https://github.com/ros2/rclcpp/issues/2814>) (#2824 <https://github.com/ros2/rclcpp/issues/2824>)
* remove redundant typesupport check in serialization module (#2808 <https://github.com/ros2/rclcpp/issues/2808>) (#2816 <https://github.com/ros2/rclcpp/issues/2816>)
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Replace std::default_random_engine with std::mt19937 (humble) (#2847 <https://github.com/ros2/rclcpp/issues/2847>)
* Added missing chrono includes (backport #2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2857 <https://github.com/ros2/rclcpp/issues/2857>)
* Harden rclcpp_action::convert(). (backport #2786 <https://github.com/ros2/rclcpp/issues/2786>) (#2788 <https://github.com/ros2/rclcpp/issues/2788>)
* Contributors: keeponoiro, mergify[bot]
```

## rclcpp_components

```
* Added missing chrono includes (backport #2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2857 <https://github.com/ros2/rclcpp/issues/2857>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

```
* Added missing chrono includes (backport #2854 <https://github.com/ros2/rclcpp/issues/2854>) (#2857 <https://github.com/ros2/rclcpp/issues/2857>)
* should pull valid transition before trying to change the state. (backport #2774 <https://github.com/ros2/rclcpp/issues/2774>) (#2785 <https://github.com/ros2/rclcpp/issues/2785>)
* Contributors: mergify[bot]
```
