### PR TITLE
off_highway_sensor_drivers: 0.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6457,6 +6457,8 @@ repositories:
       - off_highway_can
       - off_highway_general_purpose_radar
       - off_highway_general_purpose_radar_msgs
+      - off_highway_premium_radar
+      - off_highway_premium_radar_msgs
       - off_highway_premium_radar_sample
       - off_highway_premium_radar_sample_msgs
       - off_highway_radar
@@ -6468,7 +6470,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 0.8.0-1
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `0.9.0-1`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.8.0-1`

## off_highway_can

```
* Use lround and explicit cast
* Fix integer inputs for round test
* Contributors: Robin Petereit
```

## off_highway_general_purpose_radar

```
* Move PCL dependencies
* Update README
* Contributors: Calin-Vasile Sopterean, Gabriela Adriana Lapuste
```

## off_highway_general_purpose_radar_msgs

- No changes

## off_highway_premium_radar

```
* Adapt expected frequencies of diagnostic messages
* Adapt documentation of sensor state information
* Adapt documentation of measurement program
* Remove measurement cycle synchronization PDU
  Measurement cycle synchronization will be handled via diagnosis in series sensor.
* Remove sensor DTC  information PDU
* Remove sensor feedback PDU
* Remove sensor mode request PDU
* Update README
* Disable publishing of diagnosis for sensor feedback PDU
  PDU is not implemented yet in sensor software but will be available again in a future release.
* Fix review findings
* Adapt diagnostic messages
* Switch to custom message for sensor mounting position
  This removes the dependency to tf2.
* Remove Sensor Broadcast message
* Remove signal range checks as this should be done in sensor and / or application software
* Set IP addresses in default configuration to default values of series sensor
* Replace PCL point struct with message modifier and iterator
* Implement LGP interface changes for series sensor
  - Add sensor coating information (blindness)
  - Add additional misalignment indicator
  - Strip down sensor state information
* Add partial unit tests for sensor state information and blindness indicators
* Add premium radar driver for series sensor
* Contributors: Gabriela Adriana Lapuste, Robin Petereit, Sarah Huber
```

## off_highway_premium_radar_msgs

```
* Remove measurement cycle synchronization PDU
  Measurement cycle synchronization will be handled via diagnosis in series sensor.
* Remove sensor DTC  information PDU
* Remove sensor feedback PDU
* Remove sensor mode request PDU
* Switch to custom message for sensor mounting position
  This removes the dependency to tf2.
* Remove Sensor Broadcast message
* Implement LGP interface changes for series sensor
  - Add sensor coating information (blindness)
  - Add additional misalignment indicator
  - Strip down sensor state information
* Add premium radar driver for series sensor
* Contributors: Sarah Huber
```

## off_highway_premium_radar_sample

```
* Fix PduId check for get_pdu_type
* fix: tf2 uses hpp headers in rolling (and is backported)
* Move PCL dependencies
* Update README
* Add premium radar driver for series sensor
* Contributors: Calin-Vasile Sopterean, Gabriela Adriana Lapuste, Sarah Huber, Tim Clephas
```

## off_highway_premium_radar_sample_msgs

```
* Add premium radar driver for series sensor
* Contributors: Sarah Huber
```

## off_highway_radar

```
* Move PCL dependencies
* Update README
* Contributors: Calin-Vasile Sopterean, Gabriela Adriana Lapuste
```

## off_highway_radar_msgs

- No changes

## off_highway_sensor_drivers

```
* Add premium radar driver for series sensor
* Contributors: Sarah Huber
```

## off_highway_sensor_drivers_examples

```
* Move PCL dependencies
* Add premium radar driver for series sensor
* Contributors: Calin-Vasile Sopterean, Sarah Huber
```

## off_highway_uss

```
* Move PCL dependencies
* Update README
* Contributors: Calin-Vasile Sopterean, Gabriela Adriana Lapuste
```

## off_highway_uss_msgs

- No changes
