### PR TITLE
inverse_dynamics_solver: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3785,6 +3785,22 @@ repositories:
       type: git
       url: https://github.com/unisa-acg/inverse-dynamics-solver.git
       version: jazzy
+    release:
+      packages:
+      - franka_inria_inverse_dynamics_solver
+      - inverse_dynamics_solver
+      - kdl_inverse_dynamics_solver
+      - ur10_inverse_dynamics_solver
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/inverse_dynamics_solver-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/unisa-acg/inverse-dynamics-solver.git
+      version: jazzy
+    status: developed
   irobot_create_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `inverse_dynamics_solver` to `2.0.0-1`:

- upstream repository: https://github.com/unisa-acg/inverse-dynamics-solver.git
- release repository: https://github.com/ros2-gbp/inverse_dynamics_solver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## franka_inria_inverse_dynamics_solver

```
* [REF] Remove Franka's demos because Franka's description is not available in Jazzy
  - [DOC] Update documentation accordingly
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```

## inverse_dynamics_solver

```
* [REF] Remove Franka's demos because Franka's description is not available in Jazzy
  - [DOC] Update documentation accordingly
* [REF] Make robot description empty by default
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```

## kdl_inverse_dynamics_solver

```
* [DOC] Update links to match Jazzy distro
* [REF] Remove Franka's demos because Franka's description is not available in Jazzy
  - [DOC] Update documentation accordingly
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```

## ur10_inverse_dynamics_solver

```
* [DOC] Remove superfluous instructions in documentation about ros bag files conversion
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```
