### PR TITLE
dynamixel_hardware_interface: 1.4.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1380,7 +1380,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
-      version: 1.4.8-1
+      version: 1.4.9-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `1.4.9-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.8-1`

## dynamixel_hardware_interface

```
* Support ffw sensor model
* Contributors: Woojin Wie
```
