### PR TITLE
image_common: 6.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3045,7 +3045,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.1.2-1
+      version: 6.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.1.3-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.2-1`

## camera_calibration_parsers

```
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>) (#368 <https://github.com/ros-perception/image_common/issues/368>)
* Contributors: mergify[bot]
```

## camera_info_manager

```
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>) (#368 <https://github.com/ros-perception/image_common/issues/368>)
* Contributors: mergify[bot]
```

## camera_info_manager_py

- No changes

## image_common

```
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>) (#368 <https://github.com/ros-perception/image_common/issues/368>)
* Contributors: mergify[bot]
```

## image_transport

```
* Fix cmake deprecation (#367 <https://github.com/ros-perception/image_common/issues/367>) (#368 <https://github.com/ros-perception/image_common/issues/368>)
* Contributors: mergify[bot]
```

## image_transport_py

- No changes
