### PR TITLE
nanoeigenpy: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4386,6 +4386,15 @@ repositories:
       version: develop
     status: developed
   nanoeigenpy:
+    doc:
+      type: git
+      url: https://github.com/Simple-Robotics/nanoeigenpy.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/nanoeigenpy-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/Simple-Robotics/nanoeigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoeigenpy` to `0.3.0-1`:

- upstream repository: https://github.com/Simple-Robotics/nanoeigenpy.git
- release repository: https://github.com/ros2-gbp/nanoeigenpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
