### PR TITLE
moveit_msgs: 2.7.0-2 in 'kilted/distribution.yaml'

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4096,7 +4096,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_msgs-release.git
-      version: 2.6.0-2
+      version: 2.7.0-2
     source:
       type: git
       url: https://github.com/ros-planning/moveit_msgs.git


### PR DESCRIPTION
This was manually generated due to GH classic token limitations.

Increasing version of package(s) in repository moveit_msgs to 2.7.0-2:

*  upstream repository: https://github.com/moveit/moveit_msgs.git
*  release repository: https://github.com/ros2-gbp/moveit_msgs-release.git
*  distro file: `kilted/distribution.yaml`
*  bloom version: `0.13.0`
*  previous version for package: `2.6.0-1`

## moveit_msgs

```
* Add GetMultiStateValidity service (#186 <https://github.com/ros-planning/moveit_msgs/issues/186>)
* CI: Update actions
* Contributors: Lucian James, Robert Haschke
```