### PR TITLE
open3d_vendor: 0.19.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4935,10 +4935,20 @@ repositories:
       version: main
     status: developed
   open3d_vendor:
+    doc:
+      type: git
+      url: https://github.com/christian-rauch/open3d_colcon.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/open3d_vendor-release.git
+      version: 0.19.0-1
     source:
       type: git
       url: https://github.com/christian-rauch/open3d_colcon.git
       version: main
+    status: maintained
   open_manipulator:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `open3d_vendor` to `0.19.0-1`:

- upstream repository: https://github.com/christian-rauch/open3d_colcon.git
- release repository: https://github.com/ros2-gbp/open3d_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
