### PR TITLE
resource_retriever: 3.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6188,13 +6188,10 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: rolling
     release:
-      packages:
-      - libcurl_vendor
-      - resource_retriever
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.8.2-1
+      version: 3.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.9.0-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.2-1`

## resource_retriever

```
* removed libcurl_vendor package (#116 <https://github.com/ros/resource_retriever/issues/116>)
* Contributors: Alejandro Hernández Cordero
```
