### PR TITLE
ros2_control: 5.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6914,7 +6914,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.6.0-1
+      version: 5.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.7.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.6.0-1`

## controller_interface

```
* Cleanup deprecations for kilted release (#2605 <https://github.com/ros-controls/ros2_control/issues/2605>)
* Add ControllerInterfaceParams to initialize the Controllers (#2390 <https://github.com/ros-controls/ros2_control/issues/2390>)
* Let get_ordered_interfaces throw if input vector size does not fit (#2528 <https://github.com/ros-controls/ros2_control/issues/2528>)
* Update message dependencies for tests (#2497 <https://github.com/ros-controls/ros2_control/issues/2497>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager

```
* [CM] Ability to switch controllers in non-realtime loop (#2452 <https://github.com/ros-controls/ros2_control/issues/2452>)
* Added parameters to handle the overruns behaviour and prints (#2546 <https://github.com/ros-controls/ros2_control/issues/2546>)
* [Controllers] Receive a valid period on the first update cycle (#2572 <https://github.com/ros-controls/ros2_control/issues/2572>)
* Add ControllerInterfaceParams to initialize the Controllers (#2390 <https://github.com/ros-controls/ros2_control/issues/2390>)
* Add parameter to allow controllers with inactive hardware components (#2501 <https://github.com/ros-controls/ros2_control/issues/2501>)
* Fix exclusive hardware control mode switching on controller failed activation (#1522 <https://github.com/ros-controls/ros2_control/issues/1522>)
* Fix the skipped cycles of controllers running at different rate (#2557 <https://github.com/ros-controls/ros2_control/issues/2557>)
* Fix shadowed variables, redefinition and old-style casts (#2569 <https://github.com/ros-controls/ros2_control/issues/2569>)
* [Spawner] Release the lock while waiting for the interrupt (#2559 <https://github.com/ros-controls/ros2_control/issues/2559>)
* Fix the reloading controller with failed activation (#2544 <https://github.com/ros-controls/ros2_control/issues/2544>)
* Don't print the overrun warnings for the simulations (#2539 <https://github.com/ros-controls/ros2_control/issues/2539>)
* Readd the ResourceManagerParams initialization to ControllerManager (#2522 <https://github.com/ros-controls/ros2_control/issues/2522>)
* Publish controller manager statistics to better introspect the timings (#2449 <https://github.com/ros-controls/ros2_control/issues/2449>)
* Fix the CPU affinity of the ros2_control_node (#2509 <https://github.com/ros-controls/ros2_control/issues/2509>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Cleanup deprecations for kilted release (#2605 <https://github.com/ros-controls/ros2_control/issues/2605>)
* [CM] Ability to switch controllers in non-realtime loop (#2452 <https://github.com/ros-controls/ros2_control/issues/2452>)
* Addition of Default Publisher for HardwareStatus Messages (#2476 <https://github.com/ros-controls/ros2_control/issues/2476>)
* Add ControllerInterfaceParams to initialize the Controllers (#2390 <https://github.com/ros-controls/ros2_control/issues/2390>)
* Add detach async policy for rate critical frameworks (#2477 <https://github.com/ros-controls/ros2_control/issues/2477>)
* Add parameter to allow controllers with inactive hardware components (#2501 <https://github.com/ros-controls/ros2_control/issues/2501>)
* Fix shadowed class member in GenericSystem (#2561 <https://github.com/ros-controls/ros2_control/issues/2561>)
* remove virtual from the add_measurement method (#2558 <https://github.com/ros-controls/ros2_control/issues/2558>)
* Fix the reloading controller with failed activation (#2544 <https://github.com/ros-controls/ros2_control/issues/2544>)
* Fix percentage calculation of Loaned*Interface warnings (#2542 <https://github.com/ros-controls/ros2_control/issues/2542>)
* Fix interface configuration docs (#2537 <https://github.com/ros-controls/ros2_control/issues/2537>)
* Publish controller manager statistics to better introspect the timings (#2449 <https://github.com/ros-controls/ros2_control/issues/2449>)
* Enable logger service for hardware component node (#2503 <https://github.com/ros-controls/ros2_control/issues/2503>)
* Fix runtime variant access bug in HardwareComponentInterface::get_command helper method (#2491 <https://github.com/ros-controls/ros2_control/issues/2491>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Soham Patil, bijoua29, vvel-tracpilot
```

## hardware_interface_testing

```
* Cleanup deprecations for kilted release (#2605 <https://github.com/ros-controls/ros2_control/issues/2605>)
* Add parameter to allow controllers with inactive hardware components (#2501 <https://github.com/ros-controls/ros2_control/issues/2501>)
* Fix exclusive hardware control mode switching on controller failed activation (#1522 <https://github.com/ros-controls/ros2_control/issues/1522>)
* Fix shadowed variables, redefinition and old-style casts (#2569 <https://github.com/ros-controls/ros2_control/issues/2569>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add detach async policy for rate critical frameworks (#2477 <https://github.com/ros-controls/ros2_control/issues/2477>)
* Contributors: Sai Kishor Kothakota
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
