### PR TITLE
ros2_controllers: 5.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6727,7 +6727,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.3.0-1
+      version: 5.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.3.0-1`

## ackermann_steering_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## admittance_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## bicycle_steering_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## diff_drive_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## effort_controllers

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## force_torque_sensor_broadcaster

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## forward_command_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Reject non-finite values in forward controller subscriber callback (#1815 <https://github.com/ros-controls/ros2_controllers/issues/1815>)
* Contributors: Sanjeev Kumar, kaizen
```

## gpio_controllers

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## mecanum_drive_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## parallel_gripper_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## pid_controller

```
* Apply API change of PidROS (#1823 <https://github.com/ros-controls/ros2_controllers/issues/1823>)
* Change the tests to work without deprecated PID settings (#1824 <https://github.com/ros-controls/ros2_controllers/issues/1824>)
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## pose_broadcaster

- No changes

## position_controllers

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## tricycle_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## tricycle_steering_controller

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```

## velocity_controllers

```
* Use new handles API in ros2_controllers to fix deprecation warnings (#1566 <https://github.com/ros-controls/ros2_controllers/issues/1566>)
* Contributors: Sanjeev Kumar
```
