### PR TITLE
pymoveit2: 4.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6620,6 +6620,21 @@ repositories:
       url: https://github.com/ros2/pybind11_vendor.git
       version: jazzy
     status: maintained
+  pymoveit2:
+    doc:
+      type: git
+      url: https://github.com/AndrejOrsula/pymoveit2.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/pymoveit2-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/AndrejOrsula/pymoveit2.git
+      version: main
+    status: developed
   python_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pymoveit2` to `4.0.0-1`:

- upstream repository: https://github.com/AndrejOrsula/pymoveit2.git
- release repository: https://github.com/ros2-gbp/pymoveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
