### PR TITLE
rqt_shell: 1.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7847,7 +7847,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `1.4.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`

## rqt_shell

```
* make linters happy
* Fix setuptools deprecation (#26 <https://github.com/ros-visualization/rqt_shell/issues/26>)
* Contributors: Alejandro Hernandez Cordero, mosfet80
```
