### PR TITLE
openembedded: remove python2 and fix some meta layers

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -109,7 +109,7 @@ black:
   fedora: [black]
   gentoo: [dev-python/black]
   nixos: [python3Packages.black]
-  openembedded: [python3-black@meta-ros]
+  openembedded: [python3-black@meta-python]
   ubuntu:
     '*': [black]
     bionic: null
@@ -338,7 +338,7 @@ paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
+  openembedded: [python3-paramiko@meta-python]
   opensuse: [python-paramiko]
   osx:
     pip:
@@ -377,7 +377,7 @@ pydocstyle:
   freebsd: [devel/py-pydocstyle]
   gentoo: [dev-python/pydocstyle]
   nixos: [python3Packages.pydocstyle]
-  openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros-common']
+  openembedded: [python3-pydocstyle@meta-ros-common]
   osx:
     pip:
       packages: [pydocstyle]
@@ -406,7 +406,7 @@ pyflakes3:
   freebsd: [devel/py-pyflakes]
   gentoo: [dev-python/pyflakes]
   nixos: [python3Packages.pyflakes]
-  openembedded: ['${PYTHON_PN}-pyflakes@meta-ros-common']
+  openembedded: [python3-pyflakes@meta-ros-common]
   osx:
     pip:
       packages: [pyflakes]
@@ -472,7 +472,7 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   rhel: [python3-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
 pyqt6-dev-tools:
@@ -519,7 +519,6 @@ python:
   gentoo: [dev-lang/python]
   macports: [python26, python_select]
   nixos: [python]
-  openembedded: [python@meta-python2]
   opensuse: [python-devel]
   rhel:
     '7': [python2-devel]
@@ -663,7 +662,6 @@ python-autobahn:
       packages: [autobahn]
   gentoo: [dev-python/autobahn]
   nixos: [pythonPackages.autobahn]
-  openembedded: ['${PYTHON_PN}-autobahn@meta-python']
   osx:
     pip:
       packages: [autobahn]
@@ -705,7 +703,6 @@ python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
   nixos: [pythonPackages.backports_ssl_match_hostname]
-  openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
     bionic: [python-backports.ssl-match-hostname]
 python-bcrypt:
@@ -762,7 +759,6 @@ python-bluez:
   debian: [python-bluez]
   gentoo: [dev-python/pybluez]
   nixos: [pythonPackages.pybluez]
-  openembedded: ['${PYTHON_PN}-pybluez@meta-python']
   ubuntu: [python-bluez]
 python-bokeh-pip:
   debian:
@@ -790,7 +786,6 @@ python-boto3:
   debian: [python-boto3]
   gentoo: [dev-python/boto3]
   nixos: [pythonPackages.boto3]
-  openembedded: ['${PYTHON_PN}-boto3@meta-ros-common']
   opensuse: [python-boto3]
   ubuntu:
     '*': [python-boto3]
@@ -817,7 +812,6 @@ python-bson:
   fedora: [python-bson]
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.pymongo]
-  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   osx:
     pip:
       packages: [bson]
@@ -872,7 +866,6 @@ python-cantools-pip:
       packages: [cantools]
 python-catkin-lint:
   fedora: [python-catkin_lint]
-  openembedded: ['${PYTHON_PN}-catkin-lint@meta-ros-common']
   ubuntu: [python-catkin-lint]
 python-catkin-pkg:
   alpine:
@@ -887,7 +880,6 @@ python-catkin-pkg:
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   nixos: [pythonPackages.catkin-pkg]
-  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
   opensuse: [python-catkin_pkg]
   osx:
     pip:
@@ -912,7 +904,6 @@ python-catkin-pkg-modules:
   gentoo: [dev-python/catkin_pkg]
   macports: [python-catkin-pkg]
   nixos: [pythonPackages.catkin-pkg]
-  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
   opensuse: [python-catkin_pkg]
   osx:
     pip:
@@ -942,7 +933,6 @@ python-catkin-tools:
   arch: [python2-catkin-tools]
   debian: [python-catkin-tools]
   fedora: [python-catkin_tools]
-  openembedded: ['${PYTHON_PN}-catkin-tools@meta-ros-common']
   osx:
     pip:
       packages: [catkin_tools]
@@ -1020,7 +1010,7 @@ python-cheetah:
   fedora: [python-cheetah]
   gentoo: [dev-python/cheetah]
   nixos: [pythonPackages.cheetah]
