### PR TITLE
rosidl_python: 0.22.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8621,7 +8621,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.22.1-1
+      version: 0.22.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.22.2-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.22.1-1`

## rosidl_generator_py

```
* [kilted] Remove redudant numpy.array() backport #232 <https://github.com/ros2/rosidl_python/issues/232> #236 <https://github.com/ros2/rosidl_python/issues/236> (#239 <https://github.com/ros2/rosidl_python/issues/239>)
* Contributors: mergify[bot]
```
