### PR TITLE
control_msgs: 5.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1520,7 +1520,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.4.1-1
+      version: 5.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.5.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.4.1-1`

## control_msgs

```
* Add messages for motion primitives (#228 <https://github.com/ros-controls/control_msgs/issues/228>) (#230 <https://github.com/ros-controls/control_msgs/issues/230>)
* Contributors: Felix Exner
```
