### PR TITLE
ros2_tracing: 8.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6785,7 +6785,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.7.0-1
+      version: 8.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.8.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `8.7.0-1`

## lttngpy

- No changes

## ros2trace

```
* Address typing issues reported by mypy in tracetools_launch (#184 <https://github.com/ros2/ros2_tracing/issues/184>)
* Contributors: Christophe Bedard
```

## tracetools

```
* Fix Clang warnings by using proper function prototypes in macros (#179 <https://github.com/ros2/ros2_tracing/issues/179>)
* Update CMakeLists.txt (#176 <https://github.com/ros2/ros2_tracing/issues/176>)
* Removed clang warning (#168 <https://github.com/ros2/ros2_tracing/issues/168>)
* Contributors: Alejandro Hernández Cordero, Shravan Deva, mosfet80
```

## tracetools_launch

```
* Make trace action parameters substitutable for xml and yaml launch files (#188 <https://github.com/ros2/ros2_tracing/issues/188>)
* Make trace action parameters substitutable (#187 <https://github.com/ros2/ros2_tracing/issues/187>)
* Address typing issues reported by mypy in tracetools_launch (#184 <https://github.com/ros2/ros2_tracing/issues/184>)
* Contributors: Christophe Bedard, Shravan Deva
```

## tracetools_read

```
* Address typing issues reported by mypy in tracetools_launch (#184 <https://github.com/ros2/ros2_tracing/issues/184>)
* Contributors: Christophe Bedard
```

## tracetools_test

```
* Address typing issues reported by mypy in tracetools_launch (#184 <https://github.com/ros2/ros2_tracing/issues/184>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Address typing issues reported by mypy in tracetools_launch (#184 <https://github.com/ros2/ros2_tracing/issues/184>)
* Warn if kernel might be paranoid about 'perf:thread:' context fields (#173 <https://github.com/ros2/ros2_tracing/issues/173>)
* Fix pluralization in ros2 trace output (#169 <https://github.com/ros2/ros2_tracing/issues/169>)
* Contributors: Christophe Bedard, Shravan Deva
```
