### PR TITLE
python_qt_binding: 1.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7714,7 +7714,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `1.1.3-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.2-1`

## python_qt_binding

```
* fix setuptools deprecation (#151 <https://github.com/ros-visualization/python_qt_binding/issues/151>) (#155 <https://github.com/ros-visualization/python_qt_binding/issues/155>)
* Contributors: mergify[bot]
```
