### PR TITLE
plotjuggler: 3.13.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5363,7 +5363,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.13.0-1
+      version: 3.13.1-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.13.1-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.13.0-1`

## plotjuggler

```
* [Feature] New Filter to display the time since the previous datapoint (#1180 <https://github.com/facontidavide/PlotJuggler/issues/1180>)
  * add new filter to get the time since the last data point
  * rename for clarity
* fix LZ4 and ZSTD (#1188 <https://github.com/facontidavide/PlotJuggler/issues/1188>)
* fix issue #1189 <https://github.com/facontidavide/PlotJuggler/issues/1189>
* make library rosx static
* Contributors: Davide Faconti, Simon Sagmeister
```
