### PR TITLE
mola_imu_preintegration: 1.12.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4151,7 +4151,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.11.0-1
+      version: 1.12.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.12.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.11.0-1`

## mola_imu_preintegration

```
* FIX: May leave trajectory poses without populating raw IMU data
* ImuInitialCalibrator: Use IMU orientation, if available
* LocalVelocityBuffer: reduce default max_time_window to 0.5 s
* ImuIntegrationParams: Add save_to() method, and finish missing load_from() fields
* Fix comment typos
* Readme: Add missing ROS build farm badges for bin packages
* Contributors: Jose Luis Blanco-Claraco
```
