### PR TITLE
kompass: 0.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4414,7 +4414,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.3.2-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## kompass

```
* (fix) Removes Scipy dependency from DriveManager
* (docs) Adds MapServer docs
* (feature) Adds map server for serving static global map
* Contributors: ahr, mkabtoul
```

## kompass_interfaces

```
* (feature) Adds map server for serving static global map
* Contributors: ahr, mkabtoul
```
