### PR TITLE
add rsyslog to rhel, gentoo, alpine, macports and opensuse.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8722,7 +8722,6 @@ rsyslog:
   debian: [rsyslog]
   fedora: [rsyslog]
   gentoo: [app-admin/rsyslog]
-  macports: [rsyslog]
   nixos: [rsyslog]
   opensuse: [rsyslog]
   rhel: [rsyslog]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8722,7 +8722,9 @@ rsyslog:
   debian: [rsyslog]
   fedora: [rsyslog]
   gentoo: [app-admin/rsyslog]
+  macports: [rsyslog]
   nixos: [rsyslog]
+  opensuse: [rsyslog]
   rhel: [rsyslog]
   ubuntu: [rsyslog]
 rt-tests:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8721,6 +8721,7 @@ rsyslog:
   alpine: [rsyslog]
   debian: [rsyslog]
   fedora: [rsyslog]
+  gentoo: [app-admin/rsyslog]
   nixos: [rsyslog]
   rhel: [rsyslog]
   ubuntu: [rsyslog]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8721,6 +8721,7 @@ rsyslog:
   debian: [rsyslog]
   fedora: [rsyslog]
   nixos: [rsyslog]
+  rhel: [rsyslog]
   ubuntu: [rsyslog]
 rt-tests:
   arch: [rt-tests]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8718,6 +8718,7 @@ rsync:
   opensuse: [rsync]
   ubuntu: [rsync]
 rsyslog:
+  alpine: [rsyslog]
   debian: [rsyslog]
   fedora: [rsyslog]
   nixos: [rsyslog]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

rsyslog

## Package Upstream Source:

https://github.com/rsyslog/rsyslog

## Purpose of using this:

closes https://github.com/ros/rosdistro/issues/46850, that [rcl_logging_syslog](https://github.com/fujitatomoya/rcl_logging_syslog) depends on rsyslog.

## Links to Distribution Packages

- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/app-admin/rsyslog
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/rsyslog
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/rsyslog
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/rsyslog
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/rsyslog
