### PR TITLE
Add mujoco

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7482,6 +7482,13 @@ python3-mss-pip:
   '*':
     pip:
       packages: [mss]
+python3-mujoco-pip:
+  debian:
+    pip:
+      packages: [mujoco]
+  ubuntu:
+    pip:
+      packages: [mujoco]
 python3-multimethod-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

mujoco

## Package Upstream Source:

https://github.com/google-deepmind/mujoco


## Purpose of using this:

MuJoCo is a fast, accurate physics engine designed for research and development in robotics and biomechanics, offering fine-grained control over simulation and advanced features like soft contacts and inverse dynamics. Including it in the ROS distribution would streamline integration for roboticists, enabling high-fidelity simulation within the ROS ecosystem without complex external dependencies.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Python:
  - https://pypi.org/project/mujoco/ 

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->
