### PR TITLE
open_manipulator: 3.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6401,7 +6401,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `3.0.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.3-1`

## open_manipulator

```
* Changed the output path of the Qt5-generated header file (ui_main_window.h) by adding a custom command in CMake. The generated file is now copied to a structured subdirectory (gui_headers/) within the build directory to improve include path consistency and comply with linting rules
* Contributors: Hyungyu Kim
```

## open_manipulator_x_bringup

```
* None
```

## open_manipulator_x_description

```
* None
```

## open_manipulator_x_gui

```
* Changed the output path of the Qt5-generated header file (ui_main_window.h) by adding a custom command in CMake. The generated file is now copied to a structured subdirectory (gui_headers/) within the build directory to improve include path consistency and comply with linting rules
* Contributors: Hyungyu Kim
```

## open_manipulator_x_moveit_config

```
* None
```

## open_manipulator_x_playground

```
* None
```

## open_manipulator_x_teleop

```
* None
```
