### PR TITLE
dbw_ros: 2.3.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1704,7 +1704,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.3-1
+      version: 2.3.5-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.5-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.3.3-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2025/06/27 release package
* Add monitor steer rate debug message
* Add SteerInfo message
* Contributors: Kevin Hallenbeck
```

## ds_dbw_joystick_demo

- No changes

## ds_dbw_msgs

```
* Add monitor steer rate debug message
* Add SteerInfo message
* Contributors: Kevin Hallenbeck
```
