### PR TITLE
ros2_control: 4.38.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7947,7 +7947,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.37.0-1
+      version: 4.38.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.38.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.37.0-1`

## controller_interface

```
* Add ControllerInterfaceParams to initialize the Controllers (backport #2390 <https://github.com/ros-controls/ros2_control/issues/2390>) (#2601 <https://github.com/ros-controls/ros2_control/issues/2601>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Ability to switch controllers in non-realtime loop (backport #2452 <https://github.com/ros-controls/ros2_control/issues/2452>) (#2610 <https://github.com/ros-controls/ros2_control/issues/2610>)
* Add parameter to allow controllers with inactive hardware components (#2501 <https://github.com/ros-controls/ros2_control/issues/2501>) (#2584 <https://github.com/ros-controls/ros2_control/issues/2584>)
* Add ControllerInterfaceParams to initialize the Controllers (backport #2390 <https://github.com/ros-controls/ros2_control/issues/2390>) (#2601 <https://github.com/ros-controls/ros2_control/issues/2601>)
* [Controllers] Receive a valid period on the first update cycle (#2572 <https://github.com/ros-controls/ros2_control/issues/2572>) (#2602 <https://github.com/ros-controls/ros2_control/issues/2602>)
* Added parameters to handle the overruns behaviour and prints (#2546 <https://github.com/ros-controls/ros2_control/issues/2546>) (#2603 <https://github.com/ros-controls/ros2_control/issues/2603>)
* Fix exclusive hardware control mode switching on controller failed activation (#1522 <https://github.com/ros-controls/ros2_control/issues/1522>) (#2580 <https://github.com/ros-controls/ros2_control/issues/2580>)
* Fix the skipped cycles of controllers running at different rate (#2557 <https://github.com/ros-controls/ros2_control/issues/2557>) (#2573 <https://github.com/ros-controls/ros2_control/issues/2573>)
* Fix shadowed variables, redefinition and old-style casts (#2569 <https://github.com/ros-controls/ros2_control/issues/2569>) (#2570 <https://github.com/ros-controls/ros2_control/issues/2570>)
* [Spawner] Release the lock while waiting for the interrupt (#2559 <https://github.com/ros-controls/ros2_control/issues/2559>) (#2567 <https://github.com/ros-controls/ros2_control/issues/2567>)
* Fix the reloading controller with failed activation (#2544 <https://github.com/ros-controls/ros2_control/issues/2544>) (#2545 <https://github.com/ros-controls/ros2_control/issues/2545>)
* Don't print the overrun warnings for the simulations (#2539 <https://github.com/ros-controls/ros2_control/issues/2539>) (#2541 <https://github.com/ros-controls/ros2_control/issues/2541>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Ability to switch controllers in non-realtime loop (backport #2452 <https://github.com/ros-controls/ros2_control/issues/2452>) (#2610 <https://github.com/ros-controls/ros2_control/issues/2610>)
* Add parameter to allow controllers with inactive hardware components (#2501 <https://github.com/ros-controls/ros2_control/issues/2501>) (#2584 <https://github.com/ros-controls/ros2_control/issues/2584>)
* Add detach async policy for rate critical frameworks (backport #2477 <https://github.com/ros-controls/ros2_control/issues/2477>) (#2600 <https://github.com/ros-controls/ros2_control/issues/2600>)
* Add ControllerInterfaceParams to initialize the Controllers (backport #2390 <https://github.com/ros-controls/ros2_control/issues/2390>) (#2601 <https://github.com/ros-controls/ros2_control/issues/2601>)
* Silence -Wdeprecated-declarations of legacy wrappers (#2585 <https://github.com/ros-controls/ros2_control/issues/2585>)
* Fix shadowed class member in GenericSystem (#2561 <https://github.com/ros-controls/ros2_control/issues/2561>) (#2565 <https://github.com/ros-controls/ros2_control/issues/2565>)
* remove virtual from the add_measurement method (#2558 <https://github.com/ros-controls/ros2_control/issues/2558>) (#2562 <https://github.com/ros-controls/ros2_control/issues/2562>)
* Fix the reloading controller with failed activation (#2544 <https://github.com/ros-controls/ros2_control/issues/2544>) (#2545 <https://github.com/ros-controls/ros2_control/issues/2545>)
* Fix percentage calculation of Loaned*Interface warnings (#2542 <https://github.com/ros-controls/ros2_control/issues/2542>) (#2543 <https://github.com/ros-controls/ros2_control/issues/2543>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## hardware_interface_testing

```
* Add parameter to allow controllers with inactive hardware components (#2501 <https://github.com/ros-controls/ros2_control/issues/2501>) (#2584 <https://github.com/ros-controls/ros2_control/issues/2584>)
* Fix exclusive hardware control mode switching on controller failed activation (#1522 <https://github.com/ros-controls/ros2_control/issues/1522>) (#2580 <https://github.com/ros-controls/ros2_control/issues/2580>)
* Fix shadowed variables, redefinition and old-style casts (#2569 <https://github.com/ros-controls/ros2_control/issues/2569>) (#2570 <https://github.com/ros-controls/ros2_control/issues/2570>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add detach async policy for rate critical frameworks (backport #2477 <https://github.com/ros-controls/ros2_control/issues/2477>) (#2600 <https://github.com/ros-controls/ros2_control/issues/2600>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
