### PR TITLE
foxglove-sdk: 3.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2190,7 +2190,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.2.0-1
+      version: 3.2.0-2
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.2.0-2`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.0-1`

## foxglove_bridge

```
* Rewrite of foxglove_bridge to use the Foxglove SDK (various)
* fix errors on bridge shutdown (#640 <https://github.com/foxglove/foxglove-sdk/issues/640>)
* Contributors: Eric Lujan, Hans-Joachim Krauch
```

## foxglove_msgs

```
* Add RawAudio schema
* Add generated schema types for C++
* Add Kannala-Brandt distortion model to CameraCalibration
* Remove ImageMarkerArray schema
```
