### PR TITLE
control_toolbox: 4.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1535,7 +1535,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.5.0-1
+      version: 4.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.6.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.5.0-1`

## control_toolbox

```
* Deprecate prefix_is_for_params of PidROS (backport #431 <https://github.com/ros-controls/control_toolbox/issues/431>) (#434 <https://github.com/ros-controls/control_toolbox/issues/434>)
* Fix integral action for AntiWindupStrategy::NONE (#432 <https://github.com/ros-controls/control_toolbox/issues/432>) (#433 <https://github.com/ros-controls/control_toolbox/issues/433>)
* Update description of limit() function in rate_limiter (#425 <https://github.com/ros-controls/control_toolbox/issues/425>) (#429 <https://github.com/ros-controls/control_toolbox/issues/429>)
* Update documentation of PID class (backport #388 <https://github.com/ros-controls/control_toolbox/issues/388>) (#423 <https://github.com/ros-controls/control_toolbox/issues/423>)
* Contributors: Christoph Fröhlich
```
