### PR TITLE
rqt_robot_steering: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7772,7 +7772,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -7781,7 +7781,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: dashing-devel
+      version: rolling
     status: maintained
   rqt_runtime_monitor:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7777,7 +7777,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 1.0.2-1
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `4.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros2-gbp/rqt_robot_steering-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.2-1`

## rqt_robot_steering

```
* Added linters (#26 <https://github.com/ros-visualization/rqt_robot_steering/issues/26>)
* Use console_script entrypoint (#12 <https://github.com/ros-visualization/rqt_robot_steering/issues/12>)
* Contributors: Alejandro Hernández Cordero, Melvin Wang
```
