### PR TITLE
control_toolbox: 5.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1232,7 +1232,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.5.0-1
+      version: 5.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.6.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.5.0-1`

## control_toolbox

```
* Deprecate prefix_is_for_params of PidROS (#431 <https://github.com/ros-controls/control_toolbox/issues/431>)
* Fix integral action for AntiWindupStrategy::NONE (#432 <https://github.com/ros-controls/control_toolbox/issues/432>)
* Update description of limit() function in rate_limiter (#425 <https://github.com/ros-controls/control_toolbox/issues/425>)
* Update documentation of PID class (#388 <https://github.com/ros-controls/control_toolbox/issues/388>)
* Contributors: Aarav Gupta, Christoph Fröhlich, Victor Coutinho Vieira Santos
```
