### PR TITLE
rclpy: 3.3.17-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7882,7 +7882,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.16-1
+      version: 3.3.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.17-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.16-1`

## rclpy

```
* Feature: add logger_name property to subscription, publisher, service and client (backport #1471 <https://github.com/ros2/rclpy/issues/1471>) (#1476 <https://github.com/ros2/rclpy/issues/1476>)
* [rclpy] Fix spin() incorrectly removing node from executor if already attached (#1446 <https://github.com/ros2/rclpy/issues/1446>) (#1451 <https://github.com/ros2/rclpy/issues/1451>)
* Contributors: mergify[bot]
```
