### PR TITLE
rcl: 10.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5752,7 +5752,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.1.0-2
+      version: 10.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.1.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `10.1.0-2`

## rcl

```
* Assert HistoryQoS in test_info_by_topic (#1242 <https://github.com/ros2/rcl//issues/1242>) (#1247 <https://github.com/ros2/rcl//issues/1247>)
* Add a test for the subscription option 'ignore_local_publications' (#1239 <https://github.com/ros2/rcl//issues/1239>) (#1245 <https://github.com/ros2/rcl//issues/1245>)
* Removed unused nondefault_qos_profile (#1233 <https://github.com/ros2/rcl//issues/1233>) (#1234 <https://github.com/ros2/rcl//issues/1234>)
* Removed unused functions (#1230 <https://github.com/ros2/rcl//issues/1230>) (#1231 <https://github.com/ros2/rcl//issues/1231>)
* remove rmw_connext from test. (#1226 <https://github.com/ros2/rcl//issues/1226>) (#1227 <https://github.com/ros2/rcl//issues/1227>)
* Fix a dangling pointer discovered by a fresh Clang (#1222 <https://github.com/ros2/rcl//issues/1222>)
* Contributors: Alexander Kornienko, mergify[bot]
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
