### PR TITLE
mapviz: 2.5.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3744,7 +3744,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.8-1
+      version: 2.5.9-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.5.9-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.8-1`

## mapviz

```
* Improve whitespace trimming behavior (#859 <https://github.com/swri-robotics/mapviz/issues/859>)
  moved MapvizPlugin::TrimString to protected from private
  make plugins use TrimString instead of remove_if with std::isspace
  Co-authored-by: Ben Andrew <benjamin.andrew@swri.org>
* Contributors: DangitBen
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Add error status for navsatfix uninitialized origin (#860 <https://github.com/swri-robotics/mapviz/issues/860>)
  * add error status for navsatfix uninitialized origin
  * add hint in documentation
  ---------
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Improve whitespace trimming behavior (#859 <https://github.com/swri-robotics/mapviz/issues/859>)
  moved MapvizPlugin::TrimString to protected from private
  make plugins use TrimString instead of remove_if with std::isspace
  Co-authored-by: Ben Andrew <benjamin.andrew@swri.org>
* Contributors: DangitBen
```

## multires_image

- No changes

## tile_map

```
* Removing unused function (#861 <https://github.com/swri-robotics/mapviz/issues/861>)
* Improve whitespace trimming behavior (#859 <https://github.com/swri-robotics/mapviz/issues/859>)
  moved MapvizPlugin::TrimString to protected from private
  make plugins use TrimString instead of remove_if with std::isspace
  Co-authored-by: Ben Andrew <benjamin.andrew@swri.org>
* Contributors: DangitBen, David Anthony
```
