### PR TITLE
apriltag_ros: 3.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -606,11 +606,15 @@ repositories:
       version: master
     status: maintained
   apriltag_ros:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_ros-release.git
-      version: 3.2.2-3
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.3.0-1`:

- upstream repository: https://github.com/christianrauch/apriltag_ros.git
- release repository: https://github.com/ros2-gbp/apriltag_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.2-3`
