### PR TITLE
Add rko_lio to ROS Rolling index

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6209,6 +6209,12 @@ repositories:
       url: https://github.com/teamspatzenhirn/rig_reconfigure.git
       version: master
     status: developed
+  rko_lio:
+    source:
+      type: git
+      url: https://github.com/PRBonn/rko_lio.git
+      version: master
+    status: developed
   rmf_api_msgs:
     doc:
       type: git


### PR DESCRIPTION
# Please Add `rko_lio` to be indexed in the rosdistro.

ROS Distro: Rolling

# The source is here:

https://github.com/PRBonn/rko_lio

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

I'd also like to add this package to the Humble, Jazzy and Kilted indexes. 
Please let me know if these should be three separate PRs, one additional PR, or I just modify the current one. 
