### PR TITLE
mvsim: 0.14.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4393,7 +4393,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.13.3-1
+      version: 0.14.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.14.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.13.3-1`

## mvsim

```
* Merge pull request #67 <https://github.com/MRPT/mvsim/issues/67> from MRPT/wip/fpi
  Add Tire-Force Ellipse (Friction Ellipse) method (Student Project by Francisco Pérez Ibáñez)
  Co-authored-by: Francisco Pérez Ibáñez <mailto:fpi684@inlumine.ual.es>
* scripts: better force plots
* fix: build against later tf2
* Update README.md: Mark Noetic as EOL
* better integration with VSCode and colcon
* Modernize the CsvLogger interface: more efficient, better log file names, does log more details on each wheel
* Copyright notices: update year
* Update CI to use u24.04, remove obsolete u20.04
* Contributors: Jose Luis Blanco-Claraco, Francisco Pérez Ibáñez
```
