### PR TITLE
bcr_arm: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1188,6 +1188,21 @@ repositories:
       version: main
     status: maintained
   bcr_arm:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_arm.git
+      version: 0.1.0
+    release:
+      packages:
+      - bcr_arm
+      - bcr_arm_description
+      - bcr_arm_gazebo
+      - bcr_arm_moveit_config
+      - bcr_arm_ros2
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/bcr_arm-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_arm` to `0.1.0-1`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_arm.git
- release repository: https://github.com/ros2-gbp/bcr_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## bcr_arm

```
* Initial release of meta-package.
* Contributors: mathew4STAR
```

## bcr_arm_description

```
* Initial public release of BCR Arm description package.
* Updated maintainers and license information.
* Fixed linting issues.
* Contributors: Vimarsh, Mathew
```

## bcr_arm_gazebo

```
* Initial public release of BCR Arm Gazebo package.
* Updated maintainers and license information.
* Fixed linting issues.
* Contributors: Vimarsh, Mathew
```

## bcr_arm_moveit_config

```
* Initial public release of BCR Arm MoveIt configuration package.
* Added topic-based ROS 2 control instructions.
* Updated maintainers and license information.
* Fixed linting issues.
* Contributors: Vimarsh, Mathew
```

## bcr_arm_ros2

```
* Initial public release of BCR Arm ROS 2 package.
* Updated maintainers and license information.
* Contributors: Vimarsh, Mathew
```
