### PR TITLE
autoware_lanelet2_extension: 0.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -934,6 +934,10 @@ repositories:
       version: main
     status: developed
   autoware_lanelet2_extension:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+      version: 0.8.0
     release:
       packages:
       - autoware_lanelet2_extension
@@ -941,7 +945,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.7.2-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -937,7 +937,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-      version: 0.8.0
+      version: main
     release:
       packages:
       - autoware_lanelet2_extension


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.8.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.2-1`

## autoware_lanelet2_extension

```
* feat: add linestring with type getter (#73 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/73>)
* fix: skip duplicate marker (#69 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/69>)
  * fix: skip duplicate marker
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Ryohsuke Mitsudome, Zulfaqar Azmi
```

## autoware_lanelet2_extension_python

- No changes
