### PR TITLE
gz_transport_vendor: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2800,7 +2800,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_transport_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_transport_vendor.git
- release repository: https://github.com/ros2-gbp/gz_transport_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## gz_transport_vendor

```
* Merge pull request #15 <https://github.com/gazebo-release/gz_transport_vendor/issues/15> from gazebo-release/releasepy/rolling/15.0.0
  Bump version to 15.0.0
* Bump version to 15.0.0
* Set PYTHONPATH for Jetty packages (#13 <https://github.com/gazebo-release/gz_transport_vendor/issues/13>)
  * Set PYTHONPATH for unversioned packages
  Also bump to 15.0.0~pre2.
  * Set PYTHONPATH from separate dsv file
  ---------
* Contributors: Ian Chen, Jose Luis Rivero, Steve Peters
```
