### PR TITLE
simulation_interfaces: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10483,7 +10483,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.1.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## simulation_interfaces

```
* Add support for managing simulation worlds (#4 <https://github.com/ros-simulation/simulation_interfaces/issues/4>) ( #15 <https://github.com/ros-simulation/simulation_interfaces/issues/15>)
* Contributors: Ayush Ghosh <mailto:ayushg@nvidia.com>
* Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Co-authored-by: Adam Dąbrowski <mailto:adam.dabrowski@robotec.ai>
* Co-authored-by: Mateusz Żak <mailto:mateusz.zak@robotec.ai>
```
