### PR TITLE
launch: 3.4.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4044,7 +4044,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.5-1
+      version: 3.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.6-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.5-1`

## launch

```
* Using TimerAction with SetParameter from launch_ros causes crash (backport #879 <https://github.com/ros2/launch/issues/879>) (#893 <https://github.com/ros2/launch/issues/893>)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Remove LaunchDescriptionArgument (#891 <https://github.com/ros2/launch/issues/891>) (#896 <https://github.com/ros2/launch/issues/896>)
  (cherry picked from commit 8fd76bb11c45cdd072b5f3ef4f3800ff63ee3c9a)
  Co-authored-by: Harrison Chen <mailto:hchen.robotics@gmail.com>
* Contributors: Rafal Gorecki, mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
