### PR TITLE
gz_sim_vendor: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2768,7 +2768,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sim_vendor` to `0.4.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_sim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sim_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## gz_sim_vendor

```
* Merge pull request #19 <https://github.com/gazebo-release/gz_sim_vendor/issues/19> from gazebo-release/releasepy/rolling/10.0.0
  Bump version to 10.0.0
* Bump version to 10.0.0
* Set PYTHONPATH for Jetty packages (#17 <https://github.com/gazebo-release/gz_sim_vendor/issues/17>)
  * Set PYTHONPATH for unversioned packages
  * Set PYTHONPATH from separate dsv file
  ---------
* Contributors: Carlos Agüero, Jose Luis Rivero, Steve Peters
```
