### PR TITLE
rosidl_python: 0.24.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7589,7 +7589,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.24.1-2
+      version: 0.24.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.24.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.24.1-2`

## rosidl_generator_py

```
* [kilted] Remove redudant numpy.array() backport #232 <https://github.com/ros2/rosidl_python/issues/232> #236 <https://github.com/ros2/rosidl_python/issues/236>
* Contributors: Michael Carlstrom
```
