### PR TITLE
ffmpeg_encoder_decoder: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1870,7 +1870,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
-      version: 2.0.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_encoder_decoder` to `3.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
- release repository: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-1`

## ffmpeg_encoder_decoder

```
* added utility functions for splitting
* better error message when filtering decoder
* use mutex to make thread safe
* improved documentation
* use comma-separated decoder list now, use semi-colon to separate encodings
* new feature: can set AV options for decoder
* fix uninitialized memory bug
* reworked tests to cover bayer
* fix debug printout for AV_PIX_FMT_NONE
* filter misconfigured decoders
* fix bug with non-accel pix fmt
* fix nvenc encoding by looking at transfer TO formats
* decoder flush(), decoder testing, improved api docs
* new interfaces to support decoder fallback, encoder avoids cuda and vaapi hard coding, improved flush
* Contributors: Bernd Pfrommer
```
