### PR TITLE
ros2_tracing: 8.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7885,7 +7885,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.2.3-1
+      version: 8.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.4-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.2.3-1`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

```
* Removed clang warning (#168 <https://github.com/ros2/ros2_tracing/issues/168>) (#172 <https://github.com/ros2/ros2_tracing/issues/172>)
  (cherry picked from commit 169c887a41e2f5233d2407f54c4ea3a1ec7665ab)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
