### PR TITLE
tinyxml2_vendor: 0.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8658,7 +8658,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.11.0-1
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.11.0-1`

## tinyxml2_vendor

```
* Fix CMake deprecation (#24 <https://github.com/ros2/tinyxml2_vendor/issues/24>)
* fix: use path to tinyxml2 if it's the only item in TINYXML2_LIBRARY (#23 <https://github.com/ros2/tinyxml2_vendor/issues/23>)
* Contributors: Esteve Fernandez, mosfet80
```
