### PR TITLE
rosidl_typesupport_fastrtps: 3.6.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8433,7 +8433,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.6.1-1
+      version: 3.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.6.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.6.1-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Check remaining size before resizing sequences (#130 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/130>) (#132 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/132>)
  * Check remaining size before resizing sequences
  * Avoid linter complaining of too long function.
  ---------
  (cherry picked from commit 7283329f7c3cb654e7b843ab127ab2eda680662a)
  Co-authored-by: Miguel Company <mailto:miguelcompany@eprosima.com>
* Contributors: mergify[bot]
```

## rosidl_typesupport_fastrtps_cpp

```
* Check remaining size before resizing sequences (#130 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/130>) (#132 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/132>)
  * Check remaining size before resizing sequences
  * Avoid linter complaining of too long function.
  ---------
  (cherry picked from commit 7283329f7c3cb654e7b843ab127ab2eda680662a)
  Co-authored-by: Miguel Company <mailto:miguelcompany@eprosima.com>
* Contributors: mergify[bot]
```
