### PR TITLE
Revert ros2_control due to jazzy breaking deprecation.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7725,7 +7725,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.35.0-1
+      version: 4.33.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Ros2_control added a deprecation in [4.34.0](https://github.com/ros-controls/ros2_control/blob/4.34.0):

https://github.com/ros-controls/ros2_control/blob/d026efc28a26f17d67b9221261a409b79fe3577a/hardware_interface/CHANGELOG.rst?plain=1#L15

This breaks downstream packages [feetech_ros2_driver](https://github.com/JafarAbdi/feetech_ros2_driver) and [topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control). I'm reverting to the latest version without the deprecation to avoid the wipe out of those packages in the [upcoming jazzy patch sync](https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2025-08-14/).

I'll revert this change as soon as the sync is done.

FYI: @bmagyar 