### PR TITLE
angles: 1.16.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -366,7 +366,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/angles-release.git
-      version: 1.16.0-5
+      version: 1.16.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `angles` to `1.16.1-1`:

- upstream repository: https://github.com/ros/angles.git
- release repository: https://github.com/ros2-gbp/angles-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.16.0-5`

## angles

```
* Ensure that M_PI is defined in any downstream compilation unit in Windows (#44 <https://github.com/ros/angles/issues/44>)
* Enable Testing (#39 <https://github.com/ros/angles/issues/39>)
* New Maintainer (#40 <https://github.com/ros/angles/issues/40>)
* Contributors: David V. Lu!!, Silvio Traversaro
```
