### PR TITLE
ros2_fmt_logger: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7017,6 +7017,11 @@ repositories:
       type: git
       url: https://github.com/nobleo/ros2_fmt_logger.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/nobleo/ros2_fmt_logger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_fmt_logger` to `1.0.0-1`:

- upstream repository: https://github.com/nobleo/ros2_fmt_logger.git
- release repository: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ros2_fmt_logger

```
* Initial implementation for a proper ros2 logger using fmtlib
* Contributors: Tim Clephas
```
