### PR TITLE
hebi_cpp_api: 3.15.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3508,7 +3508,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
-      version: 3.13.0-3
+      version: 3.15.0-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api` to `3.15.0-1`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/ros2-gbp/hebi_cpp_api-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.13.0-3`

## hebi_cpp_api

```
* Update HEBI C++ API to version 3.15.0
* Add cartesian force/torque Vector3f members to command and feedback messages
* Add drivetrain status and motor hall state to feedback messages
* Update C API dependency to 2.22.0 to support additional feedback types listed above
* Contributors: Hariharan Ravichandran
```
