### PR TITLE
turtlebot3_home_service_challenge: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11271,6 +11271,17 @@ repositories:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git
       version: humble
+    release:
+      packages:
+      - turtlebot3_home_service_challenge
+      - turtlebot3_home_service_challenge_aruco
+      - turtlebot3_home_service_challenge_core
+      - turtlebot3_home_service_challenge_manipulator
+      - turtlebot3_home_service_challenge_tools
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/turtlebot3_home_service_challenge-release.git
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_home_service_challenge` to `1.0.4-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git
- release repository: https://github.com/ros2-gbp/turtlebot3_home_service_challenge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## turtlebot3_home_service_challenge

```
* Remove ament_lint_auto in CMakeLists.txt
* Contributors: Hyungyu Kim
```

## turtlebot3_home_service_challenge_aruco

```
* None
```

## turtlebot3_home_service_challenge_core

```
* None
```

## turtlebot3_home_service_challenge_manipulator

```
* Remove ament_lint_auto in CMakeLists.txt
* Contributors: Hyungyu Kim
```

## turtlebot3_home_service_challenge_tools

```
* Remove ament_lint_auto in CMakeLists.txt
* Contributors: Hyungyu Kim
```
