### PR TITLE
kompass: 0.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3306,7 +3306,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.3.1-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`

## kompass

```
* (fix) Adds 'reached_end' publishing in Planner
* (feature) Simplifies pointcloud callback as its processing is handled in kompass core and changes local mapper to take pointcloud data
* (fix) Adds missing inputs/outputs keys serialization in component
* (feature) Adds option to enable emergency stop usage in DriveManager without 360 scan
* (fix) Fixes list inputs parsing in component
* (feature) Adds PointCloud2 to DriveManager and Mapper allowed inputs
* Contributors: ahr, mkabtoul
```

## kompass_interfaces

- No changes
