### PR TITLE
inverse_dynamics_solver: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4187,7 +4187,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/inverse_dynamics_solver-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/unisa-acg/inverse-dynamics-solver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `inverse_dynamics_solver` to `1.0.2-1`:

- upstream repository: https://github.com/unisa-acg/inverse-dynamics-solver.git
- release repository: https://github.com/ros2-gbp/inverse_dynamics_solver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## franka_inria_inverse_dynamics_solver

- No changes

## inverse_dynamics_solver

```
* [REF] Make robot description empty by default
* Contributors: Vincenzo Petrone
```

## kdl_inverse_dynamics_solver

- No changes

## ur10_inverse_dynamics_solver

```
* [DOC] Remove superfluous instructions in documentation about ros bag files conversion
* Contributors: Vincenzo Petrone
```
