### PR TITLE
ai_worker: 1.1.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -136,7 +136,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ai_worker-release.git
-      version: 1.1.10-1
+      version: 1.1.11-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ai_worker` to `1.1.11-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ai_worker.git
- release repository: https://github.com/ros2-gbp/ai_worker-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.10-1`

## ffw

```
* Updated URDF for ZED camera
* Fix velocity limit variable for ffw_swerve_drive_controller
* Added tactile switch feature to joystick controller
* Applied Dynamic Brake for Dynamixel Y
* Contributors: Woojin Wie, Wonho Yun
```

## ffw_bringup

```
* None
```

## ffw_description

```
* Updated URDF for ZED camera
* Applied Dynamic Brake for Dynamixel Y
* Contributors: Woojin Wie
```

## ffw_joint_trajectory_command_broadcaster

```
* None
```

## ffw_joystick_controller

```
* Added tactile switch feature to joystick controller
* Contributors: Wonho Yun
```

## ffw_moveit_config

```
* None
```

## ffw_robot_manager

```
* None
```

## ffw_spring_actuator_controller

```
* None
```

## ffw_swerve_drive_controller

```
* Fix velocity limit variable
* Contributors: Woojin Wie
```

## ffw_teleop

```
* None
```
