### PR TITLE
sfgui_vendor: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9346,6 +9346,17 @@ repositories:
       url: https://github.com/septentrio-gnss/septentrio_gnss_driver.git
       version: master
     status: maintained
+  sfgui_vendor:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/JWhitleyWork/sfgui_vendor-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/JWhitleyWork/sfgui_vendor.git
+      version: main
+    status: maintained
   sick_safetyscanners2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sfgui_vendor` to `0.4.0-1`:

- upstream repository: https://github.com/JWhitleyWork/sfgui_vendor.git
- release repository: https://github.com/JWhitleyWork/sfgui_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## sfgui_vendor

```
* Enable GLOBAL_HOOK.
* Initial version.
* Contributors: Joshua Whitley
```
