### PR TITLE
gz_rendering_vendor: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2700,7 +2700,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_rendering_vendor` to `0.4.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_rendering_vendor.git
- release repository: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## gz_rendering_vendor

```
* Jetty support: 10.0.0-pre1 (#11 <https://github.com/gazebo-release/gz_rendering_vendor/issues/11>)
* Contributors: Steve Peters
```
