### PR TITLE
add 'pymoveit2' to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5553,6 +5553,11 @@ repositories:
       url: https://github.com/ros2/pybind11_vendor.git
       version: rolling
     status: maintained
+  pymoveit2:
+    source:
+      type: git
+      url: https://github.com/AndrejOrsula/pymoveit2.git
+      version: main
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`pymoveit2` (@AndrejOrsula)

## Package Upstream Source:

https://github.com/AndrejOrsula/pymoveit2.git

## Purpose of using this:

MoveIt2 client library written in Python.

# Please Add This Package to be indexed in the rosdistro.

`humble`, `jazzy`, `rolling`

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
