### PR TITLE
gz_utils_vendor: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2816,7 +2816,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_utils_vendor-release.git
-      version: 0.4.0-2
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_utils_vendor` to `0.4.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_utils_vendor.git
- release repository: https://github.com/ros2-gbp/gz_utils_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-2`

## gz_utils_vendor

```
* Bump version to 4.0.0 (#12 <https://github.com/gazebo-release/gz_utils_vendor/issues/12>)
* Add dsv for PYTHONPATH for Jetty packages (#13 <https://github.com/gazebo-release/gz_utils_vendor/issues/13>)
* Contributors: Addisu Z. Taddese, Steve Peters
```
