### PR TITLE
tf2_2d: 1.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8789,7 +8789,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tf2_2d-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_2d` to `1.6.1-1`:

- upstream repository: https://github.com/locusrobotics/tf2_2d.git
- release repository: https://github.com/ros2-gbp/tf2_2d-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-1`

## tf2_2d

```
* Update header files (#12 <https://github.com/locusrobotics/tf2_2d/issues/12>)
  * Update header files
  * Fix header order
  ---------
  Co-authored-by: Stephen Williams <mailto:swilliams@locusrobotics.com>
* Remove support for deprecated geometry_msgs::msg::Pose2D type
* Contributors: Gary Servin, Stephen Williams
```
