### PR TITLE
beckhoff_ads_driver: 1.0.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -877,6 +877,16 @@ repositories:
       url: https://github.com/wep21/bag2_to_image.git
       version: main
     status: maintained
+  beckhoff_ads_driver:
+    release:
+      packages:
+      - beckhoff_ads_bringup
+      - beckhoff_ads_hardware_interface
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/b-robotized/beckhoff_ads_driver-release.git
+      version: 1.0.0-2
+    status: maintained
   behaviortree_cpp_v4:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `beckhoff_ads_driver` to `1.0.0-2`:

- upstream repository: https://github.com/b-robotized/beckhoff_ads_driver.git
- release repository: https://github.com/b-robotized/beckhoff_ads_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## beckhoff_ads_bringup

```
* update maintainer/author
* rename bringup package to beckhoff_ads_bringup
* add LICENSE
* wrap beckhoff interfaces in a separate xacrp file
* remove initial value from statess
* adjust IP addresses
* update URDF default PLC vars
* rename everything to beckhoff_ads_hardware_interface
* Contributors: nibanovic
```

## beckhoff_ads_hardware_interface

```
* change deprecated ament_target_dependencies
* update maintainer/author
* add LICENSE
* rename everything to beckhoff_ads_hardware_interface
* Contributors: nibanovic
```
