### PR TITLE
libcaer_driver: 1.5.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4189,7 +4189,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.5.1-1
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.5.2-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.1-1`

## libcaer_driver

```
* support new transport api
* Contributors: Bernd Pfrommer
```
