### PR TITLE
launch_ros: 0.29.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3408,7 +3408,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.1-1
+      version: 0.29.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.29.2-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.29.1-1`

## launch_ros

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>)
* Contributors: mosfet80
```

## launch_testing_ros

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>)
* WaitForTopics: wait for publisher-subscriber connection to be established (#474 <https://github.com/ros2/launch_ros/issues/474>)
* Contributors: Giorgio Pintaudi, mosfet80
```

## ros2launch

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>)
* Contributors: mosfet80
```
