### PR TITLE
tsid: 1.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11590,7 +11590,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tsid-release.git
-      version: 1.8.0-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/tsid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tsid` to `1.9.0-1`:

- upstream repository: https://github.com/stack-of-tasks/tsid
- release repository: https://github.com/ros2-gbp/tsid-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.8.0-1`
