### PR TITLE
ament_cmake_ros: 0.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -208,7 +208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.15.0-1
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.15.1-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.0-1`

## ament_cmake_ros

- No changes

## ament_cmake_ros_core

- No changes

## domain_coordinator

- No changes

## rmw_test_fixture

- No changes

## rmw_test_fixture_implementation

```
* On start-after-stop, re-check RMW_IMPLEMENTATION for changes (#46 <https://github.com/ros2/ament_cmake_ros/issues/46>)
* Choose random domain IDs during default RMW isolation (#39 <https://github.com/ros2/ament_cmake_ros/issues/39>)
* Ignore SIGINT *after* child process has been spawned (#45 <https://github.com/ros2/ament_cmake_ros/issues/45>)
* Add some smoke tests for rmw_test_fixture_implementation (#42 <https://github.com/ros2/ament_cmake_ros/issues/42>)
* Copy all environment variables explicitly (#43 <https://github.com/ros2/ament_cmake_ros/issues/43>)
* Split the generator expression for each library (#36 <https://github.com/ros2/ament_cmake_ros/issues/36>)
* Contributors: Scott K Logan, Tanishq Chaudhary
```
