### PR TITLE
add 'open3d' to rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4852,7 +4852,7 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
-  open3d:
+  open3d_vendor:
     source:
       type: git
       url: https://github.com/christian-rauch/open3d_colcon.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4852,6 +4852,11 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
+  open3d:
+    source:
+      type: git
+      url: https://github.com/christian-rauch/open3d_colcon.git
+      version: main
   open_manipulator:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

~~`open3d`~~
`open3d_vendor`

## Package Upstream Source:

https://github.com/isl-org/Open3D.git

## Purpose of using this:

Open3D is an open-source library that supports rapid development of software that deals with 3D data.

# Please Add This Package to be indexed in the rosdistro.

`jazzy`, `rolling`

# The source is here:

https://github.com/christian-rauch/open3d_colcon

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
