### PR TITLE
ros_gz: 3.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7229,7 +7229,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.4-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.3-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* add bayer image two way convertion  from sensor msgs to gz msgs (#792 <https://github.com/gazebosim/ros_gz/issues/792>)
* Added missing test and parse service name from YAML (backport #776 <https://github.com/gazebosim/ros_gz/issues/776>) (#784 <https://github.com/gazebosim/ros_gz/issues/784>)
* Add Windows support for ros_gz_bridge and ros_gz_sim (#781 <https://github.com/gazebosim/ros_gz/issues/781>)
* Added documentation for python launch file bridge configuration (#777 <https://github.com/gazebosim/ros_gz/issues/777>)
* Contributors: Alon Nusem, Nizam Gifary, Silvio Traversaro, mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Implement ROS standard simulation interfaces (#790 <https://github.com/gazebosim/ros_gz/issues/790>)
* Add Windows support for ros_gz_bridge and ros_gz_sim (#781 <https://github.com/gazebosim/ros_gz/issues/781>)
* Contributors: Addisu Z. Taddese, Silvio Traversaro
```

## ros_gz_sim_demos

- No changes
