### PR TITLE
control_toolbox: 4.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1597,7 +1597,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.7.0-1
+      version: 4.7.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.7.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.7.0-1`

## control_toolbox

```
* Add backward_ros dependency (#475 <https://github.com/ros-controls/control_toolbox/issues/475>) (#476 <https://github.com/ros-controls/control_toolbox/issues/476>)
* Contributors: mergify[bot]
```
