### PR TITLE
Disable openembedded checks due to API errors

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -16,8 +16,9 @@ package_sources:
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f$releasever&arch=$basearch
   - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-$releasever&arch=$basearch
-  openembedded:
-  - !layer_index_url http://layers.openembedded.org/layerindex/api/
+  # Disabled due to API errors
+  # openembedded:
+  # - !layer_index_url http://layers.openembedded.org/layerindex/api/
   opensuse:
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/


### PR DESCRIPTION
I'm not entirely sure what's going on here, but we're getting 403 errors when GitHub Actions accesses this API. I can't reproduce the problem locally. It's possible that this is some sort of rate limiting (though a 403 is a strange way to express that), or maybe we're caught in the crossfire of AI scraping mitigation.