### PR TITLE
namosim: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5875,7 +5875,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/namosim-release.git
-      version: 0.0.1-3
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/Chroma-CITI/namosim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `namosim` to `0.0.3-1`:

- upstream repository: https://github.com/Chroma-CITI/namosim.git
- release repository: https://github.com/ros2-gbp/namosim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-3`

## namosim

- No changes
