### PR TITLE
Deactivate failing unmaintained packages

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6196,7 +6196,6 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
-      version: 0.0.1-3
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5436,7 +5436,6 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
-      version: 0.0.1-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4639,7 +4639,6 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
-      version: 0.0.1-5
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4616,7 +4616,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nmea_hardware_interface-release.git
-      version: 0.0.1-4
     source:
       type: git
       url: https://github.com/OUXT-Polaris/nmea_hardware_interface.git
@@ -5719,7 +5718,6 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/quaternion_operation-release.git
-      version: 0.0.7-4
     source:
       type: git
       url: https://github.com/OUXT-Polaris/quaternion_operation.git


### PR DESCRIPTION
From discord conversation:

> I added prerelease workflows for ros2_control repositories. I get several build failures due to unmaintained packages, like [nmea_hardware_interface](https://github.com/OUXT-Polaris/nmea_hardware_interface/pull/20) where a fix by @clalancette wasn't considered for 1.5 years now, or [this one](https://github.com/OUXT-Polaris/quaternion_operation/issues/118).

@cottsay 

> If a released package isn't building on build.ros2.org successfully for quite a long time, and the upstream maintainers aren't responding, I think that's absolutely grounds to take action.
> 
> My recommendation would be to drop the version: X.X.X line from the release: stanza in the distribution.yaml. That will stop the Rsrc_* and Rbin_* jobs from running.

Failing or deactivated
https://build.ros2.org/job/Rbin_uN64__quaternion_operation__ubuntu_noble_amd64__binary/
https://build.ros2.org/job/Rbin_uN64__nmea_hardware_interface__ubuntu_noble_amd64__binary/
https://build.ros2.org/job/Kbin_uN64__nmea_hardware_interface__ubuntu_noble_amd64__binary/
https://build.ros2.org/job/Jbin_uN64__nmea_hardware_interface__ubuntu_noble_amd64__binary/
https://build.ros2.org/job/Hbin_uJ64__nmea_hardware_interface__ubuntu_jammy_amd64__binary/

Let me know if there should be updated more, like status `unmaintained` acc. to https://www.ros.org/reps/rep-0137.html ?