### PR TITLE
NavMap: 0.2.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -25,7 +25,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/EasyNavigation/NavMap-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/EasyNavigation/NavMap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `NavMap` to `0.2.3-1`:

- upstream repository: https://github.com/EasyNavigation/NavMap.git
- release repository: https://github.com/EasyNavigation/NavMap-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-1`

## navmap_core

```
* Fix dependencies
* Contributors: Francisco Martín Rico
```

## navmap_examples

- No changes

## navmap_ros

- No changes

## navmap_ros_interfaces

```
* Fix dependencies
* Contributors: Francisco Martín Rico
```

## navmap_rviz_plugin

- No changes
