### PR TITLE
rqt_graph: 1.5.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8654,7 +8654,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.5.4-1
+      version: 1.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.5.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.5.4-1`

## rqt_graph

```
* add warning for type incompatibilities (backport #105 <https://github.com/ros-visualization/rqt_graph/issues/105>) (#108 <https://github.com/ros-visualization/rqt_graph/issues/108>)
* Remove CODEOWNERS (backport #102 <https://github.com/ros-visualization/rqt_graph/issues/102>) (#103 <https://github.com/ros-visualization/rqt_graph/issues/103>)
* Contributors: Jonas Otto, mergify[bot]
```
