### PR TITLE
ros2_controllers: 5.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6973,7 +6973,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.7.0-1
+      version: 5.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.7.0-1`

## ackermann_steering_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## bicycle_steering_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## chained_filter_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Fix: Remove deprecated rclcpp::spin_some(node) (#1928 <https://github.com/ros-controls/ros2_controllers/issues/1928>)
* Contributors: Christoph Fröhlich, Kostubh Khandelwal
```

## effort_controllers

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## gps_sensor_broadcaster

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Remove wrong and unnecessary docstrings (#1912 <https://github.com/ros-controls/ros2_controllers/issues/1912>)
* Use auto dependency management for windows workflow (#1917 <https://github.com/ros-controls/ros2_controllers/issues/1917>)
* Remove unused variables and correctly override test class method (#1918 <https://github.com/ros-controls/ros2_controllers/issues/1918>)
* Don't call release_interfaces from controllers (#1910 <https://github.com/ros-controls/ros2_controllers/issues/1910>)
* Contributors: Christoph Fröhlich
```

## mecanum_drive_controller

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* mecanum_drive_controller: Declare missing backward_ros dependency (#1941 <https://github.com/ros-controls/ros2_controllers/issues/1941>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich, Michal Sojka
```

## motion_primitives_controllers

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Update broken links on motion_primitives_controllers readme (#1919 <https://github.com/ros-controls/ros2_controllers/issues/1919>)
* Contributors: Christoph Fröhlich, Junius Santoso
```

## omni_wheel_drive_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Fix: Remove deprecated rclcpp::spin_some(node) (#1928 <https://github.com/ros-controls/ros2_controllers/issues/1928>)
* Contributors: Christoph Fröhlich, Kostubh Khandelwal
```

## parallel_gripper_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Fix: Remove deprecated rclcpp::spin_some(node) (#1928 <https://github.com/ros-controls/ros2_controllers/issues/1928>)
* Don't call release_interfaces from controllers (#1910 <https://github.com/ros-controls/ros2_controllers/issues/1910>)
* Contributors: Christoph Fröhlich, Kostubh Khandelwal
```

## pid_controller

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## pose_broadcaster

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## position_controllers

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

```
* Update API for realtime publisher (#1830 <https://github.com/ros-controls/ros2_controllers/issues/1830>)
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Fix: Remove deprecated rclcpp::spin_some(node) (#1928 <https://github.com/ros-controls/ros2_controllers/issues/1928>)
* Contributors: Christoph Fröhlich, Kostubh Khandelwal
```

## tricycle_steering_controller

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```

## velocity_controllers

```
* Remove deprecated methods from ros2_control (#1936 <https://github.com/ros-controls/ros2_controllers/issues/1936>)
* Contributors: Christoph Fröhlich
```
