### PR TITLE
fuse: 1.2.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2126,7 +2126,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.2-1
+      version: 1.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.2.4-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.2-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

```
* Fix wrong benchmark target (#418 <https://github.com/locusrobotics/fuse/issues/418>)
  See analogous CMakeLists.txt for fuse_constraints/benchmark and fuse_graph/benchmark
* Update headers for tf2_ros (#417 <https://github.com/locusrobotics/fuse/issues/417>)
* Porting StampedVariableSynchronizer changes to ROS 2 (#414 <https://github.com/locusrobotics/fuse/issues/414>)
  * Porting effort to ROS 2
  * Porting this functionality to ROS 2
  * Responding to comments
* Contributors: David Murdoch, Gary Servin, Patrick Roncagliolo
```

## fuse_msgs

- No changes

## fuse_optimizers

```
* Add diag mapping to rolling (#412 <https://github.com/locusrobotics/fuse/issues/412>)
  * mapping function is added.
  * add unit test for the fixed lag smoother.
  * fix lint warning.
  * fix lint error.
  * lint error fix.
* Contributors: needphpsql
```

## fuse_publishers

```
* Update headers for tf2_ros (#417 <https://github.com/locusrobotics/fuse/issues/417>)
* Porting StampedVariableSynchronizer changes to ROS 2 (#414 <https://github.com/locusrobotics/fuse/issues/414>)
  * Porting effort to ROS 2
  * Porting this functionality to ROS 2
  * Responding to comments
* Contributors: David Murdoch, Gary Servin
```

## fuse_tutorials

- No changes

## fuse_variables

```
* Porting StampedVariableSynchronizer changes to ROS 2 (#414 <https://github.com/locusrobotics/fuse/issues/414>)
  * Porting effort to ROS 2
  * Porting this functionality to ROS 2
  * Responding to comments
* [RST-12952] Modified the loadDeviceId() function to accept optional parameters (#409 <https://github.com/locusrobotics/fuse/issues/409>)
  * Modified the loadDeviceId() function to accept optional parameter names for the device UUID and device name
  * Use the logging interface from the node
* Contributors: David Murdoch, Stephen Williams
```

## fuse_viz

- No changes
