### PR TITLE
remove neo_simulation2

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5915,21 +5915,6 @@ repositories:
       url: https://github.com/neobotix/neo_nav2_bringup.git
       version: humble
     status: maintained
-  neo_simulation2:
-    doc:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: humble
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/neo_simulation2-release.git
-      version: 1.0.0-3
-    source:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: humble
-    status: maintained
   nerian_stereo_ros2:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5248,36 +5248,6 @@ repositories:
       url: https://github.com/neobotix/neo_nav2_bringup.git
       version: jazzy
     status: maintained
-  neo_simulation2:
-    doc:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: rolling
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/neo_simulation2-release.git
-      version: 1.0.0-5
-    source:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: rolling
-    status: maintained
-  network_bridge:
-    doc:
-      type: git
-      url: https://github.com/brow1633/network_bridge.git
-      version: main
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/network_bridge-release.git
-      version: 1.0.2-1
-    source:
-      type: git
-      url: https://github.com/brow1633/network_bridge.git
-      version: main
-    status: maintained
   nicla_vision_ros2:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5248,6 +5248,21 @@ repositories:
       url: https://github.com/neobotix/neo_nav2_bringup.git
       version: jazzy
     status: maintained
+  network_bridge:
+    doc:
+      type: git
+      url: https://github.com/brow1633/network_bridge.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/network_bridge-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/brow1633/network_bridge.git
+      version: main
+    status: maintained
   nicla_vision_ros2:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4436,21 +4436,6 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: kilted
     status: maintained
-  neo_simulation2:
-    doc:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: rolling
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/neo_simulation2-release.git
-      version: 1.0.0-5
-    source:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: rolling
-    status: maintained
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4496,21 +4496,6 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: rolling
     status: maintained
-  neo_simulation2:
-    doc:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/neo_simulation2-release.git
-      version: 1.0.0-4
-    source:
-      type: git
-      url: https://github.com/neobotix/neo_simulation2.git
-      version: rolling
-    status: maintained
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

neo_simulation2

## Package Upstream Source:

[TODO link to source repository](https://github.com/neobotix/neo_simulation2)

## Purpose of using this:

Removing it because, it supports only classic Gazebo. Neobotix doesn't have the plans to support it anymore. We are moving to the modern Gazebo. And it is all supported in the respective robot packages. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

N/A

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here:

http://sourcecode_url

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
