### PR TITLE
common_interfaces: 5.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1179,7 +1179,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.7.0-1
+      version: 5.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.8.1-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.7.0-1`

## common_interfaces

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## diagnostic_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## geometry_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## nav_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## sensor_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## sensor_msgs_py

- No changes

## shape_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## std_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## std_srvs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## stereo_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## trajectory_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```

## visualization_msgs

```
* Fix CMAKE deprecation (#288 <https://github.com/ros2/common_interfaces/issues/288>)
* Contributors: mosfet80
```
