### PR TITLE
Revert major version increment of simulation_interfaces in already released distributions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10360,7 +10360,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 2.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9453,7 +9453,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 2.0.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8355,7 +8355,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 2.0.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
According to https://docs.ros.org/en/kilted/The-ROS2-Project/Contributing/Developer-Guide.html#versioning we should not introduce breaking changes in already released distributions. This PR reverts addition of simulation_interfaces 2.0.0 to humble, jazzy and kilted.

The respective PRs are: #47106, #47107, #47108



