### PR TITLE
ffmpeg_image_transport: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2778,7 +2778,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 2.0.3-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `3.0.1-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.3-1`

## ffmpeg_image_transport

```
* improved CI workflow
* Contributors: Bernd Pfrommer
```
