### PR TITLE
demos: 0.36.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1319,7 +1319,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.36.1-1
+      version: 0.36.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.36.2-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.36.1-1`

## action_tutorials_cpp

- No changes

## action_tutorials_py

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#736 <https://github.com/ros2/demos/issues/736>)
* support cancel handler in action_tutorials_py action server. (#727 <https://github.com/ros2/demos/issues/727>) (#728 <https://github.com/ros2/demos/issues/728>)
* Contributors: mergify[bot]
```

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#736 <https://github.com/ros2/demos/issues/736>)
* Contributors: mergify[bot]
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#736 <https://github.com/ros2/demos/issues/736>)
* Contributors: mergify[bot]
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

```
* fix setuptools deprecations (#731 <https://github.com/ros2/demos/issues/731>) (#739 <https://github.com/ros2/demos/issues/739>)
* Contributors: mergify[bot]
```

## topic_monitor

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#736 <https://github.com/ros2/demos/issues/736>)
* Contributors: mergify[bot]
```

## topic_statistics_demo

- No changes
