### PR TITLE
reductstore_agent: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7027,6 +7027,11 @@ repositories:
       type: git
       url: https://github.com/reductstore/reductstore_agent.git
       version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/reductstore_agent-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/reductstore/reductstore_agent.git


### PR DESCRIPTION
Increasing version of package(s) in repository `reductstore_agent` to `0.2.0-1`:

- upstream repository: https://github.com/reductstore/reductstore_agent.git
- release repository: https://github.com/ros2-gbp/reductstore_agent-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## reductstore_agent

```
* Merge pull request #23 <https://github.com/reductstore/ros2_reduct_agent/issues/23> from reductstore/9-add-support-for-include_regex-and-exclude_regex
  Add support for include/exclude topics using regex
* Merge pull request #24 <https://github.com/reductstore/ros2_reduct_agent/issues/24> from reductstore/12-add-support-for-static-labels-from-pipeline-config
  Add support for static labels from pipeline config
* Merge pull request #22 <https://github.com/reductstore/ros2_reduct_agent/issues/22> from reductstore/8-add-reductstore-bucket-settings-to-config
  Add support for bucket settings
```
