### PR TITLE
Add coin_d4_driver to kilted

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1030,6 +1030,16 @@ repositories:
       url: https://github.com/4am-robotics/cob_common.git
       version: foxy
     status: maintained
+  coin_d4_driver:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/coin_d4_driver.git
+      version: main
+    status: developed
   color_names:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

kilted

# The source is here:

https://github.com/ROBOTIS-GIT/coin_d4_driver

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
