### PR TITLE
rqt_action: 2.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7538,7 +7538,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `2.4.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## rqt_action

```
* fix setuptools deprecations (#19 <https://github.com/ros-visualization/rqt_action/issues/19>)
* Contributors: mosfet80
```
