### PR TITLE
ros2_controllers: 5.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6684,7 +6684,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.1.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Fix atomic variables in JTC (#1749 <https://github.com/ros-controls/ros2_controllers/issues/1749>)
* Add new AntiWindup parameters to JTC (#1759 <https://github.com/ros-controls/ros2_controllers/issues/1759>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## mecanum_drive_controller

- No changes

## parallel_gripper_controller

- No changes

## pid_controller

```
* Add new members for PID controller parameters (#1585 <https://github.com/ros-controls/ros2_controllers/issues/1585>)
* Contributors: Victor Coutinho Vieira Santos
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
