### PR TITLE
ros2_controllers: 5.5.0-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6722,6 +6722,7 @@ repositories:
       - joint_state_broadcaster
       - joint_trajectory_controller
       - mecanum_drive_controller
+      - omni_wheel_drive_controller
       - parallel_gripper_controller
       - pid_controller
       - pose_broadcaster
@@ -6737,7 +6738,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.4.0-1
+      version: 5.5.0-2
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.5.0-2`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.4.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Fix child_frame_id in controller_state_msg (#1601 <https://github.com/ros-controls/ros2_controllers/issues/1601>)
* Contributors: Rehan Shah
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Reset JTC PID's to zero on_activate() (#1840 <https://github.com/ros-controls/ros2_controllers/issues/1840>)
* Fix -Wunused-result warnings in JTC (#1831 <https://github.com/ros-controls/ros2_controllers/issues/1831>)
* Contributors: Christoph Fröhlich, Marq Rasmussen
```

## mecanum_drive_controller

- No changes

## omni_wheel_drive_controller

```
* Add omni_wheel_drive_controller (#1535 <https://github.com/ros-controls/ros2_controllers/issues/1535>)
* Contributors: Aarav Gupta
```

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Add omni_wheel_drive_controller (#1535 <https://github.com/ros-controls/ros2_controllers/issues/1535>)
* Contributors: Aarav Gupta
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
