### PR TITLE
rtabmap_ros: 0.22.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7868,7 +7868,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.22.0-2
+      version: 0.22.1-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.22.1-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.22.0-2`
