### PR TITLE
ign_ros2_control: 0.7.17-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3971,7 +3971,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.16-1
+      version: 0.7.17-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.17-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.16-1`

## gz_ros2_control

```
* Remove outdated comment (#687 <https://github.com/ros-controls/gz_ros2_control/issues/687>) (#691 <https://github.com/ros-controls/gz_ros2_control/issues/691>)
* Don't remove the node at destruction (#683 <https://github.com/ros-controls/gz_ros2_control/issues/683>) (#686 <https://github.com/ros-controls/gz_ros2_control/issues/686>)
* Fix compiler warnings (backport #674 <https://github.com/ros-controls/gz_ros2_control/issues/674>) (#677 <https://github.com/ros-controls/gz_ros2_control/issues/677>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes

## gz_ros2_control_tests

- No changes

## ign_ros2_control

- No changes

## ign_ros2_control_demos

- No changes
