### PR TITLE
added robotnik initial repos, jazzy, kilted, rolling

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7565,6 +7565,30 @@ repositories:
       url: https://github.com/clearpathrobotics/robot_upstart.git
       version: foxy-devel
     status: developed
+  robotnik_common:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_common.git
+      version: jazzy
+    status: developed
+  robotnik_description:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_description.git
+      version: jazzy
+    status: developed
+  robotnik_interfaces:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
+      version: jazzy
+    status: developed
+  robotnik_simulation:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_simulation.git
+      version: jazzy
+    status: developed
   robotraconteur:
     release:
       tags:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6524,6 +6524,30 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: kilted
     status: maintained
+  robotnik_common:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_common.git
+      version: kilted
+    status: developed
+  robotnik_description:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_description.git
+      version: kilted
+    status: developed
+  robotnik_interfaces:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
+      version: kilted
+    status: developed
+  robotnik_simulation:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_simulation.git
+      version: kilted
+    status: developed
   robotraconteur:
     release:
       tags:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6569,6 +6569,30 @@ repositories:
       url: https://github.com/ros/robot_state_publisher.git
       version: rolling
     status: maintained
+  robotnik_common:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_common.git
+      version: rolling
+    status: developed
+  robotnik_description:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_description.git
+      version: rolling
+    status: developed
+  robotnik_interfaces:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
+      version: rolling
+    status: developed
+  robotnik_simulation:
+    source:
+      type: git
+      url: https://github.com/RobotnikAutomation/robotnik_simulation.git
+      version: rolling
+    status: developed
   robotraconteur:
     release:
       tags:


### PR DESCRIPTION
We would like to index the following packages into rosdistro. [jazzy, kilted, rolling]

Source code:
- [https://github.com/RobotnikAutomation/robotnik_common](https://github.com/RobotnikAutomation/robotnik_common)
- [https://github.com/RobotnikAutomation/robotnik_description](https://github.com/RobotnikAutomation/robotnik_description)
- [https://github.com/RobotnikAutomation/robotnik_interfaces](https://github.com/RobotnikAutomation/robotnik_interfaces)
- [https://github.com/RobotnikAutomation/robotnik_simulation](https://github.com/RobotnikAutomation/robotnik_simulation)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
