### PR TITLE
gz_plugin_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2684,7 +2684,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_plugin_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_plugin_vendor.git
- release repository: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-1`

## gz_plugin_vendor

```
* Jetty support: 4.0.0-pre1 (#7 <https://github.com/gazebo-release/gz_plugin_vendor/issues/7>)
* Contributors: Steve Peters
```
