### PR TITLE
rmw_fastrtps: 9.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6463,7 +6463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.0-1
+      version: 9.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.1-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `9.4.0-1`

## rmw_fastrtps_cpp

```
* fix cmake deprecation (#831 <https://github.com/ros2/rmw_fastrtps/issues/831>)
* Contributors: mosfet80
```

## rmw_fastrtps_dynamic_cpp

```
* fix cmake deprecation (#831 <https://github.com/ros2/rmw_fastrtps/issues/831>)
* Contributors: mosfet80
```

## rmw_fastrtps_shared_cpp

```
* fix cmake deprecation (#831 <https://github.com/ros2/rmw_fastrtps/issues/831>)
* Retrieve HistoryQoS in discovery when available (#829 <https://github.com/ros2/rmw_fastrtps/issues/829>)
* check a local publication to ignore with serialized message. (#823 <https://github.com/ros2/rmw_fastrtps/issues/823>)
* Contributors: Mario Domínguez López, Tomoya Fujita, mosfet80
```
