### PR TITLE
rviz: 15.0.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8242,7 +8242,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.5-1
+      version: 15.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.6-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.5-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* add ros action property (#1549 <https://github.com/ros2/rviz/issues/1549>) (#1576 <https://github.com/ros2/rviz/issues/1576>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fix pointcloud2 display divide by 0 (#1581 <https://github.com/ros2/rviz/issues/1581>) (#1582 <https://github.com/ros2/rviz/issues/1582>)
* add support for ffmpeg_image_transport and point_cloud_transport (#1568 <https://github.com/ros2/rviz/issues/1568>) (#1570 <https://github.com/ros2/rviz/issues/1570>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
