### PR TITLE
Add mujoco_vendor sources and doc

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5892,6 +5892,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mujoco_vendor:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    status: developed
   multiple_topic_monitor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5249,6 +5249,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mujoco_vendor:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    status: developed
   multisensor_calibration:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4560,6 +4560,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mujoco_vendor:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    status: developed
   multisensor_calibration:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4545,6 +4545,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mujoco_vendor:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/pal-robotics/mujoco_vendor.git
+      version: master
+    status: developed
   multisensor_calibration:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

-  humble
-  jazzy
-  kilted
-  rolling


# The source is here:

https://github.com/pal-robotics/mujoco_vendor#

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
