### PR TITLE
rclcpp: 28.1.12-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7004,7 +7004,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.11-1
+      version: 28.1.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.12-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `28.1.11-1`

## rclcpp

```
* Removed warning test_qos (#2859 <https://github.com/ros2/rclcpp/issues/2859>) (#2945 <https://github.com/ros2/rclcpp/issues/2945>)
* Allow for implicitly convertable loggers as well (#2922 <https://github.com/ros2/rclcpp/issues/2922>) (#2936 <https://github.com/ros2/rclcpp/issues/2936>) (#2937 <https://github.com/ros2/rclcpp/issues/2937>)
* Fix: improve exception context for parameter_value_from (#2917 <https://github.com/ros2/rclcpp/issues/2917>) (#2920 <https://github.com/ros2/rclcpp/issues/2920>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

```
* Clearer warning message, the old one lacked information and was perhaps misleading (#2927 <https://github.com/ros2/rclcpp/issues/2927>) (#2932 <https://github.com/ros2/rclcpp/issues/2932>)
* Contributors: mergify[bot]
```
