### PR TITLE
nanoeigenpy: 0.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4272,6 +4272,21 @@ repositories:
       url: https://github.com/MRPT/mvsim.git
       version: develop
     status: developed
+  nanoeigenpy:
+    doc:
+      type: git
+      url: https://github.com/Simple-Robotics/nanoeigenpy.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/nanoeigenpy-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/Simple-Robotics/nanoeigenpy.git
+      version: main
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoeigenpy` to `0.3.0-1`:

- upstream repository: https://github.com/Simple-Robotics/nanoeigenpy.git
- release repository: https://github.com/ros2-gbp/nanoeigenpy-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
