### PR TITLE
ur_simulation_gz: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10846,11 +10846,15 @@ repositories:
       version: jazzy
     status: developed
   ur_simulation_gz:
+    doc:
+      type: git
+      url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
+      version: ros2
     release:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_simulation_gz-release.git
-      version: 2.3.0-2
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_simulation_gz` to `2.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation.git
- release repository: https://github.com/ros2-gbp/ur_simulation_gz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-2`

## ur_simulation_gz

```
* Add launch support for UR8 Long (#111 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/111>)
* Add configuration file to docs (#107 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/107>)
* Update installation instructions in docs (#105 <https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/105>)
* Contributors: Felix Exner, URJala
```