### PR TITLE
open_manipulator: 4.0.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4790,7 +4790,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 4.0.5-1
+      version: 4.0.6-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.0.6-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.5-1`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* None
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```

## open_manipulator_bringup

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```

## open_manipulator_collision

```
* None
```

## open_manipulator_description

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```

## open_manipulator_gui

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```

## open_manipulator_moveit_config

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```

## open_manipulator_playground

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```

## open_manipulator_teleop

```
* Renamed omx to open_manipulator_x
* Contributors: Wonho Yun
```
