### PR TITLE
trac_ik: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10018,7 +10018,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `trac_ik` to `2.0.2-1`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik
- release repository: https://github.com/ros2-gbp/trac_ik-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.1-1`

## trac_ik

- No changes

## trac_ik_kinematics_plugin

```
* Add Manipulation3, maximizing smallest singular value (#46 <https://bitbucket.org/traclabs/trac_ik/pull-requests/46>)
* Contributors: Matthijs van der Burgh
```

## trac_ik_lib

```
* Add Manipulation3, maximizing smallest singular value (#46 <https://bitbucket.org/traclabs/trac_ik/pull-requests/46>)
* Contributors: Matthijs van der Burgh
```
