### PR TITLE
rmw_zenoh: 0.6.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6787,7 +6787,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.5-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.4-1`

## rmw_zenoh_cpp

```
* Change default value of ZENOH_SHM_ALLOC_SIZE to 48 MiB (#831 <https://github.com/ros2/rmw_zenoh/issues/831>)
* Fix compile with clang (#821 <https://github.com/ros2/rmw_zenoh/issues/821>)
* config: increase queries_default_timeout to 10min (#824 <https://github.com/ros2/rmw_zenoh/issues/824>)
* feat(logging): add contextual information to log messages (#811 <https://github.com/ros2/rmw_zenoh/issues/811>)
* Align the config with upstream Zenoh. (#803 <https://github.com/ros2/rmw_zenoh/issues/803>)
* fix: resolve memory leak when publishing with the default allocator (#799 <https://github.com/ros2/rmw_zenoh/issues/799>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Yadunund, Yuyuan Yuan
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

```
* Fix commands in zenoh_security_tools README (#815 <https://github.com/ros2/rmw_zenoh/issues/815>)
* Revert "fix: handle missing enclaves_dir argument for zenoh_security_tools" (#806 <https://github.com/ros2/rmw_zenoh/issues/806>)
* fix: handle missing enclaves_dir argument for zenoh_security_tools (#790 <https://github.com/ros2/rmw_zenoh/issues/790>)
* Correct a description error in the zenoh_security_tools README (#793 <https://github.com/ros2/rmw_zenoh/issues/793>)
* Contributors: Barry Xu, Christophe Bedard, Yadunund
```
