### PR TITLE
kinematics_interface: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3224,7 +3224,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.2.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## kinematics_interface

```
* Remove remnant of visibility control (#170 <https://github.com/ros-controls/kinematics_interface/issues/170>)
* Pass Eigen3 to ament_export_dependencies (#165 <https://github.com/ros-controls/kinematics_interface/issues/165>)
* Contributors: Christoph Froehlich, Christoph Fröhlich, Silvio Traversaro
```

## kinematics_interface_kdl

```
* Pass Eigen3 to ament_export_dependencies (#165 <https://github.com/ros-controls/kinematics_interface/issues/165>)
* Contributors: Silvio Traversaro
```
