### PR TITLE
ur_robot_driver: 2.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12003,7 +12003,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.8.1-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.9.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.1-1`

## ur

- No changes

## ur_bringup

```
* Add support for UR8 Long (#1491 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1491>)
* Contributors: Felix Exner
```

## ur_calibration

```
* Fix ur_calibration compilation on Windows (backport of #1400 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1400>) (#1408 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1408>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* ur_controllers: Fix compilation on Windows (backport #1402 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1402>) (#1412 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1412>)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

```
* Added 'is in remote control' call as a dashboard service (backport of #1433 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1433>) (#1436 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1436>)
* Contributors: mergify[bot]
```

## ur_moveit_config

```
* Add support for UR8 Long (#1491 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1491>)
* ur_moveit_config: Assure the description is loaded as string (#1452 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1452>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Add support for UR8 Long (#1491 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1491>)
* Fix flaky controller switch test (backport of #1447 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1447>) (#1450 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1450>)
* fix_flaky_force_mode_test (backport of #1429 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1429>) (#1448 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1448>)
* Reduce flakiness of trajectory controller tests (backport of #1443 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1443>) (#1444 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1444>)
* Added 'is in remote control' call as a dashboard service (backport of #1433 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1433>) (#1436 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1436>)
* ur_robot_driver: Fix compilation on Windows (backport of #1421 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1421>) (#1431 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1431>)
  Co-authored-by: Silvio Traversaro <mailto:silvio@traversaro.it>
* Refactor prepare_switch method (backport #1417 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1417>) (#1427 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1427>)
* Contributors: Felix Exner, mergify[bot]
```