### PR TITLE
turtle_nest: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11150,7 +11150,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtle_nest-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/Jannkar/turtle_nest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtle_nest` to `1.1.0-1`:

- upstream repository: https://github.com/Jannkar/turtle_nest.git
- release repository: https://github.com/ros2-gbp/turtle_nest-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## turtle_nest

```
* Fix cpp package test errors (#20 <https://github.com/Jannkar/turtle_nest/issues/20>)
* Add support for msgs packages (#19 <https://github.com/Jannkar/turtle_nest/issues/19>)
* Add python3-dev and pybind11-dev as dependencies (#18 <https://github.com/Jannkar/turtle_nest/issues/18>)
* Improved UI & add nodes to existing packages (#17 <https://github.com/Jannkar/turtle_nest/issues/17>)
* Contributors: Janne Karttunen
```
