### PR TITLE
event_camera_renderer: 2.0.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2316,7 +2316,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_renderer-release.git
-      version: 2.0.0-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_renderer` to `2.0.1-2`:

- upstream repository: https://github.com/ros-event-camera/event_camera_renderer.git
- release repository: https://github.com/ros2-gbp/event_camera_renderer-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## event_camera_renderer

```
* remove old ROS2 from CI
* remove ROS1 from CI
* support new transport api
* bumped cmake required
* Contributors: Bernd Pfrommer
```
