### PR TITLE
rqt_bag: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7556,7 +7556,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.2.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.1-1`

## rqt_bag

```
* Better handling of large bag files (#178 <https://github.com/ros-visualization/rqt_bag/issues/178>)
* Display roll, pitch, yaw values for quaternions (#179 <https://github.com/ros-visualization/rqt_bag/issues/179>)
* Fix flake8 error in setup.py (#192 <https://github.com/ros-visualization/rqt_bag/issues/192>)
* Improved raw view to better handle arrays and time objects (#173 <https://github.com/ros-visualization/rqt_bag/issues/173>)
* plot_view: Fixed display of initial message (#180 <https://github.com/ros-visualization/rqt_bag/issues/180>)
* fix setuptools deprecations (#185 <https://github.com/ros-visualization/rqt_bag/issues/185>)
* Contributors: Martin Pecka, Michael Carlstrom, mosfet80
```

## rqt_bag_plugins

```
* Display roll, pitch, yaw values for quaternions (#179 <https://github.com/ros-visualization/rqt_bag/issues/179>)
* Fix flake8 error in setup.py (#192 <https://github.com/ros-visualization/rqt_bag/issues/192>)
* Fixed image helper and added support for PNG-coded compressedDepth (#176 <https://github.com/ros-visualization/rqt_bag/issues/176>)
* Improve plot view (#174 <https://github.com/ros-visualization/rqt_bag/issues/174>)
* plot_view: Fixed display of initial message (#180 <https://github.com/ros-visualization/rqt_bag/issues/180>)
* fix setuptools deprecations (#185 <https://github.com/ros-visualization/rqt_bag/issues/185>)
* Contributors: Martin Pecka, Michael Carlstrom, mosfet80
```
