### PR TITLE
[index only, no release] Adding adi_3dtof_safety_bubble_detector and adi_3dtof_floor_detector packages

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -87,6 +87,16 @@ repositories:
       url: https://github.com/analogdevicesinc/adi_3dtof_adtf31xx.git
       version: humble-devel
     status: maintained
+  adi_3dtof_floor_detector:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_floor_detector.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_floor_detector.git
+      version: humble-devel
+    status: maintained
   adi_3dtof_image_stitching:
     doc:
       type: git
@@ -100,6 +110,16 @@ repositories:
     source:
       type: git
       url: https://github.com/analogdevicesinc/adi_3dtof_image_stitching.git
+      version: humble-devel
+    status: maintained
+  adi_3dtof_safety_bubble_detector:
+    doc:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_safety_bubble_detector.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/analogdevicesinc/adi_3dtof_safety_bubble_detector.git
       version: humble-devel
     status: maintained
   adi_iio:


### PR DESCRIPTION
Adding adi_3dtof_safety_bubble_detector and adi_3dtof_floor_detector packages

Please add the following dependency to the rosdep database.

## Package name:

adi_3dtof_floor_detector
adi_3dtof_safety_bubble_detector
## Package Upstream Source:

[analogdevicesinc/adi_3dtof_floor_detector](https://github.com/analogdevicesinc/adi_3dtof_floor_detector/tree/humble-devel)
[analogdevicesinc/adi_3dtof_safety_bubble_detector](https://github.com/analogdevicesinc/adi_3dtof_safety_bubble_detector/tree/humble-devel)
## Purpose of using this:

These dependencies contains algorithms for detecting floor and creating a virtual region of safety for the ADTF3175D Time of Flight sensor developed by Analog Devices Inc.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
