### PR TITLE
ur_robot_driver: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9284,7 +9284,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.0.3-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.3-1`

## ur

- No changes

## ur_calibration

```
* Use hpp headers from geometry2 (#1467 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1467>)
* Fix ur_calibration compilation on Windows (#1400 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1400>)
* Contributors: Felix Exner, Silvio Traversaro
```

## ur_controllers

```
* ur_configuration_controller: use try_set on RTBox (#1470 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1470>)
* Use hpp headers from geometry2 (#1467 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1467>)
* Use new API of PID class (#1410 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1410>)
* ur_controllers: Fix compilation on Windows (#1402 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1402>)
* Contributors: Christoph Fröhlich, Felix Exner, Silvio Traversaro
```

## ur_dashboard_msgs

```
* Added 'is in remote control' call as a dashboard service (#1433 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1433>)
* Contributors: Mads Holm Peters
```

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Migrate hardware_interface's on_init method (#1464 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1464>)
* Add scaling parameters to upstream JTC (#1465 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1465>)
* Add migration of ros2_control node to migration notes (#1458 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1458>)
* Fix flaky controller switch test (#1447 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1447>)
* fix_flaky_force_mode_test (#1429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1429>)
* Reduce flakiness of trajectory controller tests (#1443 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1443>)
* Added 'is in remote control' call as a dashboard service (#1433 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1433>)
* ur_robot_driver: Fix compilation on Windows (#1421 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1421>)
* Refactor prepare_switch method (#1417 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1417>)
* Update simulation page to also explicitly mention PolyScope X (#1415 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1415>)
* Contributors: Felix Exner, Mads Holm Peters, Silvio Traversaro
