### PR TITLE
ads_vendor: 1.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -109,7 +109,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/b-robotized/ads_vendor-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ads_vendor` to `1.0.1-1`:

- upstream repository: https://github.com/b-robotized/ads_vendor.git
- release repository: https://github.com/b-robotized/ads_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`
