### PR TITLE
image_common: 6.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2909,7 +2909,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.2.2-1
+      version: 6.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.3.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.2.2-1`

## camera_calibration_parsers

```
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>)
* Contributors: mosfet80
```

## camera_info_manager

```
* Deprecated rmw_qos_profile_t in favour of rclcpp::QoS (#364 <https://github.com/ros-perception/image_common/issues/364>)
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## camera_info_manager_py

```
* fix setuptools deprecation (#366 <https://github.com/ros-perception/image_common/issues/366>)
* Contributors: mosfet80
```

## image_common

```
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>)
* Contributors: mosfet80
```

## image_transport

```
* fixed build (#369 <https://github.com/ros-perception/image_common/issues/369>)
* Deprecated rmw_qos_profile_t in favour of rclcpp::QoS (#364 <https://github.com/ros-perception/image_common/issues/364>)
* Removed deprecated code (#356 <https://github.com/ros-perception/image_common/issues/356>)
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## image_transport_py

- No changes
