### PR TITLE
gps_umd: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2903,7 +2903,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `2.1.1-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.0-1`

## gps_msgs

- No changes

## gps_tools

```
* Declare parameters so they correctly load. (#115 <https://github.com/swri-robotics/gps_umd/issues/115>)
  Co-authored-by: James Pace <mailto:jpace121@gmail.com>
* Contributors: jpace121
```

## gps_umd

- No changes

## gpsd_client

- No changes
