### PR TITLE
realtime_tools: 4.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6260,7 +6260,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.6.0-1
+      version: 4.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.7.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.6.0-1`

## realtime_tools

```
* Update docstrings of RT publisher (#424 <https://github.com/ros-controls/realtime_tools/issues/424>)
* Deprecate get_msg method of RT publisher (#422 <https://github.com/ros-controls/realtime_tools/issues/422>)
* Deprecate msg_ field (#421 <https://github.com/ros-controls/realtime_tools/issues/421>)
* Add get_params method to the AsyncFunctionHandler (#419 <https://github.com/ros-controls/realtime_tools/issues/419>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
