### PR TITLE
mp2p_icp: 1.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5664,7 +5664,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 1.7.1-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `1.8.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.7.1-1`

## mp2p_icp

```
* Modernize and unify license notes in all files
* Merge pull request #8 <https://github.com/MOLAorg/mp2p_icp/issues/8> from MOLAorg/feat/precise-deskew
  Precise scan deskew:
  - Implement LocalVelocityBuffer inside ParameterSource's
  - Update LocalVelocityBuffer from IMU data from Generators.
  - Export / Import LocalVelocityBuffer to/from YAML
  - Implement precise cloud undistortion in FilterDeskew
  - Use precise cloud undistortion in the context of sm2mm.
* sm2mm: Use local velocity buffer if available
* add serialization to velocity buffer
* Generators now handle IMU readings and forward them to the velocity buffer
* Update to latest mola_common for embedded builds
* linter: clang-tidy fixes
* fix param name for better consistency
* feature: Option to use std::map instead of tsl robin_map in voxelization filters
* docs: fill txt2mm man page
* Feature: txt2mm new import format 'xyzrgb_normalized'
* remove code to support older MRPT versions; code style clean ups
* Fix: FilterAdjustTimestamps may trigger exception if input cloud is empty
* Contributors: Jose Luis Blanco-Claraco
```
