### PR TITLE
examples: 0.21.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1803,7 +1803,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.21.1-1
+      version: 0.21.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.21.2-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.21.1-1`

## examples_rclcpp_async_client

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_cbg_executor

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_action_client

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_action_server

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_client

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_composition

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_publisher

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_service

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_subscriber

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_minimal_timer

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_multithreaded_executor

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclcpp_wait_set

```
* Fix CMAKE deprecation (#419 <https://github.com/ros2/examples/issues/419>)
* Contributors: mosfet80
```

## examples_rclpy_executors

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_guard_conditions

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_minimal_action_client

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_minimal_action_server

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_minimal_client

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_minimal_publisher

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_minimal_service

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_minimal_subscriber

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## examples_rclpy_pointcloud_publisher

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```

## launch_testing_examples

```
* Fix setuptools deprecations (#421 <https://github.com/ros2/examples/issues/421>)
* Contributors: mosfet80
```
