### PR TITLE
gz_ros2_control: 2.0.12-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2784,7 +2784,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.11-2
+      version: 2.0.12-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.12-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.11-2`

## gz_ros2_control

```
* Modernize CMakeLists (#688 <https://github.com/ros-controls/gz_ros2_control/issues/688>) (#697 <https://github.com/ros-controls/gz_ros2_control/issues/697>)
* Remove outdated comment (#687 <https://github.com/ros-controls/gz_ros2_control/issues/687>) (#689 <https://github.com/ros-controls/gz_ros2_control/issues/689>)
* Don't remove the node at destruction (#683 <https://github.com/ros-controls/gz_ros2_control/issues/683>) (#684 <https://github.com/ros-controls/gz_ros2_control/issues/684>)
* Suppress warning (#679 <https://github.com/ros-controls/gz_ros2_control/issues/679>) (#680 <https://github.com/ros-controls/gz_ros2_control/issues/680>)
* Fix compiler warnings (#674 <https://github.com/ros-controls/gz_ros2_control/issues/674>) (#675 <https://github.com/ros-controls/gz_ros2_control/issues/675>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Update docs (#692 <https://github.com/ros-controls/gz_ros2_control/issues/692>) (#695 <https://github.com/ros-controls/gz_ros2_control/issues/695>)
* Contributors: mergify[bot]
```
