### PR TITLE
trac_ik: 2.1.1-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8976,7 +8976,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/trac_ik-release.git
-      version: 2.1.1-1
+      version: 2.1.1-2
     source:
       type: git
       url: https://bitbucket.org/traclabs/trac_ik.git


### PR DESCRIPTION
This release is to try and trigger rebuild of trac_ik_kinematics_plugin to fix [Kbin_uN64__trac_ik_kinematics_plugin__ubuntu_noble_amd64__binary](https://build.ros2.org/job/Kbin_uN64__trac_ik_kinematics_plugin__ubuntu_noble_amd64__binary/)

Increasing version of package(s) in repository `trac_ik` to `2.1.1-2`:

- upstream repository: https://bitbucket.org/traclabs/trac_ik
- release repository: https://github.com/ros2-gbp/trac_ik-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.1-1`

## trac_ik

- No changes

## trac_ik_kinematics_plugin

```
* Add Manipulation3, maximizing smallest singular value (#46 <https://bitbucket.org/traclabs/trac_ik/pull-requests/46>)
* Contributors: Matthijs van der Burgh
```

## trac_ik_lib

```
* Add Manipulation3, maximizing smallest singular value (#46 <https://bitbucket.org/traclabs/trac_ik/pull-requests/46>)
* Contributors: Matthijs van der Burgh
```
