### PR TITLE
kdl_parser_py: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3137,6 +3137,22 @@ repositories:
       url: https://github.com/ros/kdl_parser.git
       version: rolling
     status: maintained
+  kdl_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/kdl_parser_py.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/kdl_parser_py-release.git
+      version: 3.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/kdl_parser_py.git
+      version: rolling
+    status: maintained
   keyboard_handler:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser_py` to `3.0.0-1`:

- upstream repository: https://github.com/ros/kdl_parser_py.git
- release repository: https://github.com/ros2-gbp/kdl_parser_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## kdl_parser_py

```
* Port kdl_parser_py to ros2 (#3 <https://github.com/ros/kdl_parser_py/issues/3>)
* Rearrange repository to put kdl_parser_py at the top level. (#1 <https://github.com/ros/kdl_parser_py/issues/1>)
* Contributors: Adrian Zwiener, Chris Lalancette, Daniel Reuter
```
