### PR TITLE
rosidlcpp: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8541,7 +8541,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidlcpp-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.4.0-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

- No changes

## rosidlcpp_generator_core

- No changes

## rosidlcpp_generator_cpp

```
* Port rosidl`#864 <https://github.com/ros2/rosidl/pull/864>`_ (#16 <https://github.com/TonyWelte/rosidlcpp/issues/16>)
* Port rosidl`#863 <https://github.com/ros2/rosidl/pull/863>`_ (#15 <https://github.com/TonyWelte/rosidlcpp/issues/15>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_py

- No changes

## rosidlcpp_generator_type_description

- No changes

## rosidlcpp_parser

- No changes

## rosidlcpp_typesupport_c

- No changes

## rosidlcpp_typesupport_cpp

- No changes

## rosidlcpp_typesupport_fastrtps_c

```
* Port rosidl_typesupport_fastrtps`#130 <https://github.com/ros2/rosidl_typesupport_fastrtps/pull/130>`_ (#14 <https://github.com/TonyWelte/rosidlcpp/issues/14>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_cpp

```
* Port rosidl_typesupport_fastrtps`#130 <https://github.com/ros2/rosidl_typesupport_fastrtps/pull/130>`_ (#14 <https://github.com/TonyWelte/rosidlcpp/issues/14>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_c

- No changes

## rosidlcpp_typesupport_introspection_cpp

- No changes
