### PR TITLE
rviz: 15.1.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8012,7 +8012,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.6-1
+      version: 15.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.7-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `15.1.6-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Replace deprecated tf2_ros headers (#1529 <https://github.com/ros2/rviz/issues/1529>)
* Postpone hiding of properties until insertion into model is finished (#1508 <https://github.com/ros2/rviz/issues/1508>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Replace rmw_qos_profile_t with rclcpp::QoS (#1525 <https://github.com/ros2/rviz/issues/1525>)
* Replace deprecated tf2_ros headers (#1529 <https://github.com/ros2/rviz/issues/1529>)
* fix deprecated include (#1530 <https://github.com/ros2/rviz/issues/1530>)
* point_cloud_transport update API call (#1526 <https://github.com/ros2/rviz/issues/1526>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

```
* fix cmake deprecation (#1534 <https://github.com/ros2/rviz/issues/1534>)
* Contributors: mosfet80
```

## rviz_visual_testing_framework

```
* Replace deprecated tf2_ros headers (#1529 <https://github.com/ros2/rviz/issues/1529>)
* Contributors: Alejandro Hernández Cordero
```
