### PR TITLE
Add roadmap_explorer to ROS Humble, Jazzy and Kilted index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8688,6 +8688,12 @@ repositories:
       url: https://github.com/ros2/rmw_zenoh.git
       version: humble
     status: developed
+  roadmap_explorer:
+    source:
+      type: git
+      url: https://github.com/suchetanrs/roadmap-explorer.git
+      version: humble
+    status: developed
   robosoft_openai:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8692,7 +8692,7 @@ repositories:
     source:
       type: git
       url: https://github.com/suchetanrs/roadmap-explorer.git
-      version: humble
+      version: main
     status: developed
   robosoft_openai:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7649,6 +7649,12 @@ repositories:
       url: https://github.com/ros2/rmw_zenoh.git
       version: jazzy
     status: developed
+  roadmap_explorer:
+    source:
+      type: git
+      url: https://github.com/suchetanrs/roadmap-explorer.git
+      version: jazzy
+    status: developed
   robosoft_openai:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7653,7 +7653,7 @@ repositories:
     source:
       type: git
       url: https://github.com/suchetanrs/roadmap-explorer.git
-      version: jazzy
+      version: main
     status: developed
   robosoft_openai:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6744,7 +6744,7 @@ repositories:
     source:
       type: git
       url: https://github.com/suchetanrs/roadmap-explorer.git
-      version: kilted
+      version: main
     status: developed
   robot_calibration:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6740,6 +6740,12 @@ repositories:
       url: https://github.com/ros2/rmw_zenoh.git
       version: kilted
     status: developed
+  roadmap_explorer:
+    source:
+      type: git
+      url: https://github.com/suchetanrs/roadmap-explorer.git
+      version: kilted
+    status: developed
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please add these packages to be indexed in the rosdistro.

ROSDISTRO NAME: humble, jazzy, kilted

# The source is here: 

https://github.com/suchetanrs/roadmap-explorer

# Packages:

- roadmap_explorer
- roadmap_explorer_msgs
- roadmap_explorer_rviz_plugins

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
