### PR TITLE
demos: 0.37.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1397,7 +1397,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.37.2-1
+      version: 0.37.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.37.3-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.37.2-1`

## action_tutorials_cpp

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

```
* get rid of deprecated rclcpp::spin_some(). (#734 <https://github.com/ros2/demos/issues/734>)
* Contributors: Tomoya Fujita
```

## dummy_robot_bringup

- No changes

## dummy_sensors

```
* get rid of deprecated rclcpp::spin_some(). (#734 <https://github.com/ros2/demos/issues/734>)
* Contributors: Tomoya Fujita
```

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

```
* get rid of deprecated rclcpp::spin_some(). (#734 <https://github.com/ros2/demos/issues/734>)
* Contributors: Tomoya Fujita
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
