### PR TITLE
Add robotraconteur_companion package to iron/distribution.yaml

### DIFF
--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5964,6 +5964,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur.git
       version: ros
     status: maintained
+  robotraconteur_companion:
+    source:
+      type: git
+      url: https://github.com/robotraconteur/robotraconteur_companion.git
+      version: ros
+    status: maintained
   ros1_bridge:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

robotraconteur_companion

# The source is here:

https://github.com/robotraconteur/robotraconteur_companion

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
