### PR TITLE
plotjuggler: 3.10.11-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5178,7 +5178,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.8-1
+      version: 3.10.11-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.10.11-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.10.8-1`

## plotjuggler

```
* Datatamer fix (#1131 <https://github.com/facontidavide/PlotJuggler/issues/1131>)
* new clang format
* Squashed commit of the following:
  Author: Maximilien Naveau <mailto:maximilien.naveau@pal-robotics.com>
  Date:   Thu Jul 24 12:21:39 2025 +0200
  Solve the PALStatistics message parsing in case several topic are
  published.
* Fix Issues on MacOS Compilation (#1125 <https://github.com/facontidavide/PlotJuggler/issues/1125>)
* Add no splash to settings (#1122 <https://github.com/facontidavide/PlotJuggler/issues/1122>)
  * Added option to skip splash screen to settings ini file
  * Added option to preference screen
* provide install rule again from catkin build (#1124 <https://github.com/facontidavide/PlotJuggler/issues/1124>)
  Otherwise catkin install workspaces include everything except for the binary...
* try fix LZ4/ZSTD (#1121 <https://github.com/facontidavide/PlotJuggler/issues/1121>)
* Contributors: Connor Anderson, Davide Faconti, Michael Görner, thenoname
```
