### PR TITLE
Added libpsl-dev to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5854,8 +5854,8 @@ libpsl-dev:
   alpine: [libpsl-dev]
   debian: [libpsl-dev]
   fedora: [libpsl-devel]
-  opensuse: [libpsl-dev]
-  rhel: [libpsl-dev]
+  opensuse: [libpsl-devel]
+  rhel: [libpsl-devel]
   ubuntu: [libpsl-dev]
 libpt-dev:
   debian: [libpt-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5851,6 +5851,9 @@ libprocps6:
 libpsl-dev:
   debian: [libpsl-dev]
   ubuntu: [libpsl-dev]
+  opensuse: [libpsl-dev]
+  alpine: [libpsl-dev]
+  rhel: [libpsl-dev]
 libpt-dev:
   debian: [libpt-dev]
   fedora: [ptlib-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5849,12 +5849,12 @@ libprocps6:
   ubuntu:
     bionic: [libprocps6]
 libpsl-dev:
+  alpine: [libpsl-dev]
   debian: [libpsl-dev]
   fedora: [libpsl-devel]
-  ubuntu: [libpsl-dev]
   opensuse: [libpsl-dev]
-  alpine: [libpsl-dev]
   rhel: [libpsl-dev]
+  ubuntu: [libpsl-dev]
 libpt-dev:
   debian: [libpt-dev]
   fedora: [ptlib-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5848,6 +5848,9 @@ libprocps6:
     stretch: [libprocps6]
   ubuntu:
     bionic: [libprocps6]
+libpsl-dev:
+  ubuntu: [libpsl-dev]
+  debian: [libpsl-dev]
 libpt-dev:
   debian: [libpt-dev]
   fedora: [ptlib-devel]
@@ -7596,6 +7599,9 @@ meshlab:
   gentoo: [media-gfx/meshlab]
   nixos: [meshlab]
   ubuntu: [meshlab]
+meson:
+  ubuntu: [meson]
+  debian: [meson]  
 mkdocs:
   debian:
     buster: [mkdocs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5850,6 +5850,7 @@ libprocps6:
     bionic: [libprocps6]
 libpsl-dev:
   debian: [libpsl-dev]
+  fedora: [libpsl-devel]
   ubuntu: [libpsl-dev]
 libpt-dev:
   debian: [libpt-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5849,8 +5849,8 @@ libprocps6:
   ubuntu:
     bionic: [libprocps6]
 libpsl-dev:
-  ubuntu: [libpsl-dev]
   debian: [libpsl-dev]
+  ubuntu: [libpsl-dev]
 libpt-dev:
   debian: [libpt-dev]
   fedora: [ptlib-devel]
@@ -7598,10 +7598,7 @@ meshlab:
   fedora: [meshlab]
   gentoo: [media-gfx/meshlab]
   nixos: [meshlab]
-  ubuntu: [meshlab]
-meson:
-  ubuntu: [meson]
-  debian: [meson]  
+  ubuntu: [meshlab] 
 mkdocs:
   debian:
     buster: [mkdocs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7598,7 +7598,7 @@ meshlab:
   fedora: [meshlab]
   gentoo: [media-gfx/meshlab]
   nixos: [meshlab]
-  ubuntu: [meshlab] 
+  ubuntu: [meshlab]
 mkdocs:
   debian:
     buster: [mkdocs]


### PR DESCRIPTION
## Package name:

libpsl-dev

## Package Upstream Source:

https://github.com/rockdaboot/libpsl

## Purpose of using this:

This dependency provides Public Suffix List support, which is required by some networking libraries and tools.

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libpsl-dev
- Ubuntu: https://packages.ubuntu.com/jammy/libpsl-dev


# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
