### PR TITLE
sros2: 0.16.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8492,7 +8492,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.16.1-1
+      version: 0.16.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.16.2-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.16.1-1`

## sros2

```
* Timezone aware datetimes + remove hack from #209 <https://github.com/ros2/sros2/issues/209> (#300 <https://github.com/ros2/sros2/issues/300>)
* fix setuptools deprecations (#357 <https://github.com/ros2/sros2/issues/357>)
* Use rmw_test_fixture to isolate ros2cli tests (#356 <https://github.com/ros2/sros2/issues/356>)
* Contributors: Mikael Arguedas, Scott K Logan, mosfet80
```

## sros2_cmake

- No changes
