### PR TITLE
coin_d4_driver: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1110,7 +1110,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/coin_d4_driver-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coin_d4_driver` to `1.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
- release repository: https://github.com/ros2-gbp/coin_d4_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`

## coin_d4_driver

```
* Modified parameter files for single- and multi-lidar nodes used with TurtleBot3
* Contributors: Hyungyu Kim
```
