### PR TITLE
rcl: 10.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6001,7 +6001,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.2.3-1
+      version: 10.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.2.4-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.2.3-1`

## rcl

```
* Fix typos: occurrs->occurs, successfull->successful (#1259 <https://github.com/ros2/rcl/issues/1259>)
* Refer to 'the middleware' and not 'the DDS implementation' in doc (#1260 <https://github.com/ros2/rcl/issues/1260>)
* Switch to isolated testing via rmw_test_fixture (#1251 <https://github.com/ros2/rcl/issues/1251>)
* Contributors: Christophe Bedard, yadunund
```

## rcl_action

```
* add rcl_action_goal_handle_is_abortable(). (#1257 <https://github.com/ros2/rcl/issues/1257>)
* Contributors: Tomoya Fujita
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