-  openembedded: ['${PYTHON_PN}-cheetah@meta-python']
+  openembedded: [python3-cheetah@meta-python]
   opensuse: [python-Cheetah]
   ubuntu: [python-cheetah]
 python-cherrypy:
@@ -1192,7 +1182,7 @@ python-crypto:
   freebsd: [py27-pycrypto]
   gentoo: [dev-python/pycrypto]
   nixos: [pythonPackages.pycrypto]
-  openembedded: ['${PYTHON_PN}-pycrypto@meta-python']
+  openembedded: [python-pycrypto@meta-python]
   opensuse: [python2-pycrypto]
   osx:
     pip:
@@ -1295,7 +1285,6 @@ python-defusedxml:
   freebsd: [py27-defusedxml]
   gentoo: [dev-python/defusedxml]
   nixos: [pythonPackages.defusedxml]
-  openembedded: ['${PYTHON_PN}-defusedxml@meta-ros-common']
   opensuse: [python2-defusedxml]
   osx:
     pip:
@@ -1409,7 +1398,6 @@ python-empy:
   gentoo: [dev-python/empy]
   macports: [py27-empy]
   nixos: [pythonPackages.empy]
-  openembedded: ['${PYTHON_PN}-empy@meta-ros-common']
   opensuse: [python2-empy]
   osx:
     pip:
@@ -1430,7 +1418,6 @@ python-enum34:
     stretch: [python-enum34]
   gentoo: [virtual/python-enum34]
   nixos: [pythonPackages.enum34]
-  openembedded: ['${PYTHON_PN}-enum34@meta-python']
   opensuse: [python-enum34]
   ubuntu: [python-enum34]
 python-enum34-pip:
@@ -1545,7 +1532,6 @@ python-flake8:
   fedora: [python-flake8]
   gentoo: [dev-python/flake8]
   nixos: [python3Packages.flake8]
-  openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
   ubuntu:
     bionic: [python-flake8]
 python-flask:
@@ -1622,7 +1608,6 @@ python-future:
   fedora: [python-future]
   gentoo: [dev-python/future]
   nixos: [pythonPackages.future]
-  openembedded: ['${PYTHON_PN}-future@meta-python']
   opensuse: [python2-future]
   osx:
     pip:
@@ -1765,7 +1750,6 @@ python-gnupg:
   freebsd: [py27-python-gnupg]
   gentoo: [dev-python/python-gnupg]
   nixos: [pythonPackages.python-gnupg]
-  openembedded: ['${PYTHON_PN}-gnupg@meta-ros-common']
   opensuse: [python2-python-gnupg]
   rhel:
     '7': [python2-gnupg]
@@ -1985,7 +1969,6 @@ python-imaging:
   gentoo: [dev-python/pillow]
   macports: [py27-pil]
   nixos: [pythonPackages.pillow]
-  openembedded: ['${PYTHON_PN}-pillow@meta-python']
   opensuse: [python2-Pillow]
   osx:
     pip:
@@ -2330,7 +2313,6 @@ python-matplotlib:
   gentoo: [dev-python/matplotlib]
   macports: [py27-matplotlib]
   nixos: [pythonPackages.matplotlib]
-  openembedded: ['${PYTHON_PN}-matplotlib@meta-python']
   opensuse: [python2-matplotlib]
   osx:
     pip:
@@ -2364,7 +2346,6 @@ python-mock:
   freebsd: [py27-mock]
   gentoo: [dev-python/mock]
   nixos: [pythonPackages.mock]
-  openembedded: ['${PYTHON_PN}-mock@meta-python']
   opensuse: [python2-mock]
   osx:
     pip:
@@ -2394,7 +2375,6 @@ python-msgpack:
   fedora: [python-msgpack]
   gentoo: [dev-python/msgpack]
   nixos: [pythonPackages.msgpack]
-  openembedded: ['${PYTHON_PN}-msgpack@meta-python2']
   opensuse: [python2-msgpack]
   ubuntu: [python-msgpack]
 python-multicast:
@@ -2474,7 +2454,6 @@ python-netifaces:
   gentoo: [dev-python/netifaces]
   macports: [p27-netifaces]
   nixos: [pythonPackages.netifaces]
-  openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
   opensuse: [python2-netifaces]
   osx:
     pip:
@@ -2505,7 +2484,6 @@ python-nose:
   gentoo: [dev-python/nose]
   macports: [py27-nose]
   nixos: [pythonPackages.nose]
