### PR TITLE
yaets: 1.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11522,7 +11522,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/fmrico/yaets-release.git
-      version: 0.0.2-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/fmrico/yaets.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yaets` to `1.0.4-1`:

- upstream repository: https://github.com/fmrico/yaets.git
- release repository: https://github.com/fmrico/yaets-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.2-1`

## yaets

```
* Merge branch 'rolling' into jazzy-devel
* Contributors: Francisco Martín Rico
```
