### PR TITLE
at_sonde_ros_driver: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -576,6 +576,15 @@ repositories:
       version: main
     status: developed
   at_sonde_ros_driver:
+    doc:
+      type: git
+      url: https://github.com/ma-shangao/at_sonde_ros_driver.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/at_sonde_ros_driver-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ma-shangao/at_sonde_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `at_sonde_ros_driver` to `1.0.0-1`:

- upstream repository: https://github.com/ma-shangao/at_sonde_ros_driver.git
- release repository: https://github.com/ros2-gbp/at_sonde_ros_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## at_sonde_ros_driver

```
* Create dependabot.yml
* Retire ament_target_dependencies in cmake
* Set up CI, bypass linting for humble due to different default cfgsbug mode
* Set up serial communication and accept wiper warning (ID 4)
* Provide a config example.
* Initial release
* Contributors: MA Song
```
