### PR TITLE
rqt_robot_steering: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9720,7 +9720,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9715,7 +9715,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -9724,7 +9724,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: humble
     status: maintained
   rqt_runtime_monitor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `1.0.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros2-gbp/rqt_robot_steering-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## rqt_robot_steering

```
* Use console_script entrypoint (#12 <https://github.com/ros-visualization/rqt_robot_steering/issues/12>)
* Contributors: Melvin Wang
```
