### PR TITLE
ur_description: 3.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10748,7 +10748,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.2.0-1
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.0-1`

## ur_description

```
* Add support for UR8LONG (#320 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/320>)
* Bump actions/setup-python from 5 to 6 (backport #315 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/315>) (#317 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/317>)
* Bump actions/checkout from 4 to 5 (backport #310 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/310>) (#314 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/314>)
* Auto-update pre-commit hooks (backport #307 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/307>) (#312 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/312>)
* Auto-update pre-commit hooks (#305 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/305>)
* Auto-update pre-commit hooks (backport of #299 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/299>) (#301 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/301>)
* Auto-update pre-commit hooks (backport #295 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/295>) (#297 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/297>)
* Contributors: Felix Exner, mergify[bot]
```