### PR TITLE
rosdep: fixing openembedded

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -487,7 +487,7 @@ castxml:
   fedora: [castxml]
   macports: [castxml]
   nixos: [castxml]
-  openembedded: [castxml@meta-clang]
+  openembedded: [castxml@meta-oe]
   ubuntu: [castxml]
 catch2:
   alpine: [catch2]
@@ -1235,7 +1235,7 @@ fmt:
   fedora: [fmt-devel]
   gentoo: [dev-libs/libfmt]
   nixos: [fmt]
-  openembedded: [fmt@meta-oe]
+  openembedded: [fmt@openembedded-core]
   osx:
     homebrew:
       packages: [fmt]
@@ -4237,7 +4237,7 @@ libgrpc:
   fedora: [grpc-devel]
   gentoo: [net-libs/grpc]
   nixos: [grpc]
-  openembedded: [grpc@meta-networking]
+  openembedded: [grpc@meta-oe]
   opensuse: [grpc-devel]
   osx:
     homebrew:
@@ -4765,7 +4765,7 @@ libmicrohttpd:
   fedora: [libmicrohttpd-devel]
   gentoo: [net-libs/libmicrohttpd]
   nixos: [libmicrohttpd]
-  openembedded: [libmicrohttpd@meta-oe]
+  openembedded: [libmicrohttpd@openembedded-core]
   rhel: [libmicrohttpd-devel]
   ubuntu: [libmicrohttpd-dev]
 libmlpack-dev:
@@ -5062,7 +5062,7 @@ libomp-dev:
   fedora: [libomp-devel]
   gentoo: [sys-libs/libomp]
   nixos: [llvmPackages.openmp]
-  openembedded: [openmp@meta-clang]
+  openembedded: [openmp@openembedded-core]
   rhel:
     '*': [libomp-devel]
     '7': null
@@ -7310,7 +7310,7 @@ libzstd-dev:
   freebsd: [zstd]
   gentoo: [app-arch/zstd]
   nixos: [zstd]
-  openembedded: [zstd@meta-oe]
+  openembedded: [zstd@openembedded-core]
   rhel: [libzstd-devel]
   ubuntu:
     '*': [libzstd-dev]
@@ -9106,7 +9106,7 @@ sdl:
   gentoo: [media-libs/libsdl]
   macports: [libsdl]
   nixos: [SDL]
