### PR TITLE
apriltag_detector: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -573,7 +573,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `3.0.3-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.2-1`

## apriltag_detector

```
* avoid deprecated image transport functions
* Fix compilation and loading of shared libraries on Windows
  * Fix compilation and running on Windows
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* Contributors: Bernd Pfrommer, Silvio Traversaro
```

## apriltag_detector_mit

```
* Fix compilation and loading of shared libraries on Windows
  * Fix compilation and running on Windows
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* Contributors: Bernd Pfrommer, Silvio Traversaro
```

## apriltag_detector_umich

```
* Apriltag-detector-umich windows
  See https://github.com/RoboStack/ros-jazzy/pull/77
* Fix compilation and loading of shared libraries on Windows
  * Fix compilation and running on Windows
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* Contributors: Bernd Pfrommer, Griffin Tabor, Silvio Traversaro
```

## apriltag_draw

```
* avoid deprecated image transport functions
* Fix compilation and loading of shared libraries on Windows
  * Fix compilation and running on Windows
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* Contributors: Bernd Pfrommer, Silvio Traversaro
```

## apriltag_tools

```
* Merge branch 'master' into release
* Fix compilation and loading of shared libraries on Windows
  * Fix compilation and running on Windows
  ---------
  Co-authored-by: Bernd Pfrommer <mailto:bernd.pfrommer@gmail.com>
* Contributors: Bernd Pfrommer, Silvio Traversaro
```
