### PR TITLE
Firefox geckodriver

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1428,6 +1428,9 @@ gdal-bin:
   gentoo: [sci-libs/gdal]
   nixos: [gdal]
   ubuntu: [gdal-bin]
+geckodriver:
+  ubuntu:
+    focal: [firefox-geckodriver]
 geographiclib:
   debian:
     '*': [libgeographiclib-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
geckodriver

## Package Upstream Source:
https://github.com/mozilla/geckodriver

## Purpose of using this:
This dependency provides the WebDriver server for automating Mozilla Firefox, used by Selenium and other browser automation frameworks.  
We require this for automated testing and interaction with web interfaces in ROS-based systems.

## Links to Distribution Packages

- Debian: 
  - **Not available**
- Ubuntu focal: https://launchpad.net/ubuntu/focal/+package/firefox-geckodriver
