### PR TITLE
qt_gui_core: 2.10.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5816,7 +5816,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.10.1-1
+      version: 2.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.10.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.10.1-1`

## qt_dotgraph

```
* Fix setupTools deprecations (#308 <https://github.com/ros-visualization/qt_gui_core/issues/308>)
* Contributors: mosfet80
```

## qt_gui

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>)
* Contributors: mosfet80
```

## qt_gui_app

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>)
* Contributors: mosfet80
```

## qt_gui_core

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>)
* Contributors: mosfet80
```

## qt_gui_cpp

```
* Removed tinyxml2_vendor dependency (#309 <https://github.com/ros-visualization/qt_gui_core/issues/309>)
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## qt_gui_py_common

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>)
* Contributors: mosfet80
```
