### PR TITLE
mola_state_estimation: 1.11.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4187,7 +4187,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.10.0-1
+      version: 1.11.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.11.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.10.0-1`

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Move mola_imu_preintegration out of this repo
  The new repository is: https://github.com/MOLAorg/mola_imu_preintegration
* Merge pull request #4 <https://github.com/MOLAorg/mola_state_estimation/issues/4> from MOLAorg/feature/imu
  Refactor IMU library
* Fix using new IMU integration API
* Move LocalVelocityBuffer class here from mp2p_icp repository
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Move LocalVelocityBuffer class here from mp2p_icp repository
* Contributors: Jose Luis Blanco-Claraco
```
