### PR TITLE
sdformat_urdf: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8017,7 +8017,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `2.0.2-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## sdformat_test_files

- No changes

## sdformat_urdf

```
* Relax the version of urdfdom_headers (#39 <https://github.com/ros/sdformat_urdf/issues/39>)
* Explain how Gazebo and RViz can resolve mesh URIs (#26 <https://github.com/ros/sdformat_urdf/issues/26>) (#29 <https://github.com/ros/sdformat_urdf/issues/29>)
* Contributors: Alejandro Hernández Cordero, Andrew Symington
```
