### PR TITLE
leo_robot: 1.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4705,12 +4705,13 @@ repositories:
     release:
       packages:
       - leo_bringup
+      - leo_filters
       - leo_fw
       - leo_robot
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 1.5.0-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `1.6.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.0-1`

## leo_bringup

```
* Backport changes from Jazzy branch to Humble (#37 <https://github.com/LeoRover/leo_robot-ros2/issues/37>)
  * New camera implementation (#16 <https://github.com/LeoRover/leo_robot-ros2/issues/16>)
  * Add parameter handling based on rover's model (#19 <https://github.com/LeoRover/leo_robot-ros2/issues/19>)
  * Add leo_filters package (#17 <https://github.com/LeoRover/leo_robot-ros2/issues/17>)
  * Update robot_frame param (#22 <https://github.com/LeoRover/leo_robot-ros2/issues/22>)
  * Add publish_odom_tf argument to leo_bringup launch file (#26 <https://github.com/LeoRover/leo_robot-ros2/issues/26>)
  * Specify camera frame_id (#27 <https://github.com/LeoRover/leo_robot-ros2/issues/27>)
  * Use services instead of topics for reboot and shutdown commands (#28 <https://github.com/LeoRover/leo_robot-ros2/issues/28>)
  * Improve camera quality (#33 <https://github.com/LeoRover/leo_robot-ros2/issues/33>)
  * Complementary filter improvements (#34 <https://github.com/LeoRover/leo_robot-ros2/issues/34>)
* Contributors: Błażej Sowa, Aleksander Szymański, Jan Hernas
```

## leo_filters

```
* Backport changes from Jazzy branch to Humble (#37 <https://github.com/LeoRover/leo_robot-ros2/issues/37>)
  * Add leo_filters package (#17 <https://github.com/LeoRover/leo_robot-ros2/issues/17>)
  * Use target_link_libraries instead of ament_target_dependencies (#24 <https://github.com/LeoRover/leo_robot-ros2/issues/24>)
  * Don't use deprecated tf2 headers (#25 <https://github.com/LeoRover/leo_robot-ros2/issues/25>)
  * Add reset_calibration service to imu_filter (#31 <https://github.com/LeoRover/leo_robot-ros2/issues/31>)
  * Complementary filter improvements (#34 <https://github.com/LeoRover/leo_robot-ros2/issues/34>)
* Contributors: Błażej Sowa, Aleksander Szymański, Jan Hernas
```

## leo_fw

```
* Backport changes from Jazzy branch to Humble (#37 <https://github.com/LeoRover/leo_robot-ros2/issues/37>)
  * Fix mypy and pylint errors (#14 <https://github.com/LeoRover/leo_robot-ros2/issues/14>)
  * Add missing type annotations in leo_fw package nodes (#18 <https://github.com/LeoRover/leo_robot-ros2/issues/18>)
  * Add parameter handling based on rover's model (#19 <https://github.com/LeoRover/leo_robot-ros2/issues/19>)
  * Add leo_filters package (#17 <https://github.com/LeoRover/leo_robot-ros2/issues/17>)
  * Include leocore firmware version 2.0.0 (#20 <https://github.com/LeoRover/leo_robot-ros2/issues/20>)
  * Update robot_frame param (#22 <https://github.com/LeoRover/leo_robot-ros2/issues/22>)
  * Use target_link_libraries instead of ament_target_dependencies (#24 <https://github.com/LeoRover/leo_robot-ros2/issues/24>)
  * Fix node type errors (#35 <https://github.com/LeoRover/leo_robot-ros2/issues/35>)
  * Use sphinx format docstrings (#36 <https://github.com/LeoRover/leo_robot-ros2/issues/36>)
* Contributors: Błażej Sowa, Aleksander Szymański, Jan Hernas
```

## leo_robot

```
* Backport changes from Jazzy branch to Humble (#37 <https://github.com/LeoRover/leo_robot-ros2/issues/37>)
* Contributors: Błażej Sowa
```
