### PR TITLE
control_msgs: 6.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1260,7 +1260,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 6.4.0-1
+      version: 6.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `6.5.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.4.0-1`

## control_msgs

```
* Adding new HardwareStatus and HardwareDeviceStatus messages  (#240 <https://github.com/ros-controls/control_msgs//issues/240>)
* Let's not lint generated code please (#238 <https://github.com/ros-controls/control_msgs//issues/238>)
* Feature/joint wrench msgs (#221 <https://github.com/ros-controls/control_msgs//issues/221>)
* Contributors: Bence Magyar, Davide Risi, Soham Patil
```
