### PR TITLE
rqt_topic: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8157,7 +8157,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `2.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## rqt_topic

```
* Use choose_qos() from ros2 topic echo (#55 <https://github.com/ros-visualization/rqt_topic/issues/55>)
* Enable flake8 (#58 <https://github.com/ros-visualization/rqt_topic/issues/58>)
* Contributors: Alejandro Hernández Cordero, Romain Reignier
```
