### PR TITLE
protobuf_comm: 0.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5327,6 +5327,11 @@ repositories:
       version: master
     status: maintained
   protobuf_comm:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/protobuf_comm-release.git
+      version: 0.9.3-1
     source:
       type: git
       url: https://github.com/fawkesrobotics/protobuf_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `protobuf_comm` to `0.9.3-1`:

- upstream repository: https://github.com/fawkesrobotics/protobuf_comm.git
- release repository: https://github.com/ros2-gbp/protobuf_comm-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## protobuf_comm

```
* prepare for ROS release
```
