### PR TITLE
rmf_demos: 2.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6191,7 +6191,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.5.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `2.8.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## rmf_demos

```
* Add mutex group supervisor to common launch file (#310 <https://github.com/open-rmf/rmf_demos/issues/310>)
  Co-authored-by: yadunund <mailto:yadunund@intrinsic.ai>
* Contributors: Grey
```

## rmf_demos_assets

- No changes

## rmf_demos_bridges

- No changes

## rmf_demos_fleet_adapter

```
* Generate new cmd_id for stop request (#294 <https://github.com/open-rmf/rmf_demos/pull/294>)
* Contributors: Cheng-Wei Chen
```

## rmf_demos_gz

```
* Use builtin gazebo model downloading (#307 <https://github.com/open-rmf/rmf_demos/issues/307>)
* Contributors: Luca Della Vedova
```

## rmf_demos_maps

```
* Use builtin gazebo model downloading (#307 <https://github.com/open-rmf/rmf_demos/issues/307>)
* Contributors: Luca Della Vedova
```

## rmf_demos_tasks

- No changes
