### PR TITLE
gz_common_vendor: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2558,7 +2558,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## gz_common_vendor

```
* Merge pull request #17 <https://github.com/gazebo-release/gz_common_vendor/issues/17> from gazebo-release/releasepy/rolling/7.0.0
  Bump version to 7.0.0
* Merge remote-tracking branch 'origin' into releasepy/rolling/7.0.0
* Add dsv for PYTHONPATH for Jetty packages (#18 <https://github.com/gazebo-release/gz_common_vendor/issues/18>)
* Bump version to 7.0.0
* Contributors: Addisu Z. Taddese, Jose Luis Rivero, Steve Peters
```
