### PR TITLE
ros2_control: 4.33.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7634,7 +7634,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.32.0-1
+      version: 4.33.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.33.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.32.0-1`

## controller_interface

- No changes

## controller_manager

```
* Deactivate controllers with command interfaces to hardware on DEACTIVATE (#2334 <https://github.com/ros-controls/ros2_control/issues/2334>) (#2341 <https://github.com/ros-controls/ros2_control/issues/2341>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* expose get_data_type method in loaned interfaces (#2351 <https://github.com/ros-controls/ros2_control/issues/2351>) (#2357 <https://github.com/ros-controls/ros2_control/issues/2357>)
* Improve lexical casts methods (#2343 <https://github.com/ros-controls/ros2_control/issues/2343>) (#2345 <https://github.com/ros-controls/ros2_control/issues/2345>)
* Deactivate controllers with command interfaces to hardware on DEACTIVATE (#2334 <https://github.com/ros-controls/ros2_control/issues/2334>) (#2341 <https://github.com/ros-controls/ros2_control/issues/2341>)
* Add string array to lexical casts (#2333 <https://github.com/ros-controls/ros2_control/issues/2333>) (#2335 <https://github.com/ros-controls/ros2_control/issues/2335>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Deactivate controllers with command interfaces to hardware on DEACTIVATE (#2334 <https://github.com/ros-controls/ros2_control/issues/2334>) (#2341 <https://github.com/ros-controls/ros2_control/issues/2341>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* [Transmissions] Add absolute_position and torque interfaces (#2310 <https://github.com/ros-controls/ros2_control/issues/2310>) (#2319 <https://github.com/ros-controls/ros2_control/issues/2319>)
* Contributors: mergify[bot]
```
