### PR TITLE
kuka_robot_descriptions: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4452,6 +4452,7 @@ repositories:
       - kuka_agilus_support
       - kuka_cybertech_support
       - kuka_fortec_support
+      - kuka_gazebo
       - kuka_iontec_support
       - kuka_kr_moveit_config
       - kuka_lbr_iisy_moveit_config
@@ -4465,7 +4466,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_robot_descriptions-release.git
-      version: 0.9.0-2
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/kroshu/kuka_robot_descriptions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_robot_descriptions` to `1.0.0-1`:

- upstream repository: https://github.com/kroshu/kuka_robot_descriptions.git
- release repository: https://github.com/ros2-gbp/kuka_robot_descriptions-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.9.0-2`

## kuka_agilus_support

```
* GPIO support
* Robot model verification
* Xacro restructure
* Gazebo support
```

## kuka_cybertech_support

```
* GPIO support
* Robot model verification
* Xacro restructure
* Gazebo support
```

## kuka_fortec_support

```
* KR240-R3330 Support
* GPIO support
* Robot model verification
* Xacro restructure
* Gazebo support
```

## kuka_gazebo

```
* Gazebo support
```

## kuka_iontec_support

```
* GPIO support
* Robot model verification
* Xacro restructure
* Gazebo support
```

## kuka_kr_moveit_config

```
* KR240-R3330 Support
* Gazebo support
```

## kuka_lbr_iisy_moveit_config

```
* Gazebo support
```

## kuka_lbr_iisy_support

```
* Xacro restructure
* Gazebo support
```

## kuka_lbr_iiwa_moveit_config

```
* Update package version
```

## kuka_lbr_iiwa_support

```
* Xacro restructure
```

## kuka_mock_hardware_interface

```
* Update package version
```

## kuka_quantec_support

```
* GPIO support
* Robot model verification
* Xacro restructure
* Gazebo support
```

## kuka_resources

```
* Gazebo support
```

## kuka_robot_descriptions

```
* KR240-R3330 Support
* GPIO support
* Robot model verification
* Xacro restructure
* Gazebo support
```
