### PR TITLE
Add python3-obj2mjcf-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7728,6 +7728,13 @@ python3-oauth2client:
     '*': [python3-oauth2client]
     '7': null
   ubuntu: [python3-oauth2client]
+python3-obj2mjcf-pip:
+  debian:
+    pip:
+      packages: [obj2mjcf]
+  ubuntu:
+    pip:
+      packages: [obj2mjcf]
 python3-oct2py-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

obj2mjcf

## Package Upstream Source:

https://github.com/kevinzakka/obj2mjcf

## Purpose of using this:

obj2mjcf is a utility that converts 3D mesh models in the Wavefront OBJ format into MJCF XML files compatible with the MuJoCo physics engine, enabling fast simulation of custom objects. Including obj2mjcf in the ROS distribution would streamline asset preparation for physics-based robotic simulations, bridging the gap between 3D modeling tools and ROS-MuJoCo workflows.

Related to PR for mujoco: https://github.com/ros/rosdistro/pull/46859

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Python
  -  https://pypi.org/project/obj2mjcf/
