### PR TITLE
foxglove_compressed_video_transport: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2138,7 +2138,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
-      version: 1.0.3-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_compressed_video_transport` to `3.0.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
- release repository: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.3-1`

## foxglove_compressed_video_transport

```
* adjust to new image_transport and encoder/decoder API, added tests
  * adapt to new ffmpeg_encoder_decoder API
  * adjustments for new image_transport API
  * added tests
  * rename "map" parameter to "decoders"
  * parameters no longer have "." prefix
  * deal with humble brokenness where base_topic is not prefixed with namespace, but namespace is removed
  * package splitting functions into utilities file
* Contributors: Bernd Pfrommer
```
