### PR TITLE
ur_description: 3.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10891,7 +10891,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.3.0-1
+      version: 3.3.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.3.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.0-1`

## ur_description

```
* Update ur7e physical parameters to match ur5e (backport #333 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/333>) (#335 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/335>)
* Auto-update pre-commit hooks (backport #329 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/329>) (#331 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/331>)
* Adding migration notes to package docs (backport #325 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/325>) (#326 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/326>)
* Contributors: mergify[bot]
```
