### PR TITLE
protobuf_comm: 0.9.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6219,6 +6219,11 @@ repositories:
       version: master
     status: maintained
   protobuf_comm:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/protobuf_comm-release.git
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/fawkesrobotics/protobuf_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `protobuf_comm` to `0.9.3-1`:

- upstream repository: https://github.com/fawkesrobotics/protobuf_comm.git
- release repository: https://github.com/ros2-gbp/protobuf_comm-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## protobuf_comm

```
* prepare for ROS release
```
