### PR TITLE
NavMap: 0.2.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10,6 +10,27 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  NavMap:
+    doc:
+      type: git
+      url: https://github.com/EasyNavigation/NavMap.git
+      version: kilted
+    release:
+      packages:
+      - navmap_core
+      - navmap_examples
+      - navmap_ros
+      - navmap_ros_interfaces
+      - navmap_rviz_plugin
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/EasyNavigation/NavMap-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/EasyNavigation/NavMap.git
+      version: kilted
+    status: developed
   SMACC2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `NavMap` to `0.2.2-1`:

- upstream repository: https://github.com/EasyNavigation/NavMap.git
- release repository: https://github.com/EasyNavigation/NavMap-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## navmap_core

```
* Creates a surface if there isn't anyone
* Contributors: Francisco Martín Rico
```

## navmap_examples

```
* Creates a surface if there isn't anyone
* Contributors: Francisco Martín Rico
```

## navmap_ros

```
* Creates a surface if there isn't anyone
* Contributors: Francisco Martín Rico
```

## navmap_ros_interfaces

- No changes

## navmap_rviz_plugin

- No changes
