### PR TITLE
turtlebot3_simulations: 2.3.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8945,7 +8945,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
-      version: 2.3.5-1
+      version: 2.3.7-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.3.7-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.5-1`

## turtlebot3_fake_node

```
* Changed the header files in tf2/LinearMath from .h to .hpp
* Contributors: Hyungyu Kim
```

## turtlebot3_gazebo

```
* Changed the header files in tf2/LinearMath from .h to .hpp
* Contributors: Hyungyu Kim
```

## turtlebot3_simulations

```
* Changed the header files in tf2/LinearMath from .h to .hpp
* Contributors: Hyungyu Kim
```
