### PR TITLE
Add source entries for launch_frontend_py in all live distros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4618,6 +4618,12 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: humble
     status: developed
+  launch_frontend_py:
+    source:
+      type: git
+      url: https://github.com/ros-tooling/launch_frontend_py.git
+      version: main
+    status: developed
   launch_pal:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4142,6 +4142,12 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: jazzy
     status: developed
+  launch_frontend_py:
+    source:
+      type: git
+      url: https://github.com/ros-tooling/launch_frontend_py.git
+      version: main
+    status: developed
   launch_param_builder:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3475,6 +3475,12 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: kilted
     status: developed
+  launch_frontend_py:
+    source:
+      type: git
+      url: https://github.com/ros-tooling/launch_frontend_py.git
+      version: main
+    status: developed
   launch_param_builder:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3454,6 +3454,12 @@ repositories:
       url: https://github.com/ros2/launch.git
       version: rolling
     status: developed
+  launch_frontend_py:
+    source:
+      type: git
+      url: https://github.com/ros-tooling/launch_frontend_py.git
+      version: main
+    status: developed
   launch_param_builder:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

- humble
- jazzy
- kilted
- rolling

# The source is here:

https://github.com/ros-tooling/launch_frontend_py

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
