### PR TITLE
rosidl_typesupport_fastrtps: 3.9.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7612,7 +7612,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.9.1-1
+      version: 3.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.9.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.1-1`

## rosidl_typesupport_fastrtps_c

```
* Removed deprecated code (#135 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/135>)
* Contributors: Alejandro Hernández Cordero
```

## rosidl_typesupport_fastrtps_cpp

```
* Removed deprecated code (#135 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/135>)
* Contributors: Alejandro Hernández Cordero
```
