### PR TITLE
Update foxglove_bridge to 3.2.1, update repo and remove old repo

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3113,19 +3113,22 @@ repositories:
       url: https://github.com/ros-drivers/four_wheel_steering_msgs.git
       version: ros2
     status: maintained
-  foxglove_bridge:
+  foxglove-sdk:
     doc:
       type: git
-      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      url: https://github.com/foxglove/foxglove-sdk.git
       version: 0.1.0
     release:
+      packages:
+      - foxglove_bridge
+      - foxglove_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.8.5-1
+      version: 3.2.1-1
     source:
       type: git
-      url: https://github.com/foxglove/ros-foxglove-bridge.git
+      url: https://github.com/foxglove/foxglove-sdk.git
       version: main
     status: developed
   foxglove_compressed_video_transport:
@@ -3142,21 +3145,6 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
-    status: developed
-  foxglove_msgs:
-    doc:
-      type: git
-      url: https://github.com/foxglove/foxglove-sdk.git
-      version: main
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 2.3.0-1
-    source:
-      type: git
-      url: https://github.com/foxglove/foxglove-sdk.git
-      version: main
     status: developed
   franka_description:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3117,7 +3117,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git
-      version: 0.1.0
+      version: main
     release:
       packages:
       - foxglove_bridge


### PR DESCRIPTION
Update foxglove_bridge and foxglove_msgs to 3.2.1.

This PR is manually generated because we are migrating foxglove_bridge (previously in the foxglove/ros-foxglove-bridge) repo to Foxglove's monorepo (foxglove/foxglove-sdk). This repo provides both the foxglove_bridge and foxglove_msgs packages, and we needed to remove the old foxglove_msgs repo to avoid conflicts/bloom throwing an assertion.

See Rolling version of this PR: #47774 