### PR TITLE
depthai-ros: 3.0.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1392,7 +1392,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 3.0.8-1
+      version: 3.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.0.9-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.8-1`

## depthai-ros

```
* Fix backward_ros dependency
```
