### PR TITLE
insight_gui: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3620,7 +3620,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/insight_gui-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/julianmueller/insight_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `insight_gui` to `0.1.1-1`:

- upstream repository: https://github.com/julianmueller/insight_gui.git
- release repository: https://github.com/ros2-gbp/insight_gui-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.0-1`

## insight_gui

```
* update dependencies
* Contributors: Julian Müller
```
