### PR TITLE
fuse: 1.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2748,7 +2748,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.1.2-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.1-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

```
* Remove references to deprecated tf2 and tf2_ros headers (#416 <https://github.com/locusrobotics/fuse/issues/416>)
  * Removed deprecations warnings (#406 <https://github.com/locusrobotics/fuse/issues/406>)
  * Fix linter errors related to header ordering (#407 <https://github.com/locusrobotics/fuse/issues/407>)
  * Update headers for tf2_ros (#417 <https://github.com/locusrobotics/fuse/issues/417>)
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Gary Servin <mailto:gservin@locusrobotics.com>
* Contributors: Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

```
* Remove references to deprecated tf2 and tf2_ros headers (#416 <https://github.com/locusrobotics/fuse/issues/416>)
  * Removed deprecations warnings (#406 <https://github.com/locusrobotics/fuse/issues/406>)
  * Fix linter errors related to header ordering (#407 <https://github.com/locusrobotics/fuse/issues/407>)
  * Update headers for tf2_ros (#417 <https://github.com/locusrobotics/fuse/issues/417>)
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Gary Servin <mailto:gservin@locusrobotics.com>
* Contributors: Stephen Williams
```

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

```
* Remove references to deprecated tf2 and tf2_ros headers (#416 <https://github.com/locusrobotics/fuse/issues/416>)
  * Removed deprecations warnings (#406 <https://github.com/locusrobotics/fuse/issues/406>)
  * Fix linter errors related to header ordering (#407 <https://github.com/locusrobotics/fuse/issues/407>)
  * Update headers for tf2_ros (#417 <https://github.com/locusrobotics/fuse/issues/417>)
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  Co-authored-by: Gary Servin <mailto:gservin@locusrobotics.com>
* Contributors: Stephen Williams
```
