### PR TITLE
Add missing nixos rosdep rules

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -203,6 +203,7 @@ atlas:
   fedora: [atlas-devel]
   gentoo: [sci-libs/atlas]
   macports: [atlas]
+  nixos: [atlas]
   rhel: [atlas-devel]
   ubuntu: [libatlas-base-dev]
 autoconf:
@@ -3763,6 +3764,7 @@ libfftw3:
 libfl-dev:
   debian: [libfl-dev]
   fedora: [libfl-devel]
+  nixos: [flex]
   opensuse: [libfl-devel]
   ubuntu: [libfl-dev]
 libflann:
@@ -4454,6 +4456,7 @@ libiio-dev:
   debian: [libiio-dev]
   fedora: [libiio-devel]
   gentoo: [net-libs/libiio]
+  nixos: [libiio]
   ubuntu: [libiio-dev]
 libimage-exiftool-perl:
   arch: [perl-image-exiftool]
@@ -8997,6 +9000,7 @@ sound-theme-freedesktop:
   debian: [sound-theme-freedesktop]
   fedora: [sound-theme-freedesktop]
   gentoo: [x11-themes/sound-theme-freedesktop]
+  nixos: [sound-theme-freedesktop]
   openembedded: [sound-theme-freedesktop@meta-oe]
   ubuntu: [sound-theme-freedesktop]
 sox:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4979,6 +4979,7 @@ python3-asyncssh:
 python3-attrs:
   debian: [python3-attr]
   fedora: [python3-attrs]
+  nixos: [python3Packages.attrs]
   opensuse: [python3-attrs]
   rhel: [python3-attrs]
   ubuntu: [python3-attr]
@@ -6697,6 +6698,7 @@ python3-httpx:
   debian: [python3-httpx]
   fedora: [python3-httpx]
   gentoo: [dev-python/httpx]
+  nixos: [python3Packages.httpx]
   osx:
     pip:
       packages: [httpx]
@@ -7219,6 +7221,7 @@ python3-marisa:
   debian: [python3-marisa]
   fedora: [python3-marisa]
   gentoo: [dev-libs/marisa]
+  nixos: [python3Packages.marisa]
   ubuntu: [python3-marisa]
 python3-markdown:
   debian: [python3-markdown]
@@ -7456,6 +7459,7 @@ python3-msgpack-numpy:
   fedora:
     pip:
       packages: [msgpack-numpy]
+  nixos: [python3Packages.msgpack-numpy]
   opensuse: [python3-msgpack-numpy]
   osx:
     pip:
@@ -8201,6 +8205,7 @@ python3-pkg-resources:
 python3-platformdirs:
   debian: [python3-platformdirs]
   fedora: [python3-platformdirs]
+  nixos: [python3Packages.platformdirs]
   rhel:
     '*': [python3-platformdirs]
     '8': null
@@ -8511,6 +8516,7 @@ python3-pydot:
   ubuntu: [python3-pydot]
 python3-pydub:
   debian: [python3-pydub]
+  nixos: [python3Packages.pydub]
   opensuse: [python3-pydub]
   ubuntu: [python3-pydub]
 python3-pyee:
@@ -9848,6 +9854,7 @@ python3-setproctitle:
   debian: [python3-setproctitle]
   fedora: [python3-setproctitle]
   gentoo: [dev-python/setproctitle]
+  nixos: [python3Packages.setproctitle]
   opensuse: [python3-setproctitle]
   osx:
     pip:
@@ -10099,6 +10106,7 @@ python3-sounddevice-pip:
       packages: [sounddevice]
 python3-soundfile:
   debian: [python3-soundfile]
+  nixos: [python3Packages.soundfile]
   ubuntu: [python3-soundfile]
 python3-sparkfun-ublox-gps-pip:
   debian:
@@ -10732,6 +10740,7 @@ python3-unidecode:
   debian: [python3-unidecode]
   fedora: [python3-unidecode]
   gentoo: [dev-python/unidecode]
+  nixos: [python3Packages.unidecode]
   osx:
     pip:
       packages: [unidecode]
@@ -10973,6 +10982,7 @@ python3-wheel:
   debian: [python3-wheel]
   fedora: [python3-wheel]
   gentoo: [dev-python/wheel]
+  nixos: [python3Packages.wheel]
   opensuse: [python3-wheel]
   rhel: [python3-wheel]
   ubuntu: [python3-wheel]


### PR DESCRIPTION
Links to distribution packages:
https://search.nixos.org/packages?channel=unstable&show=atlas
https://search.nixos.org/packages?channel=unstable&show=flex
https://search.nixos.org/packages?channel=unstable&show=libiio
https://search.nixos.org/packages?channel=unstable&show=sound-theme-freedesktop
https://search.nixos.org/packages?channel=unstable&show=python312Packages.attrs
https://search.nixos.org/packages?channel=unstable&show=python312Packages.httpx
https://search.nixos.org/packages?channel=unstable&show=python312Packages.marisa
https://search.nixos.org/packages?channel=unstable&show=python312Packages.msgpack-numpy
https://search.nixos.org/packages?channel=unstable&show=python312Packages.platformdirs
https://search.nixos.org/packages?channel=unstable&show=python312Packages.pydub
https://search.nixos.org/packages?channel=unstable&show=python312Packages.setproctitle
https://search.nixos.org/packages?channel=unstable&show=python312Packages.soundfile
https://search.nixos.org/packages?channel=unstable&show=python312Packages.unidecode
https://search.nixos.org/packages?channel=unstable&show=python312Packages.wheel