### PR TITLE
automatika_ros_sugar: 0.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -623,7 +623,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.9-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.3.1-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.2.9-1`

## automatika_ros_sugar

```
* (refactor) Corrects type hint in callbacks
* (refactor) Adds type hints to validators
* (refactor) Minor improvements and typo correction
* (refactor) Resolves todo in component actions for active flag and adds default logger for module
* (chore) Updates service creation script with better error handling
* (docs) Updates installation instructions
* (refactor) Removes numpy-quaternion from dependencies and implements rotations using numpy
* (docs) Updates logo icon and adds 'config from file' page to docs
* (fix) Adds wait for node activation after restart and fixes optional arguments parsing in Component
* (docs) Updates events docs
* (docs) Adds international readmes
* (chore) Removes pip based test dependencies for ROS build farm
* (docs) Updates readme
* Contributors: ahr, mkabtoul
```
