### PR TITLE
roadmap_explorer: 1.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8860,6 +8860,15 @@ repositories:
       version: humble
     status: developed
   roadmap_explorer:
+    release:
+      packages:
+      - roadmap_explorer
+      - roadmap_explorer_msgs
+      - roadmap_explorer_rviz_plugins
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/roadmap_explorer-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/suchetanrs/roadmap-explorer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roadmap_explorer` to `1.0.0-1`:

- upstream repository: https://github.com/suchetanrs/roadmap-explorer.git
- release repository: https://github.com/ros2-gbp/roadmap_explorer-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## roadmap_explorer

```
* First public release of the roadmap_explorer package.
* Contributors: suchetanrs
```

## roadmap_explorer_msgs

```
* First public release of the roadmap_explorer_msgs package.
* Contributors: suchetanrs
```

## roadmap_explorer_rviz_plugins

```
* First public release of the roadmap_explorer_rviz_plugins package.
* Contributors: suchetanrs
```
