### PR TITLE
mola_imu_preintegration: 1.13.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4876,7 +4876,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.12.0-1
+      version: 1.13.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.13.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.12.0-1`

## mola_imu_preintegration

```
* FIX: Picked wrong reference stamp for integrating trajectories
* Add asString() debugging methods to sample structs
* Contributors: Jose Luis Blanco-Claraco
```
