### PR TITLE
ament_cmake_ros: 0.15.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -214,7 +214,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.15.1-1
+      version: 0.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.15.2-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.1-1`

## ament_cmake_ros

```
* fix cmake deprecation (#47 <https://github.com/ros2/ament_cmake_ros/issues/47>)
* Contributors: mosfet80
```

## ament_cmake_ros_core

```
* fix cmake deprecation (#47 <https://github.com/ros2/ament_cmake_ros/issues/47>)
* Contributors: mosfet80
```

## domain_coordinator

```
* fix setuptools deprecations (#49 <https://github.com/ros2/ament_cmake_ros/issues/49>)
* Contributors: mosfet80
```

## rmw_test_fixture

```
* fix cmake deprecation (#47 <https://github.com/ros2/ament_cmake_ros/issues/47>)
* Contributors: mosfet80
```

## rmw_test_fixture_implementation

```
* fix cmake deprecation (#47 <https://github.com/ros2/ament_cmake_ros/issues/47>)
* Contributors: mosfet80
```
