### PR TITLE
Add libqt6bluetooth6 and qt6-connectivity-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6215,18 +6215,6 @@ libqt5x11extras5-dev:
   openembedded: [qtx11extras@meta-qt5]
   rhel: [qt5-qtx11extras-devel]
   ubuntu: [libqt5x11extras5-dev]
-libqt6-connectivity:
-  alpine: [qt6-qtconnectivity]
-  arch: [qt6-connectivity]
-  debian: [libqt6bluetooth6, libqt6nfc6]
-  fedora: [qt6-qtconnectivity]
-  gentoo: ['dev-qt/qtconnectivity:6']
-  rhel:
-    '*': [qt6-qtconnectivity]
-    '8': null
-  ubuntu:
-    '*': [libqt6bluetooth6, libqt6nfc6]
-    'focal': null
 libqt6-core:
   alpine: [qt6-qtbase]
   arch: [qt6-base]
@@ -6280,6 +6268,18 @@ libqt6-quick:
     '8': null
   ubuntu:
     '*': [libqt6quick6]
+    'focal': null
+libqt6bluetooth6:
+  alpine: [qt6-qtconnectivity]
+  arch: [qt6-connectivity]
+  debian: [libqt6bluetooth6]
+  fedora: [qt6-qtconnectivity]
+  gentoo: ['dev-qt/qtconnectivity:6']
+  rhel:
+    '*': [qt6-qtconnectivity]
+    '8': null
+  ubuntu:
+    '*': [libqt6bluetooth6]
     'focal': null
 libqt6svg6:
   alpine: [qt6-qtsvg]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6215,6 +6215,18 @@ libqt5x11extras5-dev:
   openembedded: [qtx11extras@meta-qt5]
   rhel: [qt5-qtx11extras-devel]
   ubuntu: [libqt5x11extras5-dev]
+libqt6-connectivity:
+  alpine: [qt6-qtconnectivity]
+  arch: [qt6-connectivity]
+  debian: [libqt6bluetooth6, libqt6nfc6]
+  fedora: [qt6-qtconnectivity]
+  gentoo: ['dev-qt/qtconnectivity:6']
+  rhel:
+    '*': [qt6-qtconnectivity]
+    '8': null
+  ubuntu:
+    '*': [libqt6bluetooth6, libqt6nfc6]
+    'focal': null
 libqt6-core:
   alpine: [qt6-qtbase]
   arch: [qt6-base]
@@ -8779,6 +8791,18 @@ qt6-base-private-dev:
     '8': null
   ubuntu:
     '*': [qt6-base-private-dev]
+    'focal': null
+qt6-connectivity-dev:
+  alpine: [qt6-qtconnectivity-dev]
+  arch: [qt6-connectivity]
+  debian: [qt6-connectivity-dev]
+  fedora: [qt6-qtconnectivity-devel]
+  gentoo: ['dev-qt/qtconnectivity:6']
+  rhel:
+    '*': [qt6-qtconnectivity-devel]
+    '8': null
+  ubuntu:
+    '*': [qt6-connectivity-dev]
     'focal': null
 qt6-declarative-dev:
   arch: [qt6-declarative]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- libqt6bluetooth6
- qt6-connectivity-dev

## Package Upstream Source:

https://github.com/qt/qtconnectivity

## Purpose of using this:

These packages are useful to communicate to Bluetooth devices like smart batteries, smart chargers and so on.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libqt6bluetooth6
  - https://packages.debian.org/trixie/qt6-connectivity-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libqt6bluetooth6
  - https://packages.ubuntu.com/jammy/qt6-connectivity-dev
  - https://packages.ubuntu.com/noble/libqt6bluetooth6
  - https://packages.ubuntu.com/noble/qt6-connectivity-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtconnectivity/qt6-qtconnectivity/
  - https://packages.fedoraproject.org/pkgs/qt6-qtconnectivity/qt6-qtconnectivity-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt6-connectivity/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtconnectivity
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qtconnectivity
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qtconnectivity-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/qt6-qtconnectivity-6.6.2-1.el9.x86_64.rpm.html
  - https://rhel.pkgs.org/9/epel-x86_64/qt6-qtconnectivity-devel-6.6.2-1.el9.x86_64.rpm.html
