### PR TITLE
leo_robot: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3456,7 +3456,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.2.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.4.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## leo_bringup

```
* Complementary filter improvements (#34 <https://github.com/LeoRover/leo_robot-ros2/issues/34>)
* Contributors: Jan Hernas
```

## leo_filters

```
* Complementary filter improvements (#34 <https://github.com/LeoRover/leo_robot-ros2/issues/34>)
* Contributors: Jan Hernas
```

## leo_fw

```
* Fix node type errors (#35 <https://github.com/LeoRover/leo_robot-ros2/issues/35>)
* Contributors: Błażej Sowa
```

## leo_robot

- No changes
