### PR TITLE
gz_common_vendor: 0.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2550,7 +2550,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.2.3-2
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.3-2`

## gz_common_vendor

```
* Bump version to 6.1.0 (#13 <https://github.com/gazebo-release/gz_common_vendor/issues/13>)
* Contributors: Ian Chen
```
