### PR TITLE
laser_geometry: 2.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4546,7 +4546,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.4.0-2
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.4.1-1`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-2`

## laser_geometry

```
* Use constructor of rclcpp::Time instead of conversion operator (backport #91 <https://github.com/ros-perception/laser_geometry/issues/91>) (#114 <https://github.com/ros-perception/laser_geometry/issues/114>)
* Use seconds in sensor_msgs::msg::LaserScan msg inside the test (#107 <https://github.com/ros-perception/laser_geometry/issues/107>) (#111 <https://github.com/ros-perception/laser_geometry/issues/111>)
* Contributors: mergify[bot]
```
