### PR TITLE
rqt_py_console: 1.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9103,7 +9103,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.2.2-3
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `1.2.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros2-gbp/rqt_py_console-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.2-3`

## rqt_py_console

```
* fix setuptools deprecations (backport #21 <https://github.com/ros-visualization/rqt_py_console/issues/21>) (#23 <https://github.com/ros-visualization/rqt_py_console/issues/23>)
* Remove CODEOWNERS (backport #17 <https://github.com/ros-visualization/rqt_py_console/issues/17>) (#18 <https://github.com/ros-visualization/rqt_py_console/issues/18>)
* Contributors: mergify[bot]
```
