### PR TITLE
Update foxglove_bridge to 3.2.1, update repo and remove old repo

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2189,19 +2189,22 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
-  foxglove_bridge:
+  foxglove-sdk:
     doc:
       type: git
-      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     release:
+      packages:
+      - foxglove_bridge
+      - foxglove_msgs
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.8.5-1
+      version: 3.2.1-1
     source:
       type: git
-      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     status: developed
   foxglove_compressed_video_transport:
@@ -2219,21 +2222,6 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
-  foxglove_msgs:
-    doc:
-      type: git
-      url: https://github.com/foxglove/schemas.git
-      version: main
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 3.1.0-2
-    source:
-      type: git
-      url: https://github.com/foxglove/schemas.git
-      version: main
-    status: maintained
   fuse:
     doc:
       type: git


### PR DESCRIPTION
Update foxglove_bridge and foxglove_msgs to 3.2.1.

This PR is manually generated because we are migrating foxglove_bridge (previously in the foxglove/ros-foxglove-bridge) repo to Foxglove's monorepo (foxglove/foxglove-sdk). This repo provides both the foxglove_bridge and foxglove_msgs packages, and we needed to remove the old foxglove_msgs repo to avoid conflicts/bloom throwing an assertion.

See #44646 for the Rolling version of this PR.