### PR TITLE
Add MuJoCo MJX entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7486,6 +7486,22 @@ python3-mss-pip:
   '*':
     pip:
       packages: [mss]
+python3-mujoco-mjx-pip:
+  arch:
+    pip:
+      packages: [mujoco-mjx]
+  debian:
+    pip:
+      packages: [mujoco-mjx]
+  fedora:
+    pip:
+      packages: [mujoco-mjx]
+  osx:
+    pip:
+      packages: [mujoco-mjx]
+  ubuntu:
+    pip:
+      packages: [mujoco-mjx]
 python3-mujoco-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7487,19 +7487,7 @@ python3-mss-pip:
     pip:
       packages: [mss]
 python3-mujoco-mjx-pip:
-  arch:
-    pip:
-      packages: [mujoco-mjx]
-  debian:
-    pip:
-      packages: [mujoco-mjx]
-  fedora:
-    pip:
-      packages: [mujoco-mjx]
-  osx:
-    pip:
-      packages: [mujoco-mjx]
-  ubuntu:
+  '*':
     pip:
       packages: [mujoco-mjx]
 python3-mujoco-pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.
Package name:

mujoco-mjx

Package Upstream Source:

https://mujoco.readthedocs.io/en/stable/mjx.html

Purpose of using this:

This package is a re-implementation of the [MuJoCo physics engine](https://github.com/google-deepmind/mujoco) in [JAX](https://github.com/jax-ml/jax). This library is developed and maintained by Google DeepMind and is kept up-to-date with the latest developments in MuJoCo itself.

Links to Distribution Packages

    Python:
       https://pypi.org/project/mujoco-mjx/


Complements https://github.com/ros/rosdistro/pull/46859
