### PR TITLE
novatel_oem7_driver: 20.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6332,7 +6332,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 20.7.0-1
+      version: 20.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `20.8.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `20.7.0-1`

## novatel_oem7_driver

```
Documentation Release and ROS2 Fixes
Features:
* ROS2 Documentation Release
Modifications:
* RAWIMUSX and /imu/data_raw topic duplicate publishing bug fix
* Decrease Boost dependency to only headers (#98 <https://github.com/novatel/novatel_oem7_driver/pull/98>)
* Update tf2_ros to hpp headers (#104 <https://github.com/novatel/novatel_oem7_driver/pull/104>)
```
