### PR TITLE
ros2cli: 0.38.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7027,7 +7027,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.38.0-1
+      version: 0.38.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.38.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.38.0-1`

## ros2action

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* fix ros2action send_goal signal handling. (#1072 <https://github.com/ros2/ros2cli/issues/1072>) (#1074 <https://github.com/ros2/ros2cli/issues/1074>)
* Fujitatomoya/ros2 action send goal timeout (#1067 <https://github.com/ros2/ros2cli/issues/1067>) (#1068 <https://github.com/ros2/ros2cli/issues/1068>)
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>) (#1057 <https://github.com/ros2/ros2cli/issues/1057>)
* remove unnecessary '/' from ros2 action info. (#1049 <https://github.com/ros2/ros2cli/issues/1049>) (#1050 <https://github.com/ros2/ros2cli/issues/1050>)
* add QoS option to ros2service/ros2action echo commands. (#1036 <https://github.com/ros2/ros2cli/issues/1036>) (#1038 <https://github.com/ros2/ros2cli/issues/1038>)
* Contributors: mergify[bot]
```

## ros2cli

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Assert HistoryQoS in test_ros2cli_daemon (#1040 <https://github.com/ros2/ros2cli/issues/1040>) (#1044 <https://github.com/ros2/ros2cli/issues/1044>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

```
* fix cmake deprecation (#1082 <https://github.com/ros2/ros2cli/issues/1082>) (#1083 <https://github.com/ros2/ros2cli/issues/1083>)
* Contributors: mergify[bot]
```

## ros2component

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Contributors: mergify[bot]
```

## ros2doctor

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Fix stringifying InterfaceFlags when the flags are empty. (#1026 <https://github.com/ros2/ros2cli/issues/1026>) (#1027 <https://github.com/ros2/ros2cli/issues/1027>)
* Contributors: mergify[bot]
```

## ros2interface

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Contributors: mergify[bot]
```

## ros2lifecycle

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>) (#1057 <https://github.com/ros2/ros2cli/issues/1057>)
* Contributors: mergify[bot]
```

## ros2lifecycle_test_fixtures

```
* fix cmake deprecation (#1082 <https://github.com/ros2/ros2cli/issues/1082>) (#1083 <https://github.com/ros2/ros2cli/issues/1083>)
* Contributors: mergify[bot]
```

## ros2multicast

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Contributors: mergify[bot]
```

## ros2node

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Contributors: mergify[bot]
```

## ros2param

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>) (#1057 <https://github.com/ros2/ros2cli/issues/1057>)
* catch ConnectionRefusedError, so that it can fall back to DirectNode. (#1014 <https://github.com/ros2/ros2cli/issues/1014>) (#1020 <https://github.com/ros2/ros2cli/issues/1020>)
* fails the test properly to avoid TypeError exception. (#1016 <https://github.com/ros2/ros2cli/issues/1016>) (#1017 <https://github.com/ros2/ros2cli/issues/1017>)
* Contributors: mergify[bot]
```

## ros2pkg

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* fix cmake deprecation (#1082 <https://github.com/ros2/ros2cli/issues/1082>) (#1083 <https://github.com/ros2/ros2cli/issues/1083>)
* Contributors: mergify[bot]
```

## ros2run

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Contributors: mergify[bot]
```

## ros2service

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* Relax the check from exact to partial match. (#1055 <https://github.com/ros2/ros2cli/issues/1055>) (#1057 <https://github.com/ros2/ros2cli/issues/1057>)
* add QoS option to ros2service/ros2action echo commands. (#1036 <https://github.com/ros2/ros2cli/issues/1036>) (#1038 <https://github.com/ros2/ros2cli/issues/1038>)
* Contributors: mergify[bot]
```

## ros2topic

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1101 <https://github.com/ros2/ros2cli/issues/1101>)
* wait for the publisher before test command is executed. (#1094 <https://github.com/ros2/ros2cli/issues/1094>) (#1095 <https://github.com/ros2/ros2cli/issues/1095>)
* Contributors: mergify[bot]
```
