### PR TITLE
depthai: 3.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1319,11 +1319,20 @@ repositories:
       version: kilted
     status: developed
   depthai:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 3.0.2-2
+      version: 3.0.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: kilted
     status: developed
   depthai-ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `3.0.3-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.2-2`
