### PR TITLE
eigen3_cmake_module: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1643,7 +1643,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigen3_cmake_module` to `0.5.1-1`:

- upstream repository: https://github.com/ros2/eigen3_cmake_module.git
- release repository: https://github.com/ros2-gbp/eigen3_cmake_module-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.0-1`

## eigen3_cmake_module

```
* fix cmake deprecation (#10 <https://github.com/ros2/eigen3_cmake_module/issues/10>)
* Contributors: mosfet80
```
