### PR TITLE
control_toolbox: 5.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1236,7 +1236,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.6.0-1
+      version: 5.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.7.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.6.0-1`

## control_toolbox

```
* Add backward_ros dependency (#475 <https://github.com/ros-controls/control_toolbox/issues/475>)
* Remove legacy and deprecated PID parameters (#436 <https://github.com/ros-controls/control_toolbox/issues/436>)
* Fix rst errors (#447 <https://github.com/ros-controls/control_toolbox/issues/447>)
* Use the FilterTest fixture instead (#439 <https://github.com/ros-controls/control_toolbox/issues/439>)
* Fix deprecated TF headers (#444 <https://github.com/ros-controls/control_toolbox/issues/444>)
* Declare missing parameters for PID (#443 <https://github.com/ros-controls/control_toolbox/issues/443>)
* Contributors: Christoph Fröhlich, Victor Coutinho Vieira Santos
```
