### PR TITLE
add librocksdb-dev in 'rosdep/base.yml'

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8709,8 +8709,10 @@ robin-map-dev:
 robotino-api2:
   ubuntu: [robotino-api2]
 librocksdb-dev:
+  alpine: [rocksdb-dev]
   debian: [librocksdb-dev]
   fedora: [rocksdb-devel]
+  rhel: [rocksdb-devel]
   ubuntu: [librocksdb-dev]
 rsync:
   arch: [rsync]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8708,6 +8708,10 @@ robin-map-dev:
   ubuntu: [robin-map-dev]
 robotino-api2:
   ubuntu: [robotino-api2]
+librocksdb-dev:
+  debian: [librocksdb-dev]
+  fedora: [rocksdb-devel]
+  ubuntu: [librocksdb-dev]
 rsync:
   arch: [rsync]
   debian: [rsync]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6310,6 +6310,12 @@ libreadline-java:
   debian: [libreadline-java]
   gentoo: [dev-java/libreadline-java]
   ubuntu: [libreadline-java]
+librocksdb-dev:
+  alpine: [rocksdb-dev]
+  debian: [librocksdb-dev]
+  fedora: [rocksdb-devel]
+  rhel: [rocksdb-devel]
+  ubuntu: [librocksdb-dev]
 librtaudio-dev:
   arch: [rtaudio]
   debian: [librtaudio-dev]
@@ -8708,12 +8714,6 @@ robin-map-dev:
   ubuntu: [robin-map-dev]
 robotino-api2:
   ubuntu: [robotino-api2]
-librocksdb-dev:
-  alpine: [rocksdb-dev]
-  debian: [librocksdb-dev]
-  fedora: [rocksdb-devel]
-  rhel: [rocksdb-devel]
-  ubuntu: [librocksdb-dev]
 rsync:
   arch: [rsync]
   debian: [rsync]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- `librocksdb-dev`

## Package Upstream Source:

[https://github.com/facebook/rocksdb](https://github.com/facebook/rocksdb)

## Purpose of using this:

A library that provides an embeddable, persistent key-value store for fast storage.

## Links to Distribution Packages

- Alpine https://pkgs.alpinelinux.org/
  - [https://pkgs.alpinelinux.org/package/v3.19/community/aarch64/rocksdb-dev](https://pkgs.alpinelinux.org/package/v3.19/community/aarch64/rocksdb-dev)
- Debian: https://packages.debian.org/
  - [https://packages.debian.org/sid/librocksdb-dev](https://packages.debian.org/sid/librocksdb-dev)
  - [https://packages.debian.org/trixie/librocksdb-dev](https://packages.debian.org/trixie/librocksdb-dev)
  - [https://packages.debian.org/bookworm/librocksdb-dev](https://packages.debian.org/bookworm/librocksdb-dev)
  - [https://packages.debian.org/bullseye/librocksdb-dev](https://packages.debian.org/bullseye/librocksdb-dev)
- Ubuntu: https://packages.ubuntu.com/
  - [https://packages.ubuntu.com/jammy/libs/librocksdb-dev](https://packages.ubuntu.com/jammy/libs/librocksdb-dev)
  - [https://packages.ubuntu.com/noble/libs/librocksdb-dev](https://packages.ubuntu.com/noble/libs/librocksdb-dev)