### PR TITLE
plotjuggler: 3.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5363,7 +5363,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.12.0-1
+      version: 3.13.0-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.13.0-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.12.0-1`

## plotjuggler

```
* Merge branch 'plugin_manager'
* fix CI
* add WASM based pligins (experimental)
* add Ankel unordered map
* minor changes
* Merge pull request #1185 <https://github.com/facontidavide/PlotJuggler/issues/1185> from simonsag96/fix_tab_add_button
  [Bugfix] Add Tab Button being placed outside plot widget
* Fix tab adding button being placed outside plot widget
* Merge pull request #1184 <https://github.com/facontidavide/PlotJuggler/issues/1184> from MichelJansson/feature/fix-windows-icon
* Fixed windows app icon + moved resource file
* created plugin manager
* Contributors: Davide Faconti, Michel Jansson, Simon Sagmeister
```
