### PR TITLE
pluginlib: 5.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7259,10 +7259,13 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: humble
     release:
+      packages:
+      - pluginlib
+      - ros2plugin
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.1.0-3
+      version: 5.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.1.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.0-3`

## pluginlib

```
* List plugins script (backport #264 <https://github.com/ros/pluginlib/issues/264>) (#278 <https://github.com/ros/pluginlib/issues/278>)
* Fixed test_pluginlib maintainer and license (#283 <https://github.com/ros/pluginlib/issues/283>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```

## ros2plugin

```
* Add ros2plugin (backport #165 <https://github.com/ros/pluginlib/issues/165>) (#281 <https://github.com/ros/pluginlib/issues/281>)
* Contributors: mergify[bot]
```
