### PR TITLE
at_sonde_ros_driver: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -812,6 +812,15 @@ repositories:
       version: ros2-develop
     status: maintained
   at_sonde_ros_driver:
+    doc:
+      type: git
+      url: https://github.com/ma-shangao/at_sonde_ros_driver.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/at_sonde_ros_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ma-shangao/at_sonde_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `at_sonde_ros_driver` to `1.0.0-1`:

- upstream repository: https://github.com/ma-shangao/at_sonde_ros_driver.git
- release repository: https://github.com/ros2-gbp/at_sonde_ros_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## at_sonde_ros_driver

```
* Create dependabot.yml
* Retire ament_target_dependencies in cmake
* Set up CI, bypass linting for humble due to different default cfgsbug mode
* Set up serial communication and accept wiper warning (ID 4)
* Provide a config example.
* Initial release
* Contributors: MA Song
```
