### PR TITLE
gz_ros2_control: 3.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2737,7 +2737,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `3.0.4-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.3-1`

## gz_ros2_control

```
* Modernize CMakeLists (#688 <https://github.com/ros-controls/gz_ros2_control/issues/688>)
* Remove outdated comment (#687 <https://github.com/ros-controls/gz_ros2_control/issues/687>)
* Don't remove the node at destruction (#683 <https://github.com/ros-controls/gz_ros2_control/issues/683>)
* Suppress warning (#679 <https://github.com/ros-controls/gz_ros2_control/issues/679>)
* Fix compiler warnings (#674 <https://github.com/ros-controls/gz_ros2_control/issues/674>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich
```

## gz_ros2_control_demos

```
* Add a custom plugin for simulating actuator dynamics to the demos (#693 <https://github.com/ros-controls/gz_ros2_control/issues/693>)
* Update docs (#692 <https://github.com/ros-controls/gz_ros2_control/issues/692>)
* get rid of deprecated rclcpp::spin_some() (#678 <https://github.com/ros-controls/gz_ros2_control/issues/678>)
* Contributors: Alejandro Hernández Cordero, Christoph Fröhlich
```
