### PR TITLE
launch_ros: 0.26.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3973,7 +3973,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.7-1
+      version: 0.26.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.8-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.26.7-1`

## launch_ros

```
* improve type readability in errors (#469 <https://github.com/ros2/launch_ros/issues/469>) (#472 <https://github.com/ros2/launch_ros/issues/472>)
* Fix: LoadComposableNodes fails to parse wildcard param files correctly (#460 <https://github.com/ros2/launch_ros/issues/460>) (#465 <https://github.com/ros2/launch_ros/issues/465>) (#467 <https://github.com/ros2/launch_ros/issues/467>)
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
