### PR TITLE
robot_localization: 3.9.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6691,7 +6691,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.9.3-1
+      version: 3.9.4-1
     source:
       test_pull_requests: true
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6696,7 +6696,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/cra-ros-pkg/robot_localization.git
-      version: ros2
+      version: kilted-devel
     status: maintained
   robot_state_publisher:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.9.4-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.3-1`

## robot_localization

```
* Added FromLLArray service (#912 <https://github.com/cra-ros-pkg/robot_localization/issues/912>)
  * Added FromLLArray service
  ---------
  Co-authored-by: Marcin Słomiany <mailto:m.slomiany93@gmail.com>
* Add a Parameters Callback to set magnetic_declination_radians at runtime (#920 <https://github.com/cra-ros-pkg/robot_localization/issues/920>)
* Backporting IMU sub reset fix
* Fixing ROS time sources (#943 <https://github.com/cra-ros-pkg/robot_localization/issues/943>)
* Fixing off-diagonal covariance values in measurement (#942 <https://github.com/cra-ros-pkg/robot_localization/issues/942>)
* Contributors: Enzo Ghisoni, Jay Herpin, Tom Moore
```
