### PR TITLE
rqt_publisher: 1.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7726,7 +7726,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.10.0-1
+      version: 1.10.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.10.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.10.0-1`

## rqt_publisher

```
* fix setuptools deprecations (#52 <https://github.com/ros-visualization/rqt_publisher/issues/52>)
* Contributors: mosfet80
```
