### PR TITLE
rviz: 15.1.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8129,7 +8129,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.7-1
+      version: 15.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.8-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.7-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Deprecates update(float, float) methods and provides update(std::chrono::duration, std::chrono::duration) replacements. (#1533 <https://github.com/ros2/rviz//issues/1533>)
* Contributors: Mark Johnson
```

## rviz_default_plugins

```
* Support image transport lifecycle (#1472 <https://github.com/ros2/rviz//issues/1472>)
* Fix QoS profile loading for InitialPoseTool from rviz config files (#1544 <https://github.com/ros2/rviz//issues/1544>)
* Contributors: Alejandro Hernández Cordero, Kosuke Takeuchi
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Update OGRE mesh files from ROS1 RViz (#1536 <https://github.com/ros2/rviz//issues/1536>) (#1559 <https://github.com/ros2/rviz//issues/1559>)
* add resourceExists check to loadEmbeddedTexture before loading texture (#1542 <https://github.com/ros2/rviz//issues/1542>)
* Contributors: John TGZ, mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
