### PR TITLE
ur_description: 2.7.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12047,7 +12047,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.7.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-1`

## ur_description

```
* Update ur7e physical parameters to match ur5e (backport #333 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/333>) (#334 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/334>)
* Auto-update pre-commit hooks (backport #329 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/329>) (#330 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/330>)
* Contributors: mergify[bot]
```
