### PR TITLE
image_pipeline: 7.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2978,7 +2978,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 7.1.0-1
+      version: 7.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `7.1.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.1.0-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Support image_transport lifecycle (#1099 <https://github.com/ros-perception/image_pipeline/issues/1099>)
* Contributors: Alejandro Hernández Cordero
```

## image_pipeline

- No changes

## image_proc

```
* Support image_transport lifecycle (#1099 <https://github.com/ros-perception/image_pipeline/issues/1099>)
* Contributors: Alejandro Hernández Cordero
```

## image_publisher

```
* Support image_transport lifecycle (#1099 <https://github.com/ros-perception/image_pipeline/issues/1099>)
* Contributors: Alejandro Hernández Cordero
```

## image_rotate

```
* Support image_transport lifecycle (#1099 <https://github.com/ros-perception/image_pipeline/issues/1099>)
* Contributors: Alejandro Hernández Cordero
```

## image_view

```
* Support image_transport lifecycle (#1099 <https://github.com/ros-perception/image_pipeline/issues/1099>)
* Contributors: Alejandro Hernández Cordero
```

## stereo_image_proc

```
* Support image_transport lifecycle (#1099 <https://github.com/ros-perception/image_pipeline/issues/1099>)
* Contributors: Alejandro Hernández Cordero
```

## tracetools_image_pipeline

- No changes
