### PR TITLE
Added cxxopts.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3454,6 +3454,12 @@ libcurl-dev:
   opensuse: [libcurl-devel]
   rhel: [libcurl-devel]
   ubuntu: [libcurl4-openssl-dev]
+libcxxopts-dev:
+  arch: [cxxopts]
+  debian: [libcxxopts-dev]
+  fedora: [cxxopts-devel]
+  rhel: [cxxopts]
+  ubuntu: [libcxxopts-dev]
 libdbus-dev:
   arch: [dbus]
   debian: [libdbus-1-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3461,10 +3461,13 @@ libcxxopts-dev:
   fedora: [cxxopts-devel]
   gentoo: [dev-libs/cxxopts]
   nixos: [cxxopts]
-  opensuse: [cxxopts]
+  opensuse:
+    *: [cxxopts]
+    '15.2': null
   osx: [cxxopts]
-  rhel: [cxxopts]
-  ubuntu: [libcxxopts-dev]
+  ubuntu:
+    *: [libcxxopts-dev]
+    focal: null
 libdbus-dev:
   arch: [dbus]
   debian: [libdbus-1-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3455,9 +3455,14 @@ libcurl-dev:
   rhel: [libcurl-devel]
   ubuntu: [libcurl4-openssl-dev]
 libcxxopts-dev:
+  alpine: [cxxopts-dev]
   arch: [cxxopts]
   debian: [libcxxopts-dev]
   fedora: [cxxopts-devel]
+  gentoo: [dev-libs/cxxopts]
+  macos: [cxxopts]
+  nixos: [cxxopts]
+  opensuse: [cxxopts]
   rhel: [cxxopts]
   ubuntu: [libcxxopts-dev]
 libdbus-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3460,9 +3460,9 @@ libcxxopts-dev:
   debian: [libcxxopts-dev]
   fedora: [cxxopts-devel]
   gentoo: [dev-libs/cxxopts]
-  macos: [cxxopts]
   nixos: [cxxopts]
   opensuse: [cxxopts]
+  osx: [cxxopts]
   rhel: [cxxopts]
   ubuntu: [libcxxopts-dev]
 libdbus-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3462,11 +3462,11 @@ libcxxopts-dev:
   gentoo: [dev-libs/cxxopts]
   nixos: [cxxopts]
   opensuse:
-    *: [cxxopts]
+    '*': [cxxopts]
     '15.2': null
   osx: [cxxopts]
   ubuntu:
-    *: [libcxxopts-dev]
+    '*': [libcxxopts-dev]
     focal: null
 libdbus-dev:
   arch: [dbus]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

cxxopts

## Package Upstream Source:

https://github.com/jarro2783/cxxopts

## Purpose of using this:

It's a useful c++ parser library for command line args.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libcxxopts-dev
- Ubuntu: https://packages.ubuntu.com/noble/libcxxopts-dev
- Fedora: https://packages.fedoraproject.org/pkgs/cxxopts/cxxopts-devel/
- Arch: https://archlinux.org/packages/extra/any/cxxopts/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/cxxopts
- macOS: https://formulae.brew.sh/formula/cxxopts#default
- Alpine: https://pkgs.alpinelinux.org/package/edge/main/x86_64/cxxopts
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.05&show=cxxopts&from=0&size=50&sort=relevance&type=packages&query=cxxopts
- openSUSE: https://software.opensuse.org/package/cxxopts?search_term=cxxopts
