### PR TITLE
mp_units_vendor: 2.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4372,6 +4372,21 @@ repositories:
       url: https://github.com/MOLAorg/mp2p_icp.git
       version: develop
     status: developed
+  mp_units_vendor:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mp_units_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/mp_units_vendor-release.git
+      version: 2.4.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/mp_units_vendor.git
+      version: main
+    status: maintained
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp_units_vendor` to `2.4.0-1`:

- upstream repository: https://github.com/nobleo/mp_units_vendor.git
- release repository: https://github.com/ros2-gbp/mp_units_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
