### PR TITLE
robot_localization: 3.5.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8711,7 +8711,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.5.3-1
+      version: 3.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.5.4-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.3-1`

## robot_localization

```
* Backporting IMU sub reset fix
* Fixing off-diagonal covariance values in measurement (#942 <https://github.com/cra-ros-pkg/robot_localization/issues/942>)
* Add a Parameters Callback to set magnetic_declination_radians at runtime (#920 <https://github.com/cra-ros-pkg/robot_localization/issues/920>)
  * Add a Parameters Callback to be able to set magnetic_declination_radians value at runtime.
* Added subscription to stamped topic (#898 <https://github.com/cra-ros-pkg/robot_localization/issues/898>) (#899 <https://github.com/cra-ros-pkg/robot_localization/issues/899>)
  * Added subscription to stamped topic (#898 <https://github.com/cra-ros-pkg/robot_localization/issues/898>)
* Contributors: Enzo Ghisoni, Pablo, Tom Moore
```
