### PR TITLE
gz_math_vendor: 0.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2630,7 +2630,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_math_vendor-release.git
-      version: 0.2.3-2
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_math_vendor` to `0.2.5-1`:

- upstream repository: https://github.com/gazebo-release/gz_math_vendor.git
- release repository: https://github.com/ros2-gbp/gz_math_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.3-2`

## gz_math_vendor

```
* Remove 0.3.0 from changelog
* Contributors: Addisu Z. Taddese
```
