### PR TITLE
Add source and doc for pal_sea_arm repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6960,6 +6960,16 @@ repositories:
       url: https://github.com/pal-robotics/pal_robotiq_gripper.git
       version: humble-devel
     status: developed
+  pal_sea_arm:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_sea_arm.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_sea_arm.git
+      version: humble-devel
+    status: developed
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/pal-robotics/pal_sea_arm

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro: depends on https://github.com/ros/rosdistro/pull/48039
