### PR TITLE
rviz_satellite: 4.2.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8121,6 +8121,21 @@ repositories:
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
       version: main
     status: maintained
+  rviz_satellite:
+    doc:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/nobleo/rviz_satellite-release.git
+      version: 4.2.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/rviz_satellite.git
+      version: main
+    status: maintained
   rviz_visual_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.2.1-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rviz_satellite

```
* List Tim Clephas as maintainer to receive buildfarm emails
* Replace ament_target_dependencies with target_link_libraries
* Contributors: Alejandro Hernández Cordero, Tim Clephas
```
