### PR TITLE
librealsense2: 2.56.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3574,6 +3574,20 @@ repositories:
       url: https://github.com/norlab-ulaval/libpointmatcher.git
       version: master
     status: maintained
+  librealsense2:
+    doc:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/librealsense2-release.git
+      version: 2.56.4-1
+    source:
+      type: git
+      url: https://github.com/IntelRealSense/librealsense.git
+      version: master
   libstatistics_collector:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.56.4-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/ros2-gbp/librealsense2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
