### PR TITLE
rpyutils: 0.6.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7698,7 +7698,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.6.2-2
+      version: 0.6.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rpyutils` to `0.6.3-1`:

- upstream repository: https://github.com/ros2/rpyutils.git
- release repository: https://github.com/ros2-gbp/rpyutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.2-2`

## rpyutils

```
* fix setuptools deprecations (#17 <https://github.com/ros2/rpyutils/issues/17>) (#19 <https://github.com/ros2/rpyutils/issues/19>)
* Contributors: mergify[bot]
```
