### PR TITLE
rqt_reconfigure: 1.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7731,7 +7731,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.8.0-1
+      version: 1.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.8.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`

## rqt_reconfigure

```
* fix setuptools deprecation (#153 <https://github.com/ros-visualization/rqt_reconfigure/issues/153>)
* If updating remote fails, reflect the failure locally (#144 <https://github.com/ros-visualization/rqt_reconfigure/issues/144>)
* Contributors: Jonathan Selling, mosfet80
```
