### PR TITLE
Add flatbuffers to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1168,6 +1168,12 @@ flac:
   nixos: [flac]
   openembedded: [flac@openembedded-core]
   ubuntu: [flac]
+flatbuffers:
+  arch: [flatbuffers]
+  debian: [libflatbuffers-dev]
+  fedora: [flatbuffers-devel]
+  gentoo: [dev-libs/flatbuffers]
+  ubuntu: [libflatbuffers-dev]
 flawfinder:
   arch: [flawfinder]
   debian: [flawfinder]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

flatbuffers

## Package Upstream Source:

https://github.com/google/flatbuffers

## Purpose of using this:

This dependency is a popular serialization library being used in some packages such as [Groot](https://github.com/BehaviorTree/Groot).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/sid/libflatbuffers-dev
- Ubuntu: https://launchpad.net/ubuntu/jammy/+package/libflatbuffers-dev
- Fedora: https://packages.fedoraproject.org/pkgs/flatbuffers/flatbuffers-devel/
- Arch: https://archlinux.org/packages/extra/x86_64/flatbuffers/
- Gentoo: https://packages.gentoo.org/packages/dev-libs/flatbuffers
