### PR TITLE
add libyuv-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7319,6 +7319,18 @@ libyaml-dev:
   opensuse: [libyaml-devel]
   rhel: [libyaml-devel]
   ubuntu: [libyaml-dev]
+libyuv-dev:
+  alpine: [libyuv]
+  arch: [libyuv]
+  debian: [libyuv-dev]
+  fedora: [libyuv-devel]
+  freebsd: [libyuv]
+  gentoo: [media-libs/libyuv]
+  nixos: [libyuv]
+  rhel: [libyuv-devel]
+  ubuntu:
+    '*': [libyuv-dev]
+    focal: null
 libzip-dev:
   arch: [libzip]
   debian: [libzip-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libyuv-dev

## Package Upstream Source:

https://chromium.googlesource.com/libyuv/libyuv/

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libyuv-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libyuv-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libyuv/libyuv-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/libyuv/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/media-libs/libyuv
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/libyuv
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.05&show=libyuv&query=libyuv
- openSUSE: https://software.opensuse.org/package/
  - ~~https://opensuse.pkgs.org/tumbleweed/opensuse-oss-x86_64/libyuv-devel-20230517+a377993-2.1.x86_64.rpm.html~~
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/libyuv-devel-0-0.45.20201024git19d71f6.el9.x86_64.rpm.html

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

