### PR TITLE
Remove topic_based_ros2_control from distros

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10269,12 +10269,6 @@ repositories:
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
     status: developed
-  topic_based_ros2_control:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.3.0-4
   topic_tools:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9107,12 +9107,6 @@ repositories:
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
     status: developed
-  topic_based_ros2_control:
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-3
   topic_tools:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9051,12 +9051,6 @@ repositories:
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
       version: main
     status: developed
-  topic_based_ros2_control:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/topic_based_ros2_control-release.git
-      version: 0.2.0-2
   topic_tools:
     doc:
       type: git


### PR DESCRIPTION
This PR is to remove the unmaintained package [topic_based_ros2_control](https://github.com/PickNikRobotics/topic_based_ros2_control) which has moved to [topic_based_hardware_interfaces](https://github.com/ros-controls/topic_based_hardware_interfaces) and has been released to Jazzy, Kilted, and Rolling.