### PR TITLE
behaviortree_cpp_v4: 4.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -888,7 +888,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.7.2-1
+      version: 4.8.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.8.0-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.7.2-1`

## behaviortree_cpp

```
* fix issue in destruction order
* fix memory leak
* fix thread safety issues
* Improve error message
* Leave a note for posterity
* Fix windows builds
* Do not fail fast. We want results of both sanitizer runs
* Combine sanitizer actions into a single file
* use gtest_discover_tests to regiester the unit tests
  this modern approach registers many individual tests instead of a single monolitic test
  so if one fails the rest continue running which allows the developer to flag multiple
  failing tests on a single run
  It also speeds up testing since tests run in parallel
* Add support for sanitizers including some GHAs
* Remove unused conan.cmake (#1016 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1016>)
* Improve handling of dependencies (#1012 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1012>)
* update tinyxml to version 11.0
* fix potential compilation errors
* compile for c++ 17 (#1013 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1013>)
* Contributors: Davide Faconti, Eric Riff
```
