### PR TITLE
nanoeigenpy: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5685,6 +5685,21 @@ repositories:
       url: https://github.com/2b-t/myactuator_rmd.git
       version: main
     status: developed
+  nanoeigenpy:
+    doc:
+      type: git
+      url: https://github.com/Simple-Robotics/nanoeigenpy.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/nanoeigenpy-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/Simple-Robotics/nanoeigenpy.git
+      version: main
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoeigenpy` to `0.3.0-1`:

- upstream repository: https://github.com/Simple-Robotics/nanoeigenpy.git
- release repository: https://github.com/ros2-gbp/nanoeigenpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
