### PR TITLE
ros2_control: 5.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6624,7 +6624,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.3.0-1
+      version: 5.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.3.0-1`

## controller_interface

- No changes

## controller_manager

```
* Increase controller period tolerance further (#2405 <https://github.com/ros-controls/ros2_control/issues/2405>)
* Fix controller activation crash on macOS (Fixes #604 <https://github.com/ros-controls/ros2_control/issues/604>) (#2391 <https://github.com/ros-controls/ros2_control/issues/2391>)
* Increase controller period tolerance in tests (#2388 <https://github.com/ros-controls/ros2_control/issues/2388>)
* [spawner] Fix Lock timeout error crashes (#2386 <https://github.com/ros-controls/ros2_control/issues/2386>)
* [Spawner] Fix the scope issue of the logger (#2382 <https://github.com/ros-controls/ros2_control/issues/2382>)
* Increase tolerance to improve the success rate of the tests (#2373 <https://github.com/ros-controls/ros2_control/issues/2373>)
* [Spawner] Change strategy for --unload-on-kill option (#2372 <https://github.com/ros-controls/ros2_control/issues/2372>)
* Contributors: Dhruv Patel, Jasper van Brakel, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Delete copy constructor and copy and move operators (#2378 <https://github.com/ros-controls/ros2_control/issues/2378>)
* Fix the crashing joint limiters when used with multiple interfaces (#2371 <https://github.com/ros-controls/ros2_control/issues/2371>)
* add changes to cast the other data types to double (#2360 <https://github.com/ros-controls/ros2_control/issues/2360>)
* Addition of a Default Node for Hardware Component (#2348 <https://github.com/ros-controls/ros2_control/issues/2348>)
* Add pixi workflow and dependency file (#2338 <https://github.com/ros-controls/ros2_control/issues/2338>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Soham Patil
```

## hardware_interface_testing

```
* Addition of a Default Node for Hardware Component (#2348 <https://github.com/ros-controls/ros2_control/issues/2348>)
* Contributors: Soham Patil
```

## joint_limits

```
* Fix the crashing joint limiters when used with multiple interfaces (#2371 <https://github.com/ros-controls/ros2_control/issues/2371>)
* Contributors: Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Fix setuptools deprecations (#2395 <https://github.com/ros-controls/ros2_control/issues/2395>)
* Contributors: mosfet80
```

## rqt_controller_manager

```
* Fix setuptools deprecations (#2395 <https://github.com/ros-controls/ros2_control/issues/2395>)
* Contributors: mosfet80
```

## transmission_interface

- No changes
