### PR TITLE
gz_msgs_vendor: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2654,7 +2654,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_msgs_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_msgs_vendor.git
- release repository: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## gz_msgs_vendor

```
* Merge pull request #13 <https://github.com/gazebo-release/gz_msgs_vendor/issues/13> from gazebo-release/releasepy/rolling/12.0.0
  Bump version to 12.0.0
* Bump version to 12.0.0
* Set PYTHONPATH for Jetty packages (#11 <https://github.com/gazebo-release/gz_msgs_vendor/issues/11>)
  * Set PYTHONPATH for unversioned packages
  * Bump to 12.0.0~pre2
  * Set PYTHONPATH from separate dsv file
  ---------
* Contributors: Ian Chen, Jose Luis Rivero, Steve Peters
```
