### PR TITLE
gz_physics_vendor: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2686,7 +2686,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_physics_vendor` to `0.4.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_physics_vendor.git
- release repository: https://github.com/ros2-gbp/gz_physics_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## gz_physics_vendor

```
* Merge pull request #15 <https://github.com/gazebo-release/gz_physics_vendor/issues/15> from gazebo-release/releasepy/rolling/9.0.0
  Bump version to 9.0.0
* Bump version to 9.0.0
* Add dsv for PYTHONPATH for Jetty packages (#14 <https://github.com/gazebo-release/gz_physics_vendor/issues/14>)
* Contributors: Ian Chen, Jose Luis Rivero, Steve Peters
```
