### PR TITLE
Update foxglove_bridge to 3.2.0, update repo and remove old repo

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2178,7 +2178,7 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
-  foxglove_bridge:
+  foxglove-sdk:
     doc:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2181,16 +2181,16 @@ repositories:
   foxglove_bridge:
     doc:
       type: git
-      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.8.5-1
+      version: 3.2.0-1
     source:
       type: git
-      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     status: developed
   foxglove_compressed_video_transport:
@@ -2207,21 +2207,6 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
-    status: developed
-  foxglove_msgs:
-    doc:
-      type: git
-      url: https://github.com/foxglove/foxglove-sdk.git
-      version: main
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 3.1.0-1
-    source:
-      type: git
-      url: https://github.com/foxglove/foxglove-sdk.git
-      version: main
     status: developed
   fuse:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2185,8 +2185,8 @@ repositories:
       version: main
     release:
       packages:
-        - foxglove_bridge
-        - foxglove_msgs
+      - foxglove_bridge
+      - foxglove_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2184,6 +2184,9 @@ repositories:
       url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     release:
+      packages:
+        - foxglove_bridge
+        - foxglove_msgs
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git


### PR DESCRIPTION
Update foxglove_bridge and foxglove_msgs to 3.2.0.

This PR is manually generated because we are migrating foxglove_bridge (previously in the foxglove/ros-foxglove-bridge) repo to Foxglove's monorepo (foxglove/foxglove-sdk). This repo provides both the foxglove_bridge and foxglove_msgs packages, and we needed to remove the old foxglove_msgs repo to avoid conflicts/bloom throwing an assertion.
