### PR TITLE
topic_based_ros2_control: 0.3.0-4 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10027,7 +10027,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-3
+      version: 0.3.0-4
   topic_tools:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_ros2_control` to `0.3.0-4`:

- upstream repository: https://github.com/PickNikRobotics/topic_based_ros2_control.git
- release repository: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.0-3`

## topic_based_ros2_control

```
* Deprecation notices should be seen. Do not convert warnings into errors. (#36 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/36>)
* Add integration test (#28 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/28>)
  * Add ruff/ruff format to pre-commit & Add integration test
  * Set joint_states_ to initial_value as well
* Update HARDWARE_INTERFACE_VERSION_GTE from hardware_interface's version.h (#32 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/32>)
* Update README.md
* Fix RessourceManager constructor (#30 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/30>)
  * Fix rm() constructor
  * Enable CI on jazzy/rolling
  * Add macro to check hardware_interface version
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
* Update README.md (#31 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/31>)
* Allow publisher to always publish by setting the threshold to zero. (#22 <https://github.com/PickNikRobotics/topic_based_ros2_control/issues/22>)
  * Allow publisher to always publish by setting the threshold to zero.
  On documentation (https://github.com/PickNikRobotics/topic_based_ros2_control/blob/main/doc/user.md)
  trigger_joint_command_threshold can be configuration with zero so that the allow publisher to
  always send the joint command.
  However, in the code the condition was set with:
  ```
  if (diff <= trigger_joint_command_threshold\_)
  {
  return hardware_interface::return_type::OK;
  }
  ```
  In case trigger_joint_command_threshold_ is set to zero, diff can still be zero so
  it will not trigger the send.
  This PR tries to address the above mentioned case.
  * Revert "Allow publisher to always publish by setting the threshold to zero."
  This reverts commit a799b539d877d1a2ca7203f5d57bc4c805df7202.
  * Update the documentation instead (-1).
* Contributors: Bence Magyar, Christoph Fröhlich, Jafar Uruç, Yong Tang
```
