### PR TITLE
dbw_ros: 2.3.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1758,7 +1758,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.5-1
+      version: 2.3.6-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.6-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.5-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2025/08/18 release package
* Add GM ISV platform
* Add EcuInfo message for throttle monitor
* Add ThrottleOffset message
* Add gear param hash
* Add firmware info to EcuInfo message
* Minor changes to CAN message parsing header
* Contributors: Kevin Hallenbeck
```

## ds_dbw_joystick_demo

- No changes

## ds_dbw_msgs

```
* Add ThrottleOffset message
* Add firmware info to EcuInfo message
* Contributors: Kevin Hallenbeck
```
