### PR TITLE
rmw_zenoh: 0.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6782,7 +6782,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.9.1-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.10.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.9.1-1`

## rmw_zenoh_cpp

```
* Change default value of ZENOH_SHM_ALLOC_SIZE to 48 MiB (#830 <https://github.com/ros2/rmw_zenoh/issues/830>)
* config: increase queries_default_timeout to 10min (#820 <https://github.com/ros2/rmw_zenoh/issues/820>)
* Fix compile with clang (#819 <https://github.com/ros2/rmw_zenoh/issues/819>)
* feat(logging): add contextual information to log messages (#809 <https://github.com/ros2/rmw_zenoh/issues/809>)
* Align the config with upstream Zenoh. (#785 <https://github.com/ros2/rmw_zenoh/issues/785>)
* fix: resolve memory leak when publishing with the default allocator (#797 <https://github.com/ros2/rmw_zenoh/issues/797>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Yuyuan Yuan, Yadunund
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

```
* Removed tinyxml2_vendor dependency (#829 <https://github.com/ros2/rmw_zenoh/issues/829>)
* Fix commands in zenoh_security_tools README (#814 <https://github.com/ros2/rmw_zenoh/issues/814>)
* Revert "fix: handle missing enclaves_dir argument for zenoh_security_tools (#…" (#802 <https://github.com/ros2/rmw_zenoh/issues/802>)
* Correct a description error in the zenoh_security_tools README (#789 <https://github.com/ros2/rmw_zenoh/issues/789>)
* fix: handle missing enclaves_dir argument for zenoh_security_tools (#788 <https://github.com/ros2/rmw_zenoh/issues/788>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Christophe Bedard, Yadunund
```
