### PR TITLE
pymoveit2: 4.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7615,6 +7615,21 @@ repositories:
       url: https://github.com/ros2/pybind11_vendor.git
       version: humble
     status: maintained
+  pymoveit2:
+    doc:
+      type: git
+      url: https://github.com/AndrejOrsula/pymoveit2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/pymoveit2-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/AndrejOrsula/pymoveit2.git
+      version: main
+    status: developed
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pymoveit2` to `4.0.0-1`:

- upstream repository: https://github.com/AndrejOrsula/pymoveit2.git
- release repository: https://github.com/ros2-gbp/pymoveit2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
