### PR TITLE
add hydro-core from pypi

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6727,6 +6727,9 @@ python3-httpx:
     focal:
       pip:
         packages: [httpx]
+python3-hydra-core-pip:
+  '*':
+    pip: [hydra-core]
 python3-hypothesis:
   debian: [python3-hypothesis]
   fedora: [python3-hypothesis]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

hydra-core

## Package Upstream Source:

https://github.com/facebookresearch/hydra

## Purpose of using this:

From their website
| A framework for elegantly configuring complex applications.

Used mostly in ML context. Can load yaml files and configure python classes based on them.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian:
  - not available
- Ubuntu:
  - not available
- Python:
    - https://pypi.org/project/hydra-core/

As far as I am aware this code is _only_ packages via pypi. I have checked debian and ubuntu. The `hydra` packages that exist there are logon crackers and are unrelated.