### PR TITLE
rmw_fastrtps: 9.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6514,7 +6514,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.1-1
+      version: 9.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.2-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.4.1-1`

## rmw_fastrtps_cpp

- No changes

## rmw_fastrtps_dynamic_cpp

```
* Check remaining size before resizing sequences (#827 <https://github.com/ros2/rmw_fastrtps/issues/827>)
* Contributors: Miguel Company
```

## rmw_fastrtps_shared_cpp

- No changes
