### PR TITLE
yaets: 1.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9993,6 +9993,21 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: ros2
     status: maintained
+  yaets:
+    doc:
+      type: git
+      url: https://github.com/fmrico/yaets.git
+      version: kilted
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/fmrico/yaets-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/fmrico/yaets.git
+      version: kilted
+    status: developed
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `yaets` to `1.0.0-1`:

- upstream repository: https://github.com/fmrico/yaets.git
- release repository: https://github.com/fmrico/yaets-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## yaets

```
* Add all diagrams script
* Add stats script
* Add cmake export targets
* Fix yaets name
* Update README.md
* One extra exmaple in README
* Fix documentation
* Remove font sizes
* Add end to end traces
* set CI
* Update README.md
* Initial commit
* Contributors: Francisco Miguel Moreno Olivo, Francisco Martín Rico
```
