### PR TITLE
openembedded: python(3)-pyproj

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3210,7 +3210,6 @@ python-pyproj:
   debian: [python-pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [pythonPackages.pyproj]
-  openembedded: ['${PYTHON_PN}-pyproj@meta-ros-common']
   osx:
     pip:
       packages: [pyproj]
@@ -8841,7 +8840,7 @@ python3-pyproj:
   fedora: [python3-pyproj]
   gentoo: [dev-python/pyproj]
   nixos: [python3Packages.pyproj]
-  openembedded: [python3-pyproj@meta-ros-common]
+  openembedded: [python3-pyproj@meta-python]
   rhel:
     '*': ['python%{python3_pkgversion}-pyproj']
     '7': null


### PR DESCRIPTION
Removed the not longer existing Python2 recipe.

The Python3 recipe is moved from meta-ros-common to meta-python See:
  - https://layers.openembedded.org/layerindex/recipe/313896/
  - https://github.com/ros/meta-ros/commit/ad9c645276b3a3310482ebe1b21af2897e0d3d31

@robwoolley Rob, could you review please?