### PR TITLE
launch_ros: 0.19.11-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4636,7 +4636,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.19.10-1
+      version: 0.19.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.19.11-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.19.10-1`

## launch_ros

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#486 <https://github.com/ros2/launch_ros/issues/486>)
* Add LifecyleTransition action (#317 <https://github.com/ros2/launch_ros/issues/317>) (#477 <https://github.com/ros2/launch_ros/issues/477>)
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#486 <https://github.com/ros2/launch_ros/issues/486>)
* Contributors: mergify[bot]
```

## ros2launch

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#486 <https://github.com/ros2/launch_ros/issues/486>)
* Contributors: mergify[bot]
```
