### PR TITLE
pointcloud_to_laserscan: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5402,7 +5402,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
-      version: 2.0.2-2
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_to_laserscan` to `2.1.0-1`:

- upstream repository: https://github.com/ros-perception/pointcloud_to_laserscan.git
- release repository: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-2`

## pointcloud_to_laserscan

```
* remove deprecation warnings (#102 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/102>)
* Update README.md (#82 <https://github.com/ros-perception/pointcloud_to_laserscan/issues/82>)
* Contributors: Alejandro Hernández Cordero, Diego Andrés Carvajal Solano
```
