### PR TITLE
rclcpp: 30.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5896,7 +5896,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.6.1-1
+      version: 30.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `30.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `29.6.1-1`

## rclcpp

```
* Hand-code logging.hpp (#2870 <https://github.com/ros2/rclcpp/issues/2870>)
* Adressed TODO in node_graph (#2877 <https://github.com/ros2/rclcpp/issues/2877>)
* fix test_publisher_with_system_default_qos. (#2881 <https://github.com/ros2/rclcpp/issues/2881>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

```
* NEW PR: Add component_container for EventsExecutor (#2885 <https://github.com/ros2/rclcpp/issues/2885>)
* make sure that plugin arg includes the double colon. (#2878 <https://github.com/ros2/rclcpp/issues/2878>)
* Contributors: Mihir Rao, Tomoya Fujita
```

## rclcpp_lifecycle

- No changes
