### PR TITLE
turtlebot4: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10421,7 +10421,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot4` to `2.1.1-1`:

- upstream repository: https://github.com/turtlebot/turtlebot4.git
- release repository: https://github.com/ros2-gbp/turtlebot4-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## turtlebot4_description

- No changes

## turtlebot4_msgs

- No changes

## turtlebot4_navigation

```
* Fix SLAM parameter passing (#631 <https://github.com/turtlebot/turtlebot4/issues/631>)
  * Instead of manually remapping topics, rewrite the parameters to apply namespaces as needed
  * Add map_name parameter to the config so we can overwrite it correctly
* make footprint topic relative in collision monitor while using with namespace (#606 <https://github.com/turtlebot/turtlebot4/issues/606>)
* Contributors: Chris Iverach-Brereton, Kishan Sawant
```

## turtlebot4_node

- No changes
