### PR TITLE
turtlebot3_simulations: 2.3.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11316,7 +11316,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
-      version: 2.3.4-1
+      version: 2.3.8-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_simulations` to `2.3.8-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
- release repository: https://github.com/ros2-gbp/turtlebot3_simulations-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.4-1`

## turtlebot3_fake_node

```
* None
```

## turtlebot3_gazebo

```
* None
```

## turtlebot3_manipulation_gazebo

```
* Fixed the issue where the TurtleBot3 Manipulation Gazebo simulation was not working properly
* Contributors: Hyungyu Kim
```

## turtlebot3_simulations

```
* Fixed the issue where the TurtleBot3 Manipulation Gazebo simulation was not working properly
* Contributors: Hyungyu Kim
```
