### PR TITLE
launch: 3.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3938,7 +3938,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.4-1
+      version: 3.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.5-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.4.4-1`

## launch

```
* Provide copy of launch configs to TimerAction's entities (#836 <https://github.com/ros2/launch/issues/836>) (#878 <https://github.com/ros2/launch/issues/878>)
* [backport jazzy] Add a / path join operator for PathJoinSubstitution (#868 <https://github.com/ros2/launch/issues/868>) (#880 <https://github.com/ros2/launch/issues/880>)
* Contributors: Emerson Knapp, Kenji Brameld (TRACLabs)
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
