### PR TITLE
topic_based_hardware_interfaces: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8877,6 +8877,13 @@ repositories:
       type: git
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
+    release:
+      packages:
+      - joint_state_topic_hardware_interface
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/topic_based_hardware-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_hardware_interfaces` to `0.2.0-1`:

- upstream repository: https://github.com/ros-controls/topic_based_hardware_interfaces.git
- release repository: https://github.com/ros2-gbp/topic_based_hardware-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## joint_state_topic_hardware_interface

```
* Deactivate all tests (#24 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/24>)
* Fix headings (#13 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/13>)
* Switched to Default Node from CM Executor and updated to new params API (#6 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/6>)
* Add common repository features from ros-controls (#8 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/8>)
* Switch to on_init(HardwareComponentInterfaceParams) (#11 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/11>)
* Add Bence Magyar as maintainer (#4 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/4>)
* Relicense to Apache 2.0 (#3 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/3>)
* Fix CI (#1 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/1>)
* rename to joint_state_topic_hardware_interface
* Contributors: Bence Magyar, Christoph Fröhlich, Marq Rasmussen, Soham Patil
```
