### PR TITLE
robotraconteur: 1.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8618,7 +8618,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robotraconteur-release.git
-      version: 1.2.2-1
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur` to `1.2.5-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur.git
- release repository: https://github.com/ros2-gbp/robotraconteur-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.2-1`
