### PR TITLE
geometry2: 0.25.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3281,7 +3281,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.15-1
+      version: 0.25.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.25.16-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.25.15-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

```
* Change tf2_ros C to C++ headers (backport #807 <https://github.com/ros2/geometry2/issues/807>) (#810 <https://github.com/ros2/geometry2/issues/810>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

```
* Change tf2_ros C to C++ headers (backport #807 <https://github.com/ros2/geometry2/issues/807>) (#810 <https://github.com/ros2/geometry2/issues/810>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tf2_kdl

```
* Change tf2_ros C to C++ headers (backport #807 <https://github.com/ros2/geometry2/issues/807>) (#810 <https://github.com/ros2/geometry2/issues/810>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Change tf2_ros C to C++ headers (backport #807 <https://github.com/ros2/geometry2/issues/807>) (#810 <https://github.com/ros2/geometry2/issues/810>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Change tf2_ros C to C++ headers (backport #807 <https://github.com/ros2/geometry2/issues/807>) (#810 <https://github.com/ros2/geometry2/issues/810>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tf2_tools

- No changes
