### PR TITLE
image_transport_plugins: 2.5.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4065,7 +4065,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.5.3-1
+      version: 2.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.5.4-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.3-1`

## compressed_depth_image_transport

```
* Fix passing parameters to cv::imencode for OpenCV 4.7 (#207 <https://github.com/ros-perception/image_transport_plugins/issues/207>) (#210 <https://github.com/ros-perception/image_transport_plugins/issues/210>)
  (cherry picked from commit 3d192bff0b770cd9b0a202fd4c858254c1cc726f)
  Co-authored-by: Jafar Uruç <mailto:jafar.uruc@gmail.com>
* Contributors: mergify[bot]
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes
