### PR TITLE
turtle_nest: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11386,7 +11386,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtle_nest-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/Jannkar/turtle_nest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtle_nest` to `1.2.0-1`:

- upstream repository: https://github.com/Jannkar/turtle_nest.git
- release repository: https://github.com/ros2-gbp/turtle_nest-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.0-1`

## turtle_nest

```
* Add support for composable nodes (#26 <https://github.com/Jannkar/turtle_nest/issues/26>)
* Add support for Python Lifecycle Nodes (#25 <https://github.com/Jannkar/turtle_nest/issues/25>)
* Support for adding C++ lifecycle nodes (#24 <https://github.com/Jannkar/turtle_nest/issues/24>)
* Refactor node generation (#23 <https://github.com/Jannkar/turtle_nest/issues/23>)
* Contributors: Janne Karttunen
```
