### PR TITLE
rclcpp: 30.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6004,7 +6004,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 30.1.0-1
+      version: 30.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `30.1.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `30.1.0-1`

## rclcpp

```
* Removed warning (#2949 <https://github.com/ros2/rclcpp/issues/2949>)
* add note about problems with spin_until_future_complete (#2849 <https://github.com/ros2/rclcpp/issues/2849>)
* deprecate rclcpp::spin_some and rclcpp::spin_all (#2848 <https://github.com/ros2/rclcpp/issues/2848>)
* Improve the function extract_type_identifier (#2923 <https://github.com/ros2/rclcpp/issues/2923>)
* Allow for implicitly convertable loggers as well (#2922 <https://github.com/ros2/rclcpp/issues/2922>)
* Contributors: Alberto Soragna, Alejandro Hernández Cordero, Barry Xu, Tim Clephas
```

## rclcpp_action

```
* deprecate rclcpp::spin_some and rclcpp::spin_all (#2848 <https://github.com/ros2/rclcpp/issues/2848>)
* Contributors: Alberto Soragna
```

## rclcpp_components

```
* Cleanup the dependencies in rclcpp_components. (#2918 <https://github.com/ros2/rclcpp/issues/2918>)
* Contributors: Chris Lalancette
```

## rclcpp_lifecycle

```
* deprecate rclcpp::spin_some and rclcpp::spin_all (#2848 <https://github.com/ros2/rclcpp/issues/2848>)
* Clearer warning message, the old one lacked information and was perhaps misleading (#2927 <https://github.com/ros2/rclcpp/issues/2927>)
* Contributors: Alberto Soragna, Peter Mitrano (AR)
```
