### PR TITLE
nanoeigenpy: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5286,7 +5286,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/nanoeigenpy-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/Simple-Robotics/nanoeigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoeigenpy` to `0.4.0-1`:

- upstream repository: https://github.com/Simple-Robotics/nanoeigenpy.git
- release repository: https://github.com/ros2-gbp/nanoeigenpy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.3.0-1`
