### PR TITLE
Bump version of liborocos-kdl for debian

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5248,8 +5248,6 @@ liborocos-kdl:
   debian:
     '*': [liborocos-kdl1.5]
     bullseye: [liborocos-kdl1.4]
-    buster: [liborocos-kdl1.4]
-    stretch: [liborocos-kdl1.3]
   fedora: [orocos-kdl]
   gentoo: [sci-libs/orocos_kdl]
   nixos: [orocos-kdl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5246,7 +5246,9 @@ liborocos-bfl-dev:
   ubuntu: [liborocos-bfl-dev]
 liborocos-kdl:
   debian:
-    '*': [liborocos-kdl1.4]
+    '*': [liborocos-kdl1.5]
+    bullseye: [liborocos-kdl1.4]
+    buster: [liborocos-kdl1.4]
     stretch: [liborocos-kdl1.3]
   fedora: [orocos-kdl]
   gentoo: [sci-libs/orocos_kdl]


### PR DESCRIPTION
liborocos-kdl1.4 is not available from bookworm onwards.

Some packages fail now because the vendor package was removed https://github.com/ros2/ros2/pull/1742

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/bookworm/liborocos-kdl1.5