### PR TITLE
realtime_tools: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6151,7 +6151,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.5.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.4.0-1`

## realtime_tools

```
* Fix RealtimeThreadSafeBox for MSVC (#400 <https://github.com/ros-controls/realtime_tools/issues/400>)
* Fix the failing ament_cppcheck in realtime_thread_safe_box (#391 <https://github.com/ros-controls/realtime_tools/issues/391>)
* Fix macOS compatibility issues in realtime_tools package (#370 <https://github.com/ros-controls/realtime_tools/issues/370>)
* Fix the realtime publisher doc (#376 <https://github.com/ros-controls/realtime_tools/issues/376>)
* Only accept callable with T& (#372 <https://github.com/ros-controls/realtime_tools/issues/372>)
* Contributors: Christoph Fröhlich, Dhruv Patel, Sai Kishor Kothakota
```
