### PR TITLE
launch: 3.9.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3373,7 +3373,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.1-1
+      version: 3.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.2-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.1-1`

## launch

```
* Fix Setuptoolsdeprecations (#898 <https://github.com/ros2/launch/issues/898>)
* Remove LaunchDescriptionArgument (#891 <https://github.com/ros2/launch/issues/891>)
* Contributors: Harrison Chen, mosfet80
```

## launch_pytest

```
* Fix Setuptoolsdeprecations (#898 <https://github.com/ros2/launch/issues/898>)
* Contributors: mosfet80
```

## launch_testing

```
* Fix Setuptoolsdeprecations (#898 <https://github.com/ros2/launch/issues/898>)
* Contributors: mosfet80
```

## launch_testing_ament_cmake

```
* Fix CMake deprecation (#899 <https://github.com/ros2/launch/issues/899>)
* Contributors: mosfet80
```

## launch_xml

```
* Fix Setuptoolsdeprecations (#898 <https://github.com/ros2/launch/issues/898>)
* Contributors: mosfet80
```

## launch_yaml

```
* Fix Setuptoolsdeprecations (#898 <https://github.com/ros2/launch/issues/898>)
* Contributors: mosfet80
```
