### PR TITLE
mola_lidar_odometry: 0.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5488,7 +5488,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.8.0-1
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `0.9.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.8.0-1`

## mola_lidar_odometry

```
* FIX: bug in formula for pitch-roll initialization from IMU
* Store local IMU velocity buffer in key-frame simplemaps
* mola-lidar-odometry-cli: New CLI arguments to support datasets with IMUs
* Implement precise IMU-based deskew (requires latest mp2p_icp library)
* fix clang-format
* Modernize copyright notices
* rosbag2 mola-cli launch file: add MOLA_ROS2BAG_EXPORT_TO_RAWLOG_FILE optional env var
* Contributors: Jose Luis Blanco-Claraco
```
