### PR TITLE
geometry2: 0.45.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2316,7 +2316,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.44.0-1
+      version: 0.45.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.45.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.44.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Added tf2 documentation to docs.ros.org (#671 <https://github.com/ros2/geometry2/issues/671>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_bullet

```
* Set Cmake Policy CMP0144 (#819 <https://github.com/ros2/geometry2/issues/819>)
* Contributors: Cristóbal Arroyo
```

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Adding NodeInterfaces API Design (#714 <https://github.com/ros2/geometry2/issues/714>)
* ger rid of deprecated rclcpp::spin_some(). (#821 <https://github.com/ros2/geometry2/issues/821>)
* Contributors: Lucas Wendland, Tomoya Fujita
```

## tf2_ros_py

```
* Fixed inconsistency of C++ and Python implementations of StaticTransformPublisher (#820 <https://github.com/ros2/geometry2/issues/820>)
* Contributors: Dominik
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
