### PR TITLE
rqt_plot: 1.4.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8763,7 +8763,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.4.3-1
+      version: 1.4.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.4.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.3-1`

## rqt_plot

```
* Added missing test dependency (backport #118 <https://github.com/ros-visualization/rqt_plot/issues/118>) (#120 <https://github.com/ros-visualization/rqt_plot/issues/120>)
  Added missing test dependency (#118 <https://github.com/ros-visualization/rqt_plot/issues/118>)
  (cherry picked from commit 365f7a829a06681d571767348015f2ccdc2530d0)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
