### PR TITLE
realtime_tools: 4.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6275,7 +6275,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.5.0-1
+      version: 4.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.6.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.5.0-1`

## realtime_tools

```
* Add AsyncFunctionHandlerParams initialization through ROS parameters (#402 <https://github.com/ros-controls/realtime_tools/issues/402>)
* Fix -Wbraced-scalar-init (#409 <https://github.com/ros-controls/realtime_tools/issues/409>)
* Add DETACHED scheduling policy for Async function handler (#383 <https://github.com/ros-controls/realtime_tools/issues/383>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
