### PR TITLE
open_manipulator: 4.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5715,7 +5715,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 4.0.6-1
+      version: 4.0.7-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.0.7-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.6-1`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* Fixed joint offset functionality of joint trajectory command broadcaster
* Contributors: Woojin Wie
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Fixed joint offset functionality of joint trajectory command broadcaster
* Updated launch files for OMY Packing and Unpacking
* Contributors: Woojin Wie
```

## open_manipulator_bringup

```
* Updated launch files for OMY Packing and Unpacking
* Contributors: Woojin Wie
```

## open_manipulator_collision

```
* None
```

## open_manipulator_description

```
* None
```

## open_manipulator_gui

```
* None
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* None
```
