### PR TITLE
image_transport_plugins: 5.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2853,7 +2853,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: kilted
     release:
       packages:
       - compressed_depth_image_transport
@@ -2869,7 +2869,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: kilted
     status: maintained
   imu_pipeline:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2864,7 +2864,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 5.0.2-2
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `5.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.0.2-2`

## compressed_depth_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#197 <https://github.com/ros-perception/image_transport_plugins/issues/197>)
* Contributors: mergify[bot]
```

## compressed_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#197 <https://github.com/ros-perception/image_transport_plugins/issues/197>)
* Contributors: mergify[bot]
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#197 <https://github.com/ros-perception/image_transport_plugins/issues/197>)
* Contributors: mergify[bot]
```

## zstd_image_transport

```
* Use non deprecated method (#182 <https://github.com/ros-perception/image_transport_plugins/issues/182>) (#197 <https://github.com/ros-perception/image_transport_plugins/issues/197>)
* Adding the include of cstdint (#189 <https://github.com/ros-perception/image_transport_plugins/issues/189>) (#196 <https://github.com/ros-perception/image_transport_plugins/issues/196>)
* Contributors: mergify[bot]
```
