### PR TITLE
ur_description: 2.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12078,7 +12078,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.7.1-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.8.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.1-1`

## ur_description

```
* Add an initial value for the major_version state interface (#343 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/343>)
  This can be used in mock hardware tests
* Add support for UR18 (#342 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/342>)
* Contributors: Felix Exner
```