### PR TITLE
imu_calib: 0.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3916,6 +3916,17 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: humble
     status: maintained
+  imu_calib:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/Nathan85001/imu_calib-release.git
+      version: 0.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/Nathan85001/imu_calib.git
+      version: ros2
   imu_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_calib` to `0.1.0-2`:

- upstream repository: https://github.com/Nathan85001/imu_calib.git
- release repository: https://github.com/Nathan85001/imu_calib-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
