### PR TITLE
Add more qml6-module-* packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8516,7 +8516,7 @@ qml6-module-qtpositioning:
     '*': [qt6-qtdeclarative]
     '8': null
   ubuntu:
-    '*': [qml6-module-qtcharts]
+    '*': [qml6-module-qtpositioning]
     'focal': null
 qml6-module-qtqml:
   arch: [qt6-declarative]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8448,6 +8448,96 @@ qml-module-qtquick2:
   nixos: [qt5.qtquickcontrols2]
   rhel: [qt5-qtdeclarative]
   ubuntu: [qml-module-qtquick2]
+qml6-module-qt-labs-folderlistmodel:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qt-labs-folderlistmodel]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qt-labs-folderlistmodel]
+    'focal': null
+qml6-module-qt-labs-platform:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qt-labs-platform]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qt-labs-platform]
+    'focal': null
+qml6-module-qt-labs-settings:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qt-labs-settings]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qt-labs-settings]
+    'focal': null
+qml6-module-qt5compat-graphicaleffects:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qt5compat-graphicaleffects]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qt5compat-graphicaleffects]
+    'focal': null
+qml6-module-qtcharts:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtcharts]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtcharts]
+    'focal': null
+qml6-module-qtcore:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtcore]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtcore]
+    'focal': null
+qml6-module-qtpositioning:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtpositioning]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtcharts]
+    'focal': null
+qml6-module-qtqml:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtqml]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtqml]
+    'focal': null
+qml6-module-qtqml-models:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtqml-models]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtqml-models]
+    'focal': null
 qml6-module-qtqml-workerscript:
   arch: [qt6-declarative]
   debian: [qml6-module-qtqml-workerscript]
@@ -8468,6 +8558,56 @@ qml6-module-qtquick:
     '8': null
   ubuntu:
     '*': [qml6-module-qtquick]
+    'focal': null
+qml6-module-qtquick-controls:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtquick-controls]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtquick-controls]
+    'focal': null
+qml6-module-qtquick-dialogs:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtquick-dialogs]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtquick-dialogs]
+    'focal': null
+qml6-module-qtquick-layouts:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtquick-layouts]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtquick-layouts]
+    'focal': null
+qml6-module-qtquick-templates:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtquick-templates]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtquick-templates]
+    'focal': null
+qml6-module-qtquick-window:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtquick-window]
+  fedora: [qt6-qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtquick-window]
     'focal': null
 qrencode:
   arch: [qrencode]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

* `qml6-module-qt-labs-folderlistmodel`
* `qml6-module-qt-labs-settings`
* `qml6-module-qt-labs-platform`
* `qml6-module-qt5compat-graphicaleffects`
* `qml6-module-qtcharts`
* `qml6-module-qtcore`
* `qml6-module-qtpositioning`
* `qml6-module-qtqml`
* `qml6-module-qtqml-models`
* `qml6-module-qtquick-controls`
* `qml6-module-qtquick-dialogs`
* `qml6-module-qtquick-layouts`
* `qml6-module-qtquick-templates`
* `qml6-module-qtquick-window`

## Package Upstream Source:

https://github.com/qt/qtdeclarative

## Purpose of using this:

Needed by Gazebo Jetty release, specifically: `gz-gui` and `gz-sim`

https://github.com/gazebosim/gz-gui
https://github.com/gazebosim/gz-sim


## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

* `qml6-module-qt-labs-folderlistmodel`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qt-labs-folderlistmodel
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qt-labs-folderlistmodel
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qt-labs-settings`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qt-labs-settings
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qt-labs-settings
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qt-labs-platform`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qt-labs-platform
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qt-labs-platform
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qt5compat-graphicaleffects`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qt5compat-graphicaleffects
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qt5compat-graphicaleffects
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtcharts`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtcharts
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtcharts
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtcore`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtcore
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtcore
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtpositioning`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtpositioning
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtpositioning
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtqml`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtqml
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtqml
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative
 
* `qml6-module-qtqml-models`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtqml-models
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtqml-models
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtquick-controls`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtquick-controls
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtquick-controls
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtquick-dialogs`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtquick-dialogs
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtquick-dialogs
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtquick-layouts`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtquick-layouts
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtquick-layouts
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtquick-templates`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtquick-templates
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtquick-templates
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

* `qml6-module-qtquick-window`

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qml6-module-qtquick-window
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qml6-module-qtquick-window
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtdeclarative
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-declarative
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtdeclarative

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
