### PR TITLE
Add python3-mongomock-pip for debian and ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7428,13 +7428,20 @@ python3-mock:
       packages: [mock]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
-python3-mongomock-pip:
+python3-mongomock:
   debian:
-    pip:
-      packages: [mongomock]
+    '*': [python3-mongomock]
+    bookworm:
+      pip:
+        packages: [mongomock]
   ubuntu:
-    pip:
-      packages: [mongomock]
+    '*': [python3-mongomock]
+    focal:
+      pip:
+        packages: [mongomock]
+    jammy:
+      pip:
+        packages: [mongomock]
 python3-moonraker-api-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7428,6 +7428,13 @@ python3-mock:
       packages: [mock]
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
+python3-mongomock-pip:
+  debian:
+    pip:
+      packages: [mongomock]
+  ubuntu:
+    pip:
+      packages: [mongomock]
 python3-moonraker-api-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-mongomock-pip`

## Package Upstream Source:

https://github.com/mongomock/mongomock

## Purpose of using this:

Library to use for testing code that uses a mongo database. Not available via apt (yet)

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://pypi.org/project/mongomock/
- Ubuntu: https://pypi.org/project/mongomock/

# Note

I experienced the same issue reported [here](https://github.com/ros/rosdistro/pull/46675#issue-3184234496) (`ModuleNotFoundError: No module named 'lark'`) when trying to build the tests, and adding `lark` to my `requirements.txt` fixed the issue. However I saw that that was later removed from that PR so it seems like maybe I shouldn't commit it here. Let me know if I should.

