### PR TITLE
add luigi to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7210,6 +7210,10 @@ python3-lttng:
     '*': [python3-lttng]
     '7': null
   ubuntu: [python3-lttng]
+python3-luigi-pip:
+  '*':
+    pip:
+      packages: [luigi]
 python3-lxml:
   alpine: [py3-lxml]
   arch: [python-lxml]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

luigi

## Package Upstream Source:

[link to source repository](https://github.com/spotify/luigi.git)

## Purpose of using this:

To make batch processing of bagfiles easier

Distro packaging links:

## Links to Distribution Packages

- PyPi: [https://pypi.org/project/luigi/](https://pypi.org/project/luigi/)