### PR TITLE
gz_gui_vendor: 0.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2641,7 +2641,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
-      version: 0.2.1-2
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_gui_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_gui_vendor.git
- release repository: https://github.com/ros2-gbp/gz_gui_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-2`

## gz_gui_vendor

```
* Merge pull request #8 <https://github.com/gazebo-release/gz_gui_vendor/issues/8> from gazebo-release/releasepy/rolling/10.0.0
  Bump version to 10.0.0
* Bump version to 10.0.0
* Add dsv for PYTHONPATH for Jetty packages (#7 <https://github.com/gazebo-release/gz_gui_vendor/issues/7>)
* Contributors: Carlos Agüero, Jose Luis Rivero, Steve Peters
```
