### PR TITLE
automatika_embodied_agents: 0.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -826,7 +826,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_embodied_agents` to `0.4.2-1`:

- upstream repository: https://github.com/automatika-robotics/ros-agents.git
- release repository: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.1-1`

## automatika_embodied_agents

```
* (feature) Adds udp streaming to IP:PORT as an option to TextToStream component when play_on_device is enabled
* (docs) Updates docs to use new web based client
* (feature) Adds processing of audio messages in web client
* (chore) Removes chainlit based client
* (feature) Adds a custom webclient to replace chainlit
* (feature) Adds persistent ros node in web client for async stream handling
* (feature) Adds warning when not using streaming string msg_type with streaming enabled in components
* (feature) Adds streaming string msg for managing streams in external clients
* (docs) Adds recipe for vision guided point navigation
* (fix) Fixes empty image input for Detection2D msg publication
* (fix) Fixes websocket receiving in text to speech
* (fix) Fixes keyword argument in detection and tracking publishing
* (feature) Adds publishing a singular detection or tracking message from the vision component
* Contributors: ahr, mkabtoul
```
