### PR TITLE
rcl: 10.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5763,7 +5763,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.2.1-1
+      version: 10.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.2.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `10.2.1-1`

## rcl

```
* Assert HistoryQoS in test_info_by_topic (#1242 <https://github.com/ros2/rcl//issues/1242>)
* Add a test for the subscription option 'ignore_local_publications' (#1239 <https://github.com/ros2/rcl//issues/1239>)
* Contributors: Barry Xu, Mario Domínguez López
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
