### PR TITLE
pal_pro_gripper: 1.7.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6925,6 +6925,27 @@ repositories:
       url: https://github.com/pal-robotics/pal_navigation_cfg_public.git
       version: humble-devel
     status: developed
+  pal_pro_gripper:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_pro_gripper.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_pro_gripper
+      - pal_pro_gripper_bringup
+      - pal_pro_gripper_controller_configuration
+      - pal_pro_gripper_description
+      - pal_pro_gripper_wrapper
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_pro_gripper-release.git
+      version: 1.7.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_pro_gripper.git
+      version: humble-devel
+    status: developed
   pal_robotiq_gripper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_pro_gripper` to `1.7.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_pro_gripper.git
- release repository: https://github.com/pal-gbp/pal_pro_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## pal_pro_gripper

- No changes

## pal_pro_gripper_bringup

- No changes

## pal_pro_gripper_controller_configuration

```
* 100 hz to 1khz
* add update rate
* Contributors: Matteo Villani
```

## pal_pro_gripper_description

- No changes

## pal_pro_gripper_wrapper

```
* for the pipeline :/
* change topic to retrieve joint position
* Contributors: Matteo Villani
```
