### PR TITLE
Add missing libboost-* rosdep entries in Debian Bookworm

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2839,6 +2839,7 @@ libbluetooth-dev:
 libboost-atomic:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-atomic1.74.0]
     bullseye: [libboost-atomic1.74.0]
     buster: [libboost-atomic1.67.0]
   fedora: [boost-atomic]
@@ -2865,6 +2866,7 @@ libboost-atomic-dev:
 libboost-chrono:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-chrono1.74.0]
     bullseye: [libboost-chrono1.74.0]
     buster: [libboost-chrono1.67.0]
   fedora: [boost-chrono]
@@ -2892,6 +2894,7 @@ libboost-coroutine:
   alpine: [boost-dev]
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-coroutine1.74.0]
     bullseye: [libboost-coroutine1.74.0]
     buster: [libboost-coroutine1.67.0]
   fedora: [boost-coroutine]
@@ -2958,7 +2961,7 @@ libboost-dev:
 libboost-filesystem:
   arch: [boost-libs]
   debian:
-    bookworm: [libboost-filesystem-dev]
+    bookworm: [libboost-filesystem1.74.0]
     bullseye: [libboost-filesystem1.74.0]
     buster: [libboost-filesystem1.67.0]
   fedora: [boost-filesystem]
@@ -2985,6 +2988,7 @@ libboost-filesystem-dev:
 libboost-iostreams:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-iostreams1.74.0]
     bullseye: [libboost-iostreams1.74.0]
     buster: [libboost-iostreams1.67.0]
   fedora: [boost-iostreams]
@@ -3011,6 +3015,7 @@ libboost-iostreams-dev:
 libboost-math:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-math1.74.0]
     bullseye: [libboost-math1.74.0]
     buster: [libboost-math1.67.0]
   fedora: [boost-math]
@@ -3044,6 +3049,7 @@ libboost-numpy-dev:
 libboost-program-options:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-program-options1.74.0]
     bullseye: [libboost-program-options1.74.0]
     buster: [libboost-program-options1.67.0]
   fedora: [boost-program-options]
@@ -3130,6 +3136,7 @@ libboost-random-dev:
 libboost-regex:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-regex1.74.0]
     bullseye: [libboost-regex1.74.0]
     buster: [libboost-regex1.67.0]
   fedora: [boost-regex]
@@ -3156,6 +3163,7 @@ libboost-regex-dev:
 libboost-serialization:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-serialization1.74.0]
     bullseye: [libboost-serialization1.74.0]
     buster: [libboost-serialization1.67.0]
   fedora: [boost-serialization]
@@ -3182,6 +3190,7 @@ libboost-serialization-dev:
 libboost-system:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-system1.74.0]
     bullseye: [libboost-system1.74.0]
     buster: [libboost-system1.67.0]
   fedora: [boost-system]
@@ -3235,6 +3244,7 @@ libboost-thread-dev:
 libboost-timer:
   arch: [boost-libs]
   debian:
+    bookworm: [libboost-timer1.74.0]
     bullseye: [libboost-timer1.74.0]
     buster: [libboost-timer1.67.0]
   fedora: [boost-timer]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2924,7 +2924,7 @@ libboost-coroutine-dev:
 libboost-date-time:
   arch: [boost-libs]
   debian:
-    bookworm: [libboost-date-time1.81.0]
+    bookworm: [libboost-date-time1.74.0]
     bullseye: [libboost-date-time1.74.0]
     buster: [libboost-date-time1.67.0]
   fedora: [boost-date-time]
@@ -3077,7 +3077,7 @@ libboost-python:
   alpine: [boost-python2]
   arch: [boost-libs]
   debian:
-    bookworm: [libboost-python1.81.0]
+    bookworm: [libboost-python1.74.0]
     bullseye: [libboost-python1.74.0]
     buster: [libboost-python1.67.0]
   fedora: [boost-python3]
@@ -3109,7 +3109,7 @@ libboost-python-dev:
 libboost-random:
   arch: [boost-libs]
   debian:
-    bookworm: [libboost-random1.81.0]
+    bookworm: [libboost-random1.74.0]
     bullseye: [libboost-random1.74.0]
     buster: [libboost-random1.67.0]
   fedora: [boost-random]
@@ -3217,7 +3217,7 @@ libboost-system-dev:
 libboost-thread:
   arch: [boost-libs]
   debian:
-    bookworm: [libboost-thread1.81.0]
+    bookworm: [libboost-thread1.74.0]
     bullseye: [libboost-thread1.74.0]
     buster: [libboost-thread1.67.0]
   fedora: [boost-thread]


### PR DESCRIPTION
Add missing entries of libboost components for debian bookworm.

Also harmonize the version to use the default Bookworm Boost version, 1.74.0. Some entries (e.g. libboost-date-time) where pointing to 1.81.0, while others (e.g. libboost-filesystem) where pointing to the `-dev` package, which is 1.74.0.

Closes #47101

**BREAKING CHANGES**:

The following entries will be downgraded from 1.81.0 to 1.74.0:
- libboost-date-time
- libboost-python
- libboost-random
- libboost-thread

The following entries will no longer install the -dev version (the headers):
- libboost-filesystem

## Package name:

- libboost-atomic
- libboost-chrono
- libboost-coroutine
- libboost-date-time
- libboost-filesystem
- libboost-iostreams
- libboost-math
- libboost-program-options
- libboost-python-dev
- libboost-random
- libboost-regex
- libboost-serialization
- libboost-system
- libboost-thread
- libboost-timer

## Package Upstream Source:

https://github.com/boostorg/boost

## Purpose of using this:

Some entries where not usable in package.xml because then bloom would not release the package due to missing rosdep entries for bookworm.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/bookworm/libboost-atomic1.74.0
  - https://packages.debian.org/bookworm/libboost-chrono1.74.0
  - https://packages.debian.org/bookworm/libboost-coroutine1.74.0
  - https://packages.debian.org/bookworm/libboost-date-time1.74.0
  - https://packages.debian.org/bookworm/libboost-filesystem1.74.0
  - https://packages.debian.org/bookworm/libboost-iostreams1.74.0
  - https://packages.debian.org/bookworm/libboost-math1.74.0
  - https://packages.debian.org/bookworm/libboost-program-options1.74.0
  - https://packages.debian.org/bookworm/libboost-python1.74.0
  - https://packages.debian.org/bookworm/libboost-random1.74.0
  - https://packages.debian.org/bookworm/libboost-regex1.74.0
  - https://packages.debian.org/bookworm/libboost-serialization1.74.0
  - https://packages.debian.org/bookworm/libboost-system1.74.0
  - https://packages.debian.org/bookworm/libboost-thread1.74.0
  - https://packages.debian.org/bookworm/libboost-timer1.74.0
- Ubuntu: https://packages.ubuntu.com/
  - N/A, I did not modify it

