### PR TITLE
gz_gui_vendor: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2588,7 +2588,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_gui_vendor` to `0.3.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_gui_vendor.git
- release repository: https://github.com/ros2-gbp/gz_gui_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`

## gz_gui_vendor

```
* Jetty support, 10.0.0-pre1 (#6 <https://github.com/gazebo-release/gz_gui_vendor/issues/6>)
  * Jetty support: 10.0.0-pre1
  * Update to pre2, update CMakeLists based on upstream fix
  ---------
  Co-authored-by: Addisu Z. Taddese <mailto:addisu@openrobotics.org>
* Contributors: Steve Peters
```
