### PR TITLE
ros2cli: 0.32.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8015,7 +8015,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.5-1
+      version: 0.32.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.6-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.32.5-1`

## ros2action

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2cli

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2doctor

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2interface

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2lifecycle

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2node

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2param

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2pkg

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2run

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2service

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```

## ros2topic

```
* fix setuptools deprecations (#1066 <https://github.com/ros2/ros2cli/issues/1066>) (#1102 <https://github.com/ros2/ros2cli/issues/1102>)
* Contributors: mergify[bot]
```
