### PR TITLE
Add rko_lio to ROS Kilted index

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6241,6 +6241,12 @@ repositories:
       url: https://github.com/teamspatzenhirn/rig_reconfigure.git
       version: master
     status: developed
+  rko_lio:
+    source:
+      type: git
+      url: https://github.com/PRBonn/rko_lio.git
+      version: master
+    status: developed
   rmf_api_msgs:
     doc:
       type: git


### PR DESCRIPTION
# Please Add `rko_lio` to be indexed in the rosdistro.

ROSDISTRO NAME: Kilted

This package has been indexed into Rolling in #47605 

# The source is here:

https://github.com/PRBonn/rko_lio

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
