### PR TITLE
autoware_core: 1.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -906,6 +906,77 @@ repositories:
       version: main
     status: developed
   autoware_core:
+    release:
+      packages:
+      - autoware_adapi_adaptors
+      - autoware_adapi_specs
+      - autoware_behavior_velocity_planner
+      - autoware_behavior_velocity_planner_common
+      - autoware_behavior_velocity_stop_line_module
+      - autoware_component_interface_specs
+      - autoware_core
+      - autoware_core_api
+      - autoware_core_control
+      - autoware_core_localization
+      - autoware_core_map
+      - autoware_core_perception
+      - autoware_core_planning
+      - autoware_core_sensing
+      - autoware_core_vehicle
+      - autoware_crop_box_filter
+      - autoware_default_adapi
+      - autoware_downsample_filters
+      - autoware_ekf_localizer
+      - autoware_euclidean_cluster_object_detector
+      - autoware_geography_utils
+      - autoware_global_parameter_loader
+      - autoware_gnss_poser
+      - autoware_ground_filter
+      - autoware_gyro_odometer
+      - autoware_interpolation
+      - autoware_kalman_filter
+      - autoware_lanelet2_map_visualizer
+      - autoware_lanelet2_utils
+      - autoware_localization_util
+      - autoware_map_height_fitter
+      - autoware_map_loader
+      - autoware_map_projection_loader
+      - autoware_marker_utils
+      - autoware_mission_planner
+      - autoware_motion_utils
+      - autoware_motion_velocity_obstacle_stop_module
+      - autoware_motion_velocity_planner
+      - autoware_motion_velocity_planner_common
+      - autoware_ndt_scan_matcher
+      - autoware_node
+      - autoware_object_recognition_utils
+      - autoware_objects_of_interest_marker_interface
+      - autoware_osqp_interface
+      - autoware_path_generator
+      - autoware_perception_objects_converter
+      - autoware_planning_factor_interface
+      - autoware_planning_test_manager
+      - autoware_planning_topic_converter
+      - autoware_point_types
+      - autoware_pose_initializer
+      - autoware_pyplot
+      - autoware_qp_interface
+      - autoware_route_handler
+      - autoware_signal_processing
+      - autoware_simple_pure_pursuit
+      - autoware_stop_filter
+      - autoware_test_node
+      - autoware_test_utils
+      - autoware_testing
+      - autoware_trajectory
+      - autoware_twist2accel
+      - autoware_vehicle_info_utils
+      - autoware_vehicle_velocity_converter
+      - autoware_velocity_smoother
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_core-release.git
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_core` to `1.4.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_core.git
- release repository: https://github.com/ros2-gbp/autoware_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## autoware_adapi_adaptors

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_adapi_specs

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_behavior_velocity_planner

```
* Merge remote-tracking branch 'origin/main' into humble
* chore(motion_velocity_planner, behavior_velocity_planner): unifiy module load srv (#585 <https://github.com/autowarefoundation/autoware_core/issues/585>)
  port srv
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, Yuki TAKAGI
```

