### PR TITLE
geometry2: 0.44.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2279,7 +2279,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.43.1-1
+      version: 0.44.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.44.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.43.1-1`

## examples_tf2_py

```
* Fix Setuptools deprecations (#809 <https://github.com/ros2/geometry2/issues/809>)
* Contributors: mosfet80
```

## geometry2

- No changes

## tf2

```
* Add RPY quaternion constructor (#806 <https://github.com/ros2/geometry2/issues/806>)
* Contributors: Alireza Moayyedi
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Ensure variable is considered volatile in message_filter_test (#812 <https://github.com/ros2/geometry2/issues/812>)
* Contributors: Mirko Ferrati
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Add imu & mag support in tf2_sensor_msgs (#800 <https://github.com/ros2/geometry2/issues/800>) (#813 <https://github.com/ros2/geometry2/issues/813>)
* Contributors: Patrick Roncagliolo
```

## tf2_tools

```
* Fix Setuptools deprecations (#809 <https://github.com/ros2/geometry2/issues/809>)
* Contributors: mosfet80
```
