### PR TITLE
mapviz: 2.5.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4870,7 +4870,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.7-1
+      version: 2.5.8-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.8-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.7-1`

## mapviz

```
* Fixing misnamed library (#854 <https://github.com/swri-robotics/mapviz/issues/854>)
* Contributors: David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

```
* Updating to use new recursive mutex type (#855 <https://github.com/swri-robotics/mapviz/issues/855>)
* Contributors: David Anthony
```

## tile_map

- No changes
