### PR TITLE
ros2_controllers: 2.49.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8706,7 +8706,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.48.0-1
+      version: 2.49.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.49.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.48.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Update description of limit() function in speed_limiter (backport #1793 <https://github.com/ros-controls/ros2_controllers/issues/1793>) (#1794 <https://github.com/ros-controls/ros2_controllers/issues/1794>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Fix format (#1821 <https://github.com/ros-controls/ros2_controllers/issues/1821>)
* [JTC] added time_from_start to action feedback (#1755 <https://github.com/ros-controls/ros2_controllers/issues/1755>)
* Contributors: Bence Magyar, Michael Wrock
```

## mecanum_drive_controller

```
* Mecanum Drive: Populate the pose covariance matrix (backport #1772 <https://github.com/ros-controls/ros2_controllers/issues/1772>) (#1806 <https://github.com/ros-controls/ros2_controllers/issues/1806>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* fix rqt_joint_trajectory_controller for robots with namespace (backport #1792 <https://github.com/ros-controls/ros2_controllers/issues/1792>) (#1802 <https://github.com/ros-controls/ros2_controllers/issues/1802>)
* Contributors: mergify[bot]
```

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
