### PR TITLE
ros2_tracing: 8.8.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6842,7 +6842,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.8.0-1
+      version: 8.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.8.1-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.8.0-1`

## lttngpy

- No changes

## ros2trace

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>)
* Contributors: mosfet80
```

## tracetools

- No changes

## tracetools_launch

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>)
* Contributors: mosfet80
```

## tracetools_read

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>)
* Contributors: mosfet80
```

## tracetools_test

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>)
* Contributors: mosfet80
```

## tracetools_trace

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>)
* Contributors: mosfet80
```
