### PR TITLE
husarion_ugv_ros: 2.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3854,6 +3854,14 @@ repositories:
       version: ros2
     status: developed
   husarion_ugv_ros:
+    release:
+      packages:
+      - husarion_ugv_description
+      - husarion_ugv_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/husarion/husarion_ugv_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husarion_ugv_ros` to `2.2.2-1`:

- upstream repository: https://github.com/husarion/husarion_ugv_ros.git
- release repository: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## husarion_ugv_description

```
* use husarion_components_description (#577 <https://github.com/husarion/husarion_ugv_ros/issues/577>) (#583 <https://github.com/husarion/husarion_ugv_ros/issues/583>)
* update lights driver config (#543 <https://github.com/husarion/husarion_ugv_ros/issues/543>) (#579 <https://github.com/husarion/husarion_ugv_ros/issues/579>)
* Added use_sim to compontnts (#574 <https://github.com/husarion/husarion_ugv_ros/issues/574>) (#576 <https://github.com/husarion/husarion_ugv_ros/issues/576>)
* Humble gz hotfix (#530 <https://github.com/husarion/husarion_ugv_ros/issues/530>)
* Contributors: Dawid Kmak, Infra Man, Jakub Delicat
```

## husarion_ugv_msgs

- No changes
