### PR TITLE
depthai: 3.0.2-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1312,7 +1312,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 3.0.1-1
+      version: 3.0.2-2
     status: developed
   depthimage_to_laserscan:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `3.0.2-2`:
Should fix deb generation errors
- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`
