### PR TITLE
rosidlcpp: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8404,6 +8404,35 @@ repositories:
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
       version: jazzy
     status: developed
+  rosidlcpp:
+    doc:
+      type: git
+      url: https://github.com/TonyWelte/rosidlcpp.git
+      version: jazzy
+    release:
+      packages:
+      - rosidlcpp
+      - rosidlcpp_generator_c
+      - rosidlcpp_generator_core
+      - rosidlcpp_generator_cpp
+      - rosidlcpp_generator_py
+      - rosidlcpp_generator_type_description
+      - rosidlcpp_parser
+      - rosidlcpp_typesupport_c
+      - rosidlcpp_typesupport_cpp
+      - rosidlcpp_typesupport_fastrtps_c
+      - rosidlcpp_typesupport_fastrtps_cpp
+      - rosidlcpp_typesupport_introspection_c
+      - rosidlcpp_typesupport_introspection_cpp
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidlcpp-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/Tonywelte/rosidlcpp.git
+      version: jazzy
+    status: developed
   rospy_message_converter:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.3.0-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

```
* Add ros_environment dependency to fix missing ROS_DISTRO variable (#13 <https://github.com/TonyWelte/rosidlcpp/issues/13>)
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_core

```
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_cpp

```
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_py

```
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_type_description

- No changes

## rosidlcpp_parser

```
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_c

```
* Add ros_environment dependency to fix missing ROS_DISTRO variable (#13 <https://github.com/TonyWelte/rosidlcpp/issues/13>)
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_cpp

```
* Add ros_environment dependency to fix missing ROS_DISTRO variable (#13 <https://github.com/TonyWelte/rosidlcpp/issues/13>)
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_c

```
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_cpp

```
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_c

```
* Add ros_environment dependency to fix missing ROS_DISTRO variable (#13 <https://github.com/TonyWelte/rosidlcpp/issues/13>)
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_cpp

```
* Add ros_environment dependency to fix missing ROS_DISTRO variable (#13 <https://github.com/TonyWelte/rosidlcpp/issues/13>)
* Fix compilation on RHEL9 (#12 <https://github.com/TonyWelte/rosidlcpp/issues/12>)
* Add jazzy support (#11 <https://github.com/TonyWelte/rosidlcpp/issues/11>)
* Contributors: Anthony Welte
```
