### PR TITLE
robotnik_common: 1.2.0-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6569,6 +6569,17 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: rolling
     status: maintained
+  robotnik_common:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/RobotnikAutomation/robotnik_common-release.git
+      version: 1.2.0-4
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_common.git
+      version: 1.2.0
+    status: developed
   robotraconteur:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robotnik_common` to `1.2.0-4`:

- upstream repository: https://github.com/RobotnikAutomation/robotnik_common.git
- release repository: https://github.com/RobotnikAutomation/robotnik_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## robotnik_common

- No changes
