### PR TITLE
rmw_zenoh: 0.2.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7784,7 +7784,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.2.7-1
+      version: 0.2.8-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.2.8-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.7-1`

## rmw_zenoh_cpp

```
* Change default value of ZENOH_SHM_ALLOC_SIZE to 48 MiB (`#832 https://github.com/ros2/rmw_zenoh/issues/832>`_)
* config: increase queries_default_timeout to 10min (#825 <https://github.com/ros2/rmw_zenoh/issues/825>)
* Fix compile with clang (#822 <https://github.com/ros2/rmw_zenoh/issues/822>)
* feat(logging): add contextual information to log messages (#812 <https://github.com/ros2/rmw_zenoh/issues/812>)
* Align the config with upstream Zenoh. (#804 <https://github.com/ros2/rmw_zenoh/issues/804>)
* fix: resolve memory leak when publishing with the default allocator (#800 <https://github.com/ros2/rmw_zenoh/issues/800>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Yadunund, Yuyuan Yuan
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

```
* Fix commands in zenoh_security_tools README (#816 <https://github.com/ros2/rmw_zenoh/issues/816>)
* Revert "fix: handle missing enclaves_dir argument for zenoh_security_tools" (#807 <https://github.com/ros2/rmw_zenoh/issues/807>)
* Correct a description error in the zenoh_security_tools README (#794 <https://github.com/ros2/rmw_zenoh/issues/794>)
* fix: handle missing enclaves_dir argument for zenoh_security_tools (#791 <https://github.com/ros2/rmw_zenoh/issues/791>)
* Contributors: Barry Xu, Christophe Bedard, Yadunund
i
0.2.7 (2025-09-10)
------------------
* SROS: add ACL rules for TRANSIENT_LOCAL pub/sub (fix #753 <https://github.com/ros2/rmw_zenoh/issues/753>) (#781 <https://github.com/ros2/rmw_zenoh/issues/781>)
* Fix handling of enclave path in zenoh_security_tools (#772 <https://github.com/ros2/rmw_zenoh/issues/772>)
* Contributors: Julien Enoch, Yadunund
```
