### PR TITLE
navigation2: 1.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4578,11 +4578,12 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/navigation2-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git
       version: kilted
+    status: developed
   navigation_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.4.1-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/ros2-gbp/navigation2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`
