### PR TITLE
rc_genicam_driver: 0.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6766,7 +6766,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.3.2-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## rc_genicam_driver

```
* Increased tolerance for alternate exposure mode to 1 second
* Fixed rounding when converting color to monochrome
```
