### PR TITLE
mp_units_vendor: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4368,6 +4368,11 @@ repositories:
       type: git
       url: https://github.com/nobleo/mp_units_vendor.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mp_units_vendor-release.git
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/nobleo/mp_units_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp_units_vendor` to `2.4.0-1`:

- upstream repository: https://github.com/nobleo/mp_units_vendor.git
- release repository: https://github.com/ros2-gbp/mp_units_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
