### PR TITLE
rviz: 14.1.13-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9096,7 +9096,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.12-1
+      version: 14.1.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.13-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `14.1.12-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Postpone hiding of properties until insertion into model is finished (backport #1508 <https://github.com/ros2/rviz/issues/1508>) (#1521 <https://github.com/ros2/rviz/issues/1521>)
* Don't hide rows of properties not within the model (#1507 <https://github.com/ros2/rviz/issues/1507>) (#1518 <https://github.com/ros2/rviz/issues/1518>)
* Remove redundant check (#1506 <https://github.com/ros2/rviz/issues/1506>) (#1512 <https://github.com/ros2/rviz/issues/1512>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* fix deprecated include (#1530 <https://github.com/ros2/rviz/issues/1530>) (#1532 <https://github.com/ros2/rviz/issues/1532>)
* Better handling of missing transport plugins (#1488 <https://github.com/ros2/rviz/issues/1488>) (#1515 <https://github.com/ros2/rviz/issues/1515>)
* Add symbol visibility macros to make*Palette public functions (#1492 <https://github.com/ros2/rviz/issues/1492>) (#1500 <https://github.com/ros2/rviz/issues/1500>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

```
* Add RVIZ_OGRE_VENDOR_MANGLE_NAME_OF_LIBRARIES_USED_BY_RVIZ option to further mangle ogre libraries used by rviz (#1493 <https://github.com/ros2/rviz/issues/1493>) (#1497 <https://github.com/ros2/rviz/issues/1497>)
* Contributors: mergify[bot]
```

## rviz_rendering

```
* Assign the geometry to the resource group "rviz_rendering" (#1502 <https://github.com/ros2/rviz/issues/1502>) (#1504 <https://github.com/ros2/rviz/issues/1504>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
