### PR TITLE
Add qt6-scxml-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8865,6 +8865,19 @@ qt6-multimedia-dev:
   ubuntu:
     '*': [qt6-multimedia-dev]
     'focal': null
+qt6-scxml-dev:
+  arch: [qt6-scxml]
+  debian: [qt6-scxml-dev]
+  fedora: [qt6-qtscxml-devel]
+  gentoo: ['dev-qt/qtscxml:6']
+  nixos: [qt6.qtscxml]
+  openembedded: [qtscxml@meta-qt6]
+  rhel:
+    '*': [qt6-qtscxml-devel]
+    '8': null
+  ubuntu:
+    '*': [qt6-scxml-dev]
+    'focal': null
 qtbase5-dev:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8870,7 +8870,6 @@ qt6-scxml-dev:
   debian: [qt6-scxml-dev]
   fedora: [qt6-qtscxml-devel]
   gentoo: ['dev-qt/qtscxml:6']
-  nixos: [qt6.qtscxml]
   openembedded: [qtscxml@meta-qt6]
   rhel:
     '*': [qt6-qtscxml-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- `qt6-scxml-dev`


## Package Upstream Source:

https://github.com/qt/qtscxml/

## Purpose of using this:

Needed by Navigation2, specifically `nav2_rviz_plugins`

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qt6-scxml-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qt6-scxml-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtscxml/qt6-qtscxml-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?q=qt6-scxml
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtscxml
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtscxml-devel
- OpenEmbedded: https://layers.openembedded.org/layerindex/recipe/348215/
