### PR TITLE
plotjuggler: 3.13.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6271,7 +6271,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.10.11-1
+      version: 3.13.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.13.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.10.11-1`

## plotjuggler

```
* Fix issue #1194 <https://github.com/facontidavide/PlotJuggler/issues/1194>
* address issue #1195 <https://github.com/facontidavide/PlotJuggler/issues/1195>
* fix issue #1193 <https://github.com/facontidavide/PlotJuggler/issues/1193>
* bug fix
* Contributors: Davide Faconti
```
