### PR TITLE
etsi_its_messages: 3.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1696,6 +1696,56 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  etsi_its_messages:
+    doc:
+      type: git
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
+      version: main
+    release:
+      packages:
+      - etsi_its_cam_coding
+      - etsi_its_cam_conversion
+      - etsi_its_cam_msgs
+      - etsi_its_cam_ts_coding
+      - etsi_its_cam_ts_conversion
+      - etsi_its_cam_ts_msgs
+      - etsi_its_coding
+      - etsi_its_conversion
+      - etsi_its_cpm_ts_coding
+      - etsi_its_cpm_ts_conversion
+      - etsi_its_cpm_ts_msgs
+      - etsi_its_denm_coding
+      - etsi_its_denm_conversion
+      - etsi_its_denm_msgs
+      - etsi_its_denm_ts_coding
+      - etsi_its_denm_ts_conversion
+      - etsi_its_denm_ts_msgs
+      - etsi_its_mapem_ts_coding
+      - etsi_its_mapem_ts_conversion
+      - etsi_its_mapem_ts_msgs
+      - etsi_its_mcm_uulm_coding
+      - etsi_its_mcm_uulm_conversion
+      - etsi_its_mcm_uulm_msgs
+      - etsi_its_messages
+      - etsi_its_msgs
+      - etsi_its_msgs_utils
+      - etsi_its_primitives_conversion
+      - etsi_its_rviz_plugins
+      - etsi_its_spatem_ts_coding
+      - etsi_its_spatem_ts_conversion
+      - etsi_its_spatem_ts_msgs
+      - etsi_its_vam_ts_coding
+      - etsi_its_vam_ts_conversion
+      - etsi_its_vam_ts_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/etsi_its_messages-release.git
+      version: 3.3.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
+      version: main
+    status: developed
   event_camera_codecs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `3.3.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ros2-gbp/etsi_its_messages-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## etsi_its_cam_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cam_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cam_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cam_ts_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cam_ts_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cam_ts_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cpm_ts_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cpm_ts_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_cpm_ts_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_denm_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_denm_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_denm_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_denm_ts_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_denm_ts_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_denm_ts_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_mapem_ts_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_mapem_ts_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_mapem_ts_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_mcm_uulm_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_mcm_uulm_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_mcm_uulm_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_messages

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_msgs_utils

```
* Merge pull request #89 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/89> from ika-rwth-aachen/improvement/cpm-plugin
  Add object ids to RViz CPM plugin; rename plugins; add icons
* Merge pull request #85 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/85> from ika-rwth-aachen/mcm-access
  Add access functions for MCM
* Merge pull request #81 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/81> from FabianThomsen/feature/cam-yaw-rate
  Add setters and getters for yaw rate in CAM and CAM TS
* Merge pull request #88 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/88> from ika-rwth-aachen/kilted
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Merge pull request #86 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/86> from ika-rwth-aachen/fix/spatem_time_mark_interpretation
  Fix/spatem time mark interpretation
* Merge pull request #82 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/82> from ika-rwth-aachen/fix/missing_inline_on_functions
  Fix and adjust Spatem utils
* Contributors: AlexanderWilczynski, Fabian Thomsen, Jean-Pierre Busch, Lennart Reiher
```

## etsi_its_primitives_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_rviz_plugins

```
* Merge pull request #92 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/92> from ika-rwth-aachen/fix-rviz-config
  Fix rviz config after renaming displays
* Merge pull request #89 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/89> from ika-rwth-aachen/improvement/cpm-plugin
  Add object ids to RViz CPM plugin; rename plugins; add icons
* Merge pull request #88 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/88> from ika-rwth-aachen/kilted
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Merge pull request #86 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/86> from ika-rwth-aachen/fix/spatem_time_mark_interpretation
  Fix/spatem time mark interpretation
* Contributors: Fabian Thomsen, Jean-Pierre Busch, Lennart Reiher
```

## etsi_its_spatem_ts_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_spatem_ts_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_spatem_ts_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_vam_ts_coding

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_vam_ts_conversion

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```

## etsi_its_vam_ts_msgs

```
* Merge pull request #83 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/83> from ika-rwth-aachen/deprecate-ros1
  Deprecate ROS 1 Noetic
* Contributors: Lennart Reiher
```
