### PR TITLE
polygon_ros: 1.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7242,7 +7242,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/polygon_ros.git
-      version: main
+      version: kilted_and_prior
     release:
       packages:
       - polygon_demos
@@ -7257,7 +7257,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/polygon_ros.git
-      version: main
+      version: kilted_and_prior
     status: developed
   popf:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6294,7 +6294,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/polygon_ros.git
-      version: main
+      version: kilted_and_prior
     release:
       packages:
       - polygon_demos
@@ -6309,7 +6309,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/polygon_ros.git
-      version: main
+      version: kilted_and_prior
     status: developed
   popf:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5427,7 +5427,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/MetroRobots/polygon_ros.git
-      version: main
+      version: kilted_and_prior
     release:
       packages:
       - polygon_demos
@@ -5442,7 +5442,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/MetroRobots/polygon_ros.git
-      version: main
+      version: kilted_and_prior
     status: developed
   popf:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5406,7 +5406,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/polygon_ros-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `polygon_ros` to `1.3.0-1`:

- upstream repository: https://github.com/MetroRobots/polygon_ros
- release repository: https://github.com/ros2-gbp/polygon_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.0-1`
