### PR TITLE
open_manipulator: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6391,7 +6391,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.0.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.2-1`

## open_manipulator

```
* Fixed an issue where meshes were not loading in the Gazebo simulation by adding the Gazebo model path export
* Linted the codebase
* Contributors: Hyungyu Kim
```

## open_manipulator_x_bringup

```
* Linted the codebase
* Contributors: Hyungyu Kim
```

## open_manipulator_x_description

```
* Fixed an issue where meshes were not loading in the Gazebo simulation by adding the Gazebo model path export
* Linted the codebase
* Contributors: Hyungyu Kim
```

## open_manipulator_x_gui

```
* Linted the codebase
* Contributors: Hyungyu Kim
```

## open_manipulator_x_moveit_config

```
* Linted the codebase
* Contributors: Hyungyu Kim
```

## open_manipulator_x_playground

```
* Linted the codebase
* Contributors: Hyungyu Kim
```

## open_manipulator_x_teleop

```
* Linted the codebase
* Contributors: Hyungyu Kim
```
