### PR TITLE
mola: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4814,6 +4814,7 @@ repositories:
       - mola_input_euroc_dataset
       - mola_input_kitti360_dataset
       - mola_input_kitti_dataset
+      - mola_input_lidar_bin_dataset
       - mola_input_mulran_dataset
       - mola_input_paris_luco_dataset
       - mola_input_rawlog
@@ -4831,7 +4832,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 1.9.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.0.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.9.0-1`

## kitti_metrics_eval

```
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* Avoid cmake warning on no install target
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* fix clang-format
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* Add new module to replay LiDAR datasets from a directory with .bin files
* Normalize intensity in published point clouds
* Use ament linters
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* Merge branch 'develop' into feature/better-lio
* Update docs
* Add new module to replay LiDAR datasets from a directory with .bin files
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* Add new module to replay LiDAR datasets from a directory with .bin files
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* fix clang-format
* Normalize intensity in published point clouds
* Fix clang-tidy warnings
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Modernize copyright notice
* Remove old code that was needed to support very old MRPT versions
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* fix clang-format
* Modernize copyright notice
* fix clang-format
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

```
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* MolaViz: Add method clear_all_point_clouds_with_decay()
* MolaViz: Add support for inserting clouds with decay_time
* Large clean up of unused code from older MOLA versions.
  In particular, all abstract definitions of factors, entities, and WorldModel have been removed.
  It seems more natural and efficient to keep them in the specific SLAM modules.
* Allow extra parameters in mola_viz per-sensor preview windows
* fix clang-format
* Modernize copyright notice
* Remove old code that was needed to support very old MRPT versions
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* mola_launcher init message: avoid split into several log lines
* Large clean up of unused code from older MOLA versions.
  In particular, all abstract definitions of factors, entities, and WorldModel have been removed.
  It seems more natural and efficient to keep them in the specific SLAM modules.
* do not run the ament version of clang_format test
* fix clang-format
* Modernize copyright notice
* Use ament linters
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* add optional debug viz files; fix race conditions
* cov2cov pairings now saves the sqrt(cov_inv)
* Move to new mp2p_icp cov2cov matcher API
* Update missing copyright notices
* New KeyframePointCloudMap map
* Fix typos and clang-tidy hints
* Fix clang-tidy formatting tips
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* clang-format
* Fix typos and clang-tidy hints
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Remove old code that was needed to support very old MRPT versions
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Modernize copyright notice
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Merge pull request #93 <https://github.com/MOLAorg/mola/issues/93> from MOLAorg/feature/better-lio
  Changes for new LIO
* Fix warnings
* fix build against old mrpt versions
* Implement removal of decayed clouds
* MolaViz: Add method clear_all_point_clouds_with_decay()
* MolaViz: Add support for inserting clouds with decay_time
* fix clang-format
* Allow extra parameters in mola_viz per-sensor preview windows
* MolaViz: show min/max intensity in input sensor point clouds
* Remove old code that was needed to support very old MRPT versions
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Modernize copyright notice
* Use ament linters
* Contributors: Jose Luis Blanco-Claraco
```
