### PR TITLE
rqt_py_console: 1.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8115,7 +8115,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.4.0-2
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `1.4.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros2-gbp/rqt_py_console-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-2`

## rqt_py_console

```
* fix setuptools deprecations (backport #21 <https://github.com/ros-visualization/rqt_py_console/issues/21>) (#22 <https://github.com/ros-visualization/rqt_py_console/issues/22>)
* Contributors: mergify[bot]
```
