### PR TITLE
rosdep: nixos: Add python3-filelock package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5965,6 +5965,7 @@ python3-filelock:
   arch: [python-filelock]
   debian: [python3-filelock]
   fedora: [python3-filelock]
+  nixos: [python3Packages.filelock]
   opensuse: [python3-filelock]
   rhel: [python3-filelock]
   ubuntu: [python3-filelock]


### PR DESCRIPTION
This add the NixOS entry for `python3-filelock`.

https://nixpkgs.dev/python313Packages.filelock