### PR TITLE
automatika_embodied_agents: 0.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -821,7 +821,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_embodied_agents` to `0.4.1-1`:

- upstream repository: https://github.com/automatika-robotics/ros-agents.git
- release repository: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## automatika_embodied_agents

```
* (docs) Updates docs for using planning based MLLMs
* (feature) Adds options to get RGBD array from rgbd message callback
* (refactor) Breaks complex functions and fixes warmup result logging
* (feature) Adds support for planning mllm models, starting with robobrain2.0
* (docs) Adds streaming to conversational agent example
* Contributors: ahr, mkabtoul
```
