### PR TITLE
Add tf2_web_republisher package to ROS index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10967,6 +10967,13 @@ repositories:
       url: https://github.com/ros2/test_interface_files.git
       version: humble
     status: maintained
+  tf2_web_republisher:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: ros2
+    status: maintained
   tf_transformations:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9910,6 +9910,13 @@ repositories:
       url: https://github.com/locusrobotics/tf2_2d.git
       version: rolling
     status: maintained
+  tf2_web_republisher:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: ros2
+    status: maintained
   tf_transformations:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8766,6 +8766,13 @@ repositories:
       url: https://github.com/locusrobotics/tf2_2d.git
       version: rolling
     status: maintained
+  tf2_web_republisher:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: ros2
+    status: maintained
   tf_transformations:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8715,6 +8715,13 @@ repositories:
       url: https://github.com/locusrobotics/tf2_2d.git
       version: rolling
     status: maintained
+  tf2_web_republisher:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: ros2
+    status: maintained
   tf_transformations:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

tf2_web_republisher

# The source is here:

https://github.com/RobotWebTools/tf2_web_republisher/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
