### PR TITLE
realtime_tools: 3.10.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7292,7 +7292,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.9.0-1
+      version: 3.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.10.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.0-1`

## realtime_tools

```
* Add get_params method to the AsyncFunctionHandler (backport #419 <https://github.com/ros-controls/realtime_tools/issues/419>) (#420 <https://github.com/ros-controls/realtime_tools/issues/420>)
* Contributors: mergify[bot]
```
