### PR TITLE
Update cdk rosdep key for Ubuntu and Debian compatibility

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -521,11 +521,16 @@ cccc:
   nixos: [cccc]
   ubuntu: [cccc]
 cdk:
-  debian: [libcdk5]
+  debian:
+    '*': [libcdk5t64]
+    bookworm: [libcdk5nc6]
+    bullseye: [libcdk5nc6]
   fedora: [cdk]
   gentoo: [dev-libs/cdk]
   nixos: [cdk]
-  ubuntu: [libcdk5]
+  ubuntu:
+    '*': [libcdk5t64]
+    jammy: [libcdk5nc6]
 cdk-dev:
   debian: [libcdk5-dev]
   fedora: [cdk-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -530,6 +530,7 @@ cdk:
   nixos: [cdk]
   ubuntu:
     '*': [libcdk5t64]
+    focal: [libcdk5nc6]
     jammy: [libcdk5nc6]
 cdk-dev:
   debian: [libcdk5-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please update the existing `cdk` rosdep key.

## Package name:

The `cdk` rosdep key was mapped to `libcdk5` for all Ubuntu and Debian versions, but in Ubuntu 24.04 (Noble) and Debian 13 (Trixie), that package no longer exists and has been replaced with `libcdk5t64`, and in Ubuntu 22.04 (Jammy) and Debian 11 (bullseye), 12 (bookworm) `libcdk5nc6` . This update fixes the issue by mapping cdk to the current packages.

## Links to Distribution Packages

-  Debian: https://packages.debian.org/
      -   https://packages.debian.org/trixie/libcdk5t64
      -   https://packages.debian.org/bookworm/libcdk5nc6
      -   https://packages.debian.org/bullseye/libcdk5nc6
-    Ubuntu: https://packages.ubuntu.com/
      -  https://packages.ubuntu.com/jammy/libcdk5nc6
      -  https://packages.ubuntu.com/noble/libcdk5t64

This hopefully solves [#47577](https://github.com/ros/rosdistro/issues/47577) partially as I'm not sure if it's appropriate to update all the keys listed in it in one single pr.

