### PR TITLE
rcutils: 6.9.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5985,7 +5985,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.6-1
+      version: 6.9.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.7-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.9.6-1`

## rcutils

```
* Revert "use getenv_s instead of getenv for Windows. (#499 <https://github.com/ros2/rcutils/issues/499>)" (#504 <https://github.com/ros2/rcutils/issues/504>) (#505 <https://github.com/ros2/rcutils/issues/505>)
  This reverts commit 46ab4d4eeb555a2e9e880157b97f0a867d3a256c.
  (cherry picked from commit 3a4beda924bfcf766803d25752cbbf911f445e99)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
