### PR TITLE
rqt_topic: 1.7.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9198,7 +9198,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.7.3-1
+      version: 1.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.7.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.3-1`

## rqt_topic

```
* fix setuptools deprecations (backport #57 <https://github.com/ros-visualization/rqt_topic/issues/57>) (#60 <https://github.com/ros-visualization/rqt_topic/issues/60>)
* Contributors: mergify[bot]
```
