### PR TITLE
pluginlib: 5.6.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5475,10 +5475,13 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: kilted
     release:
+      packages:
+      - pluginlib
+      - ros2plugin
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.6.0-2
+      version: 5.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.6.1-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.6.0-2`

## pluginlib

```
* Add ros2plugin (backport #165 <https://github.com/ros/pluginlib/issues/165>) (#279 <https://github.com/ros/pluginlib/issues/279>)
* List plugins script (backport #264 <https://github.com/ros/pluginlib/issues/264>) (#276 <https://github.com/ros/pluginlib/issues/276>)
* fix cmake deprecation (backport #273 <https://github.com/ros/pluginlib/issues/273>) (#275 <https://github.com/ros/pluginlib/issues/275>)
* Contributors: mergify[bot]
```

## ros2plugin

```
* Add ros2plugin (backport #165 <https://github.com/ros/pluginlib/issues/165>) (#279 <https://github.com/ros/pluginlib/issues/279>)
* Contributors: mergify[bot]
```
