### PR TITLE
laser_geometry: 2.11.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3393,7 +3393,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.11.1-1
+      version: 2.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.11.2-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.11.1-1`

## laser_geometry

```
* Use seconds in sensor_msgs::msg::LaserScan msg inside the test (#107 <https://github.com/ros-perception/laser_geometry/issues/107>)
* Use constructor of rclcpp::Time instead of conversion. (#91 <https://github.com/ros-perception/laser_geometry/issues/91>)
* fix cmake deprecation (#105 <https://github.com/ros-perception/laser_geometry/issues/105>)
* Contributors: AiVerisimilitude, Alejandro Hernández Cordero, mosfet80
```
