### PR TITLE
rmw_zenoh: 0.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6568,7 +6568,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.8.2-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.8.1-1`

## rmw_zenoh_cpp

```
* rmw_zenoh_cpp: Include algorithm for std::find_if (#723 <https://github.com/ros2/rmw_zenoh/issues/723>)
* Use rfind to avoid issues with service types ending in Request or Response (#719 <https://github.com/ros2/rmw_zenoh/issues/719>)
* Remove the extra copy on the publisher side (#711 <https://github.com/ros2/rmw_zenoh/issues/711>)
* Avoid ambiguity with variable shadowing (#706 <https://github.com/ros2/rmw_zenoh/issues/706>)
* Only configure the timeout of the action-related service get_result to maximum value. (#685 <https://github.com/ros2/rmw_zenoh/issues/685>)
* Use Zenoh Querier to replace Session.get (#694 <https://github.com/ros2/rmw_zenoh/issues/694>)
* Contributors: ChenYing Kuo (CY), Filip, Jan Vermaete, yadunund
```

## zenoh_cpp_vendor

```
* Change zenoh-c features to use its default + shared-memory + transport_serial (#692 <https://github.com/ros2/rmw_zenoh/issues/692>)
* Contributors: Julien Enoch
```

## zenoh_security_tools

- No changes
