### PR TITLE
rmw_implementation: 2.15.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7533,7 +7533,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.15.5-1
+      version: 2.15.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `2.15.6-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.15.5-1`

## rmw_implementation

```
* Fixed windows warning (#254 <https://github.com/ros2/rmw_implementation/issues/254>) (#260 <https://github.com/ros2/rmw_implementation/issues/260>)
  (cherry picked from commit 8c006087e3af66a79f61dbe0ff45e7a1ef31a686)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
