### PR TITLE
clearpath_config: 2.7.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1247,7 +1247,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.7.2-1
+      version: 2.7.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.7.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.2-1`

## clearpath_config

```
* Feature: Kinova Jazzy Support (#193 <https://github.com/clearpathrobotics/clearpath_config/issues/193>)
  * Remove unsupported exception on Kinova
  * Lint and remove unused imports
  * Add arm reference from within arm's gripper
* Contributors: luis-camero
```
