### PR TITLE
Add bno08x_driver to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1176,6 +1176,16 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
+  bno08x_driver:
+    doc:
+      type: git
+      url: https://github.com/bnbhat/bno08x_ros2_driver.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/bnbhat/bno08x_ros2_driver.git
+      version: master
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/bnbhat/bno08x_ros2_driver.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
