### PR TITLE
open_manipulator: 4.0.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4764,7 +4764,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 4.0.1-1
+      version: 4.0.5-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.0.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.1-1`

## om_gravity_compensation_controller

```
* Added feedback control for leader-follower synchronization
* Contributors: Sungho Woo
```

## om_joint_trajectory_command_broadcaster

```
* Fixed lint errors
* Contributors: Sungho Woo
```

## om_spring_actuator_controller

```
* Fixed lint errors
* Contributors: Sungho Woo
```

## open_manipulator

```
* Added init_position_file argument to launch files
* Updated profile time and acceleration time for OMY series
* Fixed lint errors
* Updated Collision area for OMY series
* Added feedback control for leader-follower synchronization
* Contributors: Woojin Wie, Sungho Woo
```

## open_manipulator_bringup

```
* Added init_position_file argument to launch files
* Added qc_position file for OMY series
* Enabled self-collision avoidance by default for OMY series
* Contributors: Woojin Wie, Sungho Woo
```

## open_manipulator_collision

```
* Updated urdf file path for OMY
* Contributors: Sungho Woo
```

## open_manipulator_description

```
* Updated profile time and acceleration time for OMY series
* Updated Collision area for OMY series
* Contributors: Woojin Wie, Sungho Woo
```

## open_manipulator_gui

```
* None
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* None
```
