### PR TITLE
husarion_components_description: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3495,6 +3495,11 @@ repositories:
       version: devel
     status: developed
   husarion_components_description:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/husarion/husarion_components_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husarion_components_description` to `0.0.2-1`:

- upstream repository: https://github.com/husarion/husarion_components_description.git
- release repository: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## husarion_components_description

```
* Fix stereolabs zed origin (#7 <https://github.com/husarion/husarion_components_description/issues/7>)
* Zed add CAM05 and update ZED urdf (#5 <https://github.com/husarion/husarion_components_description/issues/5>)
* fix rplidar visual (#4 <https://github.com/husarion/husarion_components_description/issues/4>)
* Add visuals (#2 <https://github.com/husarion/husarion_components_description/issues/2>)
* Move code from ros_components_description (#1 <https://github.com/husarion/husarion_components_description/issues/1>)
* Initial commit
* Contributors: Dawid Kmak, Dominik Nowak, Rafal Gorecki
```
