### PR TITLE
rqt_image_view: 1.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7527,7 +7527,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.3.0-2
+      version: 1.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.3.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-2`

## rqt_image_view

```
* Added common linters (#91 <https://github.com/ros-visualization/rqt_image_view/issues/91>)
* update plugin.h to plugin.hpp (#86 <https://github.com/ros-visualization/rqt_image_view/issues/86>)
* Contributors: Alejandro Hernández Cordero, Zhaoyuan Cheng
```
