### PR TITLE
rmw_zenoh: 0.1.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8774,7 +8774,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.1.6-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.1.7-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.6-1`

## rmw_zenoh_cpp

```
* Change default value of ZENOH_SHM_ALLOC_SIZE to 48 MiB (#833 <https://github.com/ros2/rmw_zenoh/issues/833>)
* config: increase queries_default_timeout to 10min (#826 <https://github.com/ros2/rmw_zenoh/issues/826>)
* Fix compile with clang (#823 <https://github.com/ros2/rmw_zenoh/issues/823>)
* Align the config with upstream Zenoh. (#805 <https://github.com/ros2/rmw_zenoh/issues/805>)
* fix: resolve memory leak when publishing with the default allocator (#801 <https://github.com/ros2/rmw_zenoh/issues/801>)
* Contributors: ChenYing Kuo (CY), Julien Enoch, Yadunund, Yuyuan Yuan
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

```
* Fix commands in zenoh_security_tools README (#817 <https://github.com/ros2/rmw_zenoh/issues/817>)
* Correct a description error in the zenoh_security_tools README (#795 <https://github.com/ros2/rmw_zenoh/issues/795>)
* Revert "fix: handle missing enclaves_dir argument for zenoh_security_tools" (#808 <https://github.com/ros2/rmw_zenoh/issues/808>)
* fix: handle missing enclaves_dir argument for zenoh_security_tools (#792 <https://github.com/ros2/rmw_zenoh/issues/792>)
* Contributors: Barry Xu, Christophe Bedard, Yadunund
```
