### PR TITLE
rviz: 15.0.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8159,7 +8159,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.4-1
+      version: 15.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.4-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fix QoS profile loading for InitialPoseTool from rviz config files (#1544 <https://github.com/ros2/rviz//issues/1544>) (#1553 <https://github.com/ros2/rviz//issues/1553>)
* fix deprecated include (#1530 <https://github.com/ros2/rviz//issues/1530>) (#1531 <https://github.com/ros2/rviz//issues/1531>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Update OGRE mesh files from ROS1 RViz (#1536 <https://github.com/ros2/rviz//issues/1536>) (#1557 <https://github.com/ros2/rviz//issues/1557>)
* add resourceExists check to loadEmbeddedTexture before loading texture (#1542 <https://github.com/ros2/rviz//issues/1542>) (#1550 <https://github.com/ros2/rviz//issues/1550>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
