### PR TITLE
ros2_tracing: 8.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7077,7 +7077,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.8.1-1
+      version: 8.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.9.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.8.1-1`

## lttngpy

```
* Allow creating snapshot sessions (#195 <https://github.com/ros2/ros2_tracing/issues/195>)
* [Fix] compile fail (#194 <https://github.com/ros2/ros2_tracing/issues/194>)
* Use pybind11 from deb or pixi (#197 <https://github.com/ros2/ros2_tracing/issues/197>)
* Add support for starting tracing at runtime (#191 <https://github.com/ros2/ros2_tracing/issues/191>)
* Contributors: Alejandro Hernández Cordero, Shravan Deva, mosfet80
```

## ros2trace

```
* Update trace command's doc-string (#213 <https://github.com/ros2/ros2_tracing/issues/213>)
* Allow creating snapshot sessions (#195 <https://github.com/ros2/ros2_tracing/issues/195>)
* Add support for starting tracing at runtime (#191 <https://github.com/ros2/ros2_tracing/issues/191>)
* Contributors: Shravan Deva
```

## tracetools

```
* Add runtime tracing opt-out mechanism (#185 <https://github.com/ros2/ros2_tracing/issues/185>)
* Contributors: Michel Hidalgo
```

## tracetools_launch

```
* Add example launch files for snapshot mode (#206 <https://github.com/ros2/ros2_tracing/issues/206>)
* Allow creating snapshot sessions (#195 <https://github.com/ros2/ros2_tracing/issues/195>)
* Add launch files with preconfigured dual session (#196 <https://github.com/ros2/ros2_tracing/issues/196>)
* Add support for starting tracing at runtime (#191 <https://github.com/ros2/ros2_tracing/issues/191>)
* Contributors: Shravan Deva
```

## tracetools_read

- No changes

## tracetools_test

```
* Only check test process events in test_runtime_disable (#193 <https://github.com/ros2/ros2_tracing/issues/193>)
* Contributors: Christophe Bedard
```

## tracetools_trace

```
* Use overwrite mode for snapshot sessions (#210 <https://github.com/ros2/ros2_tracing/issues/210>)
* Allow creating snapshot sessions (#195 <https://github.com/ros2/ros2_tracing/issues/195>)
* Add support for starting tracing at runtime (#191 <https://github.com/ros2/ros2_tracing/issues/191>)
* Contributors: Shravan Deva
```
