### PR TITLE
add libicu-devel entry for rhel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4334,6 +4334,7 @@ libicu-dev:
   fedora: [libicu-devel]
   gentoo: [dev-libs/icu]
   nixos: [icu]
+  rhel: [libicu-devel]
   ubuntu: [libicu-dev]
 libignition-common3:
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

The entry is already present, but it misses a mapping for rhel, because it was not present until rhel8.

## Package name: 

libicu-dev

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/9/remi-x86_64/libicu69-devel-69.1-4.el9.remi.x86_64.rpm.html
