### PR TITLE
gz_ros2_control: 2.0.13-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2799,7 +2799,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.12-1
+      version: 2.0.13-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.13-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.12-1`

## gz_ros2_control

```
* Remove deprecated on_init (#699 <https://github.com/ros-controls/gz_ros2_control/issues/699>) (#704 <https://github.com/ros-controls/gz_ros2_control/issues/704>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes
