### PR TITLE
pal_statistics: 2.6.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4976,7 +4976,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pal_statistics-release.git
-      version: 2.6.3-1
+      version: 2.6.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_statistics` to `2.6.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_statistics.git
- release repository: https://github.com/ros2-gbp/pal_statistics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.6.3-1`

## pal_statistics

```
* Fix windows build (#18)
  * Export symbols
  * Fix typo
  * Try <> instead
  * Link against Boost::boost
  * Revert "Try <> instead"
  This reverts commit 586684f9871539fabbb675b71a9fd20b318cf1e8.
  * Update pal_statistics/CMakeLists.txt
  * link boost only on win32
  Co-authored-by: Noel Jiménez García <noel.jimenez.gar@gmail.com>
  ---------
  Co-authored-by: Noel Jiménez García <noel.jimenez.gar@gmail.com>
* Fix cmake deprecation (#19)
  * Fix cmake deprecation
  cmake version < then 3.10 is deprecated
  * Remove extra 0 in cmake version
  ---------
  Co-authored-by: Noel Jiménez García <mailto:noel.jimenez.gar@gmail.com>
* Contributors: Christoph Fröhlich, mosfet80
```

## pal_statistics_msgs

```
* Fix cmake deprecation (#19)
  * Fix cmake deprecation
  cmake version < then 3.10 is deprecated
  * Remove extra 0 in cmake version
  ---------
  Co-authored-by: Noel Jiménez García <mailto:noel.jimenez.gar@gmail.com>
* Contributors: mosfet80
```
