### PR TITLE
ros2cli: 0.18.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8897,7 +8897,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.12-1
+      version: 0.18.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.13-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.18.12-1`

## ros2action

```
* remove unnecessary '/' from ros2 action info. (backport #1049 <https://github.com/ros2/ros2cli/issues/1049>) (#1052 <https://github.com/ros2/ros2cli/issues/1052>)
* Contributors: mergify[bot]
```

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* catch ConnectionRefusedError, so that it can fall back to DirectNode. (#1014 <https://github.com/ros2/ros2cli/issues/1014>) (#1022 <https://github.com/ros2/ros2cli/issues/1022>)
* fails the test properly to avoid TypeError exception. (backport #1016 <https://github.com/ros2/ros2cli/issues/1016>) (#1019 <https://github.com/ros2/ros2cli/issues/1019>)
* Contributors: mergify[bot]
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* ros2topic: Documented now and auto keywords (#1008 <https://github.com/ros2/ros2cli/issues/1008>) (#1010 <https://github.com/ros2/ros2cli/issues/1010>)
* Conditional deserialization of message for ros2 topic hz (backport #1005 <https://github.com/ros2/ros2cli/issues/1005>) (#1007 <https://github.com/ros2/ros2cli/issues/1007>)
* Contributors: mergify[bot]
```
