### PR TITLE
multisensor_calibration: 2.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4504,6 +4504,15 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git
       version: main
+    release:
+      packages:
+      - multisensor_calibration
+      - multisensor_calibration_interface
+      - small_gicp_vendor
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/multisensor_calibration-release.git
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisensor_calibration` to `2.0.4-1`:

- upstream repository: https://github.com/FraunhoferIOSB/multisensor_calibration.git
- release repository: https://github.com/ros2-gbp/multisensor_calibration-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## multisensor_calibration

```
* refactor: Minor style changes and deprecation removals
* Prepare for Kilted + Rolling Release
* Contributors: Miguel Granero
```

## multisensor_calibration_interface

- No changes

## small_gicp_vendor

- No changes
