### PR TITLE
rosidl: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7441,7 +7441,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.0.1-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.1-1`

## rosidl_adapter

```
* Fix @optional for string literals (#905 <https://github.com/ros2/rosidl/issues/905>)
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Add Optional Parsing (#883 <https://github.com/ros2/rosidl/issues/883>)
* Contributors: Michael Carlstrom
```

## rosidl_cli

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Contributors: Michael Carlstrom
```

## rosidl_cmake

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* remove deprecated rosidl_target_interfaces. (#898 <https://github.com/ros2/rosidl/issues/898>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```

## rosidl_generator_c

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Contributors: Michael Carlstrom
```

## rosidl_generator_cpp

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Add static_cast (#884 <https://github.com/ros2/rosidl/issues/884>)
* Contributors: Michael Carlstrom
```

## rosidl_generator_type_description

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Contributors: Michael Carlstrom
```

## rosidl_parser

```
* Add Optional Parsing (#883 <https://github.com/ros2/rosidl/issues/883>)
* Contributors: Michael Carlstrom
```

## rosidl_pycommon

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Provide base classes in rosidl_pycommon (#887 <https://github.com/ros2/rosidl/issues/887>)
* Contributors: Michael Carlstrom
```

## rosidl_runtime_c

```
* Fix copy/paste errors in type support docs (#906 <https://github.com/ros2/rosidl/issues/906>)
* Contributors: Christophe Bedard
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Contributors: Michael Carlstrom
```

## rosidl_typesupport_introspection_cpp

```
* Export typing Information (#903 <https://github.com/ros2/rosidl/issues/903>)
* Contributors: Michael Carlstrom
```
