### PR TITLE
Add rdl to jazzy, kilted, and rolling distributions

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7038,6 +7038,26 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: jazzy
     status: maintained
+  rdl:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    release:
+      packages:
+      - rdl
+      - rdl_benchmark
+      - rdl_dynamics
+      - rdl_urdfreader
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://gitlab.com/jlack/rdl_release.git
+      version: 6.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    status: developed
   reach:
     source:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6115,6 +6115,26 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: kilted
     status: maintained
+  rdl:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    release:
+      packages:
+      - rdl
+      - rdl_benchmark
+      - rdl_dynamics
+      - rdl_urdfreader
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://gitlab.com/jlack/rdl_release.git
+      version: 6.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    status: developed
   reach:
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6034,6 +6034,26 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: rolling
     status: maintained
+  rdl:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    release:
+      packages:
+      - rdl
+      - rdl_benchmark
+      - rdl_dynamics
+      - rdl_urdfreader
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://gitlab.com/jlack/rdl_release.git
+      version: 6.0.0-1
+    source:
+      type: git
+      url: https://gitlab.com/jlack/rdl.git
+      version: master
+    status: developed
   reach:
     source:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

Robot Dynamics Library(RDL)

## Package Upstream Source:

[Robot Dynamics Library](https://gitlab.com/jlack/rdl)

## Purpose of using this:

Robot Dynamics Library is a c++ library for computing rigid body kinematics and dynamics

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

- Jazzy
- Kilted
- Rolling

# The source is here:

https://gitlab.com/jlack/rdl

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
