### PR TITLE
rqt_image_view: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7596,7 +7596,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.3.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.0-1`

## rqt_image_view

```
* Deprecated C headers (#92 <https://github.com/ros-visualization/rqt_image_view/issues/92>)
* Added common linters (#91 <https://github.com/ros-visualization/rqt_image_view/issues/91>)
* update plugin.h to plugin.hpp (#86 <https://github.com/ros-visualization/rqt_image_view/issues/86>)
* Contributors: Alejandro Hernández Cordero, Zhaoyuan Cheng
```
