### PR TITLE
sros2: 0.10.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10614,7 +10614,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.10.6-1
+      version: 0.10.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.10.7-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.6-1`

## sros2

```
* suppress multi-threaded warnings. (#346 <https://github.com/ros2/sros2/issues/346>) (#351 <https://github.com/ros2/sros2/issues/351>)
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
