### PR TITLE
Stop requesting gzip encoding of repository metadata

### DIFF
--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -97,7 +97,7 @@ def open_compressed_url(url, retry=2, retry_period=1, timeout=10):
 
     :returns: file-like object for streaming file data.
     """
-    request = Request(url, headers={'Accept-Encoding': 'gzip'})
+    request = Request(url)
     try:
         f = urlopen(request, timeout=timeout)
     except HTTPError as e:


### PR DESCRIPTION
On at least one RPM mirror for AlmaLinux, the server was double-compressing XML with gzip when Accept-Encoding: gzip was used. Until we can make the automatic decompression used here more robust, we should stop requesting that the server perform any extra encoding.