### PR TITLE
rosidl_core: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7460,7 +7460,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_core-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_core` to `0.4.1-1`:

- upstream repository: https://github.com/ros2/rosidl_core.git
- release repository: https://github.com/ros2-gbp/rosidl_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-1`

## rosidl_core_generators

```
* Revert "Revert "Added rosidl_generator_rs (#7 <https://github.com/ros2/rosidl_core/issues/7>)" (#8 <https://github.com/ros2/rosidl_core/issues/8>)" (#9 <https://github.com/ros2/rosidl_core/issues/9>)
* fix cmake deprecation (#10 <https://github.com/ros2/rosidl_core/issues/10>)
* Contributors: Esteve Fernandez, mosfet80
```

## rosidl_core_runtime

```
* fix cmake deprecation (#10 <https://github.com/ros2/rosidl_core/issues/10>)
* Contributors: mosfet80
```
