### PR TITLE
rviz: 15.1.10-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8231,7 +8231,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.9-1
+      version: 15.1.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.10-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.9-1`

## rviz2

- No changes

## rviz_common

```
* fix crash (#1587 <https://github.com/ros2/rviz/issues/1587>)
* added option to change filemode (#1537 <https://github.com/ros2/rviz/issues/1537>)
* Removed deprecation warning in tf2 (#1585 <https://github.com/ros2/rviz/issues/1585>)
* Std chrono update in default plugins (#1579 <https://github.com/ros2/rviz/issues/1579>)
* Contributors: Alejandro Hernández Cordero, Joshua Supratman, Mark Johnson, nelson
```

## rviz_default_plugins

```
* Removed tf2 warning (#1586 <https://github.com/ros2/rviz/issues/1586>)
* Removed deprecation warning in tf2 (#1585 <https://github.com/ros2/rviz/issues/1585>)
* Std chrono update in default plugins (#1579 <https://github.com/ros2/rviz/issues/1579>)
* Fix pointcloud2 display divide by 0 (#1581 <https://github.com/ros2/rviz/issues/1581>)
* Contributors: Alejandro Hernández Cordero, Antonio Brandi, Mark Johnson
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

```
* Removed deprecation warning in tf2 (#1585 <https://github.com/ros2/rviz/issues/1585>)
* Contributors: Alejandro Hernández Cordero
```
