### PR TITLE
rc_genicam_driver: 0.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5772,7 +5772,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.3.1-2
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.3.2-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-2`

## rc_genicam_driver

```
* Increased tolerance for alternate exposure mode to 1 second
* Fixed rounding when converting color to monochrome
```
