### PR TITLE
ros2_fmt_logger: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9076,6 +9076,21 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: humble
     status: developed
+  ros2_fmt_logger:
+    doc:
+      type: git
+      url: https://github.com/nobleo/ros2_fmt_logger.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/ros2_fmt_logger.git
+      version: main
+    status: developed
   ros2_kortex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_fmt_logger` to `1.0.1-1`:

- upstream repository: https://github.com/nobleo/ros2_fmt_logger.git
- release repository: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ros2_fmt_logger

```
* Using RCLCPP macros with the fmt_logger
* Add humble support
* Contributors: Tim Clephas
```
