### PR TITLE
rosidl: 4.9.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7223,7 +7223,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.0.0-1
+      version: 4.9.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.9.5-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>) (#866 <https://github.com/ros2/rosidl/issues/866>)
* Contributors: Christophe Bedard, Francisco Rossi, Michel Hidalgo
```

## rosidl_cmake

```
* Fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>) (#876 <https://github.com/ros2/rosidl/issues/876>)
* Contributors: mosfet80
```

## rosidl_generator_c

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>) (#866 <https://github.com/ros2/rosidl/issues/866>)
* Contributors: Christophe Bedard, Francisco Rossi, Michel Hidalgo
```

## rosidl_generator_cpp

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>) (#866 <https://github.com/ros2/rosidl/issues/866>)
* Contributors: Christophe Bedard, Francisco Rossi, Michel Hidalgo
```

## rosidl_generator_type_description

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>) (#866 <https://github.com/ros2/rosidl/issues/866>)
* Contributors: Christophe Bedard, Francisco Rossi, Michel Hidalgo
```

## rosidl_parser

```
* Fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>) (#876 <https://github.com/ros2/rosidl/issues/876>)
* Contributors: mosfet80
```

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* Fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>) (#876 <https://github.com/ros2/rosidl/issues/876>)
* Add an ament_cmake_gtest dependency to rosidl_runtime_c (#865 <https://github.com/ros2/rosidl/issues/865>) (#872 <https://github.com/ros2/rosidl/issues/872>)
* Contributors: Chris Lalancette, mosfet80
```

## rosidl_runtime_cpp

```
* Fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>) (#876 <https://github.com/ros2/rosidl/issues/876>)
* Contributors: mosfet80
```

## rosidl_typesupport_interface

```
* Fix cmake <3.10 deprecation (#875 <https://github.com/ros2/rosidl/issues/875>) (#876 <https://github.com/ros2/rosidl/issues/876>)
* Contributors: mosfet80
```

## rosidl_typesupport_introspection_c

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>) (#866 <https://github.com/ros2/rosidl/issues/866>)
* Contributors: Christophe Bedard, Francisco Rossi, Michel Hidalgo
```

## rosidl_typesupport_introspection_cpp

```
* rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>) (#866 <https://github.com/ros2/rosidl/issues/866>)
* Contributors: Christophe Bedard, Francisco Rossi, Michel Hidalgo
```
