### PR TITLE
grid_map: 2.2.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3126,7 +3126,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/grid_map-release.git
-      version: 2.2.1-1
+      version: 2.2.2-2
     source:
       type: git
       url: https://github.com/ANYbotics/grid_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `grid_map` to `2.2.2-2`:

- upstream repository: https://github.com/ANYbotics/grid_map.git
- release repository: https://github.com/ros2-gbp/grid_map-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## grid_map

- No changes

## grid_map_cmake_helpers

- No changes

## grid_map_core

- No changes

## grid_map_costmap_2d

- No changes

## grid_map_cv

- No changes

## grid_map_demos

- No changes

## grid_map_filters

- No changes

## grid_map_loader

- No changes

## grid_map_msgs

```
* Merge pull request #527 <https://github.com/ANYbotics/grid_map/issues/527> from ANYbotics/feature/ros1_bridge_mapping_support
  Added explicit ros1_bridge mapping support
* Added ros1_bridge mapping support
* Contributors: Zichong Li
```

## grid_map_octomap

- No changes

## grid_map_pcl

- No changes

## grid_map_ros

- No changes

## grid_map_rviz_plugin

- No changes

## grid_map_sdf

- No changes

## grid_map_visualization

- No changes
