### PR TITLE
Add pip version of typing-extensions package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10676,6 +10676,10 @@ python3-typing-extensions:
     bionic:
       pip:
         packages: [typing-extensions]
+python3-typing-extensions-pip:
+  '*':
+    pip:
+      packages: [typing-extensions]
 python3-tz:
   alpine: [py3-tz]
   arch: [python-pytz]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

typing-extensions (pip package)

## Package Upstream Source:

[https://github.com/python/typing_extensions](https://github.com/python/typing_extensions)

## Purpose of using this:

typing-extensions is a Python module that serves two related purposes:
- Enable use of new type system features on older Python versions. For example, typing.TypeGuard is new in Python 3.10, but typing_extensions allows users on previous Python versions to use it too.
- Enable experimentation with new type system PEPs before they are accepted and added to the typing module.

Note: A rosdep package already exists for the system package `python3-typing-extensions`; however, this PR adds the pip version, as the system package often contains outdated versions of the package, which prevents modern type annotations from being available.

Distro packaging links:

## Links to Distribution Packages

- Python:
  - https://pypi.org/project/typing-extensions/