### PR TITLE
gz_ros2_control: 1.2.16-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3368,7 +3368,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.15-1
+      version: 1.2.16-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.16-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.15-1`

## gz_ros2_control

```
* Modernize CMakeLists (backport #688 <https://github.com/ros-controls/gz_ros2_control/issues/688>) (#698 <https://github.com/ros-controls/gz_ros2_control/issues/698>)
* Remove outdated comment (#687 <https://github.com/ros-controls/gz_ros2_control/issues/687>) (#690 <https://github.com/ros-controls/gz_ros2_control/issues/690>)
* Don't remove the node at destruction (#683 <https://github.com/ros-controls/gz_ros2_control/issues/683>) (#685 <https://github.com/ros-controls/gz_ros2_control/issues/685>)
* Fix compiler warnings (#674 <https://github.com/ros-controls/gz_ros2_control/issues/674>) (#676 <https://github.com/ros-controls/gz_ros2_control/issues/676>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Update docs (#692 <https://github.com/ros-controls/gz_ros2_control/issues/692>) (#696 <https://github.com/ros-controls/gz_ros2_control/issues/696>)
* Contributors: mergify[bot]
```
