### PR TITLE
canboat_vendor: 0.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -882,7 +882,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/canboat_vendor-release.git
-      version: 0.0.3-4
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/robotic-esp/canboat_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `canboat_vendor` to `0.0.4-1`:

- upstream repository: https://github.com/robotic-esp/canboat_vendor.git
- release repository: https://github.com/ros2-gbp/canboat_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.3-4`

## canboat_vendor

```
* bugfix: add <buildtool_depend> for git to fix CI envs without it
* Update CMakeLists.txt to wait for build before copy
* Contributors: Severn Lortie
```
