### PR TITLE
rc_genicam_api: 2.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7735,7 +7735,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.6.5-1
+      version: 2.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.8.1-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.5-1`

## rc_genicam_api

```
* Windows: Fixed build issue and report missing GenTL symbol if loading of transport layer fails due to missing symbols
```
