### PR TITLE
Revert Revert moveit: 2.14.0-1 in 'kilted/distribution.yaml'

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4203,7 +4203,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.13.2-2
+      version: 2.14.0-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
This reverts commit 29b819d394766ddc9b2f41dc8e693c712b4c1462 #47018 , as suggested by @nbbrooks there.

The API incompatibility has been resolved through a release of moveit_msgs 2.7.1 #47287