### PR TITLE
plotjuggler: 3.10.10-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5150,7 +5150,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.9-1
+      version: 3.10.10-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.10.10-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.10.9-1`

## plotjuggler

```
* cosmetic change in Preferences
* Fmt cpm (#1120 <https://github.com/facontidavide/PlotJuggler/issues/1120>)
* Make export plot size an application param
* Add an action to plot a whole tab
* fix missing submodule
* fix Win CI
* Contributors: Blaise Le Coquil, Davide Faconti
```
