### PR TITLE
Add python3-docstring-parser to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5732,16 +5732,15 @@ python3-docopt:
   nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
 python3-docstring-parser:
+  '*':
+    pip:
+      packages: [docstring-parser]
   debian:
     trixie: [python3-docstring-parser]
-    sid: [python3-docstring-parser]
   fedora: [python3-docstring-parser]
   nixos: [python3Packages.docstring-parser]
   ubuntu:
     noble: [python3-docstring-parser]
-  '*':
-    pip:
-      packages: [docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5732,19 +5732,25 @@ python3-docopt:
   nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
 python3-docstring-parser:
-  arch: null
+  arch: 
+    pip:
+      packages: [docstring-parser]
   debian:
-    bookworm: null
+    bookworm: 
+      pip:
+        packages: [docstring-parser]
     trixie: [python3-docstring-parser]
     sid: [python3-docstring-parser]
   fedora: [python3-docstring-parser]
-  gentoo: null
+  gentoo: 
+    pip:
+      packages: [docstring-parser]
   nixos: [python3Packages.docstring-parser]
   ubuntu:
-    jammy: null
+    jammy: 
+      pip:
+        packages: [docstring-parser]
     noble: [python3-docstring-parser]
-  pip:
-    packages: [docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5732,25 +5732,19 @@ python3-docopt:
   nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
 python3-docstring-parser:
-  arch:
-    pip:
-      packages: [docstring-parser]
+  arch: null
   debian:
-    bookworm:
-      pip:
-        packages: [docstring-parser]
+    bookworm: null
     trixie: [python3-docstring-parser]
     sid: [python3-docstring-parser]
   fedora: [python3-docstring-parser]
-  gentoo:
-    pip:
-      packages: [docstring-parser]
+  gentoo: null
   nixos: [python3Packages.docstring-parser]
   ubuntu:
-    jammy:
-      pip:
-        packages: [docstring-parser]
+    jammy: null
     noble: [python3-docstring-parser]
+  pip:
+    packages: [docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5732,25 +5732,16 @@ python3-docopt:
   nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
 python3-docstring-parser:
-  arch: 
-    pip:
-      packages: [docstring-parser]
   debian:
-    bookworm: 
-      pip:
-        packages: [docstring-parser]
     trixie: [python3-docstring-parser]
     sid: [python3-docstring-parser]
   fedora: [python3-docstring-parser]
-  gentoo: 
-    pip:
-      packages: [docstring-parser]
   nixos: [python3Packages.docstring-parser]
   ubuntu:
-    jammy: 
-      pip:
-        packages: [docstring-parser]
     noble: [python3-docstring-parser]
+  '*':
+    pip:
+      packages: [docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5731,6 +5731,20 @@ python3-docopt:
   gentoo: [dev-python/docopt]
   nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
+python3-docstring-parser:
+  arch: null
+  debian:
+    bookworm: null
+    trixie: [python3-docstring-parser]
+    sid: [python3-docstring-parser]
+  fedora: [python3-docstring-parser]
+  gentoo: null
+  nixos: [python3Packages.docstring-parser]
+  ubuntu:
+    jammy: null
+    noble: [python3-docstring-parser]
+  pip:
+    packages: [docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5732,19 +5732,25 @@ python3-docopt:
   nixos: [python3Packages.docopt]
   ubuntu: [python3-docopt]
 python3-docstring-parser:
-  arch: null
+  arch:
+    pip:
+      packages: [docstring-parser]
   debian:
-    bookworm: null
+    bookworm:
+      pip:
+        packages: [docstring-parser]
     trixie: [python3-docstring-parser]
     sid: [python3-docstring-parser]
   fedora: [python3-docstring-parser]
-  gentoo: null
+  gentoo:
+    pip:
+      packages: [docstring-parser]
   nixos: [python3Packages.docstring-parser]
   ubuntu:
-    jammy: null
+    jammy:
+      pip:
+        packages: [docstring-parser]
     noble: [python3-docstring-parser]
-  pip:
-    packages: [docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name: 

python3-docstring-parser

## Package Upstream Source:

https://github.com/rr-/docstring_parser

## Purpose of using this:

This package parses python docstrings and makes them available for programmatic digestion. It's very useful when creating new (CLI) tools, as it allows to generate e.g. help strings for functions and parameters without duplication.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/python3-docstring-parser
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-docstring-parser
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-docstring-parser/python3-docstring-parser/index.html
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://mynixos.com/nixpkgs/package/python312Packages.docstring-parser
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

- pypi: 
  - https://pypi.org/project/docstring-parser/