### PR TITLE
network_bridge: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5391,7 +5391,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/network_bridge-release.git
-      version: 1.0.2-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/brow1633/network_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_bridge` to `2.0.0-1`:

- upstream repository: https://github.com/brow1633/network_bridge.git
- release repository: https://github.com/ros2-gbp/network_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-1`

## network_bridge

```
* Merge pull request #12 <https://github.com/brow1633/network_bridge/issues/12> from brow1633/robustify
* Guard against querying graph after context goes invalid
* make some tests/shutdown more robust
* force client to start after server in TCP test (#11 <https://github.com/brow1633/network_bridge/issues/11>)
  * force client to start after server
  * linting
  * no more python linting.
* Handling of large objects and clean management of reconnections (#7 <https://github.com/brow1633/network_bridge/issues/7>)
  * Added queuing mechanism for reception and garanteed transmission
  * Added receive queue
  * Added proper server reconnect
  * Added logger for topic creation
  * Fixed client reconnect
  * Implemented PR request
  ---------
  Co-authored-by: Cedric Pradalier <mailto:cedric.pradalier@georgiatech-metz.fr>
  Co-authored-by: Ethan Brown <mailto:97919387+brow1633@users.noreply.github.com>
* Merge pull request #9 <https://github.com/brow1633/network_bridge/issues/9> from brow1633/8-fix-ci
  update cache version, include kilted, linting
* remove whitepsace
* Merge branch 'main' into 8-fix-ci
* Fix linting error
* update cache version, include kilted
* Contributors: Cedric Pradalier, Ethan Brown
```
