### PR TITLE
Add spatialite-bin

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9331,6 +9331,12 @@ sparsehash:
   gentoo: [dev-cpp/sparsehash]
   nixos: [sparsehash]
   ubuntu: [libsparsehash-dev]
+spatialite-bin:
+  debian: [spatialite-bin]
+  fedora: [spatialite-tools]
+  gentoo: [dev-db/spatialite-tools]
+  nixos: [spatialite-tools]
+  ubuntu: [spatialite-bin]
 spdlog:
   alpine: [spdlog-dev]
   arch: [spdlog]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

spatialite-bin

## Package Upstream Source:

https://www.gaia-gis.it/fossil/spatialite-tools/index

## Purpose of using this:

To manipulate SpatiaLite DBs via a shell.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/spatialite-bin
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/spatialite-bin
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/spatialite-tools/spatialite-tools/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-db/spatialite-tools
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.05&show=spatialite-tools&query=spatialite-tools
