### PR TITLE
rko_lio: 0.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8352,6 +8352,21 @@ repositories:
       url: https://github.com/teamspatzenhirn/rig_reconfigure.git
       version: master
     status: developed
+  rko_lio:
+    doc:
+      type: git
+      url: https://github.com/PRBonn/rko_lio.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rko_lio-release.git
+      version: 0.1.6-1
+    source:
+      type: git
+      url: https://github.com/PRBonn/rko_lio.git
+      version: master
+    status: developed
   rmf_api_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.1.6-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rko_lio

```
* make fPIC a property target ON instead of a global build flag
* drop cmake min version to 3.22.0
* clean up bonxai finding and mocking a bit
* force include bonxai code when not fetching
* Contributors: Meher Malladi
```
