### PR TITLE
catch_ros2: 0.2.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -968,7 +968,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/catch_ros2-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ngmor/catch_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `catch_ros2` to `0.2.3-1`:

- upstream repository: https://github.com/ngmor/catch_ros2.git
- release repository: https://github.com/ros2-gbp/catch_ros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-1`

## catch_ros2

```
* [kilted] Update deprecated call to ament_target_dependencies
* Contributors: David V. Lu, Nick Morales
```
