### PR TITLE
ur_robot_driver: 4.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9461,7 +9461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.1.0-1
+      version: 4.2.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.2.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Realtime tools migration (#1474 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1474>)
  Use RealtimeThreadSafeBox instead of RealTimeBuffer.
* Replace SJTC implementation with upstream (#1485 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1485>)
* Contributors: Felix Exner, URJala
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for launching UR8Long (#1490 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1490>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Add support for launching UR8Long (#1490 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1490>)
* [Force mode test] Remove wrong seq entry (#1488 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1488>)
* Contributors: Felix Exner
```