### PR TITLE
image_transport_plugins: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2957,7 +2957,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 5.0.3-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `6.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.3-1`

## compressed_depth_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>)
* Merge pull request #188 <https://github.com/ros-perception/image_transport_plugins/issues/188> from bjsowa/fix/canonical-param-names
* Add TODO comments about deprecated parameters
* Simplify pre set parameter callback for compressedDepth transport
* Don't add pre set parameter callback when not needed
* Add deprecated dot parameters for compressedDepth transport
* Fix inconsistent transport param names
* Removed deprecated params (#183 <https://github.com/ros-perception/image_transport_plugins/issues/183>)
* Removed deprecated headers (#184 <https://github.com/ros-perception/image_transport_plugins/issues/184>)
* Contributors: Alejandro Hernández Cordero, Błażej Sowa, Kenji Brameld
```

## compressed_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>)
* Merge pull request #188 <https://github.com/ros-perception/image_transport_plugins/issues/188> from bjsowa/fix/canonical-param-names
* Add TODO comments about deprecated parameters
* Simplify pre set parameter callback for other transports
* Don't add pre set parameter callback when not needed
* Add deprecated dot parameters for compressed transport
* Fix inconsistent transport param names
* Removed deprecated params (#183 <https://github.com/ros-perception/image_transport_plugins/issues/183>)
* Removed deprecated headers (#184 <https://github.com/ros-perception/image_transport_plugins/issues/184>)
* Contributors: Alejandro Hernández Cordero, Błażej Sowa, Kenji Brameld
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>)
* Merge pull request #188 <https://github.com/ros-perception/image_transport_plugins/issues/188> from bjsowa/fix/canonical-param-names
* Add TODO comments about deprecated parameters
* Simplify pre set parameter callback for other transports
* Don't add pre set parameter callback when not needed
* Use post set parameter callback instead of parameter events
* Add deprecated dot parameters for theora transport
* Fix inconsistent transport param names
* Removed deprecated params (#183 <https://github.com/ros-perception/image_transport_plugins/issues/183>)
* Removed deprecated headers (#184 <https://github.com/ros-perception/image_transport_plugins/issues/184>)
* Contributors: Alejandro Hernández Cordero, Błażej Sowa, Kenji Brameld
```

## zstd_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>)
* Merge pull request #188 <https://github.com/ros-perception/image_transport_plugins/issues/188> from bjsowa/fix/canonical-param-names
* Add TODO comments about deprecated parameters
* Simplify pre set parameter callback for other transports
* Adding the include of cstdint (#189 <https://github.com/ros-perception/image_transport_plugins/issues/189>)
* Don't add pre set parameter callback when not needed
* Add deprecated dot parameters for zstd transport
* Fix inconsistent transport param names
* Contributors: Alejandro Hernández Cordero, Błażej Sowa, Jan Vermaete, Kenji Brameld
```
