### PR TITLE
plotjuggler: 3.13.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5369,7 +5369,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.13.1-1
+      version: 3.13.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.13.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.13.1-1`

## plotjuggler

```
* Fix issue #1194 <https://github.com/facontidavide/PlotJuggler/issues/1194>
* address issue #1195 <https://github.com/facontidavide/PlotJuggler/issues/1195>
* fix issue #1193 <https://github.com/facontidavide/PlotJuggler/issues/1193>
* bug fix
* Contributors: Davide Faconti
```
