### PR TITLE
ros2_control: 5.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6695,7 +6695,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.4.0-1
+      version: 5.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.4.0-1`

## controller_interface

```
* Fix missing include for std::find (#2425 <https://github.com/ros-controls/ros2_control/issues/2425>)
* Document order of interfaces (#2394 <https://github.com/ros-controls/ros2_control/issues/2394>)
* Contributors: Christoph Fröhlich, Guilhem Saurel
```

## controller_manager

```
* Fix the prepare_command_mode_switch behaviour when HW is INACTIVE (#2347 <https://github.com/ros-controls/ros2_control/issues/2347>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the prepare_command_mode_switch behaviour when HW is INACTIVE (#2347 <https://github.com/ros-controls/ros2_control/issues/2347>)
* Fix the joint limiter exception while configuring component (#2416 <https://github.com/ros-controls/ros2_control/issues/2416>)
* Migration notes on init (#2412 <https://github.com/ros-controls/ros2_control/issues/2412>)
* Contributors: Felix Exner (fexner), Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Fix the prepare_command_mode_switch behaviour when HW is INACTIVE (#2347 <https://github.com/ros-controls/ros2_control/issues/2347>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* Fix wrong strict arg of switch_controllers method (#2410 <https://github.com/ros-controls/ros2_control/issues/2410>)
* Contributors: Sai Kishor Kothakota
```

## transmission_interface

- No changes
