### PR TITLE
apriltag_ros: 3.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -443,11 +443,15 @@ repositories:
       version: master
     status: maintained
   apriltag_ros:
+    doc:
+      type: git
+      url: https://github.com/christianrauch/apriltag_ros.git
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_ros-release.git
-      version: 3.2.2-1
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_ros` to `3.3.0-1`:

- upstream repository: https://github.com/christianrauch/apriltag_ros.git
- release repository: https://github.com/ros2-gbp/apriltag_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.2-1`
