### PR TITLE
gz_fuel_tools_vendor: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2590,7 +2590,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_fuel_tools_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_fuel_tools_vendor.git
- release repository: https://github.com/ros2-gbp/gz_fuel_tools_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## gz_fuel_tools_vendor

```
* Merge pull request #12 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/12> from gazebo-release/releasepy/rolling/11.0.0
  Bump version to 11.0.0
* Bump version to 11.0.0
* Add dsv for PYTHONPATH for Jetty packages (#11 <https://github.com/gazebo-release/gz_fuel_tools_vendor/issues/11>)
* Contributors: Ian Chen, Jose Luis Rivero, Steve Peters
```
