### PR TITLE
rmw_dds_common: 4.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6645,7 +6645,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 3.2.1-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `4.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.1-2`

## rmw_dds_common

```
* Update cmake requirements (#80 <https://github.com/ros2/rmw_dds_common/issues/80>)
* Remove deprecated security utilities (#79 <https://github.com/ros2/rmw_dds_common/issues/79>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```
