### PR TITLE
python_qt_binding: 2.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6699,7 +6699,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.2.2-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## python_qt_binding

```
* fix setuptools deprecation (#151 <https://github.com/ros-visualization/python_qt_binding/issues/151>) (#154 <https://github.com/ros-visualization/python_qt_binding/issues/154>)
* Remove CODEOWNERS (#144 <https://github.com/ros-visualization/python_qt_binding/issues/144>) (#146 <https://github.com/ros-visualization/python_qt_binding/issues/146>)
* Contributors: mergify[bot]
```
