### PR TITLE
launch: 3.8.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3456,7 +3456,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.3-1
+      version: 3.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.8.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.3-1`

## launch

```
* Allow providing launch args to include using let in frontends (#848 <https://github.com/ros2/launch/issues/848>) (#909 <https://github.com/ros2/launch/issues/909>)
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Allow providing launch args to include using let in frontends (#848 <https://github.com/ros2/launch/issues/848>) (#909 <https://github.com/ros2/launch/issues/909>)
* Contributors: mergify[bot]
```

## launch_yaml

```
* Allow providing launch args to include using let in frontends (#848 <https://github.com/ros2/launch/issues/848>) (#909 <https://github.com/ros2/launch/issues/909>)
* Contributors: mergify[bot]
```
