### PR TITLE
filters: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1929,7 +1929,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/filters-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `filters` to `2.2.2-1`:

- upstream repository: https://github.com/ros/filters.git
- release repository: https://github.com/ros2-gbp/filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## filters

```
* Added throw on unconfigured update call
* Added chain length getter with tests
* Make filters compile with MSVC
* Contributors: Christoph Froehlich, oscarmartinez
```
