### PR TITLE
sdformat_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8226,7 +8226,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.5-1`

## sdformat_vendor

```
* Jetty support: bump to 16.0.0, fix package names (#16 <https://github.com/gazebo-release/sdformat_vendor/issues/16>)
  * Jetty support: bump to 16.0.0, fix package names
  Major version numbers have been removed from package
  names in Gazebo Jetty, so extra cmake config files are
  no longer needed. Also build python bindings.
  * Add option VENDOR_FROM_LIB_VCS_REF
  This allows vendoring from a specified vcs ref instead
  of the hard-coded tag. When this option is set to true,
  a branch, tag, or commit can be specified in the
  LIB_VCS_REF variable. If LIB_VCS_REF is unspecified,
  vendoring will use main.
  * 16.0.0~pre1
  ---------
* Contributors: Steve Peters
```
