### PR TITLE
mola_common: 0.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5458,7 +5458,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_common-release.git
-      version: 0.4.1-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_common` to `0.5.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_common.git
- release repository: https://github.com/ros2-gbp/mola_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.4.1-1`

## mola_common

```
* FIX: auto-created foo_version.cmake file now uses the caller's version from package.xml instead of mola_common version
* Update ROS badges in README
* cmake: fix correct cmake silent warnings of non-used variables
* silent cmake warning on unused CMAKE_EXPORT_COMPILE_COMMANDS (cmake-only pkg)
* Contributors: Jose Luis Blanco-Claraco
```
