### PR TITLE
simulation_interfaces: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10328,7 +10328,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.0.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `2.0.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## simulation_interfaces

```
Add support for managing simulation worlds #4 <https://github.com/ros-simulation/simulation_interfaces/issues/4>
* Contributors: Ayush Ghosh <mailto:ayushg@nvidia.com>
* Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Co-authored-by: Adam Dąbrowski <mailto:adam.dabrowski@robotec.ai>
Documentation fixes
* Contributors: fred-labs <mailto:fred-labs@mailbox.org>, Arjo Chakravarty <mailto:arjo129@gmail.com>
```
