### PR TITLE
openembedded: python(3)pyudev

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3360,7 +3360,6 @@ python-pyudev:
   fedora: [python-pyudev]
   gentoo: [dev-python/pyudev]
   nixos: [pythonPackages.pyudev]
-  openembedded: ['${PYTHON_PN}-pyudev@meta-python']
   ubuntu:
     '*': [python-pyudev]
 python-pyusb-pip:
@@ -9369,6 +9368,7 @@ python3-pyudev:
   fedora: [python3-pyudev]
   gentoo: [dev-python/pyudev]
   nixos: [pythonPackages.pyudev]
+  openembedded: [python3-pyudev@meta-python]
   ubuntu: [python3-pyudev]
 python3-pyvista-pip:
   debian:


### PR DESCRIPTION
Removed the not longer existing Python2 version of pyudev.

The Python3 version of pyudev is in the meta-python layer See: https://layers.openembedded.org/layerindex/recipe/66922/

@robwoolley Could you review please?