### PR TITLE
backward_ros: 1.0.8-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1067,7 +1067,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/backward_ros-release.git
-      version: 1.0.7-1
+      version: 1.0.8-2
     source:
       type: git
       url: https://github.com/pal-robotics/backward_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `backward_ros` to `1.0.8-2`:

- upstream repository: git@github.com:pal-robotics/backward_ros.git
- release repository: https://github.com/ros2-gbp/backward_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.7-1`

## backward_ros

```
* Export symbols for windows (#27)
* Contributors: Christoph Fröhlich
```
