### PR TITLE
clearpath_ros2_socketcan_interface: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1533,7 +1533,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_ros2_socketcan_interface` to `1.0.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface.git
- release repository: https://github.com/clearpath-gbp/clearpath_ros2_socketcan_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-1`

## clearpath_ros2_socketcan_interface

```
* Backports (#16 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/16>)
  * Prefix node names with can interface
  * Wait for interface to be up before launching node (#7 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/7>)
  * Wait for interface to be UP before starting node
  * Fix: Multiple IncludeLaunchDescription (#9 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/9>)
  * Use opaque function
  * Add import and context
  * Type performed context
  * Reattempt transitions on failure (#10 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/10>)
  * Reattempt lifecycle transitions on failure
  * Unique activator node names
  * Removed namespace from node name
  * Linting
  * Use arguments instead of perform(context) (#11 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/11>)
  * Fix: Use script instead of OpaqueFunction (#12 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/12>)
  * Use script instead of OpaqueFunction
  * Add missing line
  * Add license header
  * Add EOF line
  * Add retry in the event lifecycle service is not up yet
  * Fix: Spin Timeout (#13 <https://github.com/clearpathrobotics/clearpath_ros2_socketcan_interface/issues/13>)
  * Add timeout to spin to prevent script from waiting when node has failed
  * Update log to match appropriate action
  * Fixed using a global namespace.
  ---------
  Co-authored-by: Roni Kreinin <mailto:rkreinin@clearpathrobotics.com>
  Co-authored-by: Roni Kreinin <mailto:59886299+roni-kreinin@users.noreply.github.com>
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: luis-camero
```
