### PR TITLE
rmw_connextdds: 1.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6395,7 +6395,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.0-2
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.1-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.0-2`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Fixed serialized minimum sample size callback (#196 <https://github.com/ros2/rmw_connextdds/issues/196>)
* Removed warning (#187 <https://github.com/ros2/rmw_connextdds/issues/187>)
* Contributors: Alejandro Hernández Cordero, Francisco Gallego Salido
```

## rti_connext_dds_cmake_module

- No changes
