### PR TITLE
Add Raph Rover packages for indexing in Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6889,6 +6889,24 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: ros2
     status: maintained
+  raph_common:
+    source:
+      type: git
+      url: https://github.com/RaphRover/raph_common.git
+      version: jazzy
+    status: maintained
+  raph_desktop:
+    source:
+      type: git
+      url: https://github.com/RaphRover/raph_desktop.git
+      version: jazzy
+    status: maintained
+  raph_robot:
+    source:
+      type: git
+      url: https://github.com/RaphRover/raph_robot.git
+      version: jazzy
+    status: maintained
   raspimouse2:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add These Packages to be indexed in the rosdistro.

* raph_common
  * raph
  * raph_description
  * raph_interfaces
  * raph_teleop
* raph_desktop
  * raph_desktop
  * raph_viz
* raph_robot
  * raph_bringup
  * raph_robot

# The source is here:

https://github.com/RaphRover/raph_common
https://github.com/RaphRover/raph_desktop
https://github.com/RaphRover/raph_robot

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] The repositories have a LICENSE file
 - [x] The packages are expected to build on the submitted rosdistro
