### PR TITLE
gz_rendering_vendor: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2718,7 +2718,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_rendering_vendor` to `0.4.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_rendering_vendor.git
- release repository: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## gz_rendering_vendor

```
* Merge pull request #16 <https://github.com/gazebo-release/gz_rendering_vendor/issues/16> from gazebo-release/releasepy/rolling/10.0.0
  Bump version to 10.0.0
* Bump version to 10.0.0
* Add dsv for PYTHONPATH for Jetty packages (#15 <https://github.com/gazebo-release/gz_rendering_vendor/issues/15>)
* Contributors: Ian Chen, Jose Luis Rivero, Steve Peters
```
