### PR TITLE
ros_gz: 1.0.16-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7991,11 +7991,10 @@ repositories:
       - ros_gz_interfaces
       - ros_gz_sim
       - ros_gz_sim_demos
-      - test_ros_gz_bridge
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.15-1
+      version: 1.0.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.16-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.15-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Fix crash on old bridge definition (#775 <https://github.com/gazebosim/ros_gz/issues/775>)
* Contributors: Jasper van Brakel
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

```
* Correct gz sim resource path in ros_gz_sim_demos (#771 <https://github.com/gazebosim/ros_gz/issues/771>)
* Contributors: Júlia Marsal Perendreu
```
