### PR TITLE
rqt_bag: 1.5.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8608,7 +8608,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.5.4-1
+      version: 1.5.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.5.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.4-1`

## rqt_bag

```
* Display roll, pitch, yaw values for quaternions (backport #179 <https://github.com/ros-visualization/rqt_bag/issues/179>) (#199 <https://github.com/ros-visualization/rqt_bag/issues/199>)
  * Display roll, pitch, yaw values for quaternions (#179 <https://github.com/ros-visualization/rqt_bag/issues/179>)
  (cherry picked from commit 4593d82d2b23a322119c6a518befec970db7d54e)
* Improved raw view to better handle arrays and time objects (backport #173 <https://github.com/ros-visualization/rqt_bag/issues/173>) (#197 <https://github.com/ros-visualization/rqt_bag/issues/197>)
* plot_view: Fixed display of initial message (backport #180 <https://github.com/ros-visualization/rqt_bag/issues/180>) (#187 <https://github.com/ros-visualization/rqt_bag/issues/187>)
  plot_view: Fixed display of initial message (#180 <https://github.com/ros-visualization/rqt_bag/issues/180>)
  (cherry picked from commit 9ff337266e97143c2ec9eef6f9aa03bde2b31997)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Contributors: Martin Pecka, mergify[bot]
```

## rqt_bag_plugins

```
* Display roll, pitch, yaw values for quaternions (backport #179 <https://github.com/ros-visualization/rqt_bag/issues/179>) (#199 <https://github.com/ros-visualization/rqt_bag/issues/199>)
  * Display roll, pitch, yaw values for quaternions (#179 <https://github.com/ros-visualization/rqt_bag/issues/179>)
  (cherry picked from commit 4593d82d2b23a322119c6a518befec970db7d54e)
* Fixed image helper and added support for PNG-coded compressedDepth (backport #176 <https://github.com/ros-visualization/rqt_bag/issues/176>)  (#196 <https://github.com/ros-visualization/rqt_bag/issues/196>)
* Improve plot view (backport #174 <https://github.com/ros-visualization/rqt_bag/issues/174>) (#195 <https://github.com/ros-visualization/rqt_bag/issues/195>)
* plot_view: Fixed display of initial message (backport #180 <https://github.com/ros-visualization/rqt_bag/issues/180>) (#187 <https://github.com/ros-visualization/rqt_bag/issues/187>)
  plot_view: Fixed display of initial message (#180 <https://github.com/ros-visualization/rqt_bag/issues/180>)
  (cherry picked from commit 9ff337266e97143c2ec9eef6f9aa03bde2b31997)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Contributors: Martin Pecka, mergify[bot]
```
