### PR TITLE
clearpath_config: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1212,7 +1212,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.6.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## clearpath_config

```
* Feature: All Platforms Supported (#176 <https://github.com/clearpathrobotics/clearpath_config/issues/176>)
  * All platforms are now supported
  * Remove unused dependencies
* Added sensor sample for phidgets_spatial. (#175 <https://github.com/clearpathrobotics/clearpath_config/issues/175>)
* Enable foxglove bridge by default (#173 <https://github.com/clearpathrobotics/clearpath_config/issues/173>)
* Add A300 AMP attachments, samples (#158 <https://github.com/clearpathrobotics/clearpath_config/issues/158>)
  * Add attachments for A300 Observer
  * Add A300 Observer sample
  * Add parameters to set the Ouster OS-1 base & cap type
  * Add spotlight attachment
* Contributors: Chris Iverach-Brereton, Hilary Luo, Tony Baltovski, luis-camero
```
