### PR TITLE
mavlink: 2025.9.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3846,7 +3846,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mavlink-gbp-release.git
-      version: 2025.6.6-1
+      version: 2025.9.9-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavlink` to `2025.9.9-1`:

- upstream repository: https://github.com/mavlink/mavlink.git
- release repository: https://github.com/ros2-gbp/mavlink-gbp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2025.6.6-1`