-  openembedded: [libsdl@openembedded-core]
+  openembedded: [libsdl@meta-oe]
   opensuse: [libSDL-devel]
   rhel: [SDL-devel]
   ubuntu: [libsdl1.2-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1041,7 +1041,6 @@ python-click:
   fedora: [python-click]
   gentoo: [dev-python/click]
   nixos: [pythonPackages.click]
-  openembedded: ['${PYTHON_PN}-click@meta-python']
   osx:
     pip:
       packages: [click]
@@ -2272,7 +2271,6 @@ python-lxml:
   freebsd: [py27-lxml]
   gentoo: [dev-python/lxml]
   nixos: [pythonPackages.lxml]
-  openembedded: ['${PYTHON_PN}-lxml@meta-python']
   opensuse: [python2-lxml]
   osx:
     pip:
@@ -3982,7 +3980,6 @@ python-sphinx:
   gentoo: [dev-python/sphinx]
   macports: [py27-sphinx]
   nixos: [pythonPackages.sphinx]
-  openembedded: ['${PYTHON_PN}-sphinx@meta-ros-common']
   opensuse: [python-Sphinx]
   osx:
     pip:
@@ -4203,7 +4200,7 @@ python-termcolor:
   fedora: [python-termcolor]
   gentoo: [dev-python/termcolor]
   nixos: [pythonPackages.termcolor]
-  openembedded: ['${PYTHON_PN}-termcolor@openembedded-core']
+  openembedded: [python3-termcolor@meta-python]
   osx:
     pip:
       packages: [termcolor]
@@ -4300,7 +4297,6 @@ python-tqdm:
     buster: [python-tqdm]
     stretch: [python-tqdm]
   fedora: [python-tqdm]
-  openembedded: [python3-tqdm@meta-python]
   ubuntu:
     bionic: [python-tqdm]
 python-transforms3d-pip:
@@ -4372,7 +4368,7 @@ python-twisted-core:
   debian: [python-twisted-core]
   gentoo: [dev-python/twisted]
   nixos: [pythonPackages.twisted]
-  openembedded: ['${PYTHON_PN}-twisted-core@meta-python']
+  openembedded: [python3-twisted@meta-python]
   opensuse: [python2-Twisted]
   ubuntu: [python-twisted-core]
 python-twisted-web:
@@ -4708,7 +4704,6 @@ python-yaml:
   gentoo: [dev-python/pyyaml]
   macports: [py27-yaml]
   nixos: [pythonPackages.pyyaml]
-  openembedded: ['${PYTHON_PN}-pyyaml@meta-python']
   opensuse: [python2-PyYAML]
   osx:
     pip:
@@ -5379,7 +5374,7 @@ python3-click:
   fedora: [python3-click]
   gentoo: [dev-python/click]
   nixos: [python3Packages.click]
-  openembedded: [python3-click@meta-python]
+  openembedded: [python3-click@openembedded-core]
   rhel: ['python%{python3_pkgversion}-click']
   ubuntu: [python3-click]
 python3-colcon-common-extensions:
@@ -5417,7 +5412,7 @@ python3-colorama:
   fedora: [python3-colorama]
   gentoo: [dev-python/colorama]
   nixos: [python3Packages.colorama]
-  openembedded: [python3-colorama@meta-python]
+  openembedded: [python3-colorama@openembedded-core]
   rhel: ['python%{python3_pkgversion}-colorama']
   ubuntu: [python3-colorama]
 python3-colorcet:
@@ -5609,6 +5604,7 @@ python3-deprecated:
     buster: null
   fedora: [python3-deprecated]
   nixos: [python3Packages.deprecated]
+  openembedded: [python3-deprecated@meta-python]
   rhel:
     '*': [python3-deprecated]
     '7': null
@@ -6805,7 +6801,7 @@ python3-importlib-metadata:
   freebsd: [python3]
   gentoo: [dev-python/importlib-metadata]
   nixos: [python3Packages.importlib-metadata]
-  openembedded: [python3-importlib-metadata@openembedded-core]
+  openembedded: [python3-importlib-metadata@meta-python]
   osx:
     pip:
       packages: [importlib_metadata]
@@ -7203,7 +7199,7 @@ python3-lxml:
   freebsd: [devel/py-lxml]
   gentoo: [dev-python/lxml]
   nixos: [python3Packages.lxml]
-  openembedded: [python3-lxml@meta-python]
+  openembedded: [python3-lxml@openembedded-core]
   opensuse: [python3-lxml]
   osx:
     pip:
@@ -8076,6 +8072,7 @@ python3-paho-mqtt:
   debian: [python3-paho-mqtt]
   fedora: [python3-paho-mqtt]
   nixos: [python3Packages.paho-mqtt]
+  openembedded: [python3-paho-mqtt@meta-python]
   rhel:
     '*': [python3-paho-mqtt]
     '7': null
@@ -8512,7 +8509,7 @@ python3-pycryptodome:
   fedora: [python3-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
   nixos: [python3Packages.pycryptodomex]
-  openembedded: [python3-pycryptodomex@meta-python]
+  openembedded: [python3-pycryptodomex@openembedded-core]
   opensuse: [python3-pycryptodomex]
   osx:
     pip:
@@ -8793,7 +8790,7 @@ python3-pyparsing:
   fedora: [python3-pyparsing]
   gentoo: [dev-python/pyparsing]
   nixos: [python3Packages.pyparsing]
-  openembedded: [python3-pyparsing@meta-python]
+  openembedded: [python3-pyparsing@openembedded-core]
   opensuse: [python3-pyparsing]
   ubuntu: [python3-pyparsing]
 python3-pypdf:
@@ -9194,7 +9191,7 @@ python3-pytest:
   freebsd: [devel/py-pytest]
   gentoo: [dev-python/pytest]
   nixos: [python3Packages.pytest]
-  openembedded: [python3-pytest@meta-python]
+  openembedded: [python3-pytest@openembedded-core]
   opensuse: [python3-pytest]
   osx:
     pip:
@@ -9557,7 +9554,7 @@ python3-requests:
   fedora: [python3-requests]
   gentoo: [dev-python/requests]
   nixos: [python3Packages.requests]
-  openembedded: [python3-requests@meta-python]
+  openembedded: [python3-requests@openembedded-core]
   rhel: ['python%{python3_pkgversion}-requests']
   ubuntu: [python3-requests]
 python3-requests-futures:
@@ -9602,6 +9599,7 @@ python3-rich:
   fedora: [python3-rich]
   gentoo: [rich]
   nixos: [python3Packages.rich]
+  openembedded: [python3-rich@meta-python]
   osx:
     pip:
       packages: [rich]
@@ -9762,7 +9760,7 @@ python3-ruamel.yaml:
     stretch: [python3-ruamel.yaml]
   fedora: [python3-ruamel-yaml]
   nixos: [python3Packages.ruamel_yaml]
-  openembedded: [python3-ruamel-yaml@meta-python]
+  openembedded: [python3-ruamel-yaml@openembedded-core]
   rhel: ['python%{python3_pkgversion}-ruamel-yaml']
   ubuntu: [python3-ruamel.yaml]
 python3-ruff-pip:
@@ -9906,6 +9904,7 @@ python3-semver:
   fedora: [python3-semver]
   freebsd: [py36-semver]
   nixos: [python3Packages.semver]
+  openembedded: [python3-semver@meta-python]
   rhel: [python3-semver]
   ubuntu: [python3-semver]
 python3-sense-emu-pip:
@@ -10211,7 +10210,7 @@ python3-sphinx:
   fedora: [python3-sphinx]
   gentoo: [dev-python/sphinx]
   nixos: [python3Packages.sphinx]
-  openembedded: [python3-sphinx@meta-ros-common]
+  openembedded: [python3-sphinx@openembedded-core]
   opensuse: [python3-Sphinx]
   rhel: ['python%{python3_pkgversion}-sphinx']
   ubuntu: [python3-sphinx]
@@ -10636,6 +10635,7 @@ python3-tqdm:
   debian: [python3-tqdm]
   fedora: [python3-tqdm]
   nixos: [python3Packages.tqdm]
+  openembedded: [python3-tqdm@meta-python]
   osx:
     pip:
       packages: [tqdm]
@@ -10777,6 +10777,7 @@ python3-typing-extensions:
   freebsd: [devel/py-typing-extensions]
   gentoo: [dev-python/typing-extensions]
   nixos: [python3Packages.typing-extensions]
+  openembedded: [python3-typing-extensions@openembedded-core]
   opensuse: [python3-typing_extensions]
   rhel:
     '*': [python3-typing-extensions]
@@ -10966,6 +10967,7 @@ python3-waitress:
   fedora: [python3-waitress]
   gentoo: [dev-python/waitress]
   nixos: [python3Packages.waitress]
+  openembedded: [python3-waitress@meta-python]
   opensuse: [python3-waitress]
   rhel: [python3-waitress]
   ubuntu: [python3-waitress]
@@ -11146,7 +11148,7 @@ python3-yaml:
   freebsd: [devel/py-pyyaml]
   gentoo: [dev-python/pyyaml]
   nixos: [python3Packages.pyyaml]
-  openembedded: [python3-pyyaml@meta-python]
+  openembedded: [python3-pyyaml@openembedded-core]
   opensuse: [python3-PyYAML]
   osx:
     pip:


### PR DESCRIPTION
Yet another set of changes to rosdep for openembedded.
Mainly packages that moved from one layer to another.
A few python2 removals.
And a new new once that the Superflore tool was reporting as missing.

@robwoolley: please review

base.yml

  - castxml: moved from meta-clang to meta-oe
      see: https://layers.openembedded.org/layerindex/recipe/464640/
  - fmt: moved from meta-oe to openembedded-core
      see: https://layers.openembedded.org/layerindex/recipe/413335/
  - grpc: moved from meta-networking to meta-oe
      see: https://layers.openembedded.org/layerindex/recipe/164528/
      note: there is a grpc recipe in meta-ros1-noetic, but ros1 is EOL
  - libmicrohttpd: moved from meta-oe to openembedded-core
      see: https://layers.openembedded.org/layerindex/recipe/178259/
  - openmp: moved from meta-clang to meta-openembedded-core
      see: https://layers.openembedded.org/layerindex/recipe/448655/
  - libsdl: moved from openembedded-core to meta-oe
      see: https://layers.openembedded.org/layerindex/recipe/104784/

python.yml

  - python-click: removed because python2 EOLs
  - python3-click: moved from meta-python to openembedded-core
      see: https://layers.openembedded.org/layerindex/branch/master/layer/openembedded-core/
  - python-lxml: removed because python2 EOL
  - python3-lxml: moved from meta-python to openembedde-core
      see: https://layers.openembedded.org/layerindex/recipe/323021/
  - python-sphinx: removed because python2 EOL
  - python3-sphinx: removed from meta-ros-common, use openembedded-core
      see: https://github.com/ros/meta-ros/commit/fd73dfe31a9f94c5b03d07918cd187c26f4301af
      see: https://layers.openembedded.org/layerindex/recipe/299616/
  - python-tqdm: removed because python2 EOL
  - python3-tqdm: added entry at meta-python
      see: https://layers.openembedded.org/layerindex/recipe/97211/
  - python3-click: moved from meta-python to openembedde-core
      see: https://layers.openembedded.org/layerindex/recipe/346361/
  - python3-colorama: moved from meta-python to openembedded-core
      see: https://layers.openembedded.org/layerindex/recipe/449562/
  - python3-deprecated: added entry at meta-python
      see: https://layers.openembedded.org/layerindex/recipe/181538/
