### PR TITLE
Add libdwarf-dev to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3593,6 +3593,20 @@ libdw-dev:
       packages: [elfutils]
   rhel: [elfutils-devel]
   ubuntu: [libdw-dev]
+libdwarf-dev:
+  alpine: [libdwarf-dev]
+  arch: [libdwarf]
+  debian: [libdwarf-dev]
+  fedora: [libdwarf-devel]
+  gentoo: [dev-libs/libdwarf]
+  nixos: [libdwarf]
+  openembedded: [libdwarf]
+  opensuse: [libdwarf-devel]
+  osx:
+    homebrew:
+      packages: [dwarfutils]
+  rhel: [libdwarf-devel]
+  ubuntu: [libdwarf]
 libdxflib-dev:
   debian: [libdxflib-dev]
   fedora: [libdxflib-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3606,7 +3606,7 @@ libdwarf-dev:
     homebrew:
       packages: [dwarfutils]
   rhel: [libdwarf-devel]
-  ubuntu: [libdwarf]
+  ubuntu: [libdwarf-dev]
 libdxflib-dev:
   debian: [libdxflib-dev]
   fedora: [libdxflib-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libdwarf-dev

## Package Upstream Source:

https://github.com/davea42/libdwarf-code

## Purpose of using this:

We use this library in Gazebo to generate meaningful backtraces when there is a segfault.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libdwarf-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/noble/dwarfutils
- Fedora: https://packages.fedoraproject.org/
  - https://src.fedoraproject.org/rpms/libdwarf
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libdwarf/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-libs/libdwarf
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/dwarfutils
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=libdwarf-dev&branch=v3.15
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.05&show=libdwarf&query=libdwarf
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libdwarf
