### PR TITLE
rcutils: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5979,7 +5979,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.10.1-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.10.1-1`

## rcutils

```
* Hand-code logging_macros.h (#502 <https://github.com/ros2/rcutils/issues/502>)
* Implement rcutils_strnlen. (#430 <https://github.com/ros2/rcutils/issues/430>)
* Contributors: Andrei Kholodnyi, Chris Lalancette
```
