### PR TITLE
ros2_control_cmake: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7944,7 +7944,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
-      version: 0.2.1-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control_cmake` to `0.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control_cmake.git
- release repository: https://github.com/ros2-gbp/ros2_control_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`

## ros2_control_cmake

```
* Update compiler options (#15 <https://github.com/ros-controls/ros2_control_cmake/issues/15>)
* Contributors: Christoph Fröhlich
```
