### PR TITLE
rcutils: 6.9.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5954,7 +5954,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.5-2
+      version: 6.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.6-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.9.5-2`

## rcutils

```
* Use getenv_s instead of getenv for Windows (#499 <https://github.com/ros2/rcutils/issues/499>) (#500 <https://github.com/ros2/rcutils/issues/500>)
* Clean memory in test_process.cpp (backport #495 <https://github.com/ros2/rcutils/issues/495>) (#496 <https://github.com/ros2/rcutils/issues/496>)
* Contributors: Alejandro Hernandez Cordero, Tomoya Fujita
```
