### PR TITLE
mavros: 2.12.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3870,7 +3870,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.12.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.11.0-1`

## libmavconn

- No changes

## mavros

```
* launch: fix python format lint
* cmake: explicit link diagnostic_msgs
  Fix #2062 <https://github.com/mavlink/mavros/issues/2062>
* mission: switch to latched state qos from custom ones
* include: add common qos profile for latched state topics
* uncrustify to kilted
* DDS equivalent of latched topic for gp_origin topic
* code style fix
* Contributors: ArielSulton, Bruno Celaries, Vladimir Ermakov
```

## mavros_extras

```
* cmake: explicit link diagnostic_msgs
  Fix #2062 <https://github.com/mavlink/mavros/issues/2062>
* include: add common qos profile for latched state topics
* uncrustify to kilted
* DDS equivalent of latched topic for gp_origin topic
* code style fix
* fix: yaml_cpp_vendor linking in mavros_extras
* Contributors: ArielSulton, Bruno Celaries, Vladimir Ermakov
```

## mavros_msgs

- No changes
