### PR TITLE
ament_package: 0.18.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -323,7 +323,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.18.0-1
+      version: 0.18.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.18.1-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.18.0-1`

## ament_package

```
* fix setuptools deprecations (#156 <https://github.com/ament/ament_package/issues/156>)
* Contributors: mosfet80
```
