### PR TITLE
rko_lio: 0.1.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6328,7 +6328,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rko_lio-release.git
-      version: 0.1.4-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/PRBonn/rko_lio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.1.6-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.4-1`

## rko_lio

```
* make fPIC a property target ON instead of a global build flag
* drop cmake min version to 3.22.0
* clean up bonxai finding and mocking a bit
* force include bonxai code when not fetching
* Contributors: Meher Malladi
```
