### PR TITLE
rclcpp: 16.0.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8053,7 +8053,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.14-1
+      version: 16.0.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.15-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `16.0.14-1`

## rclcpp

```
* Allow for implicitly convertable loggers as well (#2922 <https://github.com/ros2/rclcpp/issues/2922>) (#2936 <https://github.com/ros2/rclcpp/issues/2936>) (#2938 <https://github.com/ros2/rclcpp/issues/2938>)
* Fix: improve exception context for parameter_value_from (backport #2917 <https://github.com/ros2/rclcpp/issues/2917>) (#2921 <https://github.com/ros2/rclcpp/issues/2921>)
* Removed warning test_qos (#2859 <https://github.com/ros2/rclcpp/issues/2859>) (#2925 <https://github.com/ros2/rclcpp/issues/2925>)
* Add qos parameter for wait_for_message function (#2903 <https://github.com/ros2/rclcpp/issues/2903>) (#2907 <https://github.com/ros2/rclcpp/issues/2907>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Add a clearer warning message, the old one lacked information and was misleading (#2924 <https://github.com/ros2/rclcpp/issues/2924>)
* Contributors: Peter Mitrano (AR)
```
