### PR TITLE
ur_simulation_gz: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12014,7 +12014,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `0.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## ur_simulation_gz

```
* Add launch support for UR8 Long (backport #111 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/111>) (#114 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/114>)
* Contributors: mergify[bot]
```
