### PR TITLE
robotraconteur_companion: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6632,6 +6632,11 @@ repositories:
       version: ros
     status: maintained
   robotraconteur_companion:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/robotraconteur_companion-release.git
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur_companion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur_companion` to `0.4.2-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur_companion.git
- release repository: https://github.com/ros2-gbp/robotraconteur_companion-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
