### PR TITLE
rclpy: 7.1.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6944,7 +6944,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.1.4-1
+      version: 7.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.5-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.1.4-1`

## rclpy

```
* Feature: add logger_name property to subscription, publisher, service and client (backport #1471 <https://github.com/ros2/rclpy/issues/1471>) (#1475 <https://github.com/ros2/rclpy/issues/1475>)
  Co-authored-by: Nadav Elkabets <mailto:32939935+nadavelkabets@users.noreply.github.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* [rclpy] Fix spin() incorrectly removing node from executor if already attached (#1446 <https://github.com/ros2/rclpy/issues/1446>) (#1450 <https://github.com/ros2/rclpy/issues/1450>)
  (cherry picked from commit 3414456ddaf1163d1951d301336028c9600bd58e)
  Co-authored-by: Alon Borenshtein <mailto:alonborn@gmail.com>
* Contributors: mergify[bot]
```
