### PR TITLE
canboat_vendor: 0.0.3-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -882,11 +882,12 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/canboat_vendor-release.git
-      version: 0.0.2-1
+      version: 0.0.3-2
     source:
       type: git
       url: https://github.com/robotic-esp/canboat_vendor.git
       version: master
+    status: developed
   cartographer:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `canboat_vendor` to `0.0.3-2`:

- upstream repository: https://github.com/robotic-esp/canboat_vendor.git
- release repository: https://github.com/ros2-gbp/canboat_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.2-1`

## canboat_vendor

```
* Add license headers
* Explicitly enumerate every program to install since newer versions of CMake won't take a directory as an argument here
* Switch to using install() in hopes that Jenkins build doesn't break
* Honour DESTDIR to prevent installs into protected /opt directory
* Contributors: Severn Lortie
```
