### PR TITLE
ros2_control: 4.36.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7778,7 +7778,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.35.0-1
+      version: 4.36.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.36.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.35.0-1`

## controller_interface

```
* Fix missing include for std::find (#2425 <https://github.com/ros-controls/ros2_control/issues/2425>) (#2427 <https://github.com/ros-controls/ros2_control/issues/2427>)
* Contributors: mergify[bot]
```

## controller_manager

- No changes

## controller_manager_msgs

```
* Update doc to clarify BEST_EFFORT behavior when switching controllers (#2448 <https://github.com/ros-controls/ros2_control/issues/2448>) (#2450 <https://github.com/ros-controls/ros2_control/issues/2450>)
* Fix typos in the documentation of SwitchController strictness (#2445 <https://github.com/ros-controls/ros2_control/issues/2445>) (#2447 <https://github.com/ros-controls/ros2_control/issues/2447>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* Start of Unification for Sensor, Actuator, and System into a Single Class (backport #2451 <https://github.com/ros-controls/ros2_control/issues/2451>) (#2460 <https://github.com/ros-controls/ros2_control/issues/2460>)
* Unify write behavior between Actuator and System hardware interfaces (#2453 <https://github.com/ros-controls/ros2_control/issues/2453>) (#2457 <https://github.com/ros-controls/ros2_control/issues/2457>)
* Fix docstring for hardware lifecycle (#2429 <https://github.com/ros-controls/ros2_control/issues/2429>) (#2430 <https://github.com/ros-controls/ros2_control/issues/2430>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Supress deprecated RM API warnings in the tests (#2428 <https://github.com/ros-controls/ros2_control/issues/2428>) (#2455 <https://github.com/ros-controls/ros2_control/issues/2455>)
* Unify write behavior between Actuator and System hardware interfaces (#2453 <https://github.com/ros-controls/ros2_control/issues/2453>) (#2457 <https://github.com/ros-controls/ros2_control/issues/2457>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
