### PR TITLE
Changing rolling source branch for robot_localization

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6551,7 +6551,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git
-      version: ros2
+      version: rolling-devel
     status: maintained
   robot_state_publisher:
     doc:


### PR DESCRIPTION
Wasn't sure what the proper process was for this. We changed the branch for `rolling` source to `rolling-devel` in the `robot_localization` repo.
