### PR TITLE
image_transport_plugins: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2957,7 +2957,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 6.0.0-1
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `6.1.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.0.0-1`

## compressed_depth_image_transport

```
* Replace rmw_qos_profile_t with rclcpp::QoS (#193 <https://github.com/ros-perception/image_transport_plugins/issues/193>)
* Contributors: Alejandro Hernández Cordero
```

## compressed_image_transport

```
* Replace rmw_qos_profile_t with rclcpp::QoS (#193 <https://github.com/ros-perception/image_transport_plugins/issues/193>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Replace rmw_qos_profile_t with rclcpp::QoS (#193 <https://github.com/ros-perception/image_transport_plugins/issues/193>)
* Contributors: Alejandro Hernández Cordero
```

## zstd_image_transport

```
* Replace rmw_qos_profile_t with rclcpp::QoS (#193 <https://github.com/ros-perception/image_transport_plugins/issues/193>)
* Contributors: Alejandro Hernández Cordero
```
