### PR TITLE
automatika_ros_sugar: 0.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -635,7 +635,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.3.2-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.1-1`

## automatika_ros_sugar

```
* (docs) Updates events docs with new classes
* (feature) Adds ros time automatically to stamped messages in publisher
* (fix) Fixes error in publishing audio msgs as byte arrays
* (fix) Fixes Pose publisher converter
* (fix) Fixes event handle once and delay options
* (fix) Fixes condition for OnChange event trigger
* (feature) Adds events for contains any/all plus change in value
* (fix) Fixes error in geomerty transformation util
* Contributors: ahr, mkabtoul
```
