### PR TITLE
rosidl: 4.6.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8272,7 +8272,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.6.5-1
+      version: 4.6.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.6.6-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.6.5-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* rosidl_cli: Add type description support (backport #857 <https://github.com/ros2/rosidl/issues/857>) (#867 <https://github.com/ros2/rosidl/issues/867>)
  * rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
  * Add type description support to rosidl_cli
  * Fix typing annotation
  * Please flake8, mypy
  * Please flake8 take 2
  ---------
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit c9a3084d8570ee7d1f3a35b81d7cf9259aee6dbc)
  # Conflicts:
  #     rosidl_cli/rosidl_cli/cli.py
  #     rosidl_cli/rosidl_cli/command/generate/api.py
  #     rosidl_cli/rosidl_cli/command/generate/extensions.py
  #     rosidl_cli/rosidl_cli/command/helpers.py
  * Solve conflicts (#868 <https://github.com/ros2/rosidl/issues/868>)
  * Please flake8 (#870 <https://github.com/ros2/rosidl/issues/870>)
  ---------
  Co-authored-by: Francisco Rossi <mailto:50388097+frneer@users.noreply.github.com>
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: mergify[bot]
```

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* rosidl_cli: Add type description support (backport #857 <https://github.com/ros2/rosidl/issues/857>) (#867 <https://github.com/ros2/rosidl/issues/867>)
  * rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
  * Add type description support to rosidl_cli
  * Fix typing annotation
  * Please flake8, mypy
  * Please flake8 take 2
  ---------
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit c9a3084d8570ee7d1f3a35b81d7cf9259aee6dbc)
  # Conflicts:
  #     rosidl_cli/rosidl_cli/cli.py
  #     rosidl_cli/rosidl_cli/command/generate/api.py
  #     rosidl_cli/rosidl_cli/command/generate/extensions.py
  #     rosidl_cli/rosidl_cli/command/helpers.py
  * Solve conflicts (#868 <https://github.com/ros2/rosidl/issues/868>)
  * Please flake8 (#870 <https://github.com/ros2/rosidl/issues/870>)
  ---------
  Co-authored-by: Francisco Rossi <mailto:50388097+frneer@users.noreply.github.com>
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: mergify[bot]
```

## rosidl_generator_cpp

```
* rosidl_cli: Add type description support (backport #857 <https://github.com/ros2/rosidl/issues/857>) (#867 <https://github.com/ros2/rosidl/issues/867>)
  * rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
  * Add type description support to rosidl_cli
  * Fix typing annotation
  * Please flake8, mypy
  * Please flake8 take 2
  ---------
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit c9a3084d8570ee7d1f3a35b81d7cf9259aee6dbc)
  # Conflicts:
  #     rosidl_cli/rosidl_cli/cli.py
  #     rosidl_cli/rosidl_cli/command/generate/api.py
  #     rosidl_cli/rosidl_cli/command/generate/extensions.py
  #     rosidl_cli/rosidl_cli/command/helpers.py
  * Solve conflicts (#868 <https://github.com/ros2/rosidl/issues/868>)
  * Please flake8 (#870 <https://github.com/ros2/rosidl/issues/870>)
  ---------
  Co-authored-by: Francisco Rossi <mailto:50388097+frneer@users.noreply.github.com>
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: mergify[bot]
```

## rosidl_generator_type_description

```
* rosidl_cli: Add type description support (backport #857 <https://github.com/ros2/rosidl/issues/857>) (#867 <https://github.com/ros2/rosidl/issues/867>)
  * rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
  * Add type description support to rosidl_cli
  * Fix typing annotation
  * Please flake8, mypy
  * Please flake8 take 2
  ---------
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit c9a3084d8570ee7d1f3a35b81d7cf9259aee6dbc)
  # Conflicts:
  #     rosidl_cli/rosidl_cli/cli.py
  #     rosidl_cli/rosidl_cli/command/generate/api.py
  #     rosidl_cli/rosidl_cli/command/generate/extensions.py
  #     rosidl_cli/rosidl_cli/command/helpers.py
  * Solve conflicts (#868 <https://github.com/ros2/rosidl/issues/868>)
  * Please flake8 (#870 <https://github.com/ros2/rosidl/issues/870>)
  ---------
  Co-authored-by: Francisco Rossi <mailto:50388097+frneer@users.noreply.github.com>
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: mergify[bot]
```

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* Add an ament_cmake_gtest dependency to rosidl_runtime_c. (#865 <https://github.com/ros2/rosidl/issues/865>) (#873 <https://github.com/ros2/rosidl/issues/873>)
  This was found while testing out a fix to colcon-core
  which will reduce the scope of test_depend.  Regardless,
  this package actually does depend on ament_cmake_gtest
  so the dependency should be there.
  (cherry picked from commit 95fa106fce55eb62a8e4954b5f5f4004af125315)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* rosidl_cli: Add type description support (backport #857 <https://github.com/ros2/rosidl/issues/857>) (#867 <https://github.com/ros2/rosidl/issues/867>)
  * rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
  * Add type description support to rosidl_cli
  * Fix typing annotation
  * Please flake8, mypy
  * Please flake8 take 2
  ---------
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit c9a3084d8570ee7d1f3a35b81d7cf9259aee6dbc)
  # Conflicts:
  #     rosidl_cli/rosidl_cli/cli.py
  #     rosidl_cli/rosidl_cli/command/generate/api.py
  #     rosidl_cli/rosidl_cli/command/generate/extensions.py
  #     rosidl_cli/rosidl_cli/command/helpers.py
  * Solve conflicts (#868 <https://github.com/ros2/rosidl/issues/868>)
  * Please flake8 (#870 <https://github.com/ros2/rosidl/issues/870>)
  ---------
  Co-authored-by: Francisco Rossi <mailto:50388097+frneer@users.noreply.github.com>
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: mergify[bot]
```

## rosidl_typesupport_introspection_cpp

```
* rosidl_cli: Add type description support (backport #857 <https://github.com/ros2/rosidl/issues/857>) (#867 <https://github.com/ros2/rosidl/issues/867>)
  * rosidl_cli: Add type description support (#857 <https://github.com/ros2/rosidl/issues/857>)
  * Add type description support to rosidl_cli
  * Fix typing annotation
  * Please flake8, mypy
  * Please flake8 take 2
  ---------
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  (cherry picked from commit c9a3084d8570ee7d1f3a35b81d7cf9259aee6dbc)
  # Conflicts:
  #     rosidl_cli/rosidl_cli/cli.py
  #     rosidl_cli/rosidl_cli/command/generate/api.py
  #     rosidl_cli/rosidl_cli/command/generate/extensions.py
  #     rosidl_cli/rosidl_cli/command/helpers.py
  * Solve conflicts (#868 <https://github.com/ros2/rosidl/issues/868>)
  * Please flake8 (#870 <https://github.com/ros2/rosidl/issues/870>)
  ---------
  Co-authored-by: Francisco Rossi <mailto:50388097+frneer@users.noreply.github.com>
  Co-authored-by: Michel Hidalgo <mailto:michel@ekumenlabs.com>
* Contributors: mergify[bot]
```
