### PR TITLE
Add `reduct-py` pip index

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7260,6 +7260,25 @@ python3-mavproxy-pip:
   ubuntu:
     pip:
       packages: [MAVProxy]
+python3-mcap-pip:
+  debian:
+    pip:
+      packages: [mcap]
+  fedora:
+    pip:
+      packages: [mcap]
+  gentoo:
+    pip:
+      packages: [mcap]
+  nixos:
+    pip:
+      packages: [mcap]
+  osx:
+    pip:
+      packages: [mcap]
+  ubuntu:
+    pip:
+      packages: [mcap]
 python3-mccabe:
   arch: [python-mccabe]
   debian: [python3-mccabe]
@@ -9403,6 +9422,25 @@ python3-rdflib:
   rhel:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
+python3-reduct-py-pip:
+  debian:
+    pip:
+      packages: [reduct-py]
+  fedora:
+    pip:
+      packages: [reduct-py]
+  gentoo:
+    pip:
+      packages: [reduct-py]
+  nixos:
+    pip:
+      packages: [reduct-py]
+  osx:
+    pip:
+      packages: [reduct-py]
+  ubuntu:
+    pip:
+      packages: [reduct-py]
 python3-reedsolo:
   arch: [python-reedsolo]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7267,12 +7267,6 @@ python3-mcap-pip:
   fedora:
     pip:
       packages: [mcap]
-  gentoo:
-    pip:
-      packages: [mcap]
-  nixos:
-    pip:
-      packages: [mcap]
   osx:
     pip:
       packages: [mcap]
@@ -9427,12 +9421,6 @@ python3-reduct-py-pip:
     pip:
       packages: [reduct-py]
   fedora:
-    pip:
-      packages: [reduct-py]
-  gentoo:
-    pip:
-      packages: [reduct-py]
-  nixos:
     pip:
       packages: [reduct-py]
   osx:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9412,16 +9412,7 @@ python3-rdflib:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
 python3-reduct-py-pip:
-  debian:
-    pip:
-      packages: [reduct-py]
-  fedora:
-    pip:
-      packages: [reduct-py]
-  osx:
-    pip:
-      packages: [reduct-py]
-  ubuntu:
+  '*':
     pip:
       packages: [reduct-py]
 python3-reedsolo:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7260,19 +7260,6 @@ python3-mavproxy-pip:
   ubuntu:
     pip:
       packages: [MAVProxy]
-python3-mcap-pip:
-  debian:
-    pip:
-      packages: [mcap]
-  fedora:
-    pip:
-      packages: [mcap]
-  osx:
-    pip:
-      packages: [mcap]
-  ubuntu:
-    pip:
-      packages: [mcap]
 python3-mccabe:
   arch: [python-mccabe]
   debian: [python3-mccabe]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- python3-reduct-py-pip
- python3-mcap-pip

## Package Upstream Source:

- https://github.com/reductstore/reduct-py
- https://github.com/foxglove/mcap

## Purpose of using this:

These dependencies are used in the `reductstore_agent` ROS 2 package for writing and managing MCAP files (`mcap`) and uploading them to ReductStore (`reduct-py`). These libraries are not available via system package managers and must be installed via pip.

This is required to support ROS 2 logging/recording workflows with ReductStore as a backend.

## Links to Distribution Packages

These packages are only available on PyPI and must be installed via pip. Not available in system package managers.