### PR TITLE
jrl-cmakemodules: 1.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3245,6 +3245,23 @@ repositories:
       url: https://github.com/ros-drivers/joystick_drivers.git
       version: ros2
     status: maintained
+  jrl-cmakemodules:
+    doc:
+      type: git
+      url: https://github.com/jrl-umi3218/jrl-cmakemodules.git
+      version: master
+    release:
+      packages:
+      - jrl_cmakemodules
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/jrl-umi3218/jrl-cmakemodules.git
+      version: master
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `jrl-cmakemodules` to `1.1.0-1`:

- upstream repository: https://github.com/jrl-umi3218/jrl-cmakemodules
- release repository: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`
