### PR TITLE
ur_description: 4.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9560,7 +9560,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `4.3.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.0-1`

## ur_description

```
* Add effort command interface to all joints (#302 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/302>)
* Auto-update pre-commit hooks (#347 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/347>)
* Contributors: Felix Exner, github-actions[bot]
```