### PR TITLE
canboat_vendor: 0.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1067,7 +1067,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/canboat_vendor-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/robotic-esp/canboat_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `canboat_vendor` to `0.0.5-1`:

- upstream repository: https://github.com/robotic-esp/canboat_vendor.git
- release repository: https://github.com/ros2-gbp/canboat_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.4-1`

## canboat_vendor

```
* Respect -fPIE flag if set
* Contributors: Severn Lortie
```
