### PR TITLE
image_transport_plugins: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3000,7 +3000,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 6.1.0-1
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `6.2.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.0-1`

## compressed_depth_image_transport

```
* Support lifecycle (#180 <https://github.com/ros-perception/image_transport_plugins/issues/180>)
* Export target in the modern way (#199 <https://github.com/ros-perception/image_transport_plugins/issues/199>)
* Contributors: Alejandro Hernández Cordero, Patrick Roncagliolo
```

## compressed_image_transport

```
* Support lifecycle (#180 <https://github.com/ros-perception/image_transport_plugins/issues/180>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Support lifecycle (#180 <https://github.com/ros-perception/image_transport_plugins/issues/180>)
* Contributors: Alejandro Hernández Cordero
```

## zstd_image_transport

```
* Support lifecycle (#180 <https://github.com/ros-perception/image_transport_plugins/issues/180>)
* Fix linter warning (#201 <https://github.com/ros-perception/image_transport_plugins/issues/201>)
* Contributors: Alejandro Hernández Cordero, Patrick Roncagliolo
```
