### PR TITLE
rqt_image_view: 1.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7617,7 +7617,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `1.3.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.3.1-1`

## rqt_image_view

```
* Porting the color scheme for 32FC1 encoding from Noetic (backport #90 <https://github.com/ros-visualization/rqt_image_view/issues/90>) (#94 <https://github.com/ros-visualization/rqt_image_view/issues/94>)
* Contributors: mergify[bot]
```
