### PR TITLE
point_cloud_transport_plugins: 4.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6439,7 +6439,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `4.0.2-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.1-1`

## draco_point_cloud_transport

```
* Fix linking to draco if DRACO_LIBRARIES is not defined (backport #66 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/66>) (#67 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/67>)
* Contributors: mergify[bot]
```

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

- No changes

## zstd_point_cloud_transport

- No changes
