### PR TITLE
Add 'lua-dev' rule for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7393,6 +7393,7 @@ lua-dev:
   macports: [lua51]
   nixos: [lua]
   openembedded: [lua@openembedded-core]
+  rhel: [compat-lua-devel]
   ubuntu: [liblua5.1-0-dev]
 lua5.2-dev:
   arch: [lua52]


### PR DESCRIPTION
This package is available via EPEL for RHEL 8, 9, and 10: https://packages.fedoraproject.org/pkgs/compat-lua/compat-lua-devel/