### PR TITLE
mrpt_navigation: 2.2.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4234,7 +4234,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.2.4-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.3-1`

## mrpt_map_server

- No changes

## mrpt_msgs_bridge

```
* fix build against latest tf2
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav_interfaces

- No changes

## mrpt_navigation

- No changes

## mrpt_pf_localization

- No changes

## mrpt_pointcloud_pipeline

- No changes

## mrpt_rawlog

- No changes

## mrpt_reactivenav2d

- No changes

## mrpt_tps_astar_planner

- No changes

## mrpt_tutorials

- No changes
