### PR TITLE
ffmpeg_image_transport: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1912,7 +1912,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 3.0.0-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `3.0.2-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.0-1`

## ffmpeg_image_transport

```
* fix param dump bug by changing decoder param sep from . to  _
* Contributors: Bernd Pfrommer
```
