### PR TITLE
point_cloud_transport_tutorial: 0.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5430,7 +5430,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_tutorial` to `0.0.5-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_tutorial
- release repository: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.4-1`

## point_cloud_transport_tutorial

```
* Removed rclcpp::spin_some deprecation warning (#17 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/17>)
* Contributors: Alejandro Hernández Cordero
```
