### PR TITLE
add python3 redis

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9438,10 +9438,10 @@ python3-rdflib:
   ubuntu: [python3-rdflib]
 python3-redis:
   debian: [python3-redis]
-  ubuntu: [python3-redis]
-  rhel: [python3-redis]
   fedora: [python3-redis]
   opensuse: [python3-redis]
+  rhel: [python3-redis]
+  ubuntu: [python3-redis]
 python3-reedsolo:
   arch: [python-reedsolo]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9440,6 +9440,8 @@ python3-redis:
   debian: [python3-redis]
   ubuntu: [python3-redis]
   rhel: [python3-redis]
+  fedora: [python3-redis]
+  opensuse: [python3-redis]
 python3-reedsolo:
   arch: [python-reedsolo]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9426,6 +9426,7 @@ python3-rdflib:
 python3-redis:
   debian: [python3-redis]
   ubuntu: [python3-redis]
+  rhel: [python3-redis]
 python3-reedsolo:
   arch: [python-reedsolo]
   debian:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9423,6 +9423,9 @@ python3-rdflib:
   rhel:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
+python3-redis:
+  debian: [python3-redis]
+  ubuntu: [python3-redis]
 python3-reedsolo:
   arch: [python-reedsolo]
   debian:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-redis

## Package Upstream Source:

https://github.com/redis/redis-py

## Purpose of using this:

I want to use Redis to cache ROS data and make it available to other applications. However, the current python-redis is not compatible with Python 3 on recent Ubuntu versions.

relates: https://github.com/ros/rosdistro/issues/46450

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/python3-redis
  - REQUIRED
- Ubuntu: https://launchpad.net/ubuntu/noble/+package/python3-redis
  - REQUIRED

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

