### PR TITLE
realtime_tools: 3.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7152,7 +7152,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.7.0-1
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.8.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.7.0-1`

## realtime_tools

```
* Fix RealtimeThreadSafeBox for MSVC (backport #400 <https://github.com/ros-controls/realtime_tools/issues/400>) (#401 <https://github.com/ros-controls/realtime_tools/issues/401>)
* Fix the failing ament_cppcheck in realtime_thread_safe_box (backport #391 <https://github.com/ros-controls/realtime_tools/issues/391>) (#396 <https://github.com/ros-controls/realtime_tools/issues/396>)
* Fix macOS compatibility issues in realtime_tools package (backport #370 <https://github.com/ros-controls/realtime_tools/issues/370>) (#381 <https://github.com/ros-controls/realtime_tools/issues/381>)
* Fix the realtime publisher doc (backport #376 <https://github.com/ros-controls/realtime_tools/issues/376>) (#377 <https://github.com/ros-controls/realtime_tools/issues/377>)
* Only accept callable with T& (backport #372 <https://github.com/ros-controls/realtime_tools/issues/372>) (#373 <https://github.com/ros-controls/realtime_tools/issues/373>)
* Contributors: mergify[bot]
```
