### PR TITLE
ur_client_library: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10733,7 +10733,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## ur_client_library

```
* Install endian header on Windows and Apple only (#372 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/372>)
* Add support for UR8 LONG (#375 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/375>)
* Change ubuntu manpage link from bionic to noble (#374 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/374>)
* Bump actions/setup-python from 5 to 6 (#373 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/373>)
* Add possibility to register multiple callbacks to ReverseInterface and TrajectoryPointInterface (#359 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/359>)
* Contributors: Felix Exner, dependabot[bot]
```