### PR TITLE
kuka_external_control_sdk: 1.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4436,7 +4436,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_external_control_sdk` to `1.4.1-1`:

- upstream repository: https://github.com/kroshu/kuka-external-control-sdk.git
- release repository: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`

## kuka_external_control_sdk

```
* Fix package dependency
```

## kuka_external_control_sdk_examples

```
* Fix SDK dependency
```
