### PR TITLE
gz_plugin_vendor: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2702,7 +2702,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_plugin_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_plugin_vendor.git
- release repository: https://github.com/ros2-gbp/gz_plugin_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## gz_plugin_vendor

```
* Merge pull request #10 <https://github.com/gazebo-release/gz_plugin_vendor/issues/10> from gazebo-release/releasepy/rolling/4.0.0
  Bump version to 4.0.0
* Bump version to 4.0.0
* Add dsv for PYTHONPATH for Jetty packages (#9 <https://github.com/gazebo-release/gz_plugin_vendor/issues/9>)
  * Set PYTHONPATH for unversioned packages
  * Set PYTHONPATH from separate dsv file
  ---------
* Contributors: Addisu Z. Taddese, Jose Luis Rivero, Steve Peters
```
