### PR TITLE
live555_vendor: 0.20250719.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4335,6 +4335,11 @@ repositories:
       version: main
     status: maintained
   live555_vendor:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/live555_vendor-release.git
+      version: 0.20250719.0-1
     source:
       type: git
       url: https://github.com/fkie/live555_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `live555_vendor` to `0.20250719.0-1`:

- upstream repository: https://github.com/fkie/live555_vendor.git
- release repository: https://github.com/ros2-gbp/live555_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## live555_vendor

```
* Update to live555 version 2025.07.19
* Contributors: Timo Röhling
```
