### PR TITLE
plotjuggler: 3.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5313,7 +5313,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.11-1
+      version: 3.12.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.12.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.10.11-1`

## plotjuggler

```
* rosx_introspection updated
* fix minimum cmake
* formatting
* giving up on MCAP
* new reference bar
* Merge pull request #1164 <https://github.com/facontidavide/PlotJuggler/issues/1164> from matthew-t-watson/main
  Fix atan bug in lua quat_to_yaw and quat_to_roll conversions for lua versions <5.3
* Fix atan bug in quat_to_x conversions
* Contributors: Davide Faconti, Matthew T. Watson
```
