### PR TITLE
frame_editor: 2.0.2-5 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2798,6 +2798,11 @@ repositories:
       version: main
     status: developed
   frame_editor:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_frame_editor_plugin-release.git
+      version: 2.0.2-5
     source:
       type: git
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2798,6 +2798,10 @@ repositories:
       version: main
     status: developed
   frame_editor:
+    doc:
+      type: git
+      url: https://github.com/ipa320/rqt_frame_editor_plugin.git
+      version: jazzy-devel
     release:
       tags:
         release: release/jazzy/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `frame_editor` to `2.0.2-5`:

- upstream repository: https://github.com/ipa320/rqt_frame_editor_plugin.git
- release repository: https://github.com/ros2-gbp/rqt_frame_editor_plugin-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## frame_editor

```
* First Port to ROS 2
* Feature: Grouping Option is now available from the GUI
* Feature: Pinning a frame to another in the gui is now possible
* Contributors: Daniel Bargmann
```
