### PR TITLE
gz_math_vendor: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2638,7 +2638,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_math_vendor-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_math_vendor` to `0.4.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_math_vendor.git
- release repository: https://github.com/ros2-gbp/gz_math_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## gz_math_vendor

```
* Bump version to 9.0.0 (#17 <https://github.com/gazebo-release/gz_math_vendor/issues/17>)
* Set PYTHONPATH for Jetty packages (#14 <https://github.com/gazebo-release/gz_math_vendor/issues/14>)
  * Set PYTHONPATH for unversioned packages
  * Bump to 9.0.0-pre2
  * Set PYTHONPATH in separate dsv file
  ---------
* Contributors: Addisu Z. Taddese, Steve Peters
```
