### PR TITLE
rviz: 15.1.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8118,7 +8118,6 @@ repositories:
     release:
       packages:
       - rviz2
-      - rviz_assimp_vendor
       - rviz_common
       - rviz_default_plugins
       - rviz_ogre_vendor
@@ -8129,7 +8128,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.8-1
+      version: 15.1.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.9-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.8-1`

## rviz2

```
* get rid of deprecated rclcpp::spin_some() (#1567 <https://github.com/ros2/rviz/issues/1567>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_common

```
* Removed deprecations (#1556 <https://github.com/ros2/rviz/issues/1556>)
* rviz common ros service property (#1548 <https://github.com/ros2/rviz/issues/1548>)
* add ros action property (#1549 <https://github.com/ros2/rviz/issues/1549>)
* Contributors: Alejandro Hernández Cordero, Joshua Supratman
```

## rviz_default_plugins

```
* add support for ffmpeg_image_transport and point_cloud_transport (#1568 <https://github.com/ros2/rviz/issues/1568>)
* Extend the message filter display for point cloud 2 display (#1566 <https://github.com/ros2/rviz/issues/1566>)
* Contributors: Kenji Brameld (TRACLabs), Lennart Reiher
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed assimp vendor package (#1574 <https://github.com/ros2/rviz/issues/1574>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
