### PR TITLE
Add mola_imu_preintegration for indexing into rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4132,6 +4132,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_gnss_to_markers.git
       version: develop
     status: developed
+  mola_imu_preintegration:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git


### PR DESCRIPTION
It was formerly part of the repo mola_state_estimation, but it will be moved to its own repository for better granularity of dependencies downstream for mp2p_icp

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/MOLAorg/mola_imu_preintegration

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
