### PR TITLE
septentrio_gnss_driver: 1.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9334,7 +9334,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.4-1
+      version: 1.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.5-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.4-1`

## septentrio_gnss_driver

```
* Fixes
  
  Revert ament_auto to fix compile definition export
* Improvements
  
  Add RTK fixed/float status in GPSFix (ROS 2 only) (thanks to @BartKeulen)
* Contributors:  Bart Keulen, Thomas Emter, Tibor Dome, septentrio-users
```
