### PR TITLE
openembedded: python3-whichcraft meta-ros-common -> meta-ros2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11107,7 +11107,7 @@ python3-whichcraft:
   fedora: [python3-whichcraft]
   gentoo: [dev-python/whichcraft]
   nixos: [python3Packages.whichcraft]
-  openembedded: [python3-whichcraft@meta-ros-common]
+  openembedded: [python3-whichcraft@meta-ros2]
   rhel:
     '*': [python3-whichcraft]
     '7': null


### PR DESCRIPTION
See: https://layers.openembedded.org/layerindex/recipe/438753/

@robwoolley Could you review please?