### PR TITLE
ros2_control: 4.37.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7792,7 +7792,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.36.0-1
+      version: 4.37.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.37.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.36.0-1`

## controller_interface

```
* Update message dependencies for tests (#2497 <https://github.com/ros-controls/ros2_control/issues/2497>) (#2500 <https://github.com/ros-controls/ros2_control/issues/2500>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Publish controller manager statistics to better introspect the timings (backport #2449 <https://github.com/ros-controls/ros2_control/issues/2449>) (#2521 <https://github.com/ros-controls/ros2_control/issues/2521>)
* Fix the CPU affinity of the ros2_control_node (#2509 <https://github.com/ros-controls/ros2_control/issues/2509>) (#2511 <https://github.com/ros-controls/ros2_control/issues/2511>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix interface configuration docs (#2537 <https://github.com/ros-controls/ros2_control/issues/2537>) (#2538 <https://github.com/ros-controls/ros2_control/issues/2538>)
* Publish controller manager statistics to better introspect the timings (backport #2449 <https://github.com/ros-controls/ros2_control/issues/2449>) (#2521 <https://github.com/ros-controls/ros2_control/issues/2521>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
