### PR TITLE
hebi_cpp_api: 3.13.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3419,7 +3419,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
-      version: 3.12.3-1
+      version: 3.13.0-3
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api` to `3.13.0-3`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/ros2-gbp/hebi_cpp_api-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.12.3-1`

## hebi_cpp_api

```
* Add non-const Group and EndEffector getters to Arm class, and Group getters to EndEffector class
* Added Arm.setEndEffector function to allow explicitly adding an end effector to an Arm object after construction
* Improved joint limit objective function stability/behavior; C++ API now has additional tuning parameter to control edge behavior
* Added time heuristic functions for choosing waypoint times (also exposed in C++ API along with trajectory time conversion methods)
* Unicast addresses can be passed into the hebiLookup object in addition to broadcast interfaces
* Added RobotModel.getMaxSpeeds and .getMaxEfforts functions to get max speeds and efforts for DoFs
* Added Group.logUserState function to write a timestamped UserState event directly to the log file (can be viewed in Scope plots)
* Added Trajectory.getMinMaxPosition, getMaxVelocity, and getMaxAcceleration functions to get extrema of the trajectory without needing to sample
* Update CMake minimum version to 3.10 to avoid compatibility/deprecation warnings on more recent versions
* Support v1.1 of the [HEBI robot config format](https://github.com/hebirobotics/robot-config), adding command lifetime and feedback frequency parameters to the config file
* add enums for T-5/8 and R/T-25 actuators and accessories.  These are used with functional RobotModel construction methods as well as getting RobotModel metadata
* Update C API to v2.20
* Suppressed uninitialized member warnings
* Contributors: Hariharan Ravichandran, Matthew Tesch, G.V. Keerthi
```
