### PR TITLE
rviz: 15.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7936,7 +7936,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.3-1
+      version: 15.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.3-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Postpone hiding of properties until insertion into model is finished (#1508 <https://github.com/ros2/rviz/issues/1508>) (#1520 <https://github.com/ros2/rviz/issues/1520>)
* Don't hide rows of properties not within the model (#1507 <https://github.com/ros2/rviz/issues/1507>) (#1517 <https://github.com/ros2/rviz/issues/1517>)
* Remove redundant check (#1506 <https://github.com/ros2/rviz/issues/1506>) (#1511 <https://github.com/ros2/rviz/issues/1511>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Better handling of missing transport plugins (#1488 <https://github.com/ros2/rviz/issues/1488>) (#1514 <https://github.com/ros2/rviz/issues/1514>)
* Add symbol visibility macros to make*Palette public functions (#1492 <https://github.com/ros2/rviz/issues/1492>) (#1499 <https://github.com/ros2/rviz/issues/1499>)
* Contributors: Alejandro Hernández Cordero, Silvio Traversaro
```

## rviz_ogre_vendor

```
* Add RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ option to further mangle ogre libraries used by rviz (#1493 <https://github.com/ros2/rviz/issues/1493>) (#1496 <https://github.com/ros2/rviz/issues/1496>)
* Contributors: Silvio Traversaro
```

## rviz_rendering

```
* Assign the geometry to the resource group "rviz_rendering" (#1502 <https://github.com/ros2/rviz/issues/1502>) (#1503 <https://github.com/ros2/rviz/issues/1503>)
* Contributors: matthias88
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
