### PR TITLE
sros2: 0.13.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9672,7 +9672,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.13.3-1
+      version: 0.13.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.13.4-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.13.3-1`

## sros2

```
* suppress multi-threaded warnings. (#346 <https://github.com/ros2/sros2/issues/346>) (#350 <https://github.com/ros2/sros2/issues/350>)
  (cherry picked from commit 06ab5aafad9c15ff2a01a268f5cd1cc6134abf3a)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
