### PR TITLE
Re-enable openembedded checks on a best-effort basis

### DIFF
--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -44,6 +44,13 @@ except ImportError:
 from zstandard import ZstdDecompressor
 
 
+class SkipPlatform(Exception):
+
+    def __init__(self, os_name):
+        super().__init__(
+            "Skipping check for '%s' due to unexpected error" % (os_name,))
+
+
 def fmt_os(os_name, os_code_name):
     return (os_name + ' ' + os_code_name) if os_code_name else os_name
 

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -16,9 +16,8 @@ package_sources:
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
   - !rpm_mirrorlist_url https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f$releasever&arch=$basearch
   - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-$releasever&arch=$basearch
-  # Disabled due to API errors
-  # openembedded:
-  # - !layer_index_url http://layers.openembedded.org/layerindex/api/
+  openembedded:
+  - !layer_index_url http://layers.openembedded.org/layerindex/api/
   opensuse:
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
   - !rpm_base_url http://download.opensuse.org/distribution/leap/$releasever/repo/non-oss/

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -35,6 +35,7 @@ import unittest
 import yaml
 
 from . import get_package_link
+from . import SkipPlatform
 from .config import load_config
 from .suggest import make_suggestion
 from .verify import verify_rules
@@ -148,7 +149,14 @@ class TestRosdepRepositoryCheck(unittest.TestCase):
                     self._config['supported_versions'].keys()).difference(rules.keys())
                 for missing_os in missing_os_names:
                     print('Looking for suggestions for %s on %s' % (key, missing_os))
-                    suggestion = make_suggestion(self._config, key, missing_os)
+                    try:
+                        suggestion = make_suggestion(self._config, key, missing_os)
+                    except SkipPlatform as e:
+                        msg = '\n::warning::' + str(e)
+                        if e.__cause__:
+                            msg += ': ' + str(e.__cause__)
+                        print(msg, file=sys.stderr)
+                        continue
                     if suggestion:
                         suggestion_url = get_package_link(
                             self._config, suggestion, missing_os,


### PR DESCRIPTION
Rather than entirely disabling queries to the openembedded layer index, allow them be skipped under certain circumstances. This will aid in our efforts to debug the failing API queries.

@robwoolley FYI
Part of #47263