### PR TITLE
rviz: 11.2.21-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10176,7 +10176,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.20-1
+      version: 11.2.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.21-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `11.2.20-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* add ros action property (#1549 <https://github.com/ros2/rviz/issues/1549>) (#1578 <https://github.com/ros2/rviz/issues/1578>)
  (cherry picked from commit 815ebb2e69e297818877a3f8a87e7ae282f224d4)
  Co-authored-by: Joshua Supratman <mailto:supratmanjoshua@gmail.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fix pointcloud2 display divide by 0 (#1581 <https://github.com/ros2/rviz/issues/1581>) (#1584 <https://github.com/ros2/rviz/issues/1584>)
  (cherry picked from commit f4f2851bdab8bd74a9b0bbef0892b0c760da1ee2)
  Co-authored-by: Antonio Brandi <mailto:34162460+AntoBrandi@users.noreply.github.com>
* Add support for ffmpeg_image_transport to Image/Camera displays and point_cloud_transport/cloudini to PointCloud2 display (backport #1568 <https://github.com/ros2/rviz/issues/1568>) (#1572 <https://github.com/ros2/rviz/issues/1572>)
  Co-authored-by: Lennart Reiher <mailto:lreiher@me.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
