### PR TITLE
clearpath_simulator: 1.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1542,7 +1542,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `1.3.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.1-1`

## clearpath_generator_gz

- No changes

## clearpath_gz

```
* Fixed generate flag for robot_spawn (#89 <https://github.com/clearpathrobotics/clearpath_simulator/issues/89>)
  * Update simulation.launch.py to have generate setting
  * properlly define the generate flag usage
  * added missing import
* Contributors: Marius Juston
```

## clearpath_simulator

- No changes
