### PR TITLE
robot_localization: 3.10.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6673,7 +6673,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.9.3-1
+      version: 3.10.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.10.0-2`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.3-1`

## robot_localization

```
* Added FromLLArray service (#912 <https://github.com/cra-ros-pkg/robot_localization/issues/912>)
  * Added FromLLArray service
  ---------
  Co-authored-by: Marcin Słomiany <mailto:m.slomiany93@gmail.com>
* Add a Parameters Callback to set magnetic_declination_radians at runtime (#920 <https://github.com/cra-ros-pkg/robot_localization/issues/920>)
* Backporting IMU sub reset fix
* Fixing ROS time sources (#943 <https://github.com/cra-ros-pkg/robot_localization/issues/943>)
* Fixing off-diagonal covariance values in measurement (#942 <https://github.com/cra-ros-pkg/robot_localization/issues/942>)
* "toggle" and "enable" services are now namespaced (#940 <https://github.com/cra-ros-pkg/robot_localization/issues/940>)
* chore: tf2_ros to hpp headers (#941 <https://github.com/cra-ros-pkg/robot_localization/issues/941>)
* Contributors: Enzo Ghisoni, Jay Herpin, Tim Clephas, Tom Moore, ari-bw
```
