### PR TITLE
ur_description: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9416,7 +9416,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `4.1.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.0-1`

## ur_description

```
* Add support for UR8LONG (#319 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/319>)
* Bump actions/setup-python from 5 to 6 (#315 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/315>)
* Bump actions/checkout from 4 to 5 (#310 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/310>)
* Auto-update pre-commit hooks (#307 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/307>)
* Auto-update pre-commit hooks (#303 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/303>)
* Auto-update pre-commit hooks (#299 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/299>)
* Auto-update pre-commit hooks (#295 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/295>)
* Contributors: Felix Exner, dependabot[bot], github-actions[bot]
```
