### PR TITLE
tecgihan_driver: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11052,7 +11052,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tecgihan/tecgihan_driver-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tecgihan_driver` to `0.1.2-1`:

- upstream repository: https://github.com/tecgihan/tecgihan_driver.git
- release repository: https://github.com/tecgihan/tecgihan_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.1-1`

## tecgihan_driver

```
Added
- Added support for DMA-03B.
Fixed
- Fixed a bug in full-scale (FS) configuration.
Contributors: Ryota Amakawa
```
