### PR TITLE
Add uhubctl to the rosdep database

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9499,6 +9499,18 @@ udev:
 udhcpc:
   debian: [udhcpc]
   ubuntu: [udhcpc]
+uhubctl:
+  debian: [uhubctl]
+  ubuntu: [uhubctl]
+  fedora: [uhubctl]
+  gentoo: [sys-power/uhubctl]
+  osx:
+    homebrew:
+      packages: [uhubctl]
+  alpine: [uhubctl]
+  nixos: [uhubctl]
+  opensuse: [uhubctl]
+  rhel: [uhubctl]
 unclutter:
   debian: [unclutter]
   nixos: [unclutter]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9500,17 +9500,17 @@ udhcpc:
   debian: [udhcpc]
   ubuntu: [udhcpc]
 uhubctl:
+  alpine: [uhubctl]
   debian: [uhubctl]
-  ubuntu: [uhubctl]
   fedora: [uhubctl]
   gentoo: [sys-power/uhubctl]
+  nixos: [uhubctl]
+  opensuse: [uhubctl]
   osx:
     homebrew:
       packages: [uhubctl]
-  alpine: [uhubctl]
-  nixos: [uhubctl]
-  opensuse: [uhubctl]
   rhel: [uhubctl]
+  ubuntu: [uhubctl]
 unclutter:
   debian: [unclutter]
   nixos: [unclutter]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

uhubctl

## Package Upstream Source:

https://github.com/mvp/uhubctl

## Purpose of using this:

I am creating a software system which keeps USB connection healthy by power cycle of USB when the connection is bad:
https://github.com/pazeshun/jsk_3rdparty/tree/power_switching_tools_ros/power_switching_tools_ros
`uhubctl` is required for switching on/off a USB hub port.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/uhubctl
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/uhubctl
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/uhubctl/uhubctl/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-power/uhubctl
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/uhubctl#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/uhubctl
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.05&show=uhubctl&from=0&size=50&sort=relevance&type=packages&query=uhubctl
- openSUSE: https://software.opensuse.org/package/
  - https://build.opensuse.org/package/show/openSUSE%3AFactory/uhubctl
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/10/epel-x86_64/uhubctl-2.6.0-1.el10_0.x86_64.rpm.html