### PR TITLE
rosbag2: 0.15.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9112,7 +9112,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.14-1
+      version: 0.15.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.15-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.15.14-1`

## mcap_vendor

- No changes

## ros2bag

```
* [Humble] Fix for failing test_record_qos_profiles on Windows (backport #1949 <https://github.com/ros2/rosbag2/issues/1949>) (#2011 <https://github.com/ros2/rosbag2/issues/2011>)
* Contributors: mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* [humble] Bugfix: ros2 bag convert dropping messages with compression mode message (backport #1975 <https://github.com/ros2/rosbag2/issues/1975>) (#2012 <https://github.com/ros2/rosbag2/issues/2012>)
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_py

```
* [humble] Bugfix: ros2 bag convert dropping messages with compression mode message (backport #1975 <https://github.com/ros2/rosbag2/issues/1975>) (#2012 <https://github.com/ros2/rosbag2/issues/2012>)
* Contributors: mergify[bot]
```

## rosbag2_storage

```
* Bugfix: Undefined behavior in the rosbag2_storage and rosbag2_storage_sqlite3 packages (#1997 <https://github.com/ros2/rosbag2/issues/1997>) (#2000 <https://github.com/ros2/rosbag2/issues/2000>)
* Contributors: mergify[bot]
```

## rosbag2_storage_default_plugins

```
* Bugfix: Undefined behavior in the rosbag2_storage and rosbag2_storage_sqlite3 packages (#1997 <https://github.com/ros2/rosbag2/issues/1997>) (#2000 <https://github.com/ros2/rosbag2/issues/2000>)
* Contributors: mergify[bot]
```

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [humble] Bugfix: ros2 bag convert dropping messages with compression mode message (backport #1975 <https://github.com/ros2/rosbag2/issues/1975>) (#2012 <https://github.com/ros2/rosbag2/issues/2012>)
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
