### PR TITLE
ur_description: 2.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11944,7 +11944,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.7.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.0-1`

## ur_description

```
* Add support for UR8 Long (#321 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/321>)
  * Add support for UR8 Long
  * Reorder model listings by generation, payload
  The list of supported robot models has been growing over time. This commit
  sorts them by generation (CB3, e-Series and UR series) and each generation
  by payload.
* Bump actions/setup-python from 5 to 6 (backport #315 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/315>) (#316 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/316>)
* Bump actions/checkout from 4 to 5 (backport #310 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/310>) (#313 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/313>)
* Auto-update pre-commit hooks (backport #307 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/307>) (#311 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/311>)
  * Auto-update pre-commit hooks
  * Use fix-byte-order-marker instead of check-byte-order-marker
* Auto-update pre-commit hooks (#300 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/300>)
* Update actions in ci-ros-lint (#306 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/306>)
* Auto-update pre-commit hooks (#304 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/304>)
* Auto-update pre-commit hooks (backport of #295 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/295>) (#296 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/296>)
* Contributors: Felix Exner, mergify[bot]
```