### PR TITLE
rqt_robot_steering: 3.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7799,7 +7799,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 1.0.2-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7794,7 +7794,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -7803,7 +7803,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: kilted
     status: maintained
   rqt_runtime_monitor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `3.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros2-gbp/rqt_robot_steering-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## rqt_robot_steering

```
* Use console_script entrypoint (#12 <https://github.com/ros-visualization/rqt_robot_steering/issues/12>)
  use console_script entrypoint. resolves inability to run in windows.
* Contributors: Melvin Wang
```
