### PR TITLE
rqt: 1.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7757,7 +7757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.10.0-1
+      version: 1.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.10.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.10.0-1`

## rqt

- No changes

## rqt_gui

```
* Fix setupTools deprecations (#322 <https://github.com/ros-visualization/rqt/issues/322>)
* Contributors: mosfet80
```

## rqt_gui_cpp

```
* fix compile with qt6 (#321 <https://github.com/ros-visualization/rqt/issues/321>)
* Contributors: mosfet80
```

## rqt_gui_py

```
* Fix setupTools deprecations (#322 <https://github.com/ros-visualization/rqt/issues/322>)
* Contributors: mosfet80
```

## rqt_py_common

```
* fix compile with qt6 (#321 <https://github.com/ros-visualization/rqt/issues/321>)
* Contributors: mosfet80
```
