### PR TITLE
Index (doc, source) rmw_email for Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6522,6 +6522,18 @@ repositories:
       url: https://github.com/signetlabdei/rmw_desert.git
       version: main
     status: maintained
+  rmw_email:
+    doc:
+      type: git
+      url: https://github.com/christophebedard/rmw_email.git
+      version: rolling
+    source:
+      test_commits: false
+      test_pull_requests: false
+      type: git
+      url: https://github.com/christophebedard/rmw_email.git
+      version: rolling
+    status: developed
   rmw_fastrtps:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rmw_email (`email`, `email_examples`, `rmw_email_cpp`) @ Rolling

# The source is here:

https://github.com/christophebedard/rmw_email

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] ~~This package is expected to build on the submitted rosdistro~~ **index only, not intended to be built by the buildfarm _for now_**
