### PR TITLE
bcr_arm: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1202,7 +1202,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/bcr_arm-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_arm.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1191,7 +1191,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_arm.git
-      version: 0.1.0
+      version: ros2
     release:
       packages:
       - bcr_arm


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_arm` to `0.1.1-1`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_arm.git
- release repository: https://github.com/ros2-gbp/bcr_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-1`
