### PR TITLE
image_common: 6.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2989,7 +2989,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.1-2
+      version: 6.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.2-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.4.1-2`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Fix QoS override tests (#376 <https://github.com/ros-perception/image_common/issues/376>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

```
* Use pybind11 from deb or pixi (#374 <https://github.com/ros-perception/image_common/issues/374>)
* Contributors: Alejandro Hernández Cordero
```
