### PR TITLE
Adding emcee to rosdistro

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -181,7 +181,7 @@ ds4drv-pip:
   ubuntu:
     pip:
       packages: [ds4drv]
-emcee:
+python3-emcee:
   debian: [python3-emcee]
   fedora: [python3-emcee]
   ubuntu: [python3-emcee]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -181,6 +181,16 @@ ds4drv-pip:
   ubuntu:
     pip:
       packages: [ds4drv]
+emcee:
+  debian:
+    pip:
+      packages: [emcee]
+  fedora:
+    pip:
+      packages: [emcee]
+  ubuntu:
+    pip:
+      packages: [emcee]
 epydoc:
   arch: [epydoc]
   debian: [python-epydoc]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -182,13 +182,7 @@ ds4drv-pip:
     pip:
       packages: [ds4drv]
 emcee-pip:
-  debian:
-    pip:
-      packages: [emcee]
-  fedora:
-    pip:
-      packages: [emcee]
-  ubuntu:
+  '*':
     pip:
       packages: [emcee]
 epydoc:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -181,10 +181,10 @@ ds4drv-pip:
   ubuntu:
     pip:
       packages: [ds4drv]
-emcee-pip:
-  '*':
-    pip:
-      packages: [emcee]
+emcee:
+  debian: [python3-emcee]
+  fedora: [python3-emcee]
+  ubuntu: [python3-emcee]
 epydoc:
   arch: [epydoc]
   debian: [python-epydoc]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -181,7 +181,7 @@ ds4drv-pip:
   ubuntu:
     pip:
       packages: [ds4drv]
-emcee:
+emcee-pip:
   debian:
     pip:
       packages: [emcee]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

emcee

## Package Upstream Source:

https://github.com/dfm/emcee

## Purpose of using this:

emcee is a usefull package for dealing with inference problems. It allows to evaluate the statistical distribution of a cause from observed datas.

## Links to Distribution Packages

- Python:
  - https://pypi.org/project/emcee/
