### PR TITLE
add gtk4/adw dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1913,7 +1913,9 @@ gtk4:
   gentoo: ['gui-libs/gtk']
   nixos: [gtk4]
   openembedded: [gtk4@openembedded-core]
-  rhel: [gtk4]
+  rhel:
+    '8': null
+    '*': [gtk4-devel]
   ubuntu:
     '*': [libgtk-4-dev]
     focal: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2652,11 +2652,13 @@ libadolc-dev:
   opensuse: [adolc-devel]
   ubuntu: [libadolc-dev]
 libadwaita-dev:
+  alpine: [libadwaita-dev]
   debian: [libadwaita-1-dev]
   fedora: [libadwaita-devel]
   gentoo: ['gui-libs/libadwaita']
   nixos: [libadwaita]
   openembedded: [libadwaita@openembedded-core]
+  rhel: [libadwaita-devel]
   ubuntu:
     '*': [libadwaita-1-dev]
     focal: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -41,6 +41,14 @@ acpitool:
   gentoo: [sys-power/acpitool]
   nixos: [acpitool]
   openembedded: [acpitool@meta-oe]
+adwaita-icon-theme:
+  arch: [adwaita-icon-theme]
+  debian: [adwaita-icon-theme]
+  fedora: [adwaita-icon-theme]
+  gentoo: ['x11-themes/adwaita-icon-theme']
+  nixos: [adwaita-icon-theme]
+  openembedded: [adwaita-icon-theme@openembedded-core]
+  ubuntu: [adwaita-icon-theme]
 alsa-oss:
   arch: [alsa-oss]
   debian: [alsa-oss]
@@ -1894,6 +1902,17 @@ gtk3:
     slackpkg:
       packages: [gtk+3]
   ubuntu: [libgtk-3-dev]
+gtk4:
+  arch: [gtk4]
+  debian: [libgtk-4-dev]
+  fedora: [gtk4-devel]
+  freebsd: [gtk4]
+  gentoo: ['gui-libs/gtk']
+  nixos: [gtk4]
+  openembedded: [gtk4@openembedded-core]
+  ubuntu:
+    '*': [libgtk-4-dev]
+    focal: null
 gurumdds-2.6:
   ubuntu:
     bionic: [gurumdds-2.6]
@@ -2632,6 +2651,15 @@ libadolc-dev:
   nixos: [adolc]
   opensuse: [adolc-devel]
   ubuntu: [libadolc-dev]
+libadwaita-dev:
+  debian: [libadwaita-1-dev]
+  fedora: [libadwaita-devel]
+  gentoo: ['gui-libs/libadwaita']
+  nixos: [libadwaita]
+  openembedded: [libadwaita@openembedded-core]
+  ubuntu:
+    '*': [libadwaita-1-dev]
+    focal: null
 libaio-dev:
   alpine: [libaio-dev]
   arch: [libaio]
@@ -4045,6 +4073,13 @@ libgif-dev:
   gentoo: [media-libs/giflib]
   nixos: [giflib]
   ubuntu: [libgif-dev]
