### PR TITLE
tiago_pro_head_robot: 1.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11348,6 +11348,26 @@ repositories:
       url: https://github.com/pal-robotics/tiago_navigation.git
       version: humble-devel
     status: developed
+  tiago_pro_head_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_head_robot.git
+      version: humble-devel
+    release:
+      packages:
+      - tiago_pro_head_bringup
+      - tiago_pro_head_controller_configuration
+      - tiago_pro_head_description
+      - tiago_pro_head_robot
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_pro_head_robot-release.git
+      version: 1.6.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_head_robot.git
+      version: humble-devel
+    status: maintained
   tiago_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_head_robot` to `1.6.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_head_robot.git
- release repository: https://github.com/pal-gbp/tiago_pro_head_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## tiago_pro_head_bringup

- No changes

## tiago_pro_head_controller_configuration

- No changes

## tiago_pro_head_description

```
* remove realsense overlay
* Contributors: antoniobrandi
```

## tiago_pro_head_robot

- No changes
