### PR TITLE
rpyutils: 0.4.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8654,7 +8654,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.4.1-3
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rpyutils` to `0.4.2-1`:

- upstream repository: https://github.com/ros2/rpyutils.git
- release repository: https://github.com/ros2-gbp/rpyutils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-3`

## rpyutils

```
* fix setuptools deprecations (#17 <https://github.com/ros2/rpyutils/issues/17>) (#20 <https://github.com/ros2/rpyutils/issues/20>)
  (cherry picked from commit bfd5a3411727ee902e3d3936c12ebba5545f483a)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#13 <https://github.com/ros2/rpyutils/issues/13>) (#14 <https://github.com/ros2/rpyutils/issues/14>)
  They are both outdated and both no longer serving their
  intended purpose.
  (cherry picked from commit 824efd64f86b1a6d18d7429a4cd212f9c6594a7e)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
