### PR TITLE
clearpath_common: 2.7.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1232,7 +1232,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.7.3-1
+      version: 2.7.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.7.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.3-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

```
* Feature: Kinova Jazzy Support (#265 <https://github.com/clearpathrobotics/clearpath_common/issues/265>)
  * Remove prefix from Kinova gripper joint
  * Switch mesh paths from file to package
  * Add custom description generator for Robotiq gripper on Kinova
  * Replace 'PI' property with 'math.pi'
  * Add ComposableNodeContainer to launch generator
  * Remove output from ComposableNode
  * Fix generator test
* Contributors: luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Feature: Kinova Jazzy Support (#265 <https://github.com/clearpathrobotics/clearpath_common/issues/265>)
  * Remove prefix from Kinova gripper joint
  * Switch mesh paths from file to package
  * Add custom description generator for Robotiq gripper on Kinova
  * Replace 'PI' property with 'math.pi'
  * Add ComposableNodeContainer to launch generator
  * Remove output from ComposableNode
  * Fix generator test
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
