### PR TITLE
rosidl: 5.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7147,7 +7147,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.9.4-2
+      version: 5.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.0.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.9.4-2`

## rosidl_adapter

- No changes

## rosidl_cli

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
* Contributors: Francisco Rossi
```

## rosidl_cmake

```
* fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>)
* Contributors: mosfet80
```

## rosidl_generator_c

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
* Contributors: Francisco Rossi
```

## rosidl_generator_cpp

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>)
* Removed deprecated methods (#863 <https://github.com/ros2/rosidl/issues/863>)
* Contributors: Alejandro Hernández Cordero, Francisco Rossi, Øystein Sture
```

## rosidl_generator_type_description

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
* Contributors: Francisco Rossi
```

## rosidl_parser

```
* fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>)
* Contributors: mosfet80
```

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>)
* Add an ament_cmake_gtest dependency to rosidl_runtime_c. (#865 <https://github.com/ros2/rosidl/issues/865>)
* Contributors: Chris Lalancette, mosfet80
```

## rosidl_runtime_cpp

```
* fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>)
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>)
* Contributors: mosfet80, Øystein Sture
```

## rosidl_typesupport_interface

```
* fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>)
* Contributors: mosfet80
```

## rosidl_typesupport_introspection_c

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
* Contributors: Francisco Rossi
```

## rosidl_typesupport_introspection_cpp

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
* Contributors: Francisco Rossi
```
