### PR TITLE
openembedded: python(3)-six

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3883,7 +3883,6 @@ python-six:
   fedora: [python-six]
   gentoo: [dev-python/six]
   nixos: [pythonPackages.six]
-  openembedded: ['${PYTHON_PN}-six@openembedded-core']
   ubuntu: [python-six]
 python-skimage:
   debian:
@@ -8321,6 +8320,7 @@ python3-posix-ipc:
     pip:
       packages: [posix-ipc]
   fedora: [python3-posix-ipc]
+  openembedded: [python3-six@openembedded-core]
   rhel:
     '9': [python3-posix-ipc]
   ubuntu:


### PR DESCRIPTION
Removed the not longer existing Python2 recipe of six.

The Python3 version of six is at openembedded-core. See: https://layers.openembedded.org/layerindex/recipe/51784/

@robwoolley Could you review please?