### PR TITLE
ros_gz: 3.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6953,11 +6953,10 @@ repositories:
       - ros_gz_interfaces
       - ros_gz_sim
       - ros_gz_sim_demos
-      - test_ros_gz_bridge
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.3-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.2-1`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

```
* Correct gz sim resource path in ros_gz_sim_demos (#771 <https://github.com/gazebosim/ros_gz/issues/771>) (#773 <https://github.com/gazebosim/ros_gz/issues/773>)
* Contributors: mergify[bot]
```
