### PR TITLE
yaets: 1.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10060,7 +10060,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/fmrico/yaets-release.git
-      version: 1.0.1-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/fmrico/yaets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaets` to `1.0.3-1`:

- upstream repository: https://github.com/fmrico/yaets.git
- release repository: https://github.com/fmrico/yaets-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## yaets

```
* Add python dep to package.xml
* Contributors: Francisco Martín Rico
```
