### PR TITLE
rdl: 6.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7148,6 +7148,18 @@ repositories:
       url: https://github.com/ros2/rcutils.git
       version: jazzy
     status: maintained
+  rdl:
+    release:
+      packages:
+      - rdl
+      - rdl_benchmark
+      - rdl_dynamics
+      - rdl_urdfreader
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/jlack1987/rdl-release.git
+      version: 6.0.0-1
+    status: maintained
   reach:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rdl` to `6.0.0-1`:

- upstream repository: https://gitlab.com/jlack/rdl
- release repository: https://github.com/jlack1987/rdl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
