### PR TITLE
rviz: 11.2.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10111,7 +10111,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.19-1
+      version: 11.2.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.20-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `11.2.19-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fix QoS profile loading for InitialPoseTool from rviz config files (#1544 <https://github.com/ros2/rviz//issues/1544>) (#1555 <https://github.com/ros2/rviz//issues/1555>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Update OGRE mesh files from ROS1 RViz (#1536 <https://github.com/ros2/rviz//issues/1536>)
* add resourceExists check to loadEmbeddedTexture before loading texture (#1542 <https://github.com/ros2/rviz//issues/1542>) (#1552 <https://github.com/ros2/rviz//issues/1552>)
* Contributors: Seunghwan Jo, mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
