### PR TITLE
ur_client_library: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10908,7 +10908,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## ur_client_library

```
* UR18 support (#387 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/387>)
* Remove output_bit_register_0...63 and input_bit_register_0..63 from RTDE list (#385 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/385>)
* Set force mode parameters from config (#383 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/383>)
* Direct torque control (#381 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/381>)
* Update RTDE list to include new fields (#380 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/380>)
* Add const qualifier to get functions and changed map value retrieval to at() function (#379 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/379>)
* Contributors: Dominic Reber, Felix Exner, Pablo David Aranda Rodriguez, URJala
```
