### PR TITLE
graph_monitor: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2434,10 +2434,11 @@ repositories:
       - rmw_stats_shim
       - rosgraph_monitor
       - rosgraph_monitor_msgs
+      - rosgraph_monitor_test
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/graph_monitor-release.git
-      version: 0.1.1-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_monitor` to `0.2.1-1`:

- upstream repository: https://github.com/ros-tooling/graph-monitor.git
- release repository: https://github.com/ros2-gbp/graph_monitor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.1.1-1`

## rmw_stats_shim

- No changes

## rosgraph_monitor

```
* Fix dependency spec in package xmls, for buildfarm fixing (#35 <https://github.com/ros-tooling/graph-monitor/issues/35>)
* Contributors: Emerson Knapp
```

## rosgraph_monitor_msgs

```
* Fix dependency spec in package xmls, for buildfarm fixing (#35 <https://github.com/ros-tooling/graph-monitor/issues/35>)
* Contributors: Emerson Knapp
```

## rosgraph_monitor_test

- No changes
