### PR TITLE
rcutils: 6.9.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6116,7 +6116,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.7-1
+      version: 6.9.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.8-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.9.7-1`

## rcutils

```
* Add rcutils_raw_steady_time_now method for slew-free clock (#507 <https://github.com/ros2/rcutils/issues/507>) (#513 <https://github.com/ros2/rcutils/issues/513>)
* Contributors: mergify[bot]
```
