### PR TITLE
network_bridge: 2.0.0-3 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4615,6 +4615,17 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: kilted
     status: maintained
+  network_bridge:
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/network_bridge-release.git
+      version: 2.0.0-3
+    source:
+      type: git
+      url: https://github.com/brow1633/network_bridge.git
+      version: main
+    status: maintained
   nlohmann_json_schema_validator_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_bridge` to `2.0.0-3`:

- upstream repository: https://github.com/brow1633/network_bridge.git
- release repository: https://github.com/ros2-gbp/network_bridge-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
