### PR TITLE
depthai-ros: 3.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1314,6 +1314,21 @@ repositories:
       url: https://github.com/luxonis/depthai-core-release.git
       version: 3.0.0-4
     status: developed
+  depthai-ros:
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 3.0.0-1
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.0.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## depthai-ros

```
* Updating to DepthAI V3
* Switching to Camera nodes instead of Mono/Color cams
* Updated socket/frame naming
* IMU publishing now in RDF frame across the board
* Using TFPublisher instead of URDF description by default for more accurate results
* Undistorted streams can now be requested
* depthai_examples have been largely modified to remove deprecated examples and simplify code
* Tests added for converters in depthai_bridge
* NN creation simplified both in depthai_examples and depthai_ros_driver
* RGBD Node and Pointcloud converter have been added
* Thermal node added
```
