### PR TITLE
realtime_tools: 4.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6294,7 +6294,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: master
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -6303,7 +6303,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
-      version: master
+      version: kilted
     status: maintained
   resource_retriever:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6299,7 +6299,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.6.0-1
+      version: 4.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.7.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.6.0-1`

## realtime_tools

```
* Update docstrings of RT publisher (#424 <https://github.com/ros-controls/realtime_tools/issues/424>)
* Deprecate get_msg method of RT publisher (#422 <https://github.com/ros-controls/realtime_tools/issues/422>)
* Deprecate msg_ field (#421 <https://github.com/ros-controls/realtime_tools/issues/421>)
* Add get_params method to the AsyncFunctionHandler (#419 <https://github.com/ros-controls/realtime_tools/issues/419>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
