### PR TITLE
imu_calib: 0.1.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3934,16 +3934,21 @@ repositories:
       version: humble
     status: maintained
   imu_calib:
+    doc:
+      type: git
+      url: https://github.com/Nathan85001/imu_calib.git
+      version: ros2
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/Nathan85001/imu_calib-release.git
-      version: 0.1.0-2
+      version: 0.1.0-3
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/Nathan85001/imu_calib.git
       version: ros2
+    status: maintained
   imu_pipeline:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_calib` to `0.1.0-3`:

- upstream repository: https://github.com/Nathan85001/imu_calib.git
- release repository: https://github.com/Nathan85001/imu_calib-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-2`
