### PR TITLE
ros_battery_monitoring: 1.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7157,7 +7157,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
-      version: 1.0.2-1
+      version: 1.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_battery_monitoring` to `1.1.0-2`:

- upstream repository: https://github.com/ipa320/ros_battery_monitoring.git
- release repository: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-1`

## battery_state_broadcaster

```
* address deprecations in ros2_control for kilted
* Don't make a temporary copy of semantic component (https://github.com/ipa320/ros_battery_monitoring/pull/9)
* Contributors: Christoph Froehlich, Jonas Otto
```

## battery_state_rviz_overlay

- No changes