## autoware_behavior_velocity_planner_common

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(autoware_behavior_velocity_planner_common): fix typo (#606 <https://github.com/autowarefoundation/autoware_core/issues/606>)
* fix(autoware_behavior_velocity_planner_common): stop line extension inside boundary (#579 <https://github.com/autowarefoundation/autoware_core/issues/579>)
  * add comment
  * add test
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Kento Yabuuchi, Ryohsuke Mitsudome
```

## autoware_behavior_velocity_stop_line_module

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_component_interface_specs

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, Yukihiro Saito
```

## autoware_core

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_core_api

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_core_control

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, Yukihiro Saito
```

## autoware_core_localization

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_core_map

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_core_perception

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_core_planning

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* feat(motion_velocity_planner, motion_velocity_planner_common): update pointcloud preprocess design (#591 <https://github.com/autowarefoundation/autoware_core/issues/591>)
  * updare pcl preprocess
  ---------
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* fix(obstacle_stop): fix for failing scenario (#566 <https://github.com/autowarefoundation/autoware_core/issues/566>)
  fix for failing scenario
* feat(obstacle_stop_module)!: add leading vehicle following by rss stop position determination (#537 <https://github.com/autowarefoundation/autoware_core/issues/537>)
  * add new feature
  ---------
* refactor: implement varying lateral acceleration and steering rate threshold in velocity smoother (#531 <https://github.com/autowarefoundation/autoware_core/issues/531>)
  * refactor: implement varying steering rate threshold in velocity smoother
  * feat: implement varying lateral acceleration limit
  * fix  typo in readme
  * fix bugs in unit conversion
  * clean up the obsolete parameter in core planning launch
  ---------
  Co-authored-by: Shumpei Wakabayashi <mailto:42209144+shmpwk@users.noreply.github.com>
* feat(obstacle_stop_module): add cut in stop feature (#517 <https://github.com/autowarefoundation/autoware_core/issues/517>)
  * restore the old function to pass universe CI
  * add new feature
  * add todo comment
  ---------
* Contributors: Arjun Jagdish Ram, Ryohsuke Mitsudome, Yuki TAKAGI, Yukihiro Saito, Yuxuan Liu
```

## autoware_core_sensing

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_core_vehicle

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_crop_box_filter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_default_adapi

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_downsample_filters

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_ekf_localizer

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_euclidean_cluster_object_detector

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_geography_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(autoware_geography_utils): disable tests for egm2008-1 (#593 <https://github.com/autowarefoundation/autoware_core/issues/593>)
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_global_parameter_loader

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_gnss_poser

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_ground_filter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_gyro_odometer

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_interpolation

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* fix(motion_utils): update motion utils trajectory (#569 <https://github.com/autowarefoundation/autoware_core/issues/569>)
* Contributors: Ryohsuke Mitsudome, Yuki TAKAGI
```

## autoware_kalman_filter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_lanelet2_map_visualizer

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* feat(lanelet2_map_visualizer): visualize road borders (#575 <https://github.com/autowarefoundation/autoware_core/issues/575>)
  * feat(lanelet2_map_visualizer): visualize fences and road borders
  * only visualize road border
  * use a more general function
  ---------
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* Contributors: Ryohsuke Mitsudome, Zulfaqar Azmi
```

## autoware_lanelet2_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* feat(autoware_lanelet2_utils): add hatched_road_markings utility (#565 <https://github.com/autowarefoundation/autoware_core/issues/565>)
* Contributors: Ryohsuke Mitsudome, Yukinari Hisaki
```

## autoware_localization_util

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_map_height_fitter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_map_loader

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_map_projection_loader

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(autoware_geography_utils): disable tests for egm2008-1 (#593 <https://github.com/autowarefoundation/autoware_core/issues/593>)
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_marker_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(autoware_marker_utils): add marker utils package in common for marker conversion (#555 <https://github.com/autowarefoundation/autoware_core/issues/555>)
  fixed PR #470 <https://github.com/autowarefoundation/autoware_core/issues/470>
* Contributors: Giovanni Muhammad Raditya, Ryohsuke Mitsudome
* Merge remote-tracking branch 'origin/main' into humble
* feat(autoware_marker_utils): add marker utils package in common for marker conversion (#555 <https://github.com/autowarefoundation/autoware_core/issues/555>)
  fixed PR #470 <https://github.com/autowarefoundation/autoware_core/issues/470>
* Contributors: Giovanni Muhammad Raditya, Ryohsuke Mitsudome
```

## autoware_mission_planner

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(autoware_mission_planner, velocity_smoother): use transient_local for operation_mode_state (#598 <https://github.com/autowarefoundation/autoware_core/issues/598>)
  subscribe transient_local with transient_local
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Kem (TiankuiXian), Ryohsuke Mitsudome
```

## autoware_motion_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* fix(motion_utils): update motion utils trajectory (#569 <https://github.com/autowarefoundation/autoware_core/issues/569>)
* feat(motion_utils): update insert orientation function to use tangent direction of a spline cruve (#556 <https://github.com/autowarefoundation/autoware_core/issues/556>)
  * update insertOrientationSpline()
  * update test
  * use insertOrientationSpline() in motion_velcity_planner_common
  ---------
* Contributors: Ryohsuke Mitsudome, Yuki TAKAGI, Yukihiro Saito
```

## autoware_motion_velocity_obstacle_stop_module

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(motion_velocity_planner, motion_velocity_planner_common): update pointcloud preprocess design (#591 <https://github.com/autowarefoundation/autoware_core/issues/591>)
  * updare pcl preprocess
  ---------
* fix(obstacle_stop): fix the brief stop decision logic (#583 <https://github.com/autowarefoundation/autoware_core/issues/583>)
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* fix(obstacle_stop_module): fix outside stop feature (#576 <https://github.com/autowarefoundation/autoware_core/issues/576>)
* fix(obstacle_stop): fix for failing scenario (#566 <https://github.com/autowarefoundation/autoware_core/issues/566>)
  fix for failing scenario
* feat(obstacle_stop_module)!: add leading vehicle following by rss stop position determination (#537 <https://github.com/autowarefoundation/autoware_core/issues/537>)
  * add new feature
  ---------
* feat(obstacle_stop_module): add cut in stop feature (#517 <https://github.com/autowarefoundation/autoware_core/issues/517>)
  * restore the old function to pass universe CI
  * add new feature
  * add todo comment
  ---------
* refactor(motion_velocity_planner_common): splt get_predicted_pose() (#558 <https://github.com/autowarefoundation/autoware_core/issues/558>)
  * rename
  * restore the old function to pass universe CI
* Contributors: Arjun Jagdish Ram, Ryohsuke Mitsudome, Takayuki Murooka, Yuki TAKAGI
```

## autoware_motion_velocity_planner

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(motion_velocity_planner, motion_velocity_planner_common): update pointcloud preprocess design (#591 <https://github.com/autowarefoundation/autoware_core/issues/591>)
  * updare pcl preprocess
  ---------
* chore(motion_velocity_planner, behavior_velocity_planner): unifiy module load srv (#585 <https://github.com/autowarefoundation/autoware_core/issues/585>)
  port srv
* refactor(motion_velocity_planner): restrict copy of planner_data  (#587 <https://github.com/autowarefoundation/autoware_core/issues/587>)
  * restrict plannar data copy
  ---------
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, Yuki TAKAGI
```

## autoware_motion_velocity_planner_common

```
* Merge remote-tracking branch 'origin/main' into humble
* refactor(mvp_common): add docstrings and comments (#600 <https://github.com/autowarefoundation/autoware_core/issues/600>)
* feat(motion_velocity_planner, motion_velocity_planner_common): update pointcloud preprocess design (#591 <https://github.com/autowarefoundation/autoware_core/issues/591>)
  * updare pcl preprocess
  ---------
* refactor(motion_velocity_planner): restrict copy of planner_data  (#587 <https://github.com/autowarefoundation/autoware_core/issues/587>)
  * restrict plannar data copy
  ---------
* fix(obstacle_stop): fix the brief stop decision logic (#583 <https://github.com/autowarefoundation/autoware_core/issues/583>)
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* chore: apply pre-commit fix (#574 <https://github.com/autowarefoundation/autoware_core/issues/574>)
* feat(motion_utils): update insert orientation function to use tangent direction of a spline cruve (#556 <https://github.com/autowarefoundation/autoware_core/issues/556>)
  * update insertOrientationSpline()
  * update test
  * use insertOrientationSpline() in motion_velcity_planner_common
  ---------
* feat(obstacle_stop_module): add cut in stop feature (#517 <https://github.com/autowarefoundation/autoware_core/issues/517>)
  * restore the old function to pass universe CI
  * add new feature
  * add todo comment
  ---------
* refactor(motion_velocity_planner_common): splt get_predicted_pose() (#558 <https://github.com/autowarefoundation/autoware_core/issues/558>)
  * rename
  * restore the old function to pass universe CI
* Contributors: Mamoru Sobue, Ryohsuke Mitsudome, Takayuki Murooka, Yuki TAKAGI
```

## autoware_ndt_scan_matcher

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(autoware_ndt_scan_matcher): extend timeout for test case (#601 <https://github.com/autowarefoundation/autoware_core/issues/601>)
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_node

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_object_recognition_utils

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_objects_of_interest_marker_interface

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_osqp_interface

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_path_generator

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(path_generator): avoid far goal connection (#594 <https://github.com/autowarefoundation/autoware_core/issues/594>)
  * use autoware_trajectory instead of vector of path points
  * fix goal connection algorithm
  * perform goal connection only if path reaches goal
  * fix tests
  * style(pre-commit): autofix
  * add description of goal connection feature
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Kosuke Takeuchi <mailto:kosuke.tnp@gmail.com>
* fix(path_generator): fix start edge intersection search (#595 <https://github.com/autowarefoundation/autoware_core/issues/595>)
  * return cropped line string as autoware_trajectory
  * separate intersection search into functions & fix start edge intersection search
  * fix tests
  * add tests for intersection search functions
  * ensure intersection point is not ends of start edge
  * update doxygen comment
  ---------
* fix(path_generator): merge waypoint groups with shared overlap interval (#586 <https://github.com/autowarefoundation/autoware_core/issues/586>)
  * merge waypoint groups with shared overlap intervals
  * replace parameters with new ones
  * update figure in description
  * style(pre-commit): autofix
  * fix(path_generator): apply clang-tidy
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
  Co-authored-by: Junya Sasaki <mailto:junya.sasaki@tier4.jp>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* fix(path_generator): update unit tests (#577 <https://github.com/autowarefoundation/autoware_core/issues/577>)
  * fix tests to use new goal connection functions
  * fix dense centerline test
  ---------
* feat(path_generator): improve goal connection for goal on the side (#564 <https://github.com/autowarefoundation/autoware_core/issues/564>)
  * change goal connection method
  * apply goal connection
  * rename parameter
  * change parameter name
  ---------
* test(path_generator): add extra tests (#449 <https://github.com/autowarefoundation/autoware_core/issues/449>)
  * add map for test
  * update test cases for get_turn_signal()
  * rename test route files
  * add test with dense centerline
  * move dense centerline map to sample_map directory
  * add tests for get_arc_length_on_path
  * modify path start point to be inside route lanelet
  * add tests for smooth goal connection
  * include necessary header
  * remove ineffective test case
  * fix comment
  * remove unnecessary lines
  * fix test case for refine_path_for_goal
  * rename parameters
  * add missing argument
  * remove include guard
  ---------
* fix(path_generator): fix waypoint interval calculation (#567 <https://github.com/autowarefoundation/autoware_core/issues/567>)
  fix waypoint interval calculation
* fix(path_generator): support 0s turn signal search time (#557 <https://github.com/autowarefoundation/autoware_core/issues/557>)
* Contributors: Kosuke Takeuchi, Mitsuhiro Sakamoto, Ryohsuke Mitsudome
```

## autoware_perception_objects_converter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_planning_factor_interface

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_planning_test_manager

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(planning_test_manager): subscription callback (#563 <https://github.com/autowarefoundation/autoware_core/issues/563>)
  * feat(planning_test_manager): subscription callback
  * fix(test_planning_test_manager): unique node names
  Update testing/autoware_planning_test_manager/test/test_planning_test_manager.cpp
  Update testing/autoware_planning_test_manager/test/test_planning_test_manager.cpp
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
  ---------
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, ralwing
```

## autoware_planning_topic_converter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_point_types

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_pose_initializer

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_pyplot

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_qp_interface

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_route_handler

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(route_handler): add bicycle lane getter (#589 <https://github.com/autowarefoundation/autoware_core/issues/589>)
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Mamoru Sobue, Ryohsuke Mitsudome
```

## autoware_signal_processing

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_simple_pure_pursuit

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, Yukihiro Saito
```

## autoware_stop_filter

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(stop_filter): add unit tests to stop filter node (#573 <https://github.com/autowarefoundation/autoware_core/issues/573>)
  * refactor(stop_filter): rename file name
  * refactor(stop_filter): rename class
  * feat(stop_filter): add integration test
  * style(stop_filter): add unit tests to stop filter
  * style(pre-commit): autofix
  * chore(stop_filter): update copyright
  * chore(stop_filter): move include files
  * style(pre-commit): autofix
  * fix(stop_filter): update test configuration to use ament_add_ros_isolated_gtest
  * chore(stop_filter): fix linter error
  * chore(stop_filter): fix linter error
  * chore(stop_filter): update copyright
  * chore(stop_filter): add author to package.xml
  ---------
  Co-authored-by: Takahisa.Ishikawa <mailto:takahisa.ishikawa@tier4.jp>
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome, Takahisa Ishikawa
```

## autoware_test_node

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_test_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* fix(test_utils): add missing lane ids in makeBehaviorNormalRoute() (#561 <https://github.com/autowarefoundation/autoware_core/issues/561>)
  add missing lane ids
* test(path_generator): add extra tests (#449 <https://github.com/autowarefoundation/autoware_core/issues/449>)
  * add map for test
  * update test cases for get_turn_signal()
  * rename test route files
  * add test with dense centerline
  * move dense centerline map to sample_map directory
  * add tests for get_arc_length_on_path
  * modify path start point to be inside route lanelet
  * add tests for smooth goal connection
  * include necessary header
  * remove ineffective test case
  * fix comment
  * remove unnecessary lines
  * fix test case for refine_path_for_goal
  * rename parameters
  * add missing argument
  * remove include guard
  ---------
* Contributors: Mitsuhiro Sakamoto, Ryohsuke Mitsudome, Yukihiro Saito
```

## autoware_testing

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_trajectory

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* feat(autoware_trajectory): make supplement_lanelet_sequence() public (#560 <https://github.com/autowarefoundation/autoware_core/issues/560>)
  * make supplement_lanelet_sequence() public
  * fix to update new end arc length
  * extend lanelet sequence after loop detection
  * include necessary header
  * use struct instead of tuple
  ---------
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* feat(autoware_trajectory): porting findNearestIndex from motion_utils to autoware_trajectory package (#507 <https://github.com/autowarefoundation/autoware_core/issues/507>)
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Mamoru Sobue <mailto:hilo.soblin@gmail.com>
* Contributors: Giovanni Muhammad Raditya, Mitsuhiro Sakamoto, Ryohsuke Mitsudome
```

## autoware_twist2accel

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_vehicle_info_utils

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_vehicle_velocity_converter

```
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* Contributors: Ryohsuke Mitsudome
```

## autoware_velocity_smoother

```
* Merge remote-tracking branch 'origin/main' into humble
* feat: change planning output topic name to /planning/trajectory (#602 <https://github.com/autowarefoundation/autoware_core/issues/602>)
  * change planning output topic name to /planning/trajectory
  * style(pre-commit): autofix
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* fix(autoware_mission_planner, velocity_smoother): use transient_local for operation_mode_state (#598 <https://github.com/autowarefoundation/autoware_core/issues/598>)
  subscribe transient_local with transient_local
* chore: bump version to 1.3.0 (#554 <https://github.com/autowarefoundation/autoware_core/issues/554>)
* refactor: implement varying lateral acceleration and steering rate threshold in velocity smoother (#531 <https://github.com/autowarefoundation/autoware_core/issues/531>)
  * refactor: implement varying steering rate threshold in velocity smoother
  * feat: implement varying lateral acceleration limit
  * fix  typo in readme
  * fix bugs in unit conversion
  * clean up the obsolete parameter in core planning launch
  ---------
  Co-authored-by: Shumpei Wakabayashi <mailto:42209144+shmpwk@users.noreply.github.com>
* Contributors: Kem (TiankuiXian), Ryohsuke Mitsudome, Yukihiro Saito, Yuxuan Liu
```
