### PR TITLE
Add greenwave_monitor to index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3576,6 +3576,12 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: main
     status: maintained
+  greenwave_monitor:
+    source:
+      type: git
+      url: https://github.com/NVIDIA-ISAAC-ROS/greenwave_monitor.git
+      version: main
+    status: maintained
   grid_map:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3101,6 +3101,12 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: main
     status: maintained
+  greenwave_monitor:
+    source:
+      type: git
+      url: https://github.com/NVIDIA-ISAAC-ROS/greenwave_monitor.git
+      version: main
+    status: maintained
   grid_map:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2507,6 +2507,12 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: main
     status: maintained
+  greenwave_monitor:
+    source:
+      type: git
+      url: https://github.com/NVIDIA-ISAAC-ROS/greenwave_monitor.git
+      version: main
+    status: maintained
   grid_map:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2503,6 +2503,12 @@ repositories:
       url: https://github.com/flynneva/grbl_ros.git
       version: main
     status: maintained
+  greenwave_monitor:
+    source:
+      type: git
+      url: https://github.com/NVIDIA-ISAAC-ROS/greenwave_monitor.git
+      version: main
+    status: maintained
   gscam:
     doc:
       type: git


### PR DESCRIPTION
Following docs [here](https://docs.ros.org/en/rolling/How-To-Guides/Releasing/Index-Your-Packages.html#make-changes-to-your-fork) please let me know if any changes are needed.

# Please Add greenwave_monitor to be indexed in the rosdistros.

humble
jazzy
kilted
rolling


# The source is here:

https://github.com/NVIDIA-ISAAC-ROS/greenwave_monitor

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
