### PR TITLE
gz_sensors_vendor: 0.2.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2744,7 +2744,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.2.1-2
+      version: 0.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.2.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-2`

## gz_sensors_vendor

```
* Bump version to 9.2.0 (#7 <https://github.com/gazebo-release/gz_sensors_vendor/issues/7>)
* Contributors: Jose Luis Rivero
```
