### PR TITLE
adding python bleak

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5088,10 +5088,7 @@ python3-bitstring:
     '7': [python36-bitstring]
   ubuntu: [python3-bitstring]
 python3-bleak:
-  debian:
-    bookworm: [python3-bleak]
-    trixie: [python3-bleak]
-    sid: [python3-bleak]
+  debian: [python3-bleak]
   ubuntu:
     '*': [python3-bleak]
     focal: null

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5088,8 +5088,14 @@ python3-bitstring:
     '7': [python36-bitstring]
   ubuntu: [python3-bitstring]
 python3-bleak:
-  debian: [python3-bleak]
-  ubuntu: [python3-bleak]
+  debian:
+    bookworm: [python3-bleak]
+    trixie:   [python3-bleak]
+    sid:      [python3-bleak]
+  ubuntu:
+    '*':    [python3-bleak]
+    focal:  null
+    jammy:  null
 python3-bloom:
   debian: [python3-bloom]
   rhel:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5087,6 +5087,9 @@ python3-bitstring:
     '*': [python3-bitstring]
     '7': [python36-bitstring]
   ubuntu: [python3-bitstring]
+python3-bleak:
+  debian: [python3-bleak]
+  ubuntu: [python3-bleak]
 python3-bloom:
   debian: [python3-bloom]
   rhel:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5090,12 +5090,12 @@ python3-bitstring:
 python3-bleak:
   debian:
     bookworm: [python3-bleak]
-    trixie:   [python3-bleak]
-    sid:      [python3-bleak]
+    trixie: [python3-bleak]
+    sid: [python3-bleak]
   ubuntu:
-    '*':    [python3-bleak]
-    focal:  null
-    jammy:  null
+    '*': [python3-bleak]
+    focal: null
+    jammy: null
 python3-bloom:
   debian: [python3-bloom]
   rhel:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE -->

Please add the following dependency to the rosdep database.

## Package name:

bleak

## Package Upstream Source:

https://github.com/hbldh/bleak

## Purpose of using this:

This library provides a cross‑platform Python BLE client API. It can be used for BLE/ROS2 integrations.

## Links to Distribution Packages

- **Debian** (bookworm):  
  https://packages.debian.org/bookworm/python3-bleak  
- **Ubuntu** (noble):  
  https://packages.ubuntu.com/noble/python3-bleak
