### PR TITLE
ros2cli: 0.40.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6988,7 +6988,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.40.0-1
+      version: 0.40.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.40.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.40.0-1`

## ros2action

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Scott K Logan, Tomoya Fujita
```

## ros2cli

```
* fix: Also catch a TimeoutError (#1092 <https://github.com/ros2/ros2cli/issues/1092>)
* Contributors: Kaju-Bubanja
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* [ros2doctor] Environment Report (#1045 <https://github.com/ros2/ros2cli/issues/1045>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Michael Carlstrom, Scott K Logan, Tomoya Fujita
```

## ros2interface

- No changes

## ros2lifecycle

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Scott K Logan, Tomoya Fujita
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Scott K Logan, Tomoya Fujita
```

## ros2param

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Scott K Logan, Tomoya Fujita
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Scott K Logan, Tomoya Fujita
```

## ros2topic

```
* Fujitatomoya/clearup isolated ros2daemon (#1098 <https://github.com/ros2/ros2cli/issues/1098>)
* wait for the publisher before test command is executed. (#1094 <https://github.com/ros2/ros2cli/issues/1094>)
* Enable test isolation on a few remaining ros2topic tests (#1087 <https://github.com/ros2/ros2cli/issues/1087>)
* Restore environment variables after launch tests (#1086 <https://github.com/ros2/ros2cli/issues/1086>)
* Contributors: Scott K Logan, Tomoya Fujita
```
