### PR TITLE
robot_localization: 3.8.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7660,7 +7660,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.8.2-1
+      version: 3.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.8.3-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.2-1`

## robot_localization

```
* Add a Parameters Callback to set magnetic_declination_radians at runtime (#920 <https://github.com/cra-ros-pkg/robot_localization/issues/920>)
  * Add a Parameters Callback to be able to set magnetic_declination_radians value at runtime.
* Fixing issue with subscriber disconnect (#944 <https://github.com/cra-ros-pkg/robot_localization/issues/944>)
  * Fixing issue with subscriber disconnect
* Fixing ROS time sources (#943 <https://github.com/cra-ros-pkg/robot_localization/issues/943>)
* Fixing off-diagonal covariance values in measurement (#942 <https://github.com/cra-ros-pkg/robot_localization/issues/942>)
* Contributors: Enzo Ghisoni, Tom Moore
```
