### PR TITLE
rmf_traffic_editor: 1.14.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6318,7 +6318,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.12.0-1
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic_editor` to `1.14.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic_editor.git
- release repository: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.12.0-1`

## rmf_building_map_tools

```
* Download models through Gazebo (#535 <https://github.com/open-rmf/rmf_traffic_editor/issues/535>)
  Co-authored-by: Grey <mailto:mxgrey@intrinsic.ai>
* Contributors: Luca Della Vedova
```

## rmf_traffic_editor

```
* Fix bug in angle difference calculation near ±π (#538 <https://github.com/open-rmf/rmf_traffic_editor/issues/538>)
* Contributors: kj
```

## rmf_traffic_editor_assets

- No changes

## rmf_traffic_editor_test_maps

```
* Download models through Gazebo (#535 <https://github.com/open-rmf/rmf_traffic_editor/issues/535>)
  Co-authored-by: Grey <mailto:mxgrey@intrinsic.ai>
* Contributors: Luca Della Vedova
```
