### PR TITLE
Add mola_imu_preintegration for indexing in remaining distros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5519,6 +5519,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_gnss_to_markers.git
       version: develop
     status: developed
+  mola_imu_preintegration:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git
@@ -5541,7 +5551,6 @@ repositories:
       version: develop
     release:
       packages:
-      - mola_imu_preintegration
       - mola_state_estimation
       - mola_state_estimation_simple
       - mola_state_estimation_smoother

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4864,6 +4864,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_gnss_to_markers.git
       version: develop
     status: developed
+  mola_imu_preintegration:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git
@@ -4886,7 +4896,6 @@ repositories:
       version: develop
     release:
       packages:
-      - mola_imu_preintegration
       - mola_state_estimation
       - mola_state_estimation_simple
       - mola_state_estimation_smoother

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4148,6 +4148,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_gnss_to_markers.git
       version: develop
     status: developed
+  mola_imu_preintegration:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_imu_preintegration.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git
@@ -4170,7 +4180,6 @@ repositories:
       version: develop
     release:
       packages:
-      - mola_imu_preintegration
       - mola_state_estimation
       - mola_state_estimation_simple
       - mola_state_estimation_smoother

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4176,7 +4176,6 @@ repositories:
       version: develop
     release:
       packages:
-      - mola_imu_preintegration
       - mola_state_estimation
       - mola_state_estimation_simple
       - mola_state_estimation_smoother


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

- humble
- jazzy
- kilted

(rolling: already there)

# The source is here:

https://github.com/MOLAorg/mola_imu_preintegration

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro


## Also note:

- This package was formerly part of another repository, so this commit also deletes those binary release lines, so avoid duplication once the new one gets released. 