-  openembedded: ['${PYTHON_PN}-nose@openembedded-core']
   opensuse: [python2-nose]
   osx:
     pip:
@@ -2530,7 +2508,6 @@ python-numpy:
   gentoo: [dev-python/numpy]
   macports: [py27-numpy]
   nixos: [pythonPackages.numpy]
-  openembedded: ['${PYTHON_PN}-numpy@openembedded-core']
   opensuse: [python2-numpy-devel]
   osx:
     pip:
@@ -2696,7 +2673,6 @@ python-paramiko:
   gentoo: [dev-python/paramiko]
   macports: [py27-paramiko]
   nixos: [pythonPackages.paramiko]
-  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
   opensuse: [python2-paramiko]
   osx:
     pip:
@@ -2839,7 +2815,6 @@ python-pip:
   fedora: [python-pip]
   gentoo: [dev-python/pip]
   nixos: [pythonPackages.pip]
-  openembedded: ['${PYTHON_PN}-pip@meta-python']
   opensuse: [python2-pip]
   ubuntu: [python-pip]
 python-pixel-ring-pip:
@@ -2929,7 +2904,6 @@ python-psutil:
   gentoo: [dev-python/psutil]
   macports: [py27-psutil]
   nixos: [pythonPackages.psutil]
-  openembedded: ['${PYTHON_PN}-psutil@meta-python']
   opensuse: [python2-psutil]
   osx:
     pip:
@@ -2958,7 +2932,6 @@ python-pyassimp:
   arch: [python2-pyassimp]
   debian: [python-pyassimp]
   gentoo: [media-libs/assimp]
-  openembedded: [python-pyassimp@meta-ros-python2]
   osx:
     lion:
       homebrew:
@@ -2969,7 +2942,6 @@ python-pyaudio:
   debian: [python-pyaudio]
   gentoo: [dev-python/pyaudio]
   nixos: [pythonPackages.pyaudio]
-  openembedded: ['${PYTHON_PN}-pyalsaaudio@meta-python']
   ubuntu: [python-pyaudio]
 python-pycodestyle:
   arch: [python2-pycodestyle]
@@ -3002,7 +2974,6 @@ python-pycryptodome:
   fedora: [python-pycryptodomex]
   gentoo: [dev-python/pycryptodome]
   nixos: [pythonPackages.pycryptodomex]
-  openembedded: ['${PYTHON_PN}-pycryptodomex@openembedded-core']
   opensuse: [python2-pycryptodomex]
   osx:
     pip:
@@ -3025,7 +2996,6 @@ python-pydot:
   gentoo: [dev-python/pydot]
   macports: [py27-pydot]
   nixos: [pythonPackages.pydot]
-  openembedded: ['${PYTHON_PN}-pydot@meta-ros-common']
   opensuse: [python2-pydot]
   osx:
     pip:
@@ -3157,7 +3127,6 @@ python-pymongo:
   fedora: [python-pymongo]
   gentoo: [dev-python/pymongo]
   nixos: [pythonPackages.pymongo]
-  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
   opensuse: [python2-pymongo]
   osx:
     pip:
