### PR TITLE
ur_robot_driver: 4.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9597,7 +9597,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for UR18 (#1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Add missing dependency to effort_controllers (#1531 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1531>)
* Add effort command interface to hardware interface (#1411 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1411>)
* Add support for UR18 (#1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>)
* Trajectory until node (#1461 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1461>)
* Wait for used controllers in test setup (#1519 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1519>)
* Running integration tests with mock hardware (#1226 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1226>)
* Add test for hardware component lifecycle (#1476 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1476>)
* Contributors: Felix Exner, URJala
```