### PR TITLE
apriltag_detector: 3.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -410,7 +410,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_detector-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/apriltag_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_detector` to `3.0.4-1`:

- upstream repository: https://github.com/ros-misc-utilities/apriltag_detector.git
- release repository: https://github.com/ros2-gbp/apriltag_detector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.3-1`

## apriltag_detector

```
* support new image transport node interface
* add isSubscribed() to detector interface and fixed bug in detect_from_bag
* added getNumTagsDetected()
* Contributors: Bernd Pfrommer
```

## apriltag_detector_mit

- No changes

## apriltag_detector_umich

- No changes

## apriltag_draw

```
* support new image transport node interface
* Contributors: Bernd Pfrommer
```

## apriltag_tools

```
* add tag_topic and image_tag_topic parameters
* add isSubscribed() to detector interface and fixed bug in detect_from_bag
* added getNumTagsDetected()
* Contributors: Bernd Pfrommer
```
