### PR TITLE
rviz: 15.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7951,7 +7951,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.4-1
+      version: 15.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.1.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Don't hide rows of properties not within the model (#1507 <https://github.com/ros2/rviz/issues/1507>)
* Remove redundant check (#1506 <https://github.com/ros2/rviz/issues/1506>)
* Fix panel deletion (#1037 <https://github.com/ros2/rviz/issues/1037>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Better handling of missing transport plugins (#1488 <https://github.com/ros2/rviz/issues/1488>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
