### PR TITLE
Add libflac-dev 

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3762,6 +3762,10 @@ libfl-dev:
   fedora: [libfl-devel]
   opensuse: [libfl-devel]
   ubuntu: [libfl-dev]
+libflac-dev:
+  debian: [libflac-dev]
+  fedora: [libflac-devel]
+  ubuntu: [libflac-dev]
 libflann:
   arch: [flann]
   debian:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`libflac-dev`

## Package Upstream Source:

https://github.com/xiph/flac

## Purpose of using this:

A library which implements reference encoders and decoders for native FLAC and Ogg FLAC, and a metadata interface

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/buster/libflac-dev
  - https://packages.debian.org/bullseye/libflac-dev
  - https://packages.debian.org/bookworm/libflac-dev
  - https://packages.debian.org/trixie/libflac-dev
  - https://packages.debian.org/sid/libflac-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libflac-dev
  - https://packages.ubuntu.com/noble/libflac-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/flac/flac-devel
