### PR TITLE
laser_geometry: 2.10.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3402,7 +3402,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.10.1-1
+      version: 2.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.10.2-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.10.1-1`

## laser_geometry

```
* Use constructor of rclcpp::Time instead of conversion. (#91 <https://github.com/ros-perception/laser_geometry/issues/91>) (#112 <https://github.com/ros-perception/laser_geometry/issues/112>)
* Use seconds in sensor_msgs::msg::LaserScan msg inside the test (#107 <https://github.com/ros-perception/laser_geometry/issues/107>) (#109 <https://github.com/ros-perception/laser_geometry/issues/109>)
* fix cmake deprecation (#105 <https://github.com/ros-perception/laser_geometry/issues/105>) (#108 <https://github.com/ros-perception/laser_geometry/issues/108>)
* Contributors: mergify[bot]
```
