### PR TITLE
kinematics_interface: 1.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3887,7 +3887,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.5.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`

## kinematics_interface

```
* Remove remnant of visibility control (backport #170 <https://github.com/ros-controls/kinematics_interface/issues/170>) (#171 <https://github.com/ros-controls/kinematics_interface/issues/171>)
* Pass Eigen3 to ament_export_dependencies (backport #165 <https://github.com/ros-controls/kinematics_interface/issues/165>) (#166 <https://github.com/ros-controls/kinematics_interface/issues/166>)
* Contributors: Silvio Traversaro
```

## kinematics_interface_kdl

```
* Pass Eigen3 to ament_export_dependencies (backport #165 <https://github.com/ros-controls/kinematics_interface/issues/165>) (#166 <https://github.com/ros-controls/kinematics_interface/issues/166>)
* Contributors: Silvio Traversaro
```