@@ -3210,7 +3179,6 @@ python-pyproj:
   debian: [python-pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [pythonPackages.pyproj]
-  openembedded: ['${PYTHON_PN}-pyproj@meta-ros-common']
   osx:
     pip:
       packages: [pyproj]
@@ -3298,7 +3266,6 @@ python-pytest:
   fedora: [python-pytest]
   gentoo: [dev-python/pytest]
   nixos: [pythonPackages.pytest]
-  openembedded: ['${PYTHON_PN}-pytest@openembedded-core']
   ubuntu: [python-pytest]
 python-pytest-cov:
   arch: [python2-pytest-cov]
@@ -3306,7 +3273,6 @@ python-pytest-cov:
   fedora: [python-pytest-cov]
   gentoo: [dev-python/pytest-cov]
   nixos: [pythonPackages.pytestcov]
-  openembedded: ['${PYTHON_PN}-pytest-cov@meta-ros-common']
   ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
@@ -3360,7 +3326,6 @@ python-pyudev:
   fedora: [python-pyudev]
   gentoo: [dev-python/pyudev]
   nixos: [pythonPackages.pyudev]
-  openembedded: ['${PYTHON_PN}-pyudev@meta-python']
   ubuntu:
     '*': [python-pyudev]
 python-pyusb-pip:
@@ -3449,7 +3414,7 @@ python-qt5-bindings:
   freebsd: [py27-qt5]
   gentoo: ['dev-python/PyQt5[gui,widgets]']
   nixos: [pythonPackages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python2-qt5-devel, python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
@@ -3463,14 +3428,14 @@ python-qt5-bindings-gl:
   freebsd: [py27-qt5-opengl]
   gentoo: ['dev-python/PyQt5[opengl]']
   nixos: [pythonPackages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
     bionic: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-quick:
   debian: [python-pyqt5.qtquick]
@@ -3484,7 +3449,7 @@ python-qt5-bindings-webkit:
   freebsd: [py27-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
   nixos: [pythonPackages.pyqt5_with_qtwebkit]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python2-qt5]
   ubuntu:
     bionic: [python-pyqt5.qtwebkit]
@@ -3521,7 +3486,6 @@ python-requests:
   fedora: [python-requests]
   gentoo: [dev-python/requests]
   nixos: [pythonPackages.requests]
-  openembedded: ['${PYTHON_PN}-requests@openembedded-core']
   osx:
     pip:
       packages: [requests]
@@ -3551,7 +3515,6 @@ python-rosdep:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
   nixos: [pythonPackages.rosdep]
-  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
   opensuse: [python-rosdep]
   osx:
     pip:
@@ -3575,7 +3538,6 @@ python-rosdep-modules:
       packages: [rosdep]
   gentoo: [dev-util/rosdep]
   nixos: [pythonPackages.rosdep]
-  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
   opensuse: [python-rosdep]
   osx:
     pip:
@@ -3630,7 +3592,6 @@ python-rospkg:
   gentoo: [dev-python/rospkg]
   macports: [py27-rospkg]
   nixos: [pythonPackages.rospkg]
-  openembedded: ['${PYTHON_PN}-rospkg@meta-ros-common']
   opensuse: [python-rospkg]
   osx:
     pip:
@@ -3791,7 +3752,6 @@ python-serial:
   debian: [python-serial]
   gentoo: [dev-python/pyserial]
   nixos: [pythonPackages.pyserial]
-  openembedded: ['${PYTHON_PN}-pyserial@meta-python']
   opensuse: [python2-pyserial]
   ubuntu:
     bionic: [python-serial]
@@ -3805,7 +3765,6 @@ python-setuptools:
   gentoo: [dev-python/setuptools]
   macports: [py27-setuptools]
   nixos: [pythonPackages.setuptools]
-  openembedded: ['${PYTHON_PN}-setuptools@openembedded-core']
   opensuse: [python2-setuptools]
   osx:
     pip:
@@ -3849,7 +3808,6 @@ python-simplejson:
   fedora: [python-simplejson]
   gentoo: [dev-python/simplejson]
   nixos: [pythonPackages.simplejson]
-  openembedded: ['${PYTHON_PN}-simplejson@meta-python']
   ubuntu: [python-simplejson]
 python-singledispatch:
   debian: [python-singledispatch]
@@ -3883,7 +3841,6 @@ python-six:
   fedora: [python-six]
   gentoo: [dev-python/six]
   nixos: [pythonPackages.six]
-  openembedded: ['${PYTHON_PN}-six@openembedded-core']
   ubuntu: [python-six]
 python-skimage:
   debian:
@@ -4253,7 +4210,6 @@ python-tk:
   debian: [python-tk]
   fedora: [python2-tkinter]
   nixos: [pythonPackages.tkinter]
-  openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
   opensuse: [python-tk]
   rhel:
     '7': [tkinter]
@@ -4270,7 +4226,6 @@ python-tornado:
   fedora: [python-tornado]
   gentoo: [www-servers/tornado]
   nixos: [pythonPackages.tornado]
-  openembedded: [python-tornado45@meta-ros-python2]
   osx:
     pip:
       packages: [tornado]
@@ -4457,7 +4412,6 @@ python-usb:
   debian: [python-usb]
   gentoo: [dev-python/pyusb]
   nixos: [pythonPackages.pyusb]
-  openembedded: ['${PYTHON_PN}-pyusb@meta-python']
   ubuntu: [python-usb]
 python-utm-pip:
   debian:
@@ -4508,7 +4462,7 @@ python-virtualenv:
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
   nixos: [pythonPackages.virtualenv]
-  openembedded: ['${PYTHON_PN}-virtualenv@meta-ros2']
+  openembedded: [python-virtualenv@meta-ros2]
   rhel:
     '7': [python-virtualenv]
     '8': [python2-virtualenv]
@@ -4593,7 +4547,6 @@ python-websocket:
   fedora: [python-websocket-client]
   gentoo: [dev-python/websocket-client]
   nixos: [pythonPackages.websocket_client]
-  openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
   opensuse: [python2-websocket-client]
   ubuntu:
     bionic: [python-websocket]
@@ -4647,7 +4600,6 @@ python-wxtools:
   freebsd: [py27-wxPython30]
   gentoo: [dev-python/wxpython]
   nixos: [pythonPackages.wxPython]
-  openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxWidgets-3_0-devel]
   rhel:
     '7': [wxPython]
@@ -5107,6 +5059,7 @@ python3-bluez:
   debian: [python3-bluez]
   fedora: [python3-bluez]
   gentoo: [dev-python/pybluez]
+  openembedded: [python3-pybluez@meta-python]
   ubuntu:
     '*': [python3-bluez]
     bionic: null
@@ -7587,7 +7540,7 @@ python3-mypy:
   freebsd: [devel/py-mypy]
   gentoo: [dev-python/mypy]
   nixos: [python3Packages.mypy]
-  openembedded: [python3-mypy@meta-ros-common]
+  openembedded: [python3-mypy@meta-python]
   opensuse: [mypy]
   osx:
     pip:
@@ -7718,7 +7671,7 @@ python3-nose:
   fedora: [python3-nose]
   gentoo: [dev-python/nose]
   nixos: [python3Packages.nose]
-  openembedded: [python3-nose@openembedded-core]
+  openembedded: [python3-nose@meta-ros-common]
   opensuse: [python3-nose]
   osx:
     pip:
@@ -8120,7 +8073,7 @@ python3-paramiko:
   fedora: [python3-paramiko]
   gentoo: [dev-python/paramiko]
   nixos: [python3Packages.paramiko]
-  openembedded: [python3-paramiko@meta-ros-common]
+  openembedded: [python3-paramiko@meta-python]
   opensuse: [python3-paramiko]
   rhel: ['python%{python3_pkgversion}-paramiko']
   ubuntu: [python3-paramiko]
@@ -8424,7 +8377,7 @@ python3-psutil:
   gentoo: [dev-python/psutil]
   macports: [py36-psutil]
   nixos: [python3Packages.psutil]
-  openembedded: [python3-psutil@meta-python]
+  openembedded: [python3-psutil@openembedded-core]
   opensuse: [python3-psutil]
   osx:
     pip:
@@ -8681,7 +8634,7 @@ python3-pykdl:
   fedora: [python3-pykdl]
   gentoo: [dev-python/python_orocos_kdl]
   nixos: [python3Packages.pykdl]
-  openembedded: [python3-pykdl@meta-ros1-noetic]
+  openembedded: [python3-pykdl@meta-ros-common]
   rhel:
     '*': [python3-pykdl]
     '7': null
@@ -8841,7 +8794,7 @@ python3-pyproj:
   fedora: [python3-pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [python3Packages.pyproj]
-  openembedded: [python3-pyproj@meta-ros-common]
+  openembedded: [python3-pyproj@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-pyproj']
     '7': null
@@ -8876,7 +8829,7 @@ python3-pyqt5.qtwebengine:
   fedora: [python3-qt5-webengine, pyqtwebengine-devel]
   gentoo: [dev-python/PyQtWebEngine]
   nixos: [python3Packages.pyqtwebengine]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qtwebengine-qt5]
   rhel:
     '*': [python3-qt5-webengine, pyqtwebengine-devel]
@@ -9252,7 +9205,6 @@ python3-pytest-dependency:
   fedora: [python3-pytest-dependency]
   gentoo: [dev-python/pytest-dependency]
   nixos: [python3Packages.pytest-dependency]
-  openembedded: [python3-pytest-dependency]
   rhel:
     '*': [python3-pytest-dependency]
     '7': null
@@ -9369,6 +9321,7 @@ python3-pyudev:
   fedora: [python3-pyudev]
   gentoo: [dev-python/pyudev]
   nixos: [pythonPackages.pyudev]
+  openembedded: [python3-pyudev@meta-python]
   ubuntu: [python3-pyudev]
 python3-pyvista-pip:
   debian:
@@ -9687,6 +9640,7 @@ python3-rosdep:
   fedora: [python3-rosdep]
   gentoo: [dev-util/rosdep]
   rhel: ['python%{python3_pkgversion}-rosdep']
+  openembedded: [python3-rosdep@meta-ros-common]
   ubuntu: [python3-rosdep]
 python3-rosdep-modules:
   debian: [python3-rosdep-modules]
@@ -10119,6 +10073,7 @@ python3-six:
   fedora: [python3-six]
   gentoo: [dev-python/six]
   nixos: [python3Packages.six]
+  openembedded: [python3-six@openembedded-core]
   ubuntu: [python3-six]
 python3-skimage:
   debian: [python3-skimage]
@@ -10579,7 +10534,7 @@ python3-tk:
   fedora: [python3-tkinter]
   gentoo: ['dev-lang/python[tk]']
   nixos: [python3Packages.tkinter]
-  openembedded: [python3-tkinter@openembedded-core]
+  openembedded: [python3@openembedded-core]
   opensuse: [python3-tk]
   rhel: ['python%{python3_pkgversion}-tkinter']
   ubuntu: [python3-tk]
@@ -11107,7 +11062,7 @@ python3-whichcraft:
   fedora: [python3-whichcraft]
   gentoo: [dev-python/whichcraft]
   nixos: [python3Packages.whichcraft]
-  openembedded: [python3-whichcraft@meta-ros-common]
+  openembedded: [python3-whichcraft@meta-ros2]
   rhel:
     '*': [python3-whichcraft]
     '7': null
@@ -11324,7 +11279,6 @@ wxpython:
   gentoo: [dev-python/wxpython]
   macports: [py27-wxpython, py27-gobject, py27-gtk, py27-cairo]
   nixos: [pythonPackages.wxPython]
-  openembedded: [wxpython@meta-ros-python2]
   opensuse: [python-wxWidgets-3_0-devel]
   rhel:
     '7': [wxPython-devel]


### PR DESCRIPTION
Python2 is removed a long time from OpenEmbedded/Yocto Some recipes moved from meta-layer

@robwoolley: Rob, the diff looks a bit too long to merge.  Should I split it?
My main goal was to fix the python2 stuff.

The output of the test is not worse as it was.  But I'm not sure how to test it?  Is running a superflore run on my fork of rosdistro test best I can do?

```
(venv) jan@jan:~/projects/rosdistro$ PYTHONPATH=test python3 -m rosdep_repo_check
Verify all rosdep keys in 'rosdep/base.yaml'
Reading OpenEmbedded layers from http://layers.openembedded.org/layerindex/api/layerItems
Reading OpenEmbedded layer branches from http://layers.openembedded.org/layerindex/api/layerBranches?filter=branch__name:master
Reading OpenEmbedded recipe metadata from http://layers.openembedded.org/layerindex/api/recipes?filter=layerbranch__branch__name:master
Verify all rosdep keys in 'rosdep/python.yaml'
* The following 24 packages were not found for openembedded master on :
- Package alsa-oss@meta-oe for rosdep key alsa-oss
- Package assimp@openembedded-core for rosdep key assimp
- Package assimp@openembedded-core for rosdep key assimp-dev
- Package babeltrace@openembedded-core for rosdep key babeltrace
- Package babeltrace@openembedded-core for rosdep key python3-babeltrace
- Package clang@meta-clang for rosdep key clang
- Package clang@meta-clang for rosdep key clang-format
- Package clang@meta-clang for rosdep key clang-tidy
- Package clang@meta-clang for rosdep key libclang-dev
- Package glfw@meta-intel-realsense for rosdep key libglfw3-dev
- Package gtk+@openembedded-core for rosdep key gtk2
- Package joystick@meta-ros-common for rosdep key joystick
- Package libdwarf for rosdep key libdwarf-dev
- Package lua@meta-oe for rosdep key lua5.2-dev
- Package msr-tools@meta-oe for rosdep key msr-tools
- Package openblas@meta-ros-common for rosdep key libblas-dev
- Package openblas@meta-ros-common for rosdep key libopenblas-dev
- Package orocos-kdl@meta-ros1-noetic for rosdep key liborocos-kdl
- Package orocos-kdl@meta-ros1-noetic for rosdep key liborocos-kdl-dev
- Package python-pycrypto@meta-python for rosdep key python-crypto
- Package python-virtualenv@meta-ros2 for rosdep key python-virtualenv
- Package wxwidgets@meta-ros-common for rosdep key wx-common
- Package wxwidgets@meta-ros-common for rosdep key wxwidgets
- Package yaml-cpp@meta-ros-common for rosdep key yaml-cpp
```
