### PR TITLE
live555_vendor: 0.20250917.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3744,7 +3744,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/live555_vendor-release.git
-      version: 0.20250719.0-1
+      version: 0.20250917.0-1
     source:
       type: git
       url: https://github.com/fkie/live555_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `live555_vendor` to `0.20250917.0-1`:

- upstream repository: https://github.com/fkie/live555_vendor.git
- release repository: https://github.com/ros2-gbp/live555_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.20250719.0-1`

## live555_vendor

```
* Update to live555 version 2025.09.17
* Fix generator expression for LIVE555_ALLOW_SERVER_PORT_REUSE
* Contributors: Timo Röhling
```
