### PR TITLE
ament_lint: 0.20.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -296,7 +296,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.20.1-1
+      version: 0.20.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.20.2-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.20.1-1`

## ament_clang_format

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_clang_tidy

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

- No changes

## ament_cmake_cppcheck

- No changes

## ament_cmake_cpplint

- No changes

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

- No changes

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

- No changes

## ament_cmake_xmllint

- No changes

## ament_copyright

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_cppcheck

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_cpplint

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_flake8

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_lint

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_lint_auto

- No changes

## ament_lint_cmake

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_lint_common

- No changes

## ament_mypy

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_pclint

```
* clean setup.py (#552 <https://github.com/ament/ament_lint/issues/552>)
* fix setuptools deprecation (#551 <https://github.com/ament/ament_lint/issues/551>)
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_pep257

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_pycodestyle

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_pyflakes

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_uncrustify

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```

## ament_xmllint

```
* fix setuptools deprecations (#547 <https://github.com/ament/ament_lint/issues/547>)
* Contributors: mosfet80
```
