### PR TITLE
gz_sensors_vendor: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2752,7 +2752,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`

## gz_sensors_vendor

```
* Merge pull request #11 <https://github.com/gazebo-release/gz_sensors_vendor/issues/11> from gazebo-release/releasepy/rolling/10.0.0
  Bump version to 10.0.0
* Bump version to 10.0.0
* Add dsv for PYTHONPATH for Jetty packages (#10 <https://github.com/gazebo-release/gz_sensors_vendor/issues/10>)
* Contributors: Carlos Agüero, Jose Luis Rivero, Steve Peters
```
