### PR TITLE
point_cloud_transport: 4.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6417,7 +6417,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 4.0.4-1
+      version: 4.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.5-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.4-1`

## point_cloud_transport

```
* Use standard unsigned int in place of uint for Windows compatibility (backport #134 <https://github.com/ros-perception/point_cloud_transport/issues/134>) (#136 <https://github.com/ros-perception/point_cloud_transport/issues/136>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

- No changes
