### PR TITLE
depthai-ros: 3.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1314,6 +1314,30 @@ repositories:
       url: https://github.com/luxonis/depthai-core-release.git
       version: 3.0.1-1
     status: developed
+  depthai-ros:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: kilted
+    release:
+      packages:
+      - depthai-ros
+      - depthai_bridge
+      - depthai_descriptions
+      - depthai_examples
+      - depthai_filters
+      - depthai_ros_driver
+      - depthai_ros_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-release.git
+      version: 3.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: kilted
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.0.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## depthai-ros

```
* Add deprecated camera.launch.py
* Minor fixes in CI
```
