### PR TITLE
mola_imu_preintegration: 1.11.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4869,6 +4869,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git
       version: develop
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.11.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mola_imu_preintegration

```
* New unit tests for IMU integration
* Move everything into namespace mola::imu to avoid ns pollution
* Move LocalVelocityBuffer class here from mp2p_icp repository
* Contributors: Jose Luis Blanco-Claraco
```
