### PR TITLE
ur_robot_driver: 3.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10793,7 +10793,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.3.3-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.3-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Use RealtimeThreadSafeBox instead of RealTimeBuffer (backport #1474 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1474>) (#1501 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1501>)
* ur_configuration_controller: use try_set on RTBox (backport of #1470 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1470>) (#1472 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1472>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

```
* Added 'is in remote control' call as a dashboard service (backport of #1433 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1433>) (#1437 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1437>)
* Contributors: mergify[bot]
```

## ur_moveit_config

```
* Add support for launching UR8Long (backport #1490 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1490>) (#1497 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1497>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Add support for launching UR8Long (backport #1490 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1490>) (#1497 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1497>)
* [Force mode test] Remove wrong seq entry (backport of #1488 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1488>) (#1489 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1489>)
* Add migration of ros2_control node to migration notes (backport of #1458 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1458>) (#1466 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1466>)
* Fix flaky controller switch test (backport of #1447 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1447>) (#1451 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1451>)
* fix_flaky_force_mode_test (backport of #1429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1429>) (#1449 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1449>)
* Reduce flakiness of trajectory controller tests (backport of #1443 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1443>) (#1445 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1445>)
* Added 'is in remote control' call as a dashboard service (backport of #1433 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1433>) (#1437 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1437>)
* ur_robot_driver: Fix compilation on Windows (backport of #1421 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1421>) (#1432 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1432>)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Contributors: mergify[bot]
```