### PR TITLE
openembedded: python(3)-psutil

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2929,7 +2929,6 @@ python-psutil:
   gentoo: [dev-python/psutil]
   macports: [py27-psutil]
   nixos: [pythonPackages.psutil]
-  openembedded: ['${PYTHON_PN}-psutil@meta-python']
   opensuse: [python2-psutil]
   osx:
     pip:
@@ -8424,7 +8423,7 @@ python3-psutil:
   gentoo: [dev-python/psutil]
   macports: [py36-psutil]
   nixos: [python3Packages.psutil]
-  openembedded: [python3-psutil@meta-python]
+  openembedded: [python3-psutil@openembedded-core]
   opensuse: [python3-psutil]
   osx:
     pip:


### PR DESCRIPTION
Removed the not longer existing Python2 version of psutil.

The Python3 recipe moved from meta-python to openembedded-core. 
See: https://git.openembedded.org/openembedded-core/commit/meta/recipes-devtools/python?id=e2c8532df68946943a1dbabd6d3be5496f05f735

@robwoolley Could you review please?