### PR TITLE
Add ros2_fmt_logger to index

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6989,6 +6989,16 @@ repositories:
       url: https://github.com/felixdivo/ros2-easy-test.git
       version: main
     status: developed
+  ros2_fmt_logger:
+    doc:
+      type: git
+      url: https://github.com/nobleo/ros2_fmt_logger.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/nobleo/ros2_fmt_logger.git
+      version: main
+    status: developed
   ros2_kortex:
     doc:
       type: git


### PR DESCRIPTION

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/nobleo/ros2_fmt_logger

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
