### PR TITLE
plotjuggler: 3.10.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6026,7 +6026,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.7-1
+      version: 3.10.8-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.10.8-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.10.7-1`

## plotjuggler

```
* fix ROS package
* Feat/cmakelist namespace (#1099 <https://github.com/facontidavide/PlotJuggler/issues/1099>)
  * add namespace when using plotjuggler, include macrodependency
  * use namespace
* Fix core22 snap by updating CMake config and pinning snapcraft to 7.x (#1098 <https://github.com/facontidavide/PlotJuggler/issues/1098>)
* fix linking to roscpp when required (#1102 <https://github.com/facontidavide/PlotJuggler/issues/1102>)
* minor speed improvement
* avoid overhead in GUI when loading MCAP
* WIP changes
* fix windows compilation (#1094 <https://github.com/facontidavide/PlotJuggler/issues/1094>)
* Contributors: Davide Faconti, Michael Görner, giusebar
```
