### PR TITLE
husarion_ugv_ros: 2.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3506,6 +3506,14 @@ repositories:
       version: ros2
     status: developed
   husarion_ugv_ros:
+    release:
+      packages:
+      - husarion_ugv_description
+      - husarion_ugv_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/husarion/husarion_ugv_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husarion_ugv_ros` to `2.3.1-1`:

- upstream repository: https://github.com/husarion/husarion_ugv_ros.git
- release repository: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## husarion_ugv_description

```
* use husarion_components_description (#577 <https://github.com/husarion/husarion_ugv_ros/issues/577>)
* Added use_sim to compontnts (#574 <https://github.com/husarion/husarion_ugv_ros/issues/574>)
* Merge branch 'ros2' of https://github.com/husarion/husarion_ugv_ros into ros2-devel
* Merge branch 'ros2' of https://github.com/husarion/husarion_ugv_ros into ros2-devel
* Merge branch 'ros2' of https://github.com/husarion/husarion_ugv_ros into ros2-devel
* Contributors: Dawid Kmak, Jakub Delicat, action-bot, kmakd
```

## husarion_ugv_msgs

```
* Merge branch 'ros2' of https://github.com/husarion/husarion_ugv_ros into ros2-devel
* Merge branch 'ros2' of https://github.com/husarion/husarion_ugv_ros into ros2-devel
* Merge branch 'ros2' of https://github.com/husarion/husarion_ugv_ros into ros2-devel
* Contributors: action-bot, kmakd
```
