### PR TITLE
rviz: 11.2.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9940,7 +9940,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.18-1
+      version: 11.2.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.19-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `11.2.18-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Postpone hiding of properties until insertion into model is finished (backport #1508 <https://github.com/ros2/rviz/issues/1508>) (#1522 <https://github.com/ros2/rviz/issues/1522>)
* Don't hide rows of properties not within the model (backport #1507 <https://github.com/ros2/rviz/issues/1507>) (#1519 <https://github.com/ros2/rviz/issues/1519>)
* Remove redundant check (#1506 <https://github.com/ros2/rviz/issues/1506>) (#1513 <https://github.com/ros2/rviz/issues/1513>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Better handling of missing transport plugins (#1488 <https://github.com/ros2/rviz/issues/1488>) (#1516 <https://github.com/ros2/rviz/issues/1516>)
* Add symbol visibility macros to make*Palette public functions (backport #1492 <https://github.com/ros2/rviz/issues/1492>) (#1501 <https://github.com/ros2/rviz/issues/1501>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
