### PR TITLE
Add Qt6 Gui, Widgets, Statemachine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6254,7 +6254,7 @@ libqt6-gui:
   debian: [libqt6gui6]
   fedora: [qt6-qtbase-gui]
   rhel:
-    '*': [qt6-qtbase]
+    '*': [qt6-qtbase-gui]
     '8': null
   ubuntu:
     '*': [libqt6gui6t64]
@@ -6307,7 +6307,6 @@ libqt6-statemachine:
 libqt6-widgets:
   arch: [qt6-base]
   debian: [libqt6widgets6]
-  fedora: [qt6-qtbase-gui]
   rhel:
     '*': [qt6-qtbase]
     '8': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6249,6 +6249,13 @@ libqt6-core:
     '*': [libqt6core6t64]
     'focal': null
     'jammy': [libqt6core6]
+libqt6-gui:
+  debian: [libqt6gui6]
+  fedora: [qt6-qtbase-gui]
+  ubuntu:
+    '*': [libqt6gui6t64]
+    'focal': null
+    'jammy': [libqt6gui6]
 libqt6-multimedia:
   arch: [qt6-multimedia]
   debian: [libqt6multimedia6]
@@ -6284,6 +6291,17 @@ libqt6-quick:
   ubuntu:
     '*': [libqt6quick6]
     'focal': null
+libqt6-statemachine:
+  debian: [libqt6statemachine6]
+  ubuntu:
+    '*': [libqt6statemachine6]
+    'focal': null
+libqt6-widgets:
+  debian: [libqt6widgets6]
+  ubuntu:
+    '*': [libqt6widgets6t64]
+    'focal': null
+    'jammy': [libqt6widgets6]
 libqt6bluetooth6:
   alpine: [qt6-qtconnectivity]
   arch: [qt6-connectivity]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6307,6 +6307,7 @@ libqt6-statemachine:
 libqt6-widgets:
   arch: [qt6-base]
   debian: [libqt6widgets6]
+  fedora: [qt6-qtbase-gui]
   rhel:
     '*': [qt6-qtbase]
     '8': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6250,8 +6250,12 @@ libqt6-core:
     'focal': null
     'jammy': [libqt6core6]
 libqt6-gui:
+  arch: [qt6-base]
   debian: [libqt6gui6]
   fedora: [qt6-qtbase-gui]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
   ubuntu:
     '*': [libqt6gui6t64]
     'focal': null
@@ -6292,12 +6296,20 @@ libqt6-quick:
     '*': [libqt6quick6]
     'focal': null
 libqt6-statemachine:
+  arch: [qt6-scxml]
   debian: [libqt6statemachine6]
+  rhel:
+    '*': [qt6-qtscxml-devel]
+    '8': null
   ubuntu:
     '*': [libqt6statemachine6]
     'focal': null
 libqt6-widgets:
+  arch: [qt6-base]
   debian: [libqt6widgets6]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
   ubuntu:
     '*': [libqt6widgets6t64]
     'focal': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6249,17 +6249,6 @@ libqt6-core:
     '*': [libqt6core6t64]
     'focal': null
     'jammy': [libqt6core6]
-libqt6-gui:
-  arch: [qt6-base]
-  debian: [libqt6gui6]
-  fedora: [qt6-qtbase-gui]
-  rhel:
-    '*': [qt6-qtbase-gui]
-    '8': null
-  ubuntu:
-    '*': [libqt6gui6t64]
-    'focal': null
-    'jammy': [libqt6gui6]
 libqt6-multimedia:
   arch: [qt6-multimedia]
   debian: [libqt6multimedia6]
@@ -6295,25 +6284,6 @@ libqt6-quick:
   ubuntu:
     '*': [libqt6quick6]
     'focal': null
-libqt6-statemachine:
-  arch: [qt6-scxml]
-  debian: [libqt6statemachine6]
-  rhel:
-    '*': [qt6-qtscxml-devel]
-    '8': null
-  ubuntu:
-    '*': [libqt6statemachine6]
-    'focal': null
-libqt6-widgets:
-  arch: [qt6-base]
-  debian: [libqt6widgets6]
-  rhel:
-    '*': [qt6-qtbase]
-    '8': null
-  ubuntu:
-    '*': [libqt6widgets6t64]
-    'focal': null
-    'jammy': [libqt6widgets6]
 libqt6bluetooth6:
   alpine: [qt6-qtconnectivity]
   arch: [qt6-connectivity]
@@ -6325,6 +6295,26 @@ libqt6bluetooth6:
     '8': null
   ubuntu:
     '*': [libqt6bluetooth6]
+    'focal': null
+libqt6gui6t64:
+  arch: [qt6-base]
+  debian: [libqt6gui6]
+  fedora: [qt6-qtbase-gui]
+  rhel:
+    '*': [qt6-qtbase-gui]
+    '8': null
+  ubuntu:
+    '*': [libqt6gui6t64]
+    'focal': null
+    'jammy': [libqt6gui6]
+libqt6statemachine6:
+  arch: [qt6-scxml]
+  debian: [libqt6statemachine6]
+  rhel:
+    '*': [qt6-qtscxml-devel]
+    '8': null
+  ubuntu:
+    '*': [libqt6statemachine6]
     'focal': null
 libqt6svg6:
   alpine: [qt6-qtsvg]
@@ -6339,6 +6329,16 @@ libqt6svg6:
   ubuntu:
     '*': [libqt6svg6]
     'focal': null
+libqt6widgets6t64:
+  arch: [qt6-base]
+  debian: [libqt6widgets6]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+  ubuntu:
+    '*': [libqt6widgets6t64]
+    'focal': null
+    'jammy': [libqt6widgets6]
 libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

I missed the runtime libraries in https://github.com/ros/rosdistro/pull/47993, since that is already approved, I am opening a new one

## Package name:

- `libqt6-gui`
- `libqt6-statemachine`
- `libqt6-widgets`

## Package Upstream Source:

https://github.com/qt/qtbase
https://github.com/qt/qtscxml

## Purpose of using this:

Needed by Navigation2, specifically nav2_rviz_plugins

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libqt6gui&searchon=names&suite=stable&section=all
  - https://packages.debian.org/search?suite=stable&section=all&arch=any&searchon=names&keywords=libqt6statemachine
  - https://packages.debian.org/search?keywords=libqt6widgets&searchon=names&suite=stable&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libqt6gui&searchon=names
  - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libqt6statemachine&searchon=names
  - https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libqt6widgets&searchon=names
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtbase/qt6-qtbase-gui/
  - skipped for statemachine and widgets
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt6-scxml/
  - https://archlinux.org/packages/extra/x86_64/qt6-base/
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtbase-gui
  - https://pkgs.org/search/?q=qt6-qtbase
  - https://pkgs.org/search/?q=qt6-qtscxml-devel
