### PR TITLE
distro: add python3-pre-commit for openembedded

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8342,6 +8342,7 @@ python3-pre-commit:
         packages: [pre-commit]
   fedora: [pre-commit]
   nixos: [pre-commit]
+  openembedded: [python3-pre-commit@meta-python]
   rhel:
     '*': [pre-commit]
     '8': null


### PR DESCRIPTION
Recipe 'python3-pre-commit' and the dependencies are added to meta-python (at master).

see: https://github.com/openembedded/meta-openembedded/commit/6485fad19084dc2c3fcb9fbb7e00ab955d110999

The recipes came from https://github.com/zboszor/meta-python-ai/

see: https://github.com/zboszor/meta-python-ai/issues/25#issuecomment-3252993150