+libgirepository-dev:
+  arch: [gobject-introspection]
+  debian: [libgirepository1.0-dev]
+  fedora: [gobject-introspection-devel]
+  gentoo: [dev-libs/gobject-introspection]
+  nixos: [gobject-introspection]
+  ubuntu: [libgirepository1.0-dev]
 libglew-dev:
   arch: [glew]
   debian: [libglew-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -42,7 +42,6 @@ acpitool:
   nixos: [acpitool]
   openembedded: [acpitool@meta-oe]
 adwaita-icon-theme:
-  alpine: [adwaita-icon-theme]
   arch: [adwaita-icon-theme]
   debian: [adwaita-icon-theme]
   fedora: [adwaita-icon-theme]
@@ -2657,7 +2656,6 @@ libadolc-dev:
   opensuse: [adolc-devel]
   ubuntu: [libadolc-dev]
 libadwaita-dev:
-  alpine: [libadwaita-dev]
   debian: [libadwaita-1-dev]
   fedora: [libadwaita-devel]
   gentoo: ['gui-libs/libadwaita']

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -42,12 +42,15 @@ acpitool:
   nixos: [acpitool]
   openembedded: [acpitool@meta-oe]
 adwaita-icon-theme:
+  alpine: [adwaita-icon-theme]
   arch: [adwaita-icon-theme]
   debian: [adwaita-icon-theme]
   fedora: [adwaita-icon-theme]
   gentoo: ['x11-themes/adwaita-icon-theme']
   nixos: [adwaita-icon-theme]
   openembedded: [adwaita-icon-theme@openembedded-core]
+  opensuse: [adwaita-icon-theme]
+  rhel: [adwaita-icon-theme]
   ubuntu: [adwaita-icon-theme]
 alsa-oss:
   arch: [alsa-oss]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2664,7 +2664,9 @@ libadwaita-dev:
   gentoo: ['gui-libs/libadwaita']
   nixos: [libadwaita]
   openembedded: [libadwaita@openembedded-core]
-  rhel: [libadwaita-devel]
+  rhel:
+    '8': null
+    '*': [libadwaita-devel]
   ubuntu:
     '*': [libadwaita-1-dev]
     focal: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1910,6 +1910,7 @@ gtk4:
   gentoo: ['gui-libs/gtk']
   nixos: [gtk4]
   openembedded: [gtk4@openembedded-core]
+  rhel: [gtk4]
   ubuntu:
     '*': [libgtk-4-dev]
     focal: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -49,7 +49,6 @@ adwaita-icon-theme:
   gentoo: ['x11-themes/adwaita-icon-theme']
   nixos: [adwaita-icon-theme]
   openembedded: [adwaita-icon-theme@openembedded-core]
-  opensuse: [adwaita-icon-theme]
   rhel: [adwaita-icon-theme]
   ubuntu: [adwaita-icon-theme]
 alsa-oss:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -48,7 +48,6 @@ adwaita-icon-theme:
   gentoo: ['x11-themes/adwaita-icon-theme']
   nixos: [adwaita-icon-theme]
   openembedded: [adwaita-icon-theme@openembedded-core]
-  rhel: [adwaita-icon-theme]
   ubuntu: [adwaita-icon-theme]
 alsa-oss:
   arch: [alsa-oss]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1914,8 +1914,8 @@ gtk4:
   nixos: [gtk4]
   openembedded: [gtk4@openembedded-core]
   rhel:
-    '8': null
     '*': [gtk4-devel]
+    '8': null
   ubuntu:
     '*': [libgtk-4-dev]
     focal: null
@@ -2665,8 +2665,8 @@ libadwaita-dev:
   nixos: [libadwaita]
   openembedded: [libadwaita@openembedded-core]
   rhel:
-    '8': null
     '*': [libadwaita-devel]
+    '8': null
   ubuntu:
     '*': [libadwaita-1-dev]
     focal: null

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,3 +8,4 @@ rosdistro
 unidiff
 yamllint
 zstandard
+lark

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,4 +8,3 @@ rosdistro
 unidiff
 yamllint
 zstandard
-lark


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

1. gtk4
2. libgirepository-dev
3. adwaita-icon-theme
4. libadwaita-dev

## Package Upstream Source:

1. https://gitlab.gnome.org/GNOME/gtk
2. https://gitlab.gnome.org/GNOME/gobject-introspection
3. https://gitlab.gnome.org/GNOME/adwaita-icon-theme
4. https://gitlab.gnome.org/GNOME/libadwaita

## Purpose of using this:

- used in the gtk4/adw gui: https://github.com/julianmueller/insight_gui/

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - 1. libgtk4-dev
  - 2. libgirepository1.0-dev
  - 3. adwaita-icon-theme
  - 4. libadwaita-1-dev
- Ubuntu: https://packages.ubuntu.com/
  - 1. libgtk4-dev
  - 2. libgirepository1.0-dev
  - 3. adwaita-icon-theme
  - 4. libadwaita-1-dev

## Additional

I also added `lark` to the requirements.txt, because my pytest failed as this was missing.
