### PR TITLE
ffmpeg_image_transport: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1885,7 +1885,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 2.0.3-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `3.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.3-1`

## ffmpeg_image_transport

```
* support falling back to alternative decoders, rename parameters, add tests etc
  * adopt the new ffmpeg_encoder_api which allows for probing of decoders. The decoder parameter can now contain a list of comma-separated decoders which will be tried in order.
  * adds gtests to the repo
  * reformat to the black python formatter
  * add arguments to some example launch files
  * allow arbitrary AVOptions setting via av_option
  * remove parameters "preset", "tune", "delay", and "crf" (must now be set via "av_options")
  * remove some default values (like bit_rate) to force user to set them explicitly
  * change the parameter names: remove the leading ".", so now the parameters are named specify "camera.image_raw.." as opposed to ".camera.image_raw..."
  * adapt to new ffmpeg_encoder_decoder API
  * change name of parameter from encoding->encoder
  * provide encoding when initializing encoder (new encoder/decoder API)
  * handle new API for image transport 6.3.0
  * deal with Humble bug: topic is passed in without being prefixed by the namespace, but then namespace is removed!
  * package splitting functions into utilities file
* stop building on foxy but still support humble
* Replaced deprecated code
* Contributors: Alejandro Hernandez Cordero, Bernd Pfrommer
```
