### PR TITLE
gz_physics_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2655,7 +2655,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_physics_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_physics_vendor.git
- release repository: https://github.com/ros2-gbp/gz_physics_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-1`

## gz_physics_vendor

```
* Bump version to 8.3.0 (#11 <https://github.com/gazebo-release/gz_physics_vendor/issues/11>)
* Contributors: Ian Chen
```
