### PR TITLE
rviz: 15.1.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7947,7 +7947,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.4-1
+      version: 15.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.1.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fixed deprecation warning on point_cloud_transport: rmw_qos_profile_t (#1491 <https://github.com/ros2/rviz/issues/1491>)
* Add symbol visibility macros to make*Palette public functions (#1492 <https://github.com/ros2/rviz/issues/1492>)
* Contributors: Alejandro Hernández Cordero, Silvio Traversaro
```

## rviz_ogre_vendor

```
* Add RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ option to further mangle ogre libraries used by rviz (#1493 <https://github.com/ros2/rviz/issues/1493>)
* Contributors: Silvio Traversaro
```

## rviz_rendering

```
* Assign the geometry to the resource group "rviz_rendering" (#1502 <https://github.com/ros2/rviz/issues/1502>)
* Removed windows warning (#1486 <https://github.com/ros2/rviz/issues/1486>)
* Contributors: Alejandro Hernández Cordero, matthias88
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
