### PR TITLE
Update libqt5-* rosdep keys for Ubuntu 24.04 (Noble) compatibility

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5982,7 +5982,10 @@ libqt5-gui:
   opensuse: [libQt5Gui5]
   rhel: [qt5-qtbase-gui]
   slackware: [qt5]
-  ubuntu: [libqt5gui5]
+  ubuntu:
+    '*': [libqt5gui5t64]
+    focal: [libqt5gui5]
+    jammy: [libqt5gui5]
 libqt5-multimedia:
   arch: [qt5-multimedia]
   debian: [libqt5multimedia5]
@@ -6120,12 +6123,18 @@ libqt5-widgets:
   opensuse: [libQt5Widgets5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
-  ubuntu: [libqt5widgets5]
+  ubuntu:
+    '*': [libqt5widgets5t64]
+    focal: [libqt5widgets5]
+    jammy: [libqt5widgets5]
 libqt5-xml:
   arch: [qt5-base]
   debian: [libqt5xml5]
   nixos: [qt5.qtbase]
-  ubuntu: [libqt5xml5]
+  ubuntu:
+    '*': [libqt5xml5t64]
+    focal: [libqt5xml5]
+    jammy: [libqt5xml5]
 libqt5multimedia5-plugins:
   arch: [qt5-multimedia]
   debian: [libqt5multimedia5-plugins]


### PR DESCRIPTION
These packages were renamed on Ubuntu 24.04. This patch renames them on 'noble', while keeping the names on 'focal' and 'jammy'.