### PR TITLE
fuse: 1.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2764,7 +2764,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.1.3-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.2-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

```
* Revert "Remove references to deprecated tf2 and tf2_ros headers (#416 <https://github.com/locusrobotics/fuse/issues/416>)"
  An updated tf2_ros package is not available yet, resulting in build failures with this commit.
  This reverts commit 9fcd6ca1a259cc1781326942c8007e19b25b4694.
* Contributors: Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

```
* Revert "Remove references to deprecated tf2 and tf2_ros headers (#416 <https://github.com/locusrobotics/fuse/issues/416>)"
  An updated tf2_ros package is not available yet, resulting in build failures with this commit.
  This reverts commit 9fcd6ca1a259cc1781326942c8007e19b25b4694.
* Contributors: Stephen Williams
```

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

```
* Revert "Remove references to deprecated tf2 and tf2_ros headers (#416 <https://github.com/locusrobotics/fuse/issues/416>)"
  An updated tf2_ros package is not available yet, resulting in build failures with this commit.
  This reverts commit 9fcd6ca1a259cc1781326942c8007e19b25b4694.
* Contributors: Stephen Williams
```
