### PR TITLE
ros2_control: 5.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6593,7 +6593,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.2.0-1
+      version: 5.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.2.0-1`

## controller_interface

- No changes

## controller_manager

```
* Cleanup old internal API (#2346 <https://github.com/ros-controls/ros2_control/issues/2346>)
* added params approach to allow propagation in gz_ros2_control (#2340 <https://github.com/ros-controls/ros2_control/issues/2340>)
* Deactivate controllers with command interfaces to hardware on DEACTIVATE (#2334 <https://github.com/ros-controls/ros2_control/issues/2334>)
* Shift to Struct based Method and Constructors, with Executor passed from CM to on_init() (#2323 <https://github.com/ros-controls/ros2_control/issues/2323>)
* Contributors: Marq Rasmussen, Sai Kishor Kothakota, Soham Patil
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add deprecations to old methods not using param structs  (#2344 <https://github.com/ros-controls/ros2_control/issues/2344>)
* expose get_data_type method in loaned interfaces (#2351 <https://github.com/ros-controls/ros2_control/issues/2351>)
* Cleanup old internal API (#2346 <https://github.com/ros-controls/ros2_control/issues/2346>)
* Improve lexical casts methods (#2343 <https://github.com/ros-controls/ros2_control/issues/2343>)
* added params approach to allow propagation in gz_ros2_control (#2340 <https://github.com/ros-controls/ros2_control/issues/2340>)
* Deactivate controllers with command interfaces to hardware on DEACTIVATE (#2334 <https://github.com/ros-controls/ros2_control/issues/2334>)
* Shift to Struct based Method and Constructors, with Executor passed from CM to on_init() (#2323 <https://github.com/ros-controls/ros2_control/issues/2323>)
* Add string array to lexical casts (#2333 <https://github.com/ros-controls/ros2_control/issues/2333>)
* Contributors: Jordan Palacios, Marq Rasmussen, Sai Kishor Kothakota, Soham Patil
```

## hardware_interface_testing

```
* Add deprecations to old methods not using param structs  (#2344 <https://github.com/ros-controls/ros2_control/issues/2344>)
* Deactivate controllers with command interfaces to hardware on DEACTIVATE (#2334 <https://github.com/ros-controls/ros2_control/issues/2334>)
* Contributors: Marq Rasmussen, Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
