### PR TITLE
py_binding_tools: 2.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5502,7 +5502,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_binding_tools-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.1.0-1`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros2-gbp/py_binding_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-1`

## py_binding_tools

```
* Remove unused ament_lint packages
* Fix some cpplint issues
* Update copyright statements
* Contributors: Robert Haschke
```
