### PR TITLE
ros2_control: 2.52.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8875,7 +8875,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.51.0-1
+      version: 2.52.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.52.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.51.0-1`

## controller_interface

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Fix missing include for std::find (#2425 <https://github.com/ros-controls/ros2_control/issues/2425>) (#2426 <https://github.com/ros-controls/ros2_control/issues/2426>)
* Document order of interfaces (#2394 <https://github.com/ros-controls/ros2_control/issues/2394>) (#2421 <https://github.com/ros-controls/ros2_control/issues/2421>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Fix typos in the documentation of SwitchController strictness (backport #2445 <https://github.com/ros-controls/ros2_control/issues/2445>) (#2446 <https://github.com/ros-controls/ros2_control/issues/2446>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Contributors: mergify[bot]
```

## ros2_control

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Contributors: mergify[bot]
```

## ros2_control_test_assets

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Fix CMake install so overriding works (backport #926 <https://github.com/ros-controls/ros2_control/issues/926>) (#2480 <https://github.com/ros-controls/ros2_control/issues/2480>)
* Contributors: mergify[bot]
```
