### PR TITLE
add cm_executors to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1341,6 +1341,16 @@ repositories:
       url: https://github.com/carologistics/clips_vendor.git
       version: main
     status: maintained
+  cm_executors:
+    doc:
+      type: git
+      url: https://github.com/cellumation/cm_executors.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/cellumation/cm_executors.git
+      version: master
+    status: maintained
   coal:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO jazzy

# The source is here:

https://github.com/cellumation/cm_executors

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
