### PR TITLE
kinematics_interface_pinocchio: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3183,8 +3183,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/kinematics_interface_pinocchio-release.git
-      version: 0.0.1-1
+      url: git@github.com:ros2-gbp/kinematics_interface_pinocchio-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/justagist/kinematics_interface_pinocchio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface_pinocchio` to `0.0.2-1`:

- upstream repository: https://github.com/justagist/kinematics_interface_pinocchio.git
- release repository: git@github.com:ros2-gbp/kinematics_interface_pinocchio-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-1`

## kinematics_interface_pinocchio

```
* fixes to adapt to upstream changes in kinematics_interface
* Contributors: David V. Lu, Saif Sidhik
```
