### PR TITLE
gz_ros2_control: 2.0.11-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2720,7 +2720,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.10-1
+      version: 2.0.11-2
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.11-2`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.10-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Fix ackermann example inertial and joint tf publish (#641 <https://github.com/ros-controls/gz_ros2_control/issues/641>) (#643 <https://github.com/ros-controls/gz_ros2_control/issues/643>)
* Contributors: mergify[bot]
```
