### PR TITLE
eigenpy: 3.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2511,7 +2511,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/eigenpy-release.git
-      version: 3.11.0-1
+      version: 3.12.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eigenpy` to `3.12.0-1`:

- upstream repository: https://github.com/stack-of-tasks/eigenpy.git
- release repository: https://github.com/ros2-gbp/eigenpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.11.0-1`
