### PR TITLE
gz_utils_vendor: 0.4.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2798,7 +2798,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.3.0-1
+      version: 0.4.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_utils_vendor` to `0.4.0-2`:

- upstream repository: https://github.com/gazebo-release/gz_utils_vendor.git
- release repository: https://github.com/ros2-gbp/gz_utils_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## gz_utils_vendor

```
* Jetty support: bump to 4.0.0, fix package names (#11 <https://github.com/gazebo-release/gz_utils_vendor/issues/11>)
  * Jetty support: bump to 4.0.0, fix package names
  Major version numbers have been removed from package
  names in Gazebo Jetty, so extra cmake config files are
  no longer needed.
  * Add option VENDOR_FROM_LIB_VCS_REF
  This allows vendoring from a specified vcs ref instead
  of the hard-coded tag. When this option is set to true,
  a branch, tag, or commit can be specified in the
  LIB_VCS_REF variable. If LIB_VCS_REF is unspecified,
  vendoring will use main.
  * remove unused cmake config file
  * use lowercase to fix linter complaint
  * Add dependency on cli11
  * 4.0.0~pre1
  * Use vendored version of CLI11
  ---------
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: Steve Peters
```
