### PR TITLE
Add pip version of docker package

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5719,6 +5719,10 @@ python3-docker:
   rhel:
     '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
+python3-docker-pip:
+  '*':
+    pip:
+      packages: [docker]
 python3-docopt:
   arch: [python-docopt]
   debian: [python3-docopt]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

docker (pip package)

## Package Upstream Source:

[https://github.com/docker/docker-py](https://github.com/docker/docker-py)

## Purpose of using this:

docker-py is a Python library for the Docker Engine API. It lets you do anything the docker command does, but from within Python apps – run containers, manage containers, manage Swarms, etc.

Note: A rosdep package already exists for the system package python3-docker; however, this PR adds the pip version, as the system package often contains outdated versions of the package, which are missing important bug fixes and new features. 

Distro packaging links:

## Links to Distribution Packages

- Python:
  - [https://pypi.org/project/docker/](https://pypi.org/project/docker/)