### PR TITLE
add jrl_cmakemodules on rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3115,6 +3115,12 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: ros2
     status: maintained
+  jrl_cmakemodules:
+    source:
+      type: git
+      url: https://github.com/jrl-umi3218/jrl-cmakemodules.git
+      version: master
+    status: maintained
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jrl_cmakemodules

This package is already used as a submodule in multiple others (eigenpy/coal/pinocchio/tsid), but it can now be installed as standalone and be depended on

# The source is here:

https://github.com/jrl-umi3218/jrl-cmakemodules

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
