### PR TITLE
librealsense2: 2.56.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4713,8 +4713,8 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.55.1-1
+      url: https://github.com/ros2-gbp/librealsense2-release.git
+      version: 2.56.4-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.56.4-1`:

- upstream repository: https://github.com/IntelRealSense/librealsense.git
- release repository: https://github.com/ros2-gbp/librealsense2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.55.1-1`
