### PR TITLE
python_qt_binding: 2.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5802,7 +5802,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.3.1-2
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.3.2-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.1-2`

## python_qt_binding

```
* fix setuptools deprecation (#151 <https://github.com/ros-visualization/python_qt_binding/issues/151>) (#153 <https://github.com/ros-visualization/python_qt_binding/issues/153>)
* fix cmake deprecation (#150 <https://github.com/ros-visualization/python_qt_binding/issues/150>) (#152 <https://github.com/ros-visualization/python_qt_binding/issues/152>)
* Remove the mirror-rolling-to-main workflow. (#145 <https://github.com/ros-visualization/python_qt_binding/issues/145>)
* Remove CODEOWNERS (#144 <https://github.com/ros-visualization/python_qt_binding/issues/144>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, mergify[bot]
```
