### PR TITLE
rosidl: 5.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7219,7 +7219,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.0.0-1
+      version: 5.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.0.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.0-1`

## rosidl_adapter

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>)
* Contributors: mosfet80
```

## rosidl_cli

```
* fix setuptools deprecations (#877 <https://github.com/ros2/rosidl/issues/877>)
* Contributors: mosfet80
```

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>)
* Contributors: mosfet80
```

## rosidl_generator_cpp

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>)
* Contributors: mosfet80
```

## rosidl_generator_type_description

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>)
* Contributors: mosfet80
```

## rosidl_parser

- No changes

## rosidl_pycommon

```
* fix setuptools deprecation (#880 <https://github.com/ros2/rosidl/issues/880>)
* Contributors: mosfet80
```

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>)
* Contributors: mosfet80
```

## rosidl_typesupport_introspection_cpp

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>)
* Contributors: mosfet80
```
