### PR TITLE
point_cloud_transport: 1.0.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7418,7 +7418,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 1.0.18-1
+      version: 1.0.19-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.19-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.18-1`

## point_cloud_transport

```
* Use standard unsigned int in place of uint for Windows compatibility (backport #134 <https://github.com/ros-perception/point_cloud_transport/issues/134>) (#137 <https://github.com/ros-perception/point_cloud_transport/issues/137>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* remove extra semicolon (#98 <https://github.com/ros-perception/point_cloud_transport/issues/98>) (#100 <https://github.com/ros-perception/point_cloud_transport/issues/100>)
* Contributors: mergify[bot]
```
