### PR TITLE
control_msgs: 6.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1173,7 +1173,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 6.3.0-1
+      version: 6.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `6.4.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.3.0-1`

## control_msgs

```
* Add messages for motion primitives (#228 <https://github.com/ros-controls/control_msgs/issues/228>)
* Add message to control a robot via linear velocity and steering position (#217 <https://github.com/ros-controls/control_msgs/issues/217>)
* Contributors: Felix Exner, wittenator
```
