### PR TITLE
ur_client_library: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9182,7 +9182,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## ur_client_library

```
* Remove print statement when executing optimovel primitives (#365 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/365>)
* Remove SDK version mapping (#355 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/355>)
* Support optimove motions in InstructionExecutor (#354 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/354>)
* Initialize ReverseInterface with a config struct (#351 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/351>)
* Join thread_move instead of killing it (#349 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/349>)
* Fix external_control urcapx version to 0.1.0 for PolyScope 10.7.0 (#350 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/350>)
* Contributors: Felix Exner
```
