### PR TITLE
control_toolbox: 4.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1561,7 +1561,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.6.0-1
+      version: 4.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.7.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.6.0-1`

## control_toolbox

```
* Declare missing parameters for PID (#443 <https://github.com/ros-controls/control_toolbox/issues/443>) (#445 <https://github.com/ros-controls/control_toolbox/issues/445>)
* Use the FilterTest fixture instead (#439 <https://github.com/ros-controls/control_toolbox/issues/439>) (#446 <https://github.com/ros-controls/control_toolbox/issues/446>)
* Add missing public dependency on fmt library (#435 <https://github.com/ros-controls/control_toolbox/issues/435>)
* Contributors: Silvio Traversaro, Christoph Fröhlich
```
