### PR TITLE
rosidlcpp: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7365,7 +7365,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidlcpp-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.2.0-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.2-1`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

```
* Fix shared/static library type for generator_c and introspection_c[pp] (#6 <https://github.com/TonyWelte/rosidlcpp/issues/6>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_core

- No changes

## rosidlcpp_generator_cpp

```
* Add name and data_type traits for actions (#7 <https://github.com/TonyWelte/rosidlcpp/issues/7>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_py

```
* Fix __eq__ for Array fields (#8 <https://github.com/TonyWelte/rosidlcpp/issues/8>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_type_description

- No changes

## rosidlcpp_parser

- No changes

## rosidlcpp_typesupport_c

- No changes

## rosidlcpp_typesupport_cpp

- No changes

## rosidlcpp_typesupport_fastrtps_c

- No changes

## rosidlcpp_typesupport_fastrtps_cpp

- No changes

## rosidlcpp_typesupport_introspection_c

```
* Fix shared/static library type for generator_c and introspection_c[pp] (#6 <https://github.com/TonyWelte/rosidlcpp/issues/6>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_cpp

```
* Fix shared/static library type for generator_c and introspection_c[pp] (#6 <https://github.com/TonyWelte/rosidlcpp/issues/6>)
* Contributors: Anthony Welte
```
