### PR TITLE
navigation2: 1.3.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5356,6 +5356,7 @@ repositories:
       - nav2_planner
       - nav2_regulated_pure_pursuit_controller
       - nav2_rotation_shim_controller
+      - nav2_route
       - nav2_rviz_plugins
       - nav2_simple_commander
       - nav2_smac_planner
@@ -5375,7 +5376,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 1.3.8-1
+      version: 1.3.9-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `navigation2` to `1.3.9-1`:

- upstream repository: https://github.com/ros-planning/navigation2.git
- release repository: https://github.com/SteveMacenski/navigation2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.8-1`
