### PR TITLE
topic_based_hardware_interfaces: 0.2.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9092,7 +9092,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_hardware-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_hardware_interfaces` to `0.2.1-1`:

- upstream repository: https://github.com/ros-controls/topic_based_hardware_interfaces.git
- release repository: https://github.com/ros2-gbp/topic_based_hardware-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.0-1`

## joint_state_topic_hardware_interface

```
* Activate test and fix it for jazzy (#34 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/34>)
* Bump version of pre-commit hooks (#26 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/26>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```
