### PR TITLE
rko_lio: 0.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6337,6 +6337,15 @@ repositories:
       version: master
     status: developed
   rko_lio:
+    doc:
+      type: git
+      url: https://github.com/PRBonn/rko_lio.git
+      version: master
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/rko_lio-release.git
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/PRBonn/rko_lio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.1.3-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rko_lio

```
* temp fix: ros builds when FETCHCONTENT_FULLY_DISABLED is ON, aka the ros build farm (#45 <https://github.com/PRBonn/rko_lio/issues/45>)
  * clean up ament target dependencies deprecation
  * update bonxai version
  * add bonxai core source to dependencies/bonxai with a check to include only on specific conditions
* Change package layout to make ros package release easier (#44 <https://github.com/PRBonn/rko_lio/issues/44>)
  * move ros/cmake and package xml out. merge core cmake into root cmake
  * build ros by default, but disable it for the python build
  * makefile recipe disables ros build by default for cpp only build
  * clean up ros workflows a bit
* Bump pypa/cibuildwheel from 3.1.4 to 3.2.0 (#42 <https://github.com/PRBonn/rko_lio/issues/42>)
  Bumps [pypa/cibuildwheel](https://github.com/pypa/cibuildwheel) from 3.1.4 to 3.2.0.
  - [Release notes](https://github.com/pypa/cibuildwheel/releases)
  - [Changelog](https://github.com/pypa/cibuildwheel/blob/main/docs/changelog.md)
  - [Commits](https://github.com/pypa/cibuildwheel/compare/v3.1.4...v3.2.0)
  ---
  updated-dependencies:
  - dependency-name: pypa/cibuildwheel
  dependency-version: 3.2.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Contributors: Meher Malladi, dependabot[bot]
```
