### PR TITLE
namosim: 0.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5875,7 +5875,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/namosim-release.git
-      version: 0.0.1-3
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/Chroma-CITI/namosim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `namosim` to `0.0.2-1`:

- upstream repository: https://github.com/Chroma-CITI/namosim.git
- release repository: https://github.com/ros2-gbp/namosim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-3`

## namosim

```
* add citation
* docs
* docs
* add demo videos
* Merge pull request #17 <https://github.com/Chroma-CITI/namosim/issues/17> from Chroma-CITI/related_work
  add demo videos to readme
* add demo videos to readme
* Merge pull request #16 <https://github.com/Chroma-CITI/namosim/issues/16> from Chroma-CITI/related_work
  Related work
* cite the collision detection algorithm
* docs
* typo
* sop
* docs/examples
* add citations
* rename env var
* add architecture diagram
* cleanup
* docs
* docs
* docs
* docs
* docs
* Merge pull request #15 <https://github.com/Chroma-CITI/namosim/issues/15> from Chroma-CITI/usage_docs
  add a guide for creating custom agents
* docs
* add contributing guidelines
* fix unit test
* add a guide for creating custom agents
* docs
* move docs from readme to docs site
* docs
* docs
* remove notebooks
* rm old notebooks
* docs
* Merge pull request #14 <https://github.com/Chroma-CITI/namosim/issues/14> from Chroma-CITI/e2e_coverage
  compute coverage for e2e tests
* merge humble
* docs
* compute coverage for e2e tests
* Merge pull request #13 <https://github.com/Chroma-CITI/namosim/issues/13> from Chroma-CITI/examples
  add examples
* add examples
* Contributors: David Brown
```
