### PR TITLE
ros2_fmt_logger: 1.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7031,6 +7031,21 @@ repositories:
       url: https://github.com/felixdivo/ros2-easy-test.git
       version: main
     status: developed
+  ros2_fmt_logger:
+    doc:
+      type: git
+      url: https://github.com/nobleo/ros2_fmt_logger.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/ros2_fmt_logger.git
+      version: main
+    status: developed
   ros2_kortex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_fmt_logger` to `1.0.1-1`:

- upstream repository: https://github.com/nobleo/ros2_fmt_logger.git
- release repository: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ros2_fmt_logger

```
* Using RCLCPP macros with the fmt_logger
* Add humble support
* Contributors: Tim Clephas
```
