### PR TITLE
mrpt_ros: 2.14.12-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4386,7 +4386,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.14.11-1
+      version: 2.14.12-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.14.12-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.11-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

```
* New method mrpt::opengl::CPointCloudColoured::setAllPointsAlpha().
```

## mrpt_libposes

- No changes

## mrpt_libros_bridge

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
