### PR TITLE
ros2_control: 4.34.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7671,7 +7671,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.33.0-1
+      version: 4.34.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.34.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.33.0-1`

## controller_interface

- No changes

## controller_manager

```
* Further Struct based Method changes to support propagation in gz_ros2_control (backport #2340 <https://github.com/ros-controls/ros2_control/issues/2340>) (#2407 <https://github.com/ros-controls/ros2_control/issues/2407>)
* Shift to Struct based Method and Constructors, with Executor passed from CM to on_init() (#2323 <https://github.com/ros-controls/ros2_control/issues/2323>) (#2339 <https://github.com/ros-controls/ros2_control/issues/2339>)
* Increase controller period tolerance further (#2405 <https://github.com/ros-controls/ros2_control/issues/2405>) (#2406 <https://github.com/ros-controls/ros2_control/issues/2406>)
* Fix controller activation crash on macOS (Fixes #604 <https://github.com/ros-controls/ros2_control/issues/604>) (#2391 <https://github.com/ros-controls/ros2_control/issues/2391>) (#2396 <https://github.com/ros-controls/ros2_control/issues/2396>)
* Increase controller period tolerance in tests (#2388 <https://github.com/ros-controls/ros2_control/issues/2388>) (#2389 <https://github.com/ros-controls/ros2_control/issues/2389>)
* [spawner] Fix Lock timeout error crashes (#2386 <https://github.com/ros-controls/ros2_control/issues/2386>) (#2387 <https://github.com/ros-controls/ros2_control/issues/2387>)
* [Spawner] Fix the scope issue of the logger (#2382 <https://github.com/ros-controls/ros2_control/issues/2382>) (#2383 <https://github.com/ros-controls/ros2_control/issues/2383>)
* Increase tolerance to improve the success rate of the tests (#2373 <https://github.com/ros-controls/ros2_control/issues/2373>) (#2377 <https://github.com/ros-controls/ros2_control/issues/2377>)
* [Spawner] Change strategy for --unload-on-kill option (#2372 <https://github.com/ros-controls/ros2_control/issues/2372>) (#2376 <https://github.com/ros-controls/ros2_control/issues/2376>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Cleanup old internal API (#2346 <https://github.com/ros-controls/ros2_control/issues/2346>) (#2358 <https://github.com/ros-controls/ros2_control/issues/2358>)
* Add deprecations to old methods not using Structs  (backport #2344 <https://github.com/ros-controls/ros2_control/issues/2344>) (#2359 <https://github.com/ros-controls/ros2_control/issues/2359>)
* Further Struct based Method changes to support propagation in gz_ros2_control (backport #2340 <https://github.com/ros-controls/ros2_control/issues/2340>) (#2407 <https://github.com/ros-controls/ros2_control/issues/2407>)
* Delete copy constructor and copy and move operators (backport #2378 <https://github.com/ros-controls/ros2_control/issues/2378>) (#2404 <https://github.com/ros-controls/ros2_control/issues/2404>)
* Shift to Struct based Method and Constructors, with Executor passed from CM to on_init() (#2323 <https://github.com/ros-controls/ros2_control/issues/2323>) (#2339 <https://github.com/ros-controls/ros2_control/issues/2339>)
* Fix the crashing joint limiters when used with multiple interfaces (#2371 <https://github.com/ros-controls/ros2_control/issues/2371>) (#2398 <https://github.com/ros-controls/ros2_control/issues/2398>)
* Add pixi workflow and dependency file (#2338 <https://github.com/ros-controls/ros2_control/issues/2338>) (#2364 <https://github.com/ros-controls/ros2_control/issues/2364>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Add deprecations to old methods not using Structs  (backport #2344 <https://github.com/ros-controls/ros2_control/issues/2344>) (#2359 <https://github.com/ros-controls/ros2_control/issues/2359>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Fix the crashing joint limiters when used with multiple interfaces (#2371 <https://github.com/ros-controls/ros2_control/issues/2371>) (#2398 <https://github.com/ros-controls/ros2_control/issues/2398>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
