### PR TITLE
pluginlib: 5.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5411,10 +5411,13 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: rolling
     release:
+      packages:
+      - pluginlib
+      - ros2plugin
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.7.0-1
+      version: 5.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.8.0-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.7.0-1`

## pluginlib

```
* refactor: replace regex with find_last_of to split plugin name (#271 <https://github.com/ros/pluginlib/issues/271>)
* Removed tinyxml2_vendor dependency (#274 <https://github.com/ros/pluginlib/issues/274>)
* Add ros2plugin (#165 <https://github.com/ros/pluginlib/issues/165>)
* Contributors: Alejandro Hernández Cordero, Jeremie Deray, ipa-fez
```

## ros2plugin

```
* Add ros2plugin (#165 <https://github.com/ros/pluginlib/issues/165>)
* Contributors: Jeremie Deray
```
