### PR TITLE
Remove pybind11-json-vendor package from rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5488,16 +5488,11 @@ repositories:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
       version: main
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
       version: main
-    status: developed
+    status: unmaintained
   pybind11_vendor:
     doc:
       type: git


### PR DESCRIPTION
This PR removes the `pybind11-json-vendor` package from Rolling and marks it as unmaintained.

The package was used in the Open-RMF project but since it was vendored a system dependency was added to Ubuntu, the package migrated to it and it is now archived https://github.com/open-rmf/pybind11_json_vendor/