### PR TITLE
gz_tools_vendor: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2766,7 +2766,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_tools_vendor-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_tools_vendor` to `0.2.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_tools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.0-1`

## gz_tools_vendor

```
* Jetty support: minor updates (#9 <https://github.com/gazebo-release/gz_tools_vendor/issues/9>)
  * Add option VENDOR_FROM_LIB_VCS_REF
  This allows vendoring from a specified vcs ref instead
  of the hard-coded tag. When this option is set to true,
  a branch, tag, or commit can be specified in the
  LIB_VCS_REF variable. If LIB_VCS_REF is unspecified,
  vendoring will use gz-tools2.
  * 2.0.3
  ---------
* Contributors: Steve Peters
```
