### PR TITLE
pymoveit2: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5674,10 +5674,20 @@ repositories:
       version: rolling
     status: maintained
   pymoveit2:
+    doc:
+      type: git
+      url: https://github.com/AndrejOrsula/pymoveit2.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pymoveit2-release.git
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/AndrejOrsula/pymoveit2.git
       version: main
+    status: maintained
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pymoveit2` to `4.0.0-1`:

- upstream repository: https://github.com/AndrejOrsula/pymoveit2.git
- release repository: https://github.com/ros2-gbp/pymoveit2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
