### PR TITLE
gz_ros2_control: 1.2.15-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3306,7 +3306,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.14-1
+      version: 1.2.15-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.15-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.2.14-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Fix ackermann example inertial and joint tf publish (#641 <https://github.com/ros-controls/gz_ros2_control/issues/641>) (#644 <https://github.com/ros-controls/gz_ros2_control/issues/644>)
* Contributors: mergify[bot]
```
