### PR TITLE
rc_reason_clients: 0.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6785,7 +6785,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rc_reason_clients-release.git
-      version: 0.4.0-2
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_reason_clients` to `0.5.0-1`:

- upstream repository: https://github.com/roboception/rc_reason_clients_ros2.git
- release repository: https://github.com/ros2-gbp/rc_reason_clients-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-2`

## rc_reason_clients

```
* SilhouetteMatchClient: fix publish params
* CadMatchDetectObject: don't send LC compartment if box invalid
* message_conversion: ignore extra field in json when converting to ROS messages
* ignore tags in HandEyeCalibration_Response
* setup.py: replace deprecated tests_require with extras_require
```

## rc_reason_msgs

```
* add overexposed field to SetHandEyeCalibrationPose_Response
```
