### PR TITLE
turtlebot3_home_service_challenge: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11281,7 +11281,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3_home_service_challenge-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3_home_service_challenge` to `1.0.5-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3_home_service_challenge.git
- release repository: https://github.com/ros2-gbp/turtlebot3_home_service_challenge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.4-1`

## turtlebot3_home_service_challenge

```
* Added a missing buildtool_depend (ament_cmake) to the package.xml of turtlebot3_home_service_challenge_tools
* Contributors: Hyungyu Kim
```

## turtlebot3_home_service_challenge_aruco

```
* None
```

## turtlebot3_home_service_challenge_core

```
* None
```

## turtlebot3_home_service_challenge_manipulator

```
* None
```

## turtlebot3_home_service_challenge_tools

```
* Added a missing buildtool_depend (ament_cmake) to the package.xml of turtlebot3_home_service_challenge_tools
* Contributors: Hyungyu Kim
```
