### PR TITLE
depthai: 3.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1312,7 +1312,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 3.0.0-4
+      version: 3.0.1-1
     status: developed
   depthimage_to_laserscan:
     doc:


### PR DESCRIPTION
Updating due to bug in dependencies: https://build.ros2.org/job/Kbin_unv8_uNv8__depthai__ubuntu_noble_arm64__binary/1/console
(Lacking zip and tar packages).
Jobs will probably fail on rhel as it cannot find those from package.xml

Increasing version of package(s) in repository `depthai` to `3.0.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.0-4`
