### PR TITLE
openembedded: remove not existing python3-pytest-dependency recipe

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9252,7 +9252,6 @@ python3-pytest-dependency:
   fedora: [python3-pytest-dependency]
   gentoo: [dev-python/pytest-dependency]
   nixos: [python3Packages.pytest-dependency]
-  openembedded: [python3-pytest-dependency]
   rhel:
     '*': [python3-pytest-dependency]
     '7': null


### PR DESCRIPTION
This packages is added to python.yaml in commit 52973d3d3a3e5f989772f4233ec24a2f1b3b679c. But there is no OpenEmbedded/Yocto recipe for it.

@robwoolley Could you review please?