### PR TITLE
ros2_controllers: 5.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6807,6 +6807,7 @@ repositories:
       - ackermann_steering_controller
       - admittance_controller
       - bicycle_steering_controller
+      - chained_filter_controller
       - diff_drive_controller
       - effort_controllers
       - force_torque_sensor_broadcaster
@@ -6817,6 +6818,7 @@ repositories:
       - joint_state_broadcaster
       - joint_trajectory_controller
       - mecanum_drive_controller
+      - motion_primitives_controllers
       - omni_wheel_drive_controller
       - parallel_gripper_controller
       - pid_controller
@@ -6833,7 +6835,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.5.0-1
+      version: 5.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.5.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* tf2_ros to hpp headers (#1866 <https://github.com/ros-controls/ros2_controllers/issues/1866>)
* Remove usage of get_ordered_interfaces but update parameter validation instead (#1816 <https://github.com/ros-controls/ros2_controllers/issues/1816>)
* Contributors: Christoph Fröhlich, Tim Clephas
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

```
* Add a generic chained_filter_controller (#1634 <https://github.com/ros-controls/ros2_controllers/issues/1634>)
* Contributors: Ankur Bodhe, Christoph Froehlich
```

## diff_drive_controller

- No changes

## effort_controllers

```
* Remove usage of get_ordered_interfaces but update parameter validation instead (#1816 <https://github.com/ros-controls/ros2_controllers/issues/1816>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Remove usage of get_ordered_interfaces but update parameter validation instead (#1816 <https://github.com/ros-controls/ros2_controllers/issues/1816>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

```
* Add calibration possibility to IMU broadcaster (#1833 <https://github.com/ros-controls/ros2_controllers/issues/1833>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* docs(joint_state_broadcaster): clarify /dynamic_joint_states contents (#1865 <https://github.com/ros-controls/ros2_controllers/issues/1865>)
* Contributors: rishitej04
```

## joint_trajectory_controller

```
* Filling index field in feedback message of the action interface (#1850 <https://github.com/ros-controls/ros2_controllers/issues/1850>)
* Contributors: Giuseppe Monetti
```

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

```
* Refactoring to motion_primitives_base_controller (#1857 <https://github.com/ros-controls/ros2_controllers/issues/1857>)
* Contributors: Mathias Fuhrer
```

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

```
* Implement realtime-safe stall detection for parallel gripper controller (#1855 <https://github.com/ros-controls/ros2_controllers/issues/1855>)
* Contributors: Ashwin Sushil
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

```
* Remove usage of get_ordered_interfaces but update parameter validation instead (#1816 <https://github.com/ros-controls/ros2_controllers/issues/1816>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Add motion_primitives_controllers to metapackage
* Add a generic chained_filter_controller (#1634 <https://github.com/ros-controls/ros2_controllers/issues/1634>)
* Contributors: Ankur Bodhe, Mathias Fuhrer, Christoph Froehlich
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

```
* Remove usage of get_ordered_interfaces but update parameter validation instead (#1816 <https://github.com/ros-controls/ros2_controllers/issues/1816>)
* Contributors: Christoph Fröhlich
```
