### PR TITLE
rqt_robot_steering: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8820,7 +8820,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -8829,7 +8829,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: jazzy
     status: maintained
   rqt_runtime_monitor:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8825,7 +8825,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 1.0.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros2-gbp/rqt_robot_steering-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## rqt_robot_steering

```
* Use console_script entrypoint (#12 <https://github.com/ros-visualization/rqt_robot_steering/issues/12>)
  use console_script entrypoint. resolves inability to run in windows.
* Contributors: Melvin Wang
```
