### PR TITLE
image_transport_plugins: 4.0.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3678,7 +3678,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 4.0.5-1
+      version: 4.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `4.0.6-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.5-1`

## compressed_depth_image_transport

```
* Fix passing parameters to cv::imencode for OpenCV 4.7 (#207 <https://github.com/ros-perception/image_transport_plugins/issues/207>) (#209 <https://github.com/ros-perception/image_transport_plugins/issues/209>)
  (cherry picked from commit 3d192bff0b770cd9b0a202fd4c858254c1cc726f)
  Co-authored-by: Jafar Uruç <mailto:jafar.uruc@gmail.com>
* Contributors: mergify[bot]
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes

## zstd_image_transport

- No changes
