### PR TITLE
ur_msgs: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9286,7 +9286,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `2.3.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## ur_msgs

```
* Trajectory until action definition (#38 <https://github.com/ros-industrial/ur_msgs/issues/38>)
* Contributors: URJala
```