### PR TITLE
ros2_control: 4.35.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7705,7 +7705,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.34.0-1
+      version: 4.35.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.35.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.34.0-1`

## controller_interface

```
* Document order of interfaces (#2394 <https://github.com/ros-controls/ros2_control/issues/2394>) (#2422 <https://github.com/ros-controls/ros2_control/issues/2422>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Fix the prepare_command_mode_switch behaviour when HW is INACTIVE (#2347 <https://github.com/ros-controls/ros2_control/issues/2347>) (#2418 <https://github.com/ros-controls/ros2_control/issues/2418>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the joint limiter exception while configuring component (#2416 <https://github.com/ros-controls/ros2_control/issues/2416>) (#2417 <https://github.com/ros-controls/ros2_control/issues/2417>)
* Fix the prepare_command_mode_switch behaviour when HW is INACTIVE (#2347 <https://github.com/ros-controls/ros2_control/issues/2347>) (#2418 <https://github.com/ros-controls/ros2_control/issues/2418>)
* Addition of a Default Node for Hardware Component (#2348 <https://github.com/ros-controls/ros2_control/issues/2348>) (#2413 <https://github.com/ros-controls/ros2_control/issues/2413>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix the prepare_command_mode_switch behaviour when HW is INACTIVE (#2347 <https://github.com/ros-controls/ros2_control/issues/2347>) (#2418 <https://github.com/ros-controls/ros2_control/issues/2418>)
* Addition of a Default Node for Hardware Component (#2348 <https://github.com/ros-controls/ros2_control/issues/2348>) (#2413 <https://github.com/ros-controls/ros2_control/issues/2413>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

```
* Fix wrong strict arg of switch_controllers method (#2410 <https://github.com/ros-controls/ros2_control/issues/2410>) (#2411 <https://github.com/ros-controls/ros2_control/issues/2411>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
