### PR TITLE
Revert "automatika_ros_sugar: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -623,7 +623,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.3.0-1
+      version: 0.2.9-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Reverts ros/rosdistro#46504

FYI: @aleph-ra reverting to avoid the failing package in the [next jazzy sync.](https://discourse.ros.org/t/preparing-for-jazzy-sync-2025-06-27/44452)

It seems that the branch is not found in the [ros2 gbp repo](https://github.com/ros2-gbp/automatika_ros_sugar-release) as the buildfarm job is failing with:

`fatal: Remote branch debian/ros-jazzy-automatika-ros-sugar_0.3.0-1_noble not found in upstream origin`

[You can find the full log here.](https://build.ros2.org/view/Jbin_uN64/job/Jsrc_uN__automatika_ros_sugar__ubuntu_noble__source/15/console). My guess is some error during the run of bloom, maybe a re-blooming of the package helps creating the corresponding branches in ros2-bgp. Also it might help they're there when the PR is created.