### PR TITLE
ffmpeg_encoder_decoder: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1897,7 +1897,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_encoder_decoder` to `3.0.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_encoder_decoder.git
- release repository: https://github.com/ros2-gbp/ffmpeg_encoder_decoder-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.0-1`

## ffmpeg_encoder_decoder

```
* new CI workflow
* Contributors: Bernd Pfrommer
```
