### PR TITLE
Add python3-pytest-dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9253,7 +9253,20 @@ python3-pytest-mock:
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
 python3-pytest-dependency:
-  ubuntu: [python3-pytest-dependency]
+  alpine: [py3-pytest-dependency]
+  arch: [python-pytest-dependency]
+  debian: [python3-pytest-dependency]
+  fedora: [python3-pytest-dependency]
+  gentoo: [dev-python/pytest-dependency]
+  nixos: [python3Packages.pytest-dependency]
+  openembedded: [python3-pytest-dependency]
+  rhel:
+    '*': [python3-pytest-dependency]
+    '7': null
+    '8': null
+  ubuntu:
+    '*': [python3-pytest-dependency]
+    focal: null
 python3-pytest-order:
   arch: [python-pytest-order]
   debian: [python3-pytest-order]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9237,21 +9237,6 @@ python3-pytest-cov:
   openembedded: [python3-pytest-cov@meta-ros-common]
   rhel: ['python%{python3_pkgversion}-pytest-cov']
   ubuntu: [python3-pytest-cov]
-python3-pytest-mock:
-  alpine: [py3-pytest-mock]
-  arch: [python-pytest-mock]
-  debian: [python3-pytest-mock]
-  fedora: [python3-pytest-mock]
-  freebsd: [devel/py-pytest-mock]
-  gentoo: [dev-python/pytest-mock]
-  nixos: [python3Packages.pytest-mock]
-  openembedded: [python3-pytest-mock@meta-ros-common]
-  opensuse: [python3-pytest-mock]
-  osx:
-    pip:
-      packages: [pytest-mock]
-  rhel: ['python%{python3_pkgversion}-pytest-mock']
-  ubuntu: [python3-pytest-mock]
 python3-pytest-dependency:
   alpine: [py3-pytest-dependency]
   arch: [python-pytest-dependency]
@@ -9267,6 +9252,21 @@ python3-pytest-dependency:
   ubuntu:
     '*': [python3-pytest-dependency]
     focal: null
+python3-pytest-mock:
+  alpine: [py3-pytest-mock]
+  arch: [python-pytest-mock]
+  debian: [python3-pytest-mock]
+  fedora: [python3-pytest-mock]
+  freebsd: [devel/py-pytest-mock]
+  gentoo: [dev-python/pytest-mock]
+  nixos: [python3Packages.pytest-mock]
+  openembedded: [python3-pytest-mock@meta-ros-common]
+  opensuse: [python3-pytest-mock]
+  osx:
+    pip:
+      packages: [pytest-mock]
+  rhel: ['python%{python3_pkgversion}-pytest-mock']
+  ubuntu: [python3-pytest-mock]
 python3-pytest-order:
   arch: [python-pytest-order]
   debian: [python3-pytest-order]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9252,6 +9252,8 @@ python3-pytest-mock:
       packages: [pytest-mock]
   rhel: ['python%{python3_pkgversion}-pytest-mock']
   ubuntu: [python3-pytest-mock]
+python3-pytest-dependency:
+  ubuntu: [python3-pytest-dependency]
 python3-pytest-order:
   arch: [python-pytest-order]
   debian: [python3-pytest-order]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pytest-dependency

## Package Upstream Source:

https://github.com/RKrahl/pytest-dependency

## Purpose of using this:

For integration tests it can be useful to run tests in order.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/python3-pytest-dependency
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=python3-pytest-dependency
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=py3-pytest-dependency
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?query=pytest-dependency
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pytest-dependency
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=pytest-dependency
