### PR TITLE
neo_nav2_bringup: 1.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4615,6 +4615,17 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: kilted
     status: maintained
+  neo_nav2_bringup:
+    doc:
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: iron
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
+      version: 1.0.4-1
+    status: maintained
   network_bridge:
     release:
       tags:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4616,15 +4616,16 @@ repositories:
       version: kilted
     status: maintained
   neo_nav2_bringup:
-    doc:
-      type: git
-      url: https://github.com/neobotix/neo_nav2_bringup.git
-      version: iron
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
       version: 1.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/neobotix/neo_nav2_bringup.git
+      version: kilted
     status: maintained
   network_bridge:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.0.4-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
