### PR TITLE
launch_ros: 0.28.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3491,7 +3491,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.28.2-1
+      version: 0.28.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.28.3-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.28.2-1`

## launch_ros

```
* Fix SetUseSimTime for launch frontends (#488 <https://github.com/ros2/launch_ros/issues/488>) (#489 <https://github.com/ros2/launch_ros/issues/489>)
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#484 <https://github.com/ros2/launch_ros/issues/484>)
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#484 <https://github.com/ros2/launch_ros/issues/484>)
* Contributors: mergify[bot]
```

## ros2launch

```
* fix setuptools deprecations (#475 <https://github.com/ros2/launch_ros/issues/475>) (#484 <https://github.com/ros2/launch_ros/issues/484>)
* Contributors: mergify[bot]
```
