### PR TITLE
novatel_oem7_driver: 24.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5585,7 +5585,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 24.1.0-1
+      version: 24.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `24.2.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `24.1.0-1`

## novatel_oem7_driver

```
Documentation Release and ROS2 Fixes
Features:
* ROS2 Documentation Release
Modifications:
* RAWIMUSX and /imu/data_raw topic duplicate publishing bug fix
* Decrease Boost dependency to only headers (#98 <https://github.com/novatel/novatel_oem7_driver/pull/98>)
* Update tf2_ros to hpp headers (#104 <https://github.com/novatel/novatel_oem7_driver/pull/104>)
* Similar Changes as Release 20.8.0 for Humble
```
