### PR TITLE
Revert "Revert ros2_control due to jazzy breaking deprecation. (#47292)"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7725,7 +7725,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.33.0-1
+      version: 4.35.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
This reverts commit 22049aa8368c382f9a3bff36e1d225942e5fe657.

Undoing https://github.com/ros/rosdistro/pull/47292 and bringing this version back since fixes are in with the releases of: https://github.com/ros/rosdistro/pull/47306 and https://github.com/ros/rosdistro/pull/47305.

FYI: @bmagyar, @JafarAbdi 