### PR TITLE
fuse: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2166,7 +2166,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.3-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.3.0-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.3-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

- No changes

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

- No changes

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

- No changes
