### PR TITLE
rosbag2: 0.26.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8109,7 +8109,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.7-1
+      version: 0.26.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.8-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.7-1`

## liblz4_vendor

- No changes

## mcap_vendor

```
* mcap_vendor: update to v1.3.1 (#2069 <https://github.com/ros2/rosbag2/issues/2069>)
* Backporting Missing cstdint Include (#2008 <https://github.com/ros2/rosbag2/issues/2008>) (#2015 <https://github.com/ros2/rosbag2/issues/2015>)
* Contributors: james-rms, David Anthony <mailto:djanthony@gmail.com>, Barry Xu <mailto:barry.xu@sony.com>
```

## ros2bag

```
* Change Python player and recorder to be more as a classes (#2047 <https://github.com/ros2/rosbag2/issues/2047>) (#2054 <https://github.com/ros2/rosbag2/issues/2054>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2

- No changes

## rosbag2_compression

```
* Bugfix: ros2 bag convert dropping messages with compression mode message (#1975 <https://github.com/ros2/rosbag2/issues/1975>) (#1985 <https://github.com/ros2/rosbag2/issues/1985>)
* Contributors: Ben <mailto:benjamin.andrew@swri.org>, Michael Orlov <mailto:morlovmr@gmail.com>
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* [jazzy] Add support for searching message definitions in nested subdirectories (backport #2055 <https://github.com/ros2/rosbag2/issues/2055>) (#2064 <https://github.com/ros2/rosbag2/issues/2064>)
* [jazzy] Fix for issue when inner message definition not found for service events (#2042 <https://github.com/ros2/rosbag2/issues/2042>)
* [jazzy] Improvements in message publishing timings (backport #2025 <https://github.com/ros2/rosbag2/issues/2025>) (#2027 <https://github.com/ros2/rosbag2/issues/2027>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Address clang warning in the TimeControllerClock::wakeup() (#1962 <https://github.com/ros2/rosbag2/issues/1962>) (#1977 <https://github.com/ros2/rosbag2/issues/1977>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Barry Xu,
  Alejandro Hernández Cordero<mailto:ahcorde@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

```
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Add a simple example showing how to convert bags to the csv file (#1974 <https://github.com/ros2/rosbag2/issues/1974>) (#1982 <https://github.com/ros2/rosbag2/issues/1982>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* Change Python player and recorder to be more as a classes (#2047 <https://github.com/ros2/rosbag2/issues/2047>) (#2054 <https://github.com/ros2/rosbag2/issues/2054>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Bugfix: ros2 bag convert dropping messages with compression mode message (#1975 <https://github.com/ros2/rosbag2/issues/1975>) (#1985 <https://github.com/ros2/rosbag2/issues/1985>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>,
  Christophe Bedard <mailto:bedard.christophe@gmail.com>, Ben <mailto:benjamin.andrew@swri.org>
```

## rosbag2_storage

```
* Bugfix: Undefined behavior in the rosbag2_storage and rosbag2_storage_sqlite3 packages (#1997 <https://github.com/ros2/rosbag2/issues/1997>) (#1999 <https://github.com/ros2/rosbag2/issues/1999>)
* [jazzy] Use DDS queue depth for subscriptions as a maximum value across publishers (backport #1960 <https://github.com/ros2/rosbag2/issues/1960>) (#1980 <https://github.com/ros2/rosbag2/issues/1980>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

```
* Bugfix: Undefined behavior in the rosbag2_storage and rosbag2_storage_sqlite3 packages (#1997 <https://github.com/ros2/rosbag2/issues/1997>) (#1999 <https://github.com/ros2/rosbag2/issues/1999>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2_test_common

```
* [jazzy] Address flakiness in tests where need to spin a node (backport #2001 <https://github.com/ros2/rosbag2/issues/2001>) (#2019 <https://github.com/ros2/rosbag2/issues/2019>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* [jazzy] Use DDS queue depth for subscriptions as a maximum value across publishers (backport #1960 <https://github.com/ros2/rosbag2/issues/1960>) (#1980 <https://github.com/ros2/rosbag2/issues/1980>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2_test_msgdefs

```
* [jazzy] Add support for searching message definitions in nested subdirectories (backport #2055 <https://github.com/ros2/rosbag2/issues/2055>) (#2064 <https://github.com/ros2/rosbag2/issues/2064>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>
```

## rosbag2_tests

```
* [jazzy] Bugfix for deadlocks in Rosbag2 player when calling stop API (backport #2057 <https://github.com/ros2/rosbag2/issues/2057>) (#2060 <https://github.com/ros2/rosbag2/issues/2060>)
* [jazzy] Address flakiness in tests where need to spin a node (backport #2001 <https://github.com/ros2/rosbag2/issues/2001>) (#2019 <https://github.com/ros2/rosbag2/issues/2019>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## rosbag2_transport

```
* [jazzy] Bugfix for deadlocks in Rosbag2 player when calling stop API (backport #2057 <https://github.com/ros2/rosbag2/issues/2057>) (#2060 <https://github.com/ros2/rosbag2/issues/2060>)
* Skip flaky can_record_again_after_stop test (#2031 <https://github.com/ros2/rosbag2/issues/2031>) (#2033 <https://github.com/ros2/rosbag2/issues/2033>)
* [jazzy] Address flakiness in tests where need to spin a node (backport #2001 <https://github.com/ros2/rosbag2/issues/2001>) (#2019 <https://github.com/ros2/rosbag2/issues/2019>)
* [jazzy] Improvements in message publishing timings (backport #2025 <https://github.com/ros2/rosbag2/issues/2025>) (#2027 <https://github.com/ros2/rosbag2/issues/2027>)
* [jazzy] Upstream quality changes from Apex.AI part-2 (backport #1924 <https://github.com/ros2/rosbag2/issues/1924>) (#1987 <https://github.com/ros2/rosbag2/issues/1987>)
* Bugfix: ros2 bag convert dropping messages with compression mode message (#1975 <https://github.com/ros2/rosbag2/issues/1975>) (#1985 <https://github.com/ros2/rosbag2/issues/1985>)
* [jazzy] Use DDS queue depth for subscriptions as a maximum value across publishers (backport #1960 <https://github.com/ros2/rosbag2/issues/1960>) (#1980 <https://github.com/ros2/rosbag2/issues/1980>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, Ben <mailto:benjamin.andrew@swri.org>,
  Christophe Bedard <mailto:bedard.christophe@gmail.com>
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
