### PR TITLE
plotjuggler_ros: 2.3.0-1 in 'jazzy/distribution.yaml'

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6132,7 +6132,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.1.2-2
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git


### PR DESCRIPTION
Trying to fix this package's [regression for jazzy](https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION) before the [upcoming patch release](https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2025-08-14/).

It seems like the [latest udpate of PlotJuggler in jazzy](https://github.com/ros/rosdistro/pull/46355/commits/e29d99dbc2a24a3f65eccfc9b7f1d6bded1b3541) has broken `plotjuggler_ros` and it's failing on the buildfarm with ([complete log here](https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__plotjuggler_ros__ubuntu_noble_amd64__binary/93/console)):

```
14:24:31 /tmp/binarydeb/ros-jazzy-plotjuggler-ros-2.1.2/src/ros_parsers/ros2_parser.cpp:11:10: fatal error: PlotJuggler/contrib/fmt/core.h: No such file or directory
14:24:31    11 | #include <PlotJuggler/contrib/fmt/core.h>
```

It looks like it's now ` #include <fmt/core.h>` instead. It also seems that this is is correct in `2.3.0` already:

https://github.com/PlotJuggler/plotjuggler-ros-plugins/blob/afe4e40b51cbbb0444556aa0fb13178d7db202cb/src/ros_parsers/ros2_parser.cpp#L11

This PR upgrades `plotjuggler_ros` to the latest [previously submitted version for Jazzy](https://github.com/ros/rosdistro/pull/47074) in an effort to fix the regression.

PTAL @facontidavide, please advise and feel free to suggest a different version.