### PR TITLE
depthai-ros: 3.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1351,7 +1351,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 3.0.1-1
+      version: 3.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.0.3-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## depthai-ros

```
* Various minor fixes
* Adding rgbd for stereo left/right
* Improved ToF performance
* Improved stereo alignment
```
