### PR TITLE
qt_gui_core: 2.9.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5851,7 +5851,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.9.1-1
+      version: 2.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.9.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.1-1`

## qt_dotgraph

```
* Fix setupTools deprecations (#308 <https://github.com/ros-visualization/qt_gui_core/issues/308>) (#311 <https://github.com/ros-visualization/qt_gui_core/issues/311>)
* Contributors: mergify[bot]
```

## qt_gui

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>) (#310 <https://github.com/ros-visualization/qt_gui_core/issues/310>)
* Contributors: mergify[bot]
```

## qt_gui_app

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>) (#310 <https://github.com/ros-visualization/qt_gui_core/issues/310>)
* Contributors: mergify[bot]
```

## qt_gui_core

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>) (#310 <https://github.com/ros-visualization/qt_gui_core/issues/310>)
* Contributors: mergify[bot]
```

## qt_gui_cpp

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>) (#310 <https://github.com/ros-visualization/qt_gui_core/issues/310>)
* Contributors: mergify[bot]
```

## qt_gui_py_common

```
* Fix cmake deprecations (#307 <https://github.com/ros-visualization/qt_gui_core/issues/307>) (#310 <https://github.com/ros-visualization/qt_gui_core/issues/310>)
  cmake version < then 3.10 is deprecated
  (cherry picked from commit 9635717a56d1c034ae0c6d4ef0280b7ddbfb8801)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```
