### PR TITLE
demos: 0.20.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2106,7 +2106,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.20.5-1
+      version: 0.20.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.20.6-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.20.5-1`

## action_tutorials_cpp

- No changes

## action_tutorials_interfaces

- No changes

## action_tutorials_py

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#738 <https://github.com/ros2/demos/issues/738>)
* Contributors: mergify[bot]
```

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#738 <https://github.com/ros2/demos/issues/738>)
* Contributors: mergify[bot]
```

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#738 <https://github.com/ros2/demos/issues/738>)
* Contributors: mergify[bot]
```

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

```
* fix setuptools deprecations (#731 <https://github.com/ros2/demos/issues/731>) (#741 <https://github.com/ros2/demos/issues/741>)
* Contributors: mergify[bot]
```

## topic_monitor

```
* fix setuptools deprecations (#733 <https://github.com/ros2/demos/issues/733>) (#738 <https://github.com/ros2/demos/issues/738>)
* Update README.md (backport #718 <https://github.com/ros2/demos/issues/718>) (#721 <https://github.com/ros2/demos/issues/721>)
* Contributors: mergify[bot]
```

## topic_statistics_demo

- No changes
