### PR TITLE
ros2cli: 0.32.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7933,7 +7933,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.4-1
+      version: 0.32.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.5-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.32.4-1`

## ros2action

```
* fix ros2action send_goal signal handling. (#1072 <https://github.com/ros2/ros2cli/issues/1072>) (#1075 <https://github.com/ros2/ros2cli/issues/1075>)
  (cherry picked from commit 87e88c8a2f756deb1652274ba4920c85f5b179f2)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Fujitatomoya/ros2 action send goal timeout (backport #1067 <https://github.com/ros2/ros2cli/issues/1067>) (#1069 <https://github.com/ros2/ros2cli/issues/1069>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* remove unnecessary '/' from ros2 action info. (backport #1049 <https://github.com/ros2/ros2cli/issues/1049>) (#1051 <https://github.com/ros2/ros2cli/issues/1051>)
  * remove unnecessary '/' from ros2 action info. (#1049 <https://github.com/ros2/ros2cli/issues/1049>)
  (cherry picked from commit ad66780fd46d73368c82d8c6645505e6e600e0fb)
  # Conflicts:
  #     ros2action/ros2action/api/__init__.py
  * Fixed merge
  ---------
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* catch ConnectionRefusedError, so that it can fall back to DirectNode. (#1014 <https://github.com/ros2/ros2cli/issues/1014>) (#1021 <https://github.com/ros2/ros2cli/issues/1021>)
  (cherry picked from commit 0a5b5603d9651c8b98e574142325069a04f31101)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* fails the test properly to avoid TypeError exception. (backport #1016 <https://github.com/ros2/ros2cli/issues/1016>) (#1018 <https://github.com/ros2/ros2cli/issues/1018>)
  * fails the test properly to avoid TypeError exception. (#1016 <https://github.com/ros2/ros2cli/issues/1016>)
  (cherry picked from commit 7ced7454ad1813171cc4e583f7b7bd4c4c43c66f)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## ros2pkg

```
* Support empy4 and empy3 (#921 <https://github.com/ros2/ros2cli/issues/921>) (#1034 <https://github.com/ros2/ros2cli/issues/1034>)
  (cherry picked from commit f75f4e2499fcd0037eb4ae277d424b4618ae4af3)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

```
* add QoS option to ros2service/ros2action echo commands. (#1039 <https://github.com/ros2/ros2cli/issues/1039>)
* Contributors: Tomoya Fujita
```

## ros2topic

- No changes
