### PR TITLE
teleop_twist_keyboard: 2.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8844,7 +8844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `teleop_twist_keyboard` to `2.4.1-1`:

- upstream repository: https://github.com/ros2/teleop_twist_keyboard.git
- release repository: https://github.com/ros2-gbp/teleop_twist_keyboard-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## teleop_twist_keyboard

```
* replace tests_require with extra_require (#38 <https://github.com/ros2/teleop_twist_keyboard/issues/38>)
  * replace tests_require with extra_require
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Set all parameters as read-only. (#40 <https://github.com/ros2/teleop_twist_keyboard/issues/40>)
  * Reject parameter updates.
  While there are a number of parameters here that can be
  set at startup, none of them can actually be configured
  at runtime successfully.  Set them to read-only.
* Add speed&turn parameters (#34 <https://github.com/ros2/teleop_twist_keyboard/issues/34>)
  * Add speed&turn parameters
  Co-authored-by: G.A. vd. Hoorn <mailto:g.a.vanderhoorn@tudelft.nl>
* Contributors: Arend-Jan van Hilten, Chris Lalancette, Plumezz
```
