### PR TITLE
laser_geometry: 2.7.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4067,7 +4067,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.7.1-1
+      version: 2.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.7.2-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.1-1`

## laser_geometry

```
* Use constructor of rclcpp::Time instead of conversion. (#91 <https://github.com/ros-perception/laser_geometry/issues/91>) (#113 <https://github.com/ros-perception/laser_geometry/issues/113>)
* Use seconds in sensor_msgs::msg::LaserScan msg inside the test (#107 <https://github.com/ros-perception/laser_geometry/issues/107>) (#110 <https://github.com/ros-perception/laser_geometry/issues/110>)
* Contributors: mergify[bot]
```
