### PR TITLE
Add persist_parameter_server to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7069,6 +7069,12 @@ repositories:
       url: https://github.com/ros2/performance_test_fixture.git
       version: humble
     status: maintained
+  persist_parameter_server:
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
+      version: rolling
+    status: maintained
   phidgets_drivers:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6154,6 +6154,12 @@ repositories:
       url: https://github.com/ros2/performance_test_fixture.git
       version: jazzy
     status: maintained
+  persist_parameter_server:
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
+      version: rolling
+    status: maintained
   phidgets_drivers:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5285,6 +5285,12 @@ repositories:
       url: https://github.com/ros2/performance_test_fixture.git
       version: kilted
     status: maintained
+  persist_parameter_server:
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
+      version: rolling
+    status: maintained
   phidgets_drivers:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5249,6 +5249,12 @@ repositories:
       url: https://github.com/ros2/performance_test_fixture.git
       version: rolling
     status: maintained
+  persist_parameter_server:
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
+      version: rolling
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

persist_parameter_server

# The source is here:

https://github.com/fujitatomoya/ros2_persist_parameter_server

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
