### PR TITLE
control_toolbox: 3.6.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1860,7 +1860,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.6.1-1
+      version: 3.6.2-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `3.6.2-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.6.1-1`

## control_toolbox

```
* Update description of limit() function in rate_limiter (#425 <https://github.com/ros-controls/control_toolbox/issues/425>) (#428 <https://github.com/ros-controls/control_toolbox/issues/428>)
* Delete .gitignore (#341 <https://github.com/ros-controls/control_toolbox/issues/341>) (#342 <https://github.com/ros-controls/control_toolbox/issues/342>)
* Update README.md to be consistent within ros-controls (#320 <https://github.com/ros-controls/control_toolbox/issues/320>) (#337 <https://github.com/ros-controls/control_toolbox/issues/337>)
* Contributors: mergify[bot]
```
