### PR TITLE
rclcpp: 29.5.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5871,7 +5871,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.5.1-1
+      version: 29.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.5.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `29.5.1-1`

## rclcpp

```
* Shutdown deadlock fix jazzy (#2887 <https://github.com/ros2/rclcpp/issues/2887>) (#2888 <https://github.com/ros2/rclcpp/issues/2888>)
* Fix test_publisher_with_system_default_qos (#2881 <https://github.com/ros2/rclcpp/issues/2881>) (#2884 <https://github.com/ros2/rclcpp/issues/2884>)
* Contributors: Tomoya Fujita, Janosch Machowinski
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
