### PR TITLE
cascade_lifecycle: 2.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -994,7 +994,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cascade_lifecycle-release.git
-      version: 2.0.2-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/fmrico/cascade_lifecycle.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cascade_lifecycle` to `2.0.4-1`:

- upstream repository: https://github.com/fmrico/cascade_lifecycle.git
- release repository: https://github.com/ros2-gbp/cascade_lifecycle-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-1`

## cascade_lifecycle_msgs

- No changes

## rclcpp_cascade_lifecycle

```
* Fix deprecation of ament_target_dependencies
* Contributors: Francisco Martín Ricoo, David Lu, Alejandro Hernández Cordero
```

## rclpy_cascade_lifecycle

- No changes
