### PR TITLE
Add pip fallbacks for python3-docstring-parser

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5747,6 +5747,9 @@ python3-docstring-parser:
   nixos: [python3Packages.docstring-parser]
   ubuntu:
     '*': [python3-docstring-parser]
+    focal:
+      pip:
+        packages: [docstring-parser]
     jammy:
       pip:
         packages: [docstring-parser]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5736,10 +5736,16 @@ python3-docstring-parser:
     pip:
       packages: [docstring-parser]
   debian:
+    '*':
+      pip:
+        packages: [docstring-parser]
     trixie: [python3-docstring-parser]
   fedora: [python3-docstring-parser]
   nixos: [python3Packages.docstring-parser]
   ubuntu:
+    '*':
+      pip:
+        packages: [docstring-parser]
     noble: [python3-docstring-parser]
 python3-docutils:
   arch: [python-docutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5736,17 +5736,20 @@ python3-docstring-parser:
     pip:
       packages: [docstring-parser]
   debian:
-    '*':
+    '*': [python3-docstring-parser]
+    bookworm:
       pip:
         packages: [docstring-parser]
-    trixie: [python3-docstring-parser]
+    bullseye:
+      pip:
+        packages: [docstring-parser]
   fedora: [python3-docstring-parser]
   nixos: [python3Packages.docstring-parser]
   ubuntu:
-    '*':
+    '*': [python3-docstring-parser]
+    jammy:
       pip:
         packages: [docstring-parser]
-    noble: [python3-docstring-parser]
 python3-docutils:
   arch: [python-docutils]
   debian: [python3-docutils]


### PR DESCRIPTION
Please update the following dependency.

## Package name:

python3-docstring-parser (*rule update*)

## Package Upstream Source:

https://github.com/rr-/docstring_parser

## Purpose of using this:

This package parses python docstrings and makes them available for programmatic digestion. It's very useful when creating new (CLI) tools, as it allows to generate e.g. help strings for functions and parameters without duplication.

Distro packaging links:

## Links to Distribution Packages

I previously assumed that the os_name fallback would also apply to missing os_version tags (related issue: https://github.com/ros-infrastructure/rosdep/pull/1015). This fixes this oversight.

- pypi
  - https://pypi.org/project/docstring-parser/
