### PR TITLE
tf2_web_republisher: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11122,6 +11122,18 @@ repositories:
       version: humble
     status: maintained
   tf2_web_republisher:
+    doc:
+      type: git
+      url: https://github.com/RobotWebTools/tf2_web_republisher.git
+      version: ros2
+    release:
+      packages:
+      - tf2_web_republisher
+      - tf2_web_republisher_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/tf2_web_republisher-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf2_web_republisher` to `1.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/tf2_web_republisher
- release repository: https://github.com/ros2-gbp/tf2_web_republisher-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## tf2_web_republisher

```
* Port to ROS 2 (#35 <https://github.com/RobotWebTools/tf2_web_republisher/issues/35>)
* Contributors: Paul Gesel, Błażej Sowa
```

## tf2_web_republisher_interfaces

```
* Port to ROS 2 (#35 <https://github.com/RobotWebTools/tf2_web_republisher/issues/35>)
* Contributors: Paul Gesel, Błażej Sowa
```
