### PR TITLE
teleop_twist_joy: 2.4.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10830,7 +10830,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_joy-release.git
-      version: 2.4.7-1
+      version: 2.4.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_joy` to `2.4.8-1`:

- upstream repository: https://github.com/ros2/teleop_twist_joy.git
- release repository: https://github.com/ros2-gbp/teleop_twist_joy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.4.7-1`

## teleop_twist_joy

```
* Add PS5 controller configuration for teleop twist joy node (#55 <https://github.com/ros2/teleop_twist_joy/issues/55>) (#59 <https://github.com/ros2/teleop_twist_joy/issues/59>)
* Pass configuration through to the Joy node. (#57 <https://github.com/ros2/teleop_twist_joy/issues/57>) (#58 <https://github.com/ros2/teleop_twist_joy/issues/58>)
* Contributors: mergify[bot]
```
