### PR TITLE
xacro: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11179,7 +11179,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/xacro-release.git
-      version: 2.0.13-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros/xacro.git


### PR DESCRIPTION
Increasing version of package(s) in repository `xacro` to `2.1.0-1`:

- upstream repository: https://github.com/ros/xacro.git
- release repository: https://github.com/ros2-gbp/xacro-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.13-1`

## xacro

```
* Resolve macro arguments within caller's scope (#373 <https://github.com/ros/xacro/issues/373>)
* Remove consecutive dashes in the input file name (#372 <https://github.com/ros/xacro/issues/372>)
* Expose bool() in global and python namespace (#371 <https://github.com/ros/xacro/issues/371>)
* Remove extra line in doc string (#362 <https://github.com/ros/xacro/issues/362>)
* Contributors: Jasper van Brakel, Robert Haschke, Tully Foote
```
