### PR TITLE
control_toolbox: 5.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1236,7 +1236,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.7.0-1
+      version: 5.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.8.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.7.0-1`

## control_toolbox

```
* Cleanup prefix_is_for_params (#494 <https://github.com/ros-controls/control_toolbox/issues/494>)
* Increase PID ROS wrapper test coverage  (#484 <https://github.com/ros-controls/control_toolbox/issues/484>)
* Fix -Wuninitialized-const-reference (#485 <https://github.com/ros-controls/control_toolbox/issues/485>)
* Contributors: Abdullah, Christoph Fröhlich
```
