### PR TITLE
launch_ros: 0.28.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3298,7 +3298,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.28.1-2
+      version: 0.28.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.28.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.28.1-2`

## launch_ros

```
* improve type readability in errors (#469 <https://github.com/ros2/launch_ros/issues/469>) (#471 <https://github.com/ros2/launch_ros/issues/471>)
* Fix: LoadComposableNodes fails to parse wildcard param files correctly (#460 <https://github.com/ros2/launch_ros/issues/460>) (#465 <https://github.com/ros2/launch_ros/issues/465>) (#466 <https://github.com/ros2/launch_ros/issues/466>)
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
