### PR TITLE
rmw_fastrtps: 6.2.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8424,7 +8424,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 6.2.7-1
+      version: 6.2.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `6.2.8-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.2.7-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

- No changes

## rmw_fastrtps_shared_cpp

```
* check a local publication to ignore with serialized message. (backport #823 <https://github.com/ros2/rmw_fastrtps/issues/823>) (#826 <https://github.com/ros2/rmw_fastrtps/issues/826>)
* Contributors: mergify[bot]
```
