### PR TITLE
rqt_dotgraph: 0.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7716,7 +7716,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_dotgraph-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/niwcpac/rqt_dotgraph.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_dotgraph` to `0.0.5-1`:

- upstream repository: https://github.com/niwcpac/rqt_dotgraph.git
- release repository: https://github.com/ros2-gbp/rqt_dotgraph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.4-1`

## rqt_dotgraph

```
* Contributors: Alexander Xydes, Thomas Denewiler
```
