### PR TITLE
coin_d4_driver: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1597,7 +1597,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/coin_d4_driver-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coin_d4_driver` to `1.0.1-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
- release repository: https://github.com/ros2-gbp/coin_d4_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`

## coin_d4_driver

```
* Modified parameter files for single- and multi-lidar nodes used with TurtleBot3
* Contributors: Hyungyu Kim
```
