### PR TITLE
common_interfaces: 5.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1179,7 +1179,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.7.0-1
+      version: 5.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.8.0-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.7.0-1`

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Removed deprecated geometry_msgs/Pose2d (#283 <https://github.com/ros2/common_interfaces/issues/283>)
* Contributors: Alejandro Hernández Cordero
```

## nav_msgs

- No changes

## sensor_msgs

```
* Enhance NV12 and NV21 Support in sensor_msgs::image_encodings (#264 <https://github.com/ros2/common_interfaces/issues/264>)
* Contributors: Zhaoyuan Cheng
```

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
