### PR TITLE
sros2: 0.16.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8396,7 +8396,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.16.0-1
+      version: 0.16.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.16.1-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.16.0-1`

## sros2

```
* update utilities to pass instance not class of ec.SECP256R1 (#352 <https://github.com/ros2/sros2/issues/352>)
* suppress multi-threaded warnings. (#346 <https://github.com/ros2/sros2/issues/346>)
* Contributors: Tomoya Fujita, cdisco
```

## sros2_cmake

```
* Update CMakeLists.txt (#344 <https://github.com/ros2/sros2/issues/344>)
* Contributors: mosfet80
```
