### PR TITLE
image_common: 6.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2952,7 +2952,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.3.0-1
+      version: 6.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.3.0-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

```
* Fix compilation error with clang (#372 <https://github.com/ros-perception/image_common/issues/372>)
* Support lifecycle node - NodeInterfaces (#352 <https://github.com/ros-perception/image_common/issues/352>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Fix compilation error with clang (#372 <https://github.com/ros-perception/image_common/issues/372>)
* Support lifecycle node - NodeInterfaces (#352 <https://github.com/ros-perception/image_common/issues/352>)
* Fixed clang build (#371 <https://github.com/ros-perception/image_common/issues/371>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

```
* Support lifecycle node - NodeInterfaces (#352 <https://github.com/ros-perception/image_common/issues/352>)
* Contributors: Alejandro Hernández Cordero
```
