### PR TITLE
turtlebot3: 2.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10040,7 +10040,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.3.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ros2-gbp/turtlebot3-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.1-1`

## turtlebot3

```
* Added class member variable initialization statement in the odometry node
* Contributors: Hyungyu Kim
```

## turtlebot3_bringup

```
* None
```

## turtlebot3_cartographer

```
* None
```

## turtlebot3_description

```
* None
```

## turtlebot3_example

```
* None
```

## turtlebot3_navigation2

```
* None
```

## turtlebot3_node

```
* Added class member variable initialization statement in the odometry node
* Contributors: Hyungyu Kim
```

## turtlebot3_teleop

```
* None
```
