### PR TITLE
Add source and doc for tiago_pro_head_simulation repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11400,6 +11400,16 @@ repositories:
       url: https://github.com/pal-robotics/tiago_navigation.git
       version: humble-devel
     status: developed
+  tiago_pro_head_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_head_simulation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_head_simulation.git
+      version: humble-devel
+    status: developed
   tiago_robot:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/pal-robotics/tiago_pro_head_simulation

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro: depends on https://github.com/ros/rosdistro/pull/48037
