### PR TITLE
image_transport_plugins: 5.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3027,7 +3027,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 5.1.0-1
+      version: 5.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `5.1.1-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.0-1`

## compressed_depth_image_transport

```
* Fix passing parameters to cv::imencode for OpenCV 4.7 (#207 <https://github.com/ros-perception/image_transport_plugins/issues/207>) (#208 <https://github.com/ros-perception/image_transport_plugins/issues/208>)
  (cherry picked from commit 3d192bff0b770cd9b0a202fd4c858254c1cc726f)
  Co-authored-by: Jafar Uruç <mailto:jafar.uruc@gmail.com>
* Contributors: mergify[bot]
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes

## zstd_image_transport

- No changes
