### PR TITLE
point_cloud_transport_plugins: 1.0.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7439,7 +7439,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 1.0.11-1
+      version: 1.0.12-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `1.0.12-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.11-1`

## draco_point_cloud_transport

```
* Fix linking to draco if DRACO_LIBRARIES is not defined (backport #66 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/66>) (#68 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/68>)
* Contributors: mergify[bot]
```

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

- No changes

## zstd_point_cloud_transport

- No changes
