### PR TITLE
Add mp_units_vendor to index

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4363,6 +4363,16 @@ repositories:
       url: https://github.com/MOLAorg/mp2p_icp.git
       version: develop
     status: developed
+  mp_units_vendor:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mp_units_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/nobleo/mp_units_vendor.git
+      version: main
+    status: maintained
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/nobleo/mp_units_vendor.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
