### PR TITLE
python-ruamel.yaml: ubuntu focal 

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3697,6 +3697,7 @@ python-ruamel.yaml:
   nixos: [pythonPackages.ruamel_yaml]
   ubuntu:
     bionic: [python-ruamel.yaml]
+    focal: [ruamel.yaml]
 python-rx-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3697,7 +3697,7 @@ python-ruamel.yaml:
   nixos: [pythonPackages.ruamel_yaml]
   ubuntu:
     bionic: [python-ruamel.yaml]
-    focal: [ruamel.yaml]
+    focal: [python3-ruamel.yaml]
 python-rx-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

ruamel.yaml

## Package Upstream Source:

https://sourceforge.net/projects/ruamel-yaml/

## Purpose of using this:

ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order
We already have this package for ubuntu bionic ([added here](https://github.com/ros/rosdistro/pull/16309)), but the package name has changed for focal. This PR adds support for focal

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- python: https://pypi.org/project/ruamel.yaml/
