### PR TITLE
crazyswarm2: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1777,7 +1777,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/crazyswarm2-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/IMRCLab/crazyswarm2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crazyswarm2` to `1.0.3-1`:

- upstream repository: https://github.com/IMRCLab/crazyswarm2.git
- release repository: https://github.com/ros2-gbp/crazyswarm2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## crazyflie

```
* Improve package.xml (separate maintainer tags, update year)
* Contributors: Kimberly N. McGuire
```

## crazyflie_examples

```
* Improve package.xml (separate maintainer tags, update year)
* Contributors: Kimberly N. McGuire
```

## crazyflie_interfaces

```
* add more dependencies to fix the binary build
* Improve package.xml (separate maintainer tags, update year)
* Contributors: Kimberly N. McGuire
```

## crazyflie_py

```
* Improve package.xml (separate maintainer tags, update year)
* Contributors: Kimberly N. McGuire
```

## crazyflie_sim

```
* Improve package.xml (separate maintainer tags, update year)
* Contributors: Kimberly N. McGuire
```
