### PR TITLE
navigation2: 1.1.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6067,6 +6067,7 @@ repositories:
       - nav2_planner
       - nav2_regulated_pure_pursuit_controller
       - nav2_rotation_shim_controller
+      - nav2_route
       - nav2_rviz_plugins
       - nav2_simple_commander
       - nav2_smac_planner
@@ -6083,7 +6084,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.1.18-1
+      version: 1.1.19-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.1.19-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.18-1`
