### PR TITLE
rosbag2: 0.26.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8196,7 +8196,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.8-1
+      version: 0.26.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.9-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.8-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* [jazzy] Expose more of the player/recorder API through Python (backport #2062 <https://github.com/ros2/rosbag2/issues/2062>) (#2100 <https://github.com/ros2/rosbag2/issues/2100>)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* [jazzy] Fix reindex duration bug when bag file durations overlap (backport #2036 <https://github.com/ros2/rosbag2/issues/2036>) (#2107 <https://github.com/ros2/rosbag2/issues/2107>)
  Co-authored-by: Chui Vanfleet <mailto:26607858+ChuiVanfleet@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* Fix warning: initialize number_of_threads (#2121 <https://github.com/ros2/rosbag2/issues/2121>) (#2123 <https://github.com/ros2/rosbag2/issues/2123>)
  Co-authored-by: Cristóbal Arroyo <mailto:cristobal.arroyo@ekumenlabs.com>
* Bugfix: prosbag2_performance_benchmarking outputs incorrect results for topics with frequency more than 1 kHz (#2077 <https://github.com/ros2/rosbag2/issues/2077>) (#2080 <https://github.com/ros2/rosbag2/issues/2080>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Fixes in the rosbag2_performance_benchmarking message data generator (#2078 <https://github.com/ros2/rosbag2/issues/2078>) (#2084 <https://github.com/ros2/rosbag2/issues/2084>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Enable rosbag2_performance_benchmarking package to be built by default (#2093 <https://github.com/ros2/rosbag2/issues/2093>) (#2097 <https://github.com/ros2/rosbag2/issues/2097>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Fix for failure in the benchmark_launch when using Process.wait twice (#2076 <https://github.com/ros2/rosbag2/issues/2076>) (#2082 <https://github.com/ros2/rosbag2/issues/2082>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_performance_benchmarking_msgs

```
* Enable rosbag2_performance_benchmarking package to be built by default (#2093 <https://github.com/ros2/rosbag2/issues/2093>) (#2097 <https://github.com/ros2/rosbag2/issues/2097>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_py

```
* [jazzy] Add public API to get player's starting time and playback duration (backport #2095 <https://github.com/ros2/rosbag2/issues/2095>) (#2102 <https://github.com/ros2/rosbag2/issues/2102>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Expose more of the player/recorder API through Python (backport #2062 <https://github.com/ros2/rosbag2/issues/2062>) (#2100 <https://github.com/ros2/rosbag2/issues/2100>)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* [jazzy] Expose more of the player/recorder API through Python (backport #2062 <https://github.com/ros2/rosbag2/issues/2062>) (#2100 <https://github.com/ros2/rosbag2/issues/2100>)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* [jazzy] Add public API to get player's starting time and playback duration (backport #2095 <https://github.com/ros2/rosbag2/issues/2095>) (#2102 <https://github.com/ros2/rosbag2/issues/2102>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
