### PR TITLE
rmw_connextdds: 1.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6446,7 +6446,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.2-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.1-1`

## rmw_connextdds

```
* Fix cmake deprecation (#198 <https://github.com/ros2/rmw_connextdds/issues/198>)
* Contributors: mosfet80
```

## rmw_connextdds_common

```
* Fix cmake deprecation (#198 <https://github.com/ros2/rmw_connextdds/issues/198>)
* Contributors: mosfet80
```

## rti_connext_dds_cmake_module

```
* Fix cmake deprecation (#198 <https://github.com/ros2/rmw_connextdds/issues/198>)
* Contributors: mosfet80
```
