### PR TITLE
pluginlib: 5.4.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6324,10 +6324,13 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: jazzy
     release:
+      packages:
+      - pluginlib
+      - ros2plugin
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.4.2-2
+      version: 5.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.4.3-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.4.2-2`

## pluginlib

```
* Fixed test_pluginlib maintainer and license (#282 <https://github.com/ros/pluginlib/issues/282>)
* List plugins script (backport #264 <https://github.com/ros/pluginlib/issues/264>) (#277 <https://github.com/ros/pluginlib/issues/277>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## ros2plugin

```
* Add ros2plugin (backport #165 <https://github.com/ros/pluginlib/issues/165>) (#280 <https://github.com/ros/pluginlib/issues/280>)
* Contributors: mergify[bot]
```
