### PR TITLE
web_video_server: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11179,7 +11179,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/web_video_server-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `2.1.1-1`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/ros2-gbp/web_video_server-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## web_video_server

```
* Fix build with the current FFmpeg avformat (#190)
* Update package.xml to include necessary lib boost (#186)
* Add Kilted workflow (#183)
* Fix -Wmaybe-uninitialized warning (#185)
* Contributors: Błażej Sowa, Fabian Freihube, Janosch Machowinski, Alexis Tsogias, Julian Francis
```
