### PR TITLE
catch_ros2: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1159,7 +1159,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ngmor/catch_ros2.git
-      version: rolling
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -1168,7 +1168,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ngmor/catch_ros2.git
-      version: rolling
+      version: jazzy
     status: maintained
   class_loader:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1164,7 +1164,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/catch_ros2-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/ngmor/catch_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros2` to `0.2.2-1`:

- upstream repository: https://github.com/ngmor/catch_ros2.git
- release repository: https://github.com/ros2-gbp/catch_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-2`

## catch_ros2

```
* Revert to Catch2 v3.4.0 to standardize with Ubuntu 24.04-provided Catch2 version
* Contributors: Nick Morales
```
