### PR TITLE
yasmin: 3.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12616,7 +12616,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `3.4.0-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.0-1`

## yasmin

```
* fixing python remapping
* adding status to states
* wait for a state to cancel the state machine if running
* fixing flags names in python state
* set_current_state function for state machine
* adding publisher demo to README
* Fixing set log level in Cpp (#61 <https://github.com/uleroboticsgroup/yasmin/issues/61>)
* Contributors: Miguel Ángel González Santamarta, Simone Morettini
```

## yasmin_demos

```
* fixing python remapping
* fixing logs and viewer names in demos and README
* parameters state added
* adding publisher demo to README
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* fixing int64_t in get paramters state for foxy/galactic
* fixing get values of C++get parameters state
* parameters state added
* adding publisher demo to README
* adding missing cond.clear to monitor state
* improving monitor state by replacing sleeps with events and conds
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

- No changes
