### PR TITLE
ros2_control: 5.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6776,7 +6776,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.5.0-1
+      version: 5.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.5.0-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

```
* Update doc to clarify BEST_EFFORT behavior when switching controllers (#2448 <https://github.com/ros-controls/ros2_control/issues/2448>)
* Fix typos in the documentation of SwitchController strictness (#2445 <https://github.com/ros-controls/ros2_control/issues/2445>)
* Contributors: Johannes Huemer, Peter Mitrano (AR)
```

## hardware_interface

```
* Remove extra semicolons (#2478 <https://github.com/ros-controls/ros2_control/issues/2478>)
* Docs: clarify getter comments to reference HardwareComponentInterface (#2471 <https://github.com/ros-controls/ros2_control/issues/2471>)
* Start of Unification for Sensor, Actuator, and System into a Single Class (#2451 <https://github.com/ros-controls/ros2_control/issues/2451>) (#2459 <https://github.com/ros-controls/ros2_control/issues/2459>)
* Unify write behavior between Actuator and System hardware interfaces (#2453 <https://github.com/ros-controls/ros2_control/issues/2453>)
* Revert "Start of Unification for Sensor, Actuator, and System into a Si…" (#2456 <https://github.com/ros-controls/ros2_control/issues/2456>)
* Start of Unification for Sensor, Actuator, and System into a Single Class (#2451 <https://github.com/ros-controls/ros2_control/issues/2451>)
* Fix docstring for hardware lifecycle (#2429 <https://github.com/ros-controls/ros2_control/issues/2429>)
* Contributors: Bence Magyar, Christoph Fröhlich, Soham Patil, Tapia Danish, rishitej04
```

## hardware_interface_testing

```
* Unify write behavior between Actuator and System hardware interfaces (#2453 <https://github.com/ros-controls/ros2_control/issues/2453>)
* Supress deprecated RM API warnings in the tests (#2428 <https://github.com/ros-controls/ros2_control/issues/2428>)
* Contributors: Sai Kishor Kothakota, Soham Patil
```

## joint_limits

```
* Remove extra semicolons (#2478 <https://github.com/ros-controls/ros2_control/issues/2478>)
* Contributors: Tapia Danish
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
