### PR TITLE
rosdep: fixing openembedded

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7310,7 +7310,7 @@ libzstd-dev:
   freebsd: [zstd]
   gentoo: [app-arch/zstd]
   nixos: [zstd]
-  openembedded: [zstd@meta-oe]
+  openembedded: [zstd@openembedded-core]
   rhel: [libzstd-devel]
   ubuntu:
     '*': [libzstd-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4203,7 +4203,7 @@ python-termcolor:
   fedora: [python-termcolor]
   gentoo: [dev-python/termcolor]
   nixos: [pythonPackages.termcolor]
-  openembedded: ['${PYTHON_PN}-termcolor@openembedded-core']
+  openembedded: [python3-termcolor@meta-python]
   osx:
     pip:
       packages: [termcolor]
@@ -4372,7 +4372,7 @@ python-twisted-core:
   debian: [python-twisted-core]
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
-  openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
+  openembedded: [python3-twisted@meta-python]
   opensuse: [python2-Twisted]
   ubuntu: [python-twisted-core]
 python-twisted-web:
@@ -4708,7 +4708,6 @@ python-yaml:
   gentoo: [dev-python/pyyaml]
   macports: [py27-yaml]
   nixos: [pythonPackages.pyyaml]
-  openembedded: ['${PYTHON_PN}-pyyaml@meta-python']
   opensuse: [python2-PyYAML]
   osx:
     pip:
@@ -8498,7 +8497,7 @@ python3-pycryptodome:
   fedora: [python3-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
   nixos: [python3Packages.pycryptodomex]
-  openembedded: [python3-pycryptodomex@meta-python]
+  openembedded: [python3-pycryptodomex@openembedded-core]
   opensuse: [python3-pycryptodomex]
   osx:
     pip:
@@ -8779,7 +8778,7 @@ python3-pyparsing:
   fedora: [python3-pyparsing]
   gentoo: [dev-python/pyparsing]
   nixos: [python3Packages.pyparsing]
-  openembedded: [python3-pyparsing@meta-python]
+  openembedded: [python3-pyparsing@openembedded-core]
   opensuse: [python3-pyparsing]
   ubuntu: [python3-pyparsing]
 python3-pypdf:
@@ -9180,7 +9179,7 @@ python3-pytest:
   freebsd: [devel/py-pytest]
   gentoo: [dev-python/pytest]
   nixos: [python3Packages.pytest]
-  openembedded: [python3-pytest@meta-python]
+  openembedded: [python3-pytest@openembedded-core]
   opensuse: [python3-pytest]
   osx:
     pip:
@@ -9543,7 +9542,7 @@ python3-requests:
   fedora: [python3-requests]
   gentoo: [dev-python/requests]
   nixos: [python3Packages.requests]
-  openembedded: [python3-requests@meta-python]
+  openembedded: [python3-requests@openembedded-core]
   rhel: ['python%{python3_pkgversion}-requests']
   ubuntu: [python3-requests]
 python3-requests-futures:
@@ -9748,7 +9747,7 @@ python3-ruamel.yaml:
     stretch: [python3-ruamel.yaml]
   fedora: [python3-ruamel-yaml]
   nixos: [python3Packages.ruamel_yaml]
-  openembedded: [python3-ruamel-yaml@meta-python]
+  openembedded: [python3-ruamel-yaml@openembedded-core]
   rhel: ['python%{python3_pkgversion}-ruamel-yaml']
   ubuntu: [python3-ruamel.yaml]
 python3-ruff-pip:
@@ -11132,7 +11131,7 @@ python3-yaml:
   freebsd: [devel/py-pyyaml]
   gentoo: [dev-python/pyyaml]
   nixos: [python3Packages.pyyaml]
-  openembedded: [python3-pyyaml@meta-python]
+  openembedded: [python3-pyyaml@openembedded-core]
   opensuse: [python3-PyYAML]
   osx:
     pip:


### PR DESCRIPTION
Second set of fixes on rosdistro for OpenEmbedded.

base.yml

  zstd: recipe moved from meta-oe to openembedded-core
    see: https://git.openembedded.org/openembedded-core/commit/meta/recipes-extended/zstd?id=b132e9e8647c74fba439c689ec1409993e8590ed

python.yaml

  python3-twisted: python3-twisted-core is a package of the recipe python3-twisted
  python3-termcolor: part of meta-python
    see: https://layers.openembedded.org/layerindex/recipe/96040/
  python3-ruamel-yaml: recipe part of openembedded-core
    see: https://layers.openembedded.org/layerindex/recipe/240204/
  python3-requests: moved from meta-python to meta-openembedded
    see: https://git.openembedded.org/openembedded-core/commit/meta/recipes-devtools/python?id=5971e3540763f628918992919315ec49b016c02e
  python-pyyaml: python2 recipe no longer exist in Yocto/Openembedded
  python3-pyyaml: moved from meta-python to openembedded-core
    see: https://git.openembedded.org/openembedded-core/commit/meta/recipes-devtools/python?id=0a8600f9cec0a88b90693302554c82cfe28152ae
  python3-pytest: moved from meta-python to openembedded-core
    see: https://git.openembedded.org/openembedded-core/commit/meta/recipes-devtools/python?id=3299ddeab5eb32a21efaee63c2b7f490089b8476
  python3-pyparsing: moved from meta-python to openembedded-core
    see: https://git.openembedded.org/openembedded-core/commit/meta/recipes-devtools/python?id=85c025a7072558e49e4cf77ce03b3d156b9377a0
  python3-pycryptodomex: recipe part of openembedded-core
    see: https://git.openembedded.org/openembedded-core/tree/meta/recipes-devtools/python/python3-pycryptodomex_3.23.0.bb

