### PR TITLE
grid_map: 2.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2499,6 +2499,37 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: main
     status: maintained
+  grid_map:
+    doc:
+      type: git
+      url: https://github.com/ANYbotics/grid_map.git
+      version: kilted
+    release:
+      packages:
+      - grid_map
+      - grid_map_cmake_helpers
+      - grid_map_core
+      - grid_map_costmap_2d
+      - grid_map_cv
+      - grid_map_demos
+      - grid_map_filters
+      - grid_map_loader
+      - grid_map_msgs
+      - grid_map_octomap
+      - grid_map_pcl
+      - grid_map_ros
+      - grid_map_rviz_plugin
+      - grid_map_sdf
+      - grid_map_visualization
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/grid_map-release.git
+      version: 2.4.0-1
+    source:
+      type: git
+      url: https://github.com/ANYbotics/grid_map.git
+      version: kilted
+    status: developed
   gscam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `2.4.0-1`:

- upstream repository: https://github.com/ANYbotics/grid_map.git
- release repository: https://github.com/ros2-gbp/grid_map-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## grid_map

- No changes

## grid_map_cmake_helpers

- No changes

## grid_map_core

```
* Fix UB in SpiralIterator::operator++ (#481 <https://github.com/ANYbotics/grid_map/issues/481>)
  * Calling pop_back on an iterator past the end is UB
* Contributors: Ryan
```

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

- No changes

## grid_map_loader

- No changes

## grid_map_msgs

- No changes

## grid_map_octomap

```
* build: switch to use system octomap (#483 <https://github.com/ANYbotics/grid_map/issues/483>)
* Contributors: Daisuke Nishimatsu
```

## grid_map_pcl

- No changes

## grid_map_ros

```
* Add test dependency to on rosbad default plugins (#491 <https://github.com/ANYbotics/grid_map/issues/491>)
* chore: replace deprecated rcpputils filesystem with std::filesystem (#467 <https://github.com/ANYbotics/grid_map/issues/467>)
* Contributors: Daisuke Nishimatsu, Ryan
```

## grid_map_rviz_plugin

```
* Remove map_msgs exported dependency (#524 <https://github.com/ANYbotics/grid_map/issues/524>)
  * This is unused
* Contributors: Ryan
```

## grid_map_sdf

- No changes

## grid_map_visualization

- No changes
