### PR TITLE
etsi_its_messages: 3.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2562,6 +2562,7 @@ repositories:
       - etsi_its_cam_ts_msgs
       - etsi_its_coding
       - etsi_its_conversion
+      - etsi_its_conversion_srvs
       - etsi_its_cpm_ts_coding
       - etsi_its_cpm_ts_conversion
       - etsi_its_cpm_ts_msgs
@@ -2591,7 +2592,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/etsi_its_messages-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `etsi_its_messages` to `3.4.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/etsi_its_messages.git
- release repository: https://github.com/ros2-gbp/etsi_its_messages-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.3.0-1`

## etsi_its_cam_coding

- No changes

## etsi_its_cam_conversion

- No changes

## etsi_its_cam_msgs

- No changes

## etsi_its_cam_ts_coding

- No changes

## etsi_its_cam_ts_conversion

- No changes

## etsi_its_cam_ts_msgs

- No changes

## etsi_its_coding

- No changes

## etsi_its_conversion

```
* Merge pull request #106 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/106> from Tezozomoc47/make-converter-service-based
  Add the service-based approach for message conversion
* Merge pull request #108 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/108> from ika-rwth-aachen/fix-udp-src-port
  Fix setting of BTP destination port in udp_msg.src_port
* Merge pull request #99 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/99> from ika-rwth-aachen/codex/enable-parallel-execution-for-etsi_its_conversion
* Merge pull request #100 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/100> from Tezozomoc47/use-udppacket-srcport-for-btp
  Added filling of the UdpPacket.src_port to transport BtpDestinationPort information without touching the byte payload.
* Contributors: Lennart Reiher, Tezozomoc47
```

## etsi_its_conversion_srvs

```
* Merge pull request #106 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/106> from Tezozomoc47/make-converter-service-based
  Add the service-based approach for message conversion
* Contributors: Lennart Reiher
```

## etsi_its_cpm_ts_coding

- No changes

## etsi_its_cpm_ts_conversion

- No changes

## etsi_its_cpm_ts_msgs

- No changes

## etsi_its_denm_coding

- No changes

## etsi_its_denm_conversion

- No changes

## etsi_its_denm_msgs

- No changes

## etsi_its_denm_ts_coding

- No changes

## etsi_its_denm_ts_conversion

- No changes

## etsi_its_denm_ts_msgs

- No changes

## etsi_its_mapem_ts_coding

- No changes

## etsi_its_mapem_ts_conversion

- No changes

## etsi_its_mapem_ts_msgs

- No changes

## etsi_its_mcm_uulm_coding

- No changes

## etsi_its_mcm_uulm_conversion

- No changes

## etsi_its_mcm_uulm_msgs

- No changes

## etsi_its_messages

- No changes

## etsi_its_msgs

- No changes

## etsi_its_msgs_utils

```
* Merge pull request #106 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/106> from Tezozomoc47/make-converter-service-based
  Add the service-based approach for message conversion
* Merge pull request #105 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/105> from ika-rwth-aachen/fix-bit-string-access
  Fix getter/setter convenience access functions for BIT_STRING
* Contributors: Lennart Reiher, Tezozomoc47
```

## etsi_its_primitives_conversion

- No changes

## etsi_its_rviz_plugins

```
* Merge pull request #96 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/96> from ika-rwth-aachen/improvement/denm-plugin
  Add overlay to DENM plugin
* Merge pull request #93 <https://github.com/ika-rwth-aachen/etsi_its_messages/issues/93> from ika-rwth-aachen/rviz-satellite
* Contributors: Jean-Pierre Busch, Lennart Reiher, Tezozomoc47
```

## etsi_its_spatem_ts_coding

- No changes

## etsi_its_spatem_ts_conversion

- No changes

## etsi_its_spatem_ts_msgs

- No changes

## etsi_its_vam_ts_coding

- No changes

## etsi_its_vam_ts_conversion

- No changes

## etsi_its_vam_ts_msgs

- No changes
