### PR TITLE
rtsp_image_transport: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9164,6 +9164,11 @@ repositories:
       type: git
       url: https://github.com/fkie/rtsp_image_transport.git
       version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rtsp_image_transport-release.git
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/fkie/rtsp_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsp_image_transport` to `2.0.1-1`:

- upstream repository: https://github.com/fkie/rtsp_image_transport.git
- release repository: https://github.com/ros2-gbp/rtsp_image_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rtsp_image_transport

```
* Drop support for pre-Jazzy Waitable API
* Add ROS Kilted to CI
* Update links in README.rst for ROS 2
* Add preliminary AV1 support (once implemented in live555)
* Add popular aliases for codec names
* Rename parameter bit_rate to target_bitrate
  (#2 <https://github.com/fkie/rtsp_image_transport/issues/2>)
* Contributors: Timo Röhling
```
