### PR TITLE
rename src/doc branches for ros-event-camera repos

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2456,7 +2456,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2465,13 +2465,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: humble
+      version: release
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2480,7 +2480,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: humble
+      version: release
     status: developed
   event_camera_py:
     doc:
@@ -2501,7 +2501,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2510,7 +2510,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: humble
+      version: release
     status: developed
   example_interfaces:
     doc:
@@ -4569,7 +4569,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4578,13 +4578,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: humble
+      version: release
     status: developed
   libcaer_vendor:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: humble
+      version: release
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4593,7 +4593,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: humble
+      version: release
     status: developed
   libcamera:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2222,7 +2222,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2231,13 +2231,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: rolling
+      version: release
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2246,7 +2246,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: rolling
+      version: release
     status: developed
   event_camera_py:
     doc:
@@ -2267,7 +2267,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2276,7 +2276,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: rolling
+      version: release
     status: developed
   example_interfaces:
     doc:
@@ -4134,7 +4134,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -4143,13 +4143,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: rolling
+      version: release
     status: developed
   libcaer_vendor:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: jazzy
+      version: release
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -4158,7 +4158,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: jazzy
+      version: release
     status: developed
   libcamera:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1616,7 +1616,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1625,13 +1625,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: rolling
+      version: release
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1640,7 +1640,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: rolling
+      version: release
     status: developed
   event_camera_py:
     doc:
@@ -1661,7 +1661,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1670,7 +1670,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: rolling
+      version: release
     status: developed
   example_interfaces:
     doc:
@@ -3414,7 +3414,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -3423,13 +3423,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: rolling
+      version: release
     status: developed
   libcaer_vendor:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -3438,7 +3438,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: rolling
+      version: release
     status: developed
   libcamera:
     doc:


### PR DESCRIPTION
At some point I maintained per-release branches for all repos of the ros-event-camera release team. Now I only maintain a single "release" branch and keep the source identical across all rosdistros.

This PR renames the branches from ${ROSDISTRO} -> release
