### PR TITLE
Add 'python3-toml' rule for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10454,6 +10454,7 @@ python3-toml:
   fedora: [python3-toml]
   gentoo: [dev-python/toml]
   nixos: [python3Packages.toml]
+  rhel: [python3-toml]
   ubuntu: [python3-toml]
 python3-toppra-pip:
   debian:


### PR DESCRIPTION
RHEL 8 (via EPEL): https://cofractal-ewr.mm.fcix.net/epel/8/Everything/x86_64/Packages/p/python3-toml-0.10.0-3.el8.noarch.rpm
RHEL 9: http://southfront.mm.fcix.net/almalinux/9.6/AppStream/x86_64/os/Packages/python3-toml-0.10.2-6.el9.noarch.rpm