### PR TITLE
laser_filters: 2.0.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3900,7 +3900,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.0.8-1
+      version: 2.0.9-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.0.9-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.8-1`

## laser_filters

```
* Fix compile warning in speckle filter
* Port ros1 functionalities
* Make reconfigurable parameters writable
* Remove rolling from ros2 branch CI Rolling is now released from the "rolling" branch.
* Use correct footprint subscriber callback for static polygon filter
* Added heartbeat diagnostics
* Added window size check to prevent segfault in speckle filter
* Added params_prefix to reconfigure callback
* Remove use of boost from polygon_filter
* Remove iron from ci - EOL
* Contributors: Alejandro Hernández Cordero, Jeanine van Bruggen, Jonathan Binney, Silvio Traversaro
```
