### PR TITLE
rko_lio: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6303,6 +6303,15 @@ repositories:
       version: master
     status: developed
   rko_lio:
+    doc:
+      type: git
+      url: https://github.com/PRBonn/rko_lio.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rko_lio-release.git
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/PRBonn/rko_lio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.1.2-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rko_lio

```
* Drop irregular lidar frames (#35 <https://github.com/PRBonn/rko_lio/issues/35>)
  * if incoming lidar scan has a stamp with too big of a delta to the previous, we treat it as an error
* fix component registration so online node component shows up in ros2 component types (#34 <https://github.com/PRBonn/rko_lio/issues/34>)
* Contributors: Meher Malladi
```
