### PR TITLE
ads_vendor: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -114,6 +114,18 @@ repositories:
       url: https://github.com/analogdevicesinc/imu_ros2.git
       version: rolling
     status: maintained
+  ads_vendor:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/b-robotized/ads_vendor-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/b-robotized/ads_vendor.git
+      version: rolling
+    status: maintained
   ai_worker:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ads_vendor` to `1.0.0-1`:

- upstream repository: https://github.com/b-robotized/ads_vendor.git
- release repository: https://github.com/b-robotized/ads_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ads_vendor

```
* use modern CMakeLists export
* add source build CI
* add pre-commit
* update maintainer/author
* add license
* add readme
* vendor the ADS client library
* RosTeamWS: package created with initial files
* Contributors: nibanovic
```
