### PR TITLE
rmf_ros2: 2.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6243,7 +6243,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.10.1-1
+      version: 2.11.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.11.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.10.1-1`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Fix a race condition that can cause an endless loop when waiting for a lift (#449 <https://github.com/open-rmf/rmf_ros2/issues/449>)
* Fix orientation mismatch when !skip_rotation_commands (#422 <https://github.com/open-rmf/rmf_ros2/issues/422>)
* Migrate fleet_adapter to target_link_libraries (#438 <https://github.com/open-rmf/rmf_ros2/issues/438>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_fleet_adapter_python

```
* Remove pybind11 vendored dependencies (#444 <https://github.com/open-rmf/rmf_ros2/issues/444>)
* Add a check for numpy version (#451 <https://github.com/open-rmf/rmf_ros2/pull/451>)
* Contributors: Luca Della Vedova, Arjo Chakravarty
```

## rmf_reservation_node

- No changes

## rmf_task_ros2

```
* Remove deprecated Pose2D message (#450 <https://github.com/open-rmf/rmf_ros2/issues/450>)
* Allow creating Auctioneer with node interfaces to support lifecycle nodes (#420 <https://github.com/open-rmf/rmf_ros2/issues/420>)
* Contributors: Aaron Chong, Luca Della Vedova
```

## rmf_traffic_ros2

```
* Remove deprecated Pose2D message (#450 <https://github.com/open-rmf/rmf_ros2/issues/450>)
* Contributors: Luca Della Vedova
```

## rmf_websocket

- No changes
