### PR TITLE
launch_ros: 0.26.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4137,7 +4137,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.8-1
+      version: 0.26.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.9-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.8-1`

## launch_ros

```
* Fix SetUseSimTime for launch frontends (#488 <https://github.com/ros2/launch_ros/issues/488>) (#490 <https://github.com/ros2/launch_ros/issues/490>)
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#485 <https://github.com/ros2/launch_ros/issues/485>)
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#485 <https://github.com/ros2/launch_ros/issues/485>)
* Contributors: mergify[bot]
```

## ros2launch

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#485 <https://github.com/ros2/launch_ros/issues/485>)
* Contributors: mergify[bot]
```
