### PR TITLE
rcl_interfaces: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5844,7 +5844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `2.4.2-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.1-1`

## action_msgs

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## builtin_interfaces

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## composition_interfaces

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## lifecycle_msgs

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## rcl_interfaces

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## rosgraph_msgs

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## service_msgs

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## statistics_msgs

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## test_msgs

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```

## type_description_interfaces

```
* Fix cmake deprecation (#180 <https://github.com/ros2/rcl_interfaces/issues/180>)
* Contributors: mosfet80
```
