### PR TITLE
clips_executive: 0.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1026,13 +1026,14 @@ repositories:
       - cx_protobuf_plugin
       - cx_ros_comm_gen
       - cx_ros_msgs_plugin
+      - cx_ros_param_plugin
       - cx_tf2_pose_tracker_plugin
       - cx_tutorial_agents
       - cx_utils
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/clips_executive-release.git
-      version: 0.1.1-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/carologistics/clips_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clips_executive` to `0.1.3-1`:

- upstream repository: https://github.com/carologistics/clips_executive.git
- release repository: https://github.com/ros2-gbp/clips_executive-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## clips_executive

```
* 0.1.3
* ros_param_plugin: plugin for retrieving params from parent ROS node
  This plugin is meant to ease the customization when starting the CX via
  run or launch.
  Params of other nodes may be retrieved via the ROS bindings (calling the
  respective parameter services).
* Contributors: Tarik Viehmann
```

## cx_ament_index_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_bringup

```
* 0.1.3
* project: remove occurrences of pkgconfig (it is not used)
* cx_bringup: make cx_protobuf_plugin a build-time dependency
  This is required when generating custom plugins from it.
* cx_bringup: add usage example for ros param plugin
* Contributors: Tarik Viehmann
```

## cx_clips_env_manager

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_config_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_example_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_executive_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_file_load_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_msgs

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_protobuf_plugin

```
* 0.1.3
* project: remove occurrences of pkgconfig (it is not used)
* Contributors: Tarik Viehmann
```

## cx_ros_comm_gen

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_ros_msgs_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_ros_param_plugin

```
* 0.1.3
* ros_param_plugin: plugin for retrieving params from parent ROS node
  This plugin is meant to ease the customization when starting the CX via
  run or launch.
  Params of other nodes may be retrieved via the ROS bindings (calling the
  respective parameter services).
* Contributors: Tarik Viehmann
```

## cx_tf2_pose_tracker_plugin

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_tutorial_agents

```
* 0.1.3
* Contributors: Tarik Viehmann
```

## cx_utils

```
* 0.1.3
* cx_utils: also created latest symlink
* Contributors: Tarik Viehmann
```
