### PR TITLE
dynamixel_hardware_interface: 1.4.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2169,7 +2169,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
-      version: 1.4.9-1
+      version: 1.4.10-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `1.4.10-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.9-1`

## dynamixel_hardware_interface

```
* Added unit system to model files
* Added support for Dynamixel Y Error Code handling
* Contributors: Woojin Wie
```
