### PR TITLE
marti_common: 3.8.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4438,7 +4438,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.8.5-1
+      version: 3.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.8.6-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.5-1`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

- No changes

## swri_opencv_util

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_transform_util

```
* Switch to using yaml_cpp_vendor (#784 <https://github.com/swri-robotics/marti_common/issues/784>)
  * switch to yaml_cpp_vendor to ensure that the version that is used is the same as is used in core ros packages
  ---------
  Co-authored-by: Mark B. Allan <mailto:Mark.B.Allan@nasa.gov>
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Contributors: Mark B. Allan
```
