### PR TITLE
Update kilted branches in gz_*_vendor repositories

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2401,7 +2401,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2411,7 +2411,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_common_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_dartsim_vendor:
     doc:
@@ -2433,7 +2433,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2443,13 +2443,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_gui_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2465,7 +2465,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2475,7 +2475,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_launch_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_math_vendor:
     doc:
@@ -2497,7 +2497,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2507,7 +2507,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_msgs_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_ogre_next_vendor:
     doc:
@@ -2529,7 +2529,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_physics_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2539,13 +2539,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_physics_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_plugin_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2555,13 +2555,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_plugin_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_rendering_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2571,7 +2571,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_rendering_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_ros2_control:
     doc:
@@ -2595,7 +2595,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2605,13 +2605,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_sensors_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_sim_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2621,13 +2621,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_sim_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_tools_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2637,13 +2637,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_tools_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_transport_vendor:
     doc:
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -2653,7 +2653,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_transport_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_utils_vendor:
     doc:


### PR DESCRIPTION
kilted branches were created for all the Gazebo vendor repositories so we no longer use rolling for any Kilted configuration.