### PR TITLE
mrpt_ros: 2.14.13-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4450,7 +4450,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.14.12-1
+      version: 2.14.13-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.14.13-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.12-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

```
* Fix build against ffmpeg 8.0 (Debian bug #1115064)
```

## mrpt_libmaps

- No changes

## mrpt_libmath

```
* New classes mrpt::math::TOrientedBox, mrpt::math::TOrientedBoxf
```

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

```
* Harden opengl unit tests against crashes on non-GPU runners.
* Fix mrpt::opengl::CEllipsoid3D wrong direction.
```

## mrpt_libposes

- No changes

## mrpt_libros_bridge

- No changes

## mrpt_libslam

```
* Fix potential race conditions in TBB-parallel particle filters with 2D gridmap.
```

## mrpt_libtclap

- No changes
