### PR TITLE
insight_gui: 0.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3755,7 +3755,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/insight_gui-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/julianmueller/insight_gui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `insight_gui` to `0.1.2-1`:

- upstream repository: https://github.com/julianmueller/insight_gui.git
- release repository: https://github.com/ros2-gbp/insight_gui-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.1-1`

## insight_gui

```
* Merge pull request #4 <https://github.com/julianmueller/insight_gui/issues/4> from julianmueller/codex/fix-package.xml-dependencies-for-builds
* Restore rosdep keys for GTK stack build dependencies
* fix label length issue
* replace multicast page icon
* add multicast send/receive page
* add canvas sidebar
* update styling of canvas blocks
* working on canvas, graph and introduction of tf tree
* work on grpah page,
* add static stransformer page, and more icons
* add overview page
* Contributors: Julian Müller
```
