### PR TITLE
rqt_graph: 1.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7606,7 +7606,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.8.0-1
+      version: 1.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.8.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`

## rqt_graph

```
* add warning for type incompatibilities (#105 <https://github.com/ros-visualization/rqt_graph/issues/105>)
* Remove rqt_graph script. (#66 <https://github.com/ros-visualization/rqt_graph/issues/66>)
* fix setuptools deprecations (#107 <https://github.com/ros-visualization/rqt_graph/issues/107>)
* Contributors: Chris Lalancette, Jonas Otto, mosfet80
```
