### PR TITLE
add tweeny

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6748,6 +6748,13 @@ libturbojpeg:
   rhel: [libjpeg-turbo-devel, turbojpeg-devel]
   ubuntu:
     '*': [libturbojpeg0-dev]
+libtweeny-dev:
+  alpine: [tweeny]
+  debian: [libtweeny-dev]
+  fedora: [tweeny-devel]
+  freebsd: [tweeny]
+  nixos: [tweeny]
+  ubuntu: [libtweeny-dev]
 libudev-dev:
   arch: [systemd]
   debian: [libudev-dev]
@@ -9743,13 +9750,6 @@ ttf-sazanami-mincho:
   fedora: [sazanami-mincho-fonts]
   gentoo: [media-fonts/sazanami]
   ubuntu: [ttf-sazanami-mincho]
-tweeny:
-  alpine: [tweeny]
-  debian: [libtweeny-dev]
-  fedora: [tweeny-devel]
-  freebsd: [tweeny]
-  nixos: [tweeny]
-  ubuntu: [libtweeny-dev]
 udev:
   arch: [systemd]
   debian: [udev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9743,6 +9743,13 @@ ttf-sazanami-mincho:
   fedora: [sazanami-mincho-fonts]
   gentoo: [media-fonts/sazanami]
   ubuntu: [ttf-sazanami-mincho]
+tweeny:
+  alpine: [tweeny]
+  arch: [tweeny]
+  debian: [libtweeny-dev]
+  fedora: [tweeny]
+  freebsd: [tweeny]
+  ubuntu: [libtweeny-dev]
 udev:
   arch: [systemd]
   debian: [udev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9746,10 +9746,9 @@ ttf-sazanami-mincho:
 tweeny:
   alpine: [tweeny]
   debian: [libtweeny-dev]
-  fedora: [tweeny]
+  fedora: [tweeny-devel]
   freebsd: [tweeny]
   nixos: [tweeny]
-  opensuse: [tweeny]
   ubuntu: [libtweeny-dev]
 udev:
   arch: [systemd]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9749,6 +9749,7 @@ tweeny:
   debian: [libtweeny-dev]
   fedora: [tweeny]
   freebsd: [tweeny]
+  opensuse: [tweeny]
   ubuntu: [libtweeny-dev]
 udev:
   arch: [systemd]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9745,10 +9745,10 @@ ttf-sazanami-mincho:
   ubuntu: [ttf-sazanami-mincho]
 tweeny:
   alpine: [tweeny]
-  arch: [tweeny]
   debian: [libtweeny-dev]
   fedora: [tweeny]
   freebsd: [tweeny]
+  nixos: [tweeny]
   opensuse: [tweeny]
   ubuntu: [libtweeny-dev]
 udev:


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`tweeny`

## Package Upstream Source:

https://github.com/mobius3/tweeny

## Purpose of using this:

For tweening, particularly in animation.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bullseye/libtweeny-dev
  - https://packages.debian.org/bookworm/libtweeny-dev
  - https://packages.debian.org/trixie/libtweeny-dev
  - https://packages.debian.org/forky/libtweeny-dev
  - https://packages.debian.org/sid/libtweeny-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libtweeny-dev
  - https://packages.ubuntu.com/noble/libtweeny-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/tweeny/
- FreeBSD: https://www.freshports.org/
  - https://www.freshports.org/graphics/tweeny/
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/tweeny
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.05&show=tweeny&query=tweeny
