### PR TITLE
Add Qt6 svg, qt5-compat, base-private and declarative-private packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8546,6 +8546,7 @@ qt6-5compat-dev:
   ubuntu:
     '*': [qt6-5compat-dev]
     'focal': null
+    'jammy': [libqt6core5compat6-dev]
 qt6-base-dev:
   alpine: [qt6-qtbase-dev]
   arch: [qt6-base]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6206,7 +6206,7 @@ libqt6-quick:
   ubuntu:
     '*': [libqt6quick6]
     'focal': null
-libqt6svg:
+libqt6svg6:
   alpine: [qt6-qtsvg]
   arch: [qt6-svg]
   debian: [libqt6svg6]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6206,6 +6206,19 @@ libqt6-quick:
   ubuntu:
     '*': [libqt6quick6]
     'focal': null
+libqt6svg:
+  alpine: [qt6-qtsvg]
+  arch: [qt6-svg]
+  debian: [libqt6svg6]
+  fedora: [qt6-qtsvg]
+  gentoo: ['dev-qt/qtsvg:6']
+  openembedded: [qtsvg@meta-qt6]
+  rhel:
+    '*': [qt6-qtsvg-devel]
+    '8': null
+  ubuntu:
+    '*': [libqt6svg6]
+    'focal': null
 libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]
@@ -8519,6 +8532,19 @@ qt5-qmake:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qt5-qmake]
+qt6-5compat-dev:
+  alpine: [qt6-qt5compat]
+  arch: [qt6-5compat]
+  debian: [qt6-5compat-dev]
+  fedora: [qt6-qt5compat]
+  gentoo: ['dev-qt/qt5compat:6']
+  openembedded: [qt5compat@meta-qt6]
+  rhel:
+    '*': [qt6-qt5compat-devel]
+    '8': null
+  ubuntu:
+    '*': [qt6-5compat-dev]
+    'focal': null
 qt6-base-dev:
   alpine: [qt6-qtbase-dev]
   arch: [qt6-base]
@@ -8537,6 +8563,19 @@ qt6-base-dev:
   ubuntu:
     '*': [qt6-base-dev]
     'focal': null
+qt6-base-private-dev:
+  alpine: [qt6-qtbase-private-dev]
+  arch: [qt6-base]
+  debian: [qt6-base-private-dev]
+  fedora: [qt6-qtbase-private-devel]
+  gentoo: ['dev-qt/qtbase:6']
+  openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase-private-devel]
+    '8': null
+  ubuntu:
+    '*': [qt6-base-private-dev]
+    'focal': null
 qt6-declarative-dev:
   arch: [qt6-declarative]
   debian: [qt6-declarative-dev]
@@ -8549,6 +8588,19 @@ qt6-declarative-dev:
     '8': null
   ubuntu:
     '*': [qt6-declarative-dev]
+    'focal': null
+qt6-declarative-private-dev:
+  alpine: [qt6-qtdeclarative-private-dev]
+  arch: [qt6-declarative]
+  debian: [qt6-declarative-private-dev]
+  fedora: [qt6-qtdeclarative-devel]
+  gentoo: ['dev-qt/qtdeclarative:6']
+  openembedded: [qtdeclarative@meta-qt6]
+  rhel:
+    '*': [qt6-qtdeclarative-private-devel]
+    '8': null
+  ubuntu:
+    '*': [qt6-declarative-private-dev]
     'focal': null
 qt6-multimedia-dev:
   arch: [qt6-multimedia]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

* `libqt6svg6`
* `qt6-5compat-dev`
* `qt6-base-private-dev`
* `qt6-declarative-private-dev`


## Package Upstream Source:

https://github.com/qt/qtsvg
https://github.com/qt/qt5compat
https://github.com/qt/qtbase
https://github.com/qt/qtdeclarative

## Purpose of using this:

Needed by Gazebo Jetty release, specifically: `gz-gui` and `gz-sim`
* https://github.com/gazebosim/gz-gui
* https://github.com/gazebosim/gz-sim

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

* `libqt6svg6`:

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libqt6svg6
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libqt6svg6
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtsvg/qt6-qtsvg/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=qt6-svg
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtsvg
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qtsvg
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtsvg-devel
- openembedded:
  -  https://layers.openembedded.org/layerindex/recipe/348237/

* `qt6-5compat-dev`:

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qt6-5compat-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qt6-5compat-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qt5compat/qt6-qt5compat/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=qt6-5compat
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qt5compat
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qt5compat-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qt5compat-devel
- openembedded:
  -  https://layers.openembedded.org/layerindex/recipe/348252/

* `qt6-base-private-dev`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qt6-base-private-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qt6-base-private-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtbase/qt6-qtbase-private-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=qt6-base
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtbase
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qtbase-private-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/qt6-qtbase-private-devel
- openembedded:
  -  https://layers.openembedded.org/layerindex/recipe/348233/

* `qt6-declarative-private-dev`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qt6-declarative-private-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qt6-declarative-private-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtdeclarative/qt6-qtdeclarative/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtdeclarative
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qtdeclarative-private-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative-devel
- openembedded:
  -  https://layers.openembedded.org/layerindex/recipe/348212/

