### PR TITLE
rcutils: 6.7.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7011,7 +7011,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.7.2-1
+      version: 6.7.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.7.3-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.7.2-1`

## rcutils

```
* Revert "use getenv_s instead of getenv for Windows. (#499 <https://github.com/ros2/rcutils/issues/499>)" (#504 <https://github.com/ros2/rcutils/issues/504>) (#506 <https://github.com/ros2/rcutils/issues/506>)
  This reverts commit 46ab4d4eeb555a2e9e880157b97f0a867d3a256c.
  (cherry picked from commit 3a4beda924bfcf766803d25752cbbf911f445e99)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* use getenv_s instead of getenv for Windows. (#499 <https://github.com/ros2/rcutils/issues/499>) (#501 <https://github.com/ros2/rcutils/issues/501>)
  (cherry picked from commit 46ab4d4eeb555a2e9e880157b97f0a867d3a256c)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#483 <https://github.com/ros2/rcutils/issues/483>) (#484 <https://github.com/ros2/rcutils/issues/484>)
  They are both out-of-date, and no longer serving their
  intended purpose.  Delete them.
  (cherry picked from commit f662ccae73e367d8074a481f854adfb5d6541c53)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
