### PR TITLE
rcl_interfaces: 1.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7798,7 +7798,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `1.2.2-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.1-1`

## action_msgs

- No changes

## builtin_interfaces

```
* Add info to duration message and time message comments (backport #176 <https://github.com/ros2/rcl_interfaces/issues/176>) (#179 <https://github.com/ros2/rcl_interfaces/issues/179>)
* Contributors: mergify[bot]
```

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

- No changes

## rosgraph_msgs

- No changes

## statistics_msgs

- No changes

## test_msgs

- No changes
