### PR TITLE
ur_description: 4.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9517,7 +9517,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 4.1.0-1
+      version: 4.1.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `4.1.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.0-1`

## ur_description

```
* Update ur7e physical parameters to match ur5e (#333 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/333>)
* Auto-update pre-commit hooks (#329 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/329>)
* Adding migration notes to package docs (#325 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/325>)
* Contributors: Felix Exner, URJala, github-actions[bot]
```