### PR TITLE
ackermann_nlmpc: 1.0.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -50,6 +50,14 @@ repositories:
       version: ros2
     status: maintained
   ackermann_nlmpc:
+    release:
+      packages:
+      - ackermann_nlmpc
+      - ackermann_nlmpc_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ackmerann_nlmpc-release.git
+      version: 1.0.2-2
     source:
       type: git
       url: https://git.ime.uni-luebeck.de/public-projects/asl/ackermann_nlmpc.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ackermann_nlmpc` to `1.0.2-2`:

- upstream repository: https://git.ime.uni-luebeck.de/public-projects/asl/ackermann_nlmpc.git
- release repository: https://github.com/ros2-gbp/ackmerann_nlmpc-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ackermann_nlmpc

```
* first release
```

## ackermann_nlmpc_msgs

```
* first release
```
