### PR TITLE
feetech_ros2_driver: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2422,7 +2422,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
-      version: 0.1.0-3
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/JafarAbdi/feetech_ros2_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `feetech_ros2_driver` to `0.2.0-1`:

- upstream repository: https://github.com/JafarAbdi/feetech_ros2_driver.git
- release repository: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-3`

## feetech_ros2_driver

```
* 🛠️ Bump actions/checkout from 4 to 5 (#15 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/15>)
  Bumps [actions/checkout](https://github.com/actions/checkout) from 4 to 5.
  - [Release notes](https://github.com/actions/checkout/releases)
  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/actions/checkout/compare/v4...v5)
  ---
  updated-dependencies:
  - dependency-name: actions/checkout
  dependency-version: '5'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Add option to enable warnings as errors & enable by default in CI (#16 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/16>)
* Fix error for colcon build (#13 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/13>)
  * fix error for compile
  * add #include <fmt/ranges.h> to demo.cpp
  * use fmt::join(keys, ", ")
* Add on_deactivate function to disable torque when exit (#12 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/12>)
* Disable holding torque for joints without command interfaces (#10 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/10>)
* Write commands only if joint has any command interfaces defined (#9 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/9>)
* Move ROS 2 unrelated code to a core standalone cmake package (#7 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/7>)
* Contributors: Bence Magyar, Jafar Uruç, Tsogoo, dependabot[bot], yadunund
```
