### PR TITLE
gz_transport_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2782,7 +2782,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_transport_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_transport_vendor.git
- release repository: https://github.com/ros2-gbp/gz_transport_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-1`

## gz_transport_vendor

```
* Jetty support, 15.0.0-pre1 (#11 <https://github.com/gazebo-release/gz_transport_vendor/issues/11>)
  * Jetty support: 15.0.0-pre1
  * Add zenoh-cpp-vendor
  * Rename to zenoh_cpp_vendor
  ---------
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: Steve Peters
```
