### PR TITLE
rqt_image_view: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7640,7 +7640,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_image_view` to `2.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_image_view.git
- release repository: https://github.com/ros2-gbp/rqt_image_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## rqt_image_view

```
* Update cmake requirements (fix cmake derpecation +switch to cxx17) (#81 <https://github.com/ros-visualization/rqt_image_view/issues/81>)
* Replace rmw_qos_profile_t with rclcpp::QoS (#93 <https://github.com/ros-visualization/rqt_image_view/issues/93>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```
