### PR TITLE
Set plotjuggler to last jazzy package working version.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6026,7 +6026,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.8-1
+      version: 3.9.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
@@ -6056,7 +6056,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.3.0-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
FYI: @facontidavide 

It seems like, even after https://github.com/ros/rosdistro/pull/46647, `plotjuggler` is still having dependency issues when building the package on the buildfarm, 

```
14:40:31 /tmp/binarydeb/ros-jazzy-plotjuggler-3.10.8/plotjuggler_plugins/ParserROS/ros_parser.cpp:2:10: fatal error: data_tamer_parser/data_tamer_parser.hpp: No such file or directory
14:40:31     2 | #include "data_tamer_parser/data_tamer_parser.hpp"
14:40:31       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
14:40:31 compilation terminated.
```

[Full build log here](https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__plotjuggler__ubuntu_noble_amd64__binary/96/console).

Due to the current [jazzy sync](https://discourse.ros.org/t/preparing-for-jazzy-sync-2025-06-27/), this PR brings `plotjuggler` and `plotjuggler_ros` rosdistro versions to the latest known version working in the buildfarm.