### PR TITLE
remove package behaviortree_cpp_v3 from newer distros

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -773,21 +773,6 @@ repositories:
       url: https://github.com/wep21/bag2_to_image.git
       version: main
     status: maintained
-  behaviortree_cpp_v3:
-    doc:
-      type: git
-      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: v3.8
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.6-3
-    source:
-      type: git
-      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: v3.8
-    status: developed
   behaviortree_cpp_v4:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -838,21 +838,6 @@ repositories:
       url: https://github.com/wep21/bag2_to_image.git
       version: main
     status: maintained
-  behaviortree_cpp_v3:
-    doc:
-      type: git
-      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: v3.8
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.6-2
-    source:
-      type: git
-      url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-      version: v3.8
-    status: developed
   behaviortree_cpp_v4:
     doc:
       type: git


### PR DESCRIPTION
## Package name:

behaviortree_cpp_v3

## Package Upstream Source:

[TODO link to source repository](https://github.com/BehaviorTree/BehaviorTree.CPP.git)

## Purpose of using this:

Remove behaviortree_cpp_v3 from kilted and rolling

## Links to Distribution Packages

Not applicable?

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
