### PR TITLE
rqt: 1.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8802,7 +8802,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.6.0-2
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.6.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-2`

## rqt

- No changes

## rqt_gui

```
* Fix setupTools deprecations (backport #322 <https://github.com/ros-visualization/rqt/issues/322>) (#327 <https://github.com/ros-visualization/rqt/issues/327>)
* Contributors: mergify[bot]
```

## rqt_gui_cpp

- No changes

## rqt_gui_py

```
* Fix setupTools deprecations (backport #322 <https://github.com/ros-visualization/rqt/issues/322>) (#327 <https://github.com/ros-visualization/rqt/issues/327>)
* Contributors: mergify[bot]
```

## rqt_py_common

- No changes
