### PR TITLE
rqt_dotgraph: 0.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8726,7 +8726,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_dotgraph-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/niwcpac/rqt_dotgraph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dotgraph` to `0.0.5-1`:

- upstream repository: https://github.com/niwcpac/rqt_dotgraph.git
- release repository: https://github.com/ros2-gbp/rqt_dotgraph-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.4-1`

## rqt_dotgraph

```
* Contributors: Alexander Xydes, Thomas Denewiler
```
