### PR TITLE
open_manipulator: 4.0.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5761,7 +5761,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 4.0.7-1
+      version: 4.0.8-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.0.8-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.7-1`

## om_gravity_compensation_controller

```
* Added parameter for enabling spring effect
* Added parameters about scaling factors for input joint velocities and accelerations
* Contributors: Woojin Wie
```

## om_joint_trajectory_command_broadcaster

```
* None
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Added camera_usb_cam launch file
* Support OMX series
* Removed unused use_sim_time parameter in the configuration files
* Added OMY-F3M Leader and OMY-L100 Follower configuration files
* Renamed ros2_control files to include operating mode
* Added parameter for enabling spring effect
* Added parameters about scaling factors for input joint velocities and accelerations
* Added usb-cam package dependency in Dockerfile
* Contributors: Woojin Wie, Junha Cha, Wonho Yun
```

## open_manipulator_bringup

```
* Added camera_usb_cam launch file
* Support OMX series
* Removed unused use_sim_time parameter in the configuration files
* Added OMY-F3M Leader and OMY-L100 Follower configuration files
* Contributors: Woojin Wie, Junha Cha
```

## open_manipulator_collision

```
* None
```

## open_manipulator_description

```
* Support OMX series
* Renamed ros2_control files to include operating mode
* Contributors: Woojin Wie, Junha Cha
```

## open_manipulator_gui

```
* None
```

## open_manipulator_moveit_config

```
* Support OMX series
* Contributors: Woojin Wie, Junha Cha
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* None
```
