### PR TITLE
ffmpeg_image_transport_tools: 3.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1942,7 +1942,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
-      version: 3.0.0-1
+      version: 3.0.0-2
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_tools` to `3.0.0-2`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.0-1`

## ffmpeg_image_transport_tools

```
* use head_ref for workflow
* added ffmpeg_encoder_decoder to repos file
* added gitignore for tests and updated README
* added uncompress_bag and tests
* adapt to decoder api changes
* switch to black python formatting
* more documentation, better logging
* be able to compare different size images
* keep recording time stamps for flushing
* dont create emtpy history file
* added quality test/decoding
* added compress_bag and fixed some bugs
* Contributors: Bernd Pfrommer
```
