### PR TITLE
geometry2: 0.36.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2800,7 +2800,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.11-1
+      version: 0.36.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.12-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.36.11-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Add normals rotation in PointCloud2 doTransform (#792 <https://github.com/ros2/geometry2/issues/792>) (#794 <https://github.com/ros2/geometry2/issues/794>)
* Contributors: mergify[bot]
```

## tf2_tools

- No changes
