### PR TITLE
mola_state_estimation: 1.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5522,7 +5522,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.9.0-1
+      version: 1.10.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.10.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.9.0-1`

## mola_imu_preintegration

```
* Add class ImuTransformer
* Update copyright notice
* Import IMU initialization class ImuInitialCalibrator, refactored from the mola LO package
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Update copyright notice
* Make unhandled sensor input topic message less verbose
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Fix build against gtsam>=4.3
* Update copyright notice
* Make unhandled sensor input topic message less verbose
* Contributors: Jose Luis Blanco-Claraco
```
