### PR TITLE
geometry2: 0.41.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2232,7 +2232,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.41.1-1
+      version: 0.41.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.41.2-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.41.1-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

```
* Change tf2_ros C to C++ headers (#808 <https://github.com/ros2/geometry2/issues/808>)
* Contributors: Gary Servin
```

## tf2_eigen

```
* Change tf2_ros C to C++ headers (#808 <https://github.com/ros2/geometry2/issues/808>)
* Contributors: Gary Servin
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Change tf2_ros C to C++ headers (#808 <https://github.com/ros2/geometry2/issues/808>)
* Contributors: Gary Servin
```

## tf2_kdl

```
* Change tf2_ros C to C++ headers (#808 <https://github.com/ros2/geometry2/issues/808>)
* Contributors: Gary Servin
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Change tf2_ros C to C++ headers (#808 <https://github.com/ros2/geometry2/issues/808>)
* Contributors: Gary Servin
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Change tf2_ros C to C++ headers (#808 <https://github.com/ros2/geometry2/issues/808>)
* Contributors: Gary Servin
```

## tf2_tools

- No changes
