### PR TITLE
plotjuggler: 3.10.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5171,7 +5171,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.6-1
+      version: 3.10.9-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.10.9-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.10.6-1`

## plotjuggler

```
* add Arrow to conan and fix Windows CI (#1109 <https://github.com/facontidavide/PlotJuggler/issues/1109>)
* modernize cmake
* apply formatting to cmakelists
* Fix compilation with recent protobuf (#1108 <https://github.com/facontidavide/PlotJuggler/issues/1108>)
* Change behavior of DataLoadCSV::readDataFromFile to skip incomplete/corrupted lines.
* Fix line numbers in DataLoadCVS::readDataFromFile.
  Line numbers within the error/warning messages boxes didn't show the correct line numbers if the CVS file contained empty lines.
* Contributors: Davide Faconti, Silvio Traversaro, Valentin Platzgummer
```
