### PR TITLE
launch_frontend_py: 0.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3485,6 +3485,15 @@ repositories:
       version: kilted
     status: developed
   launch_frontend_py:
+    doc:
+      type: git
+      url: https://github.com/ros-tooling/launch_frontend_py.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_frontend_py-release.git
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/launch_frontend_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_frontend_py` to `0.1.0-1`:

- upstream repository: https://github.com/ros-tooling/launch_frontend_py.git
- release repository: https://github.com/ros2-gbp/launch_frontend_py-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## launch_frontend_py

```
* Repository created with README and LICENSE
* CI via github actions
* Initial implementation of package functionality, these PRs making incremental progress
  * Launch description initial (#2 <https://github.com/ros-tooling/launch_frontend_py/issues/2>)
  * Try more action types, clean up exporting, add basic test (#3 <https://github.com/ros-tooling/launch_frontend_py/issues/3>)
  * Handle creating exposed actions as needed regardless of import order (#4 <https://github.com/ros-tooling/launch_frontend_py/issues/4>)
  * Handle positional list arg as children (#7 <https://github.com/ros-tooling/launch_frontend_py/issues/7>)
  * Rename from launch_py to launch_frontend_py (#9 <https://github.com/ros-tooling/launch_frontend_py/issues/9>)
  * Add tests for running actual launchfile (#11 <https://github.com/ros-tooling/launch_frontend_py/issues/11>)
  * Enable Python reserved names in Action attributes (#12 <https://github.com/ros-tooling/launch_frontend_py/issues/12>)
  * Add basic usage to readme (#15 <https://github.com/ros-tooling/launch_frontend_py/issues/15>)
  * Let all imports come from toplevel module, as one line (#16 <https://github.com/ros-tooling/launch_frontend_py/issues/16>)
* Contributors: Emerson Knapp
```
