### PR TITLE
franka_description: 1.0.1-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3005,7 +3005,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/franka_description-release.git
-      version: 0.4.0-3
+      version: 1.0.1-3
     source:
       type: git
       url: https://github.com/frankaemika/franka_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_description` to `1.0.1-3`:

- upstream repository: https://github.com/frankarobotics/franka_description
- release repository: https://github.com/ros2-gbp/franka_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-3`

## franka_description

```
* fix: cover and mount replaced by new designs
```
