### PR TITLE
mapviz: 2.5.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4847,7 +4847,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.6-1
+      version: 2.5.7-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.7-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.6-1`

## mapviz

```
* Switching recursive mutex for new API (#853 <https://github.com/swri-robotics/mapviz/issues/853>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

- No changes
