### PR TITLE
EasyNavigation: 0.1.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10,6 +10,34 @@ release_platforms:
   ubuntu:
   - noble
 repositories:
+  EasyNavigation:
+    doc:
+      type: git
+      url: https://github.com/EasyNavigation/EasyNavigation.git
+      version: jazzy
+    release:
+      packages:
+      - easynav
+      - easynav_common
+      - easynav_controller
+      - easynav_core
+      - easynav_interfaces
+      - easynav_localizer
+      - easynav_maps_manager
+      - easynav_planner
+      - easynav_sensors
+      - easynav_support_py
+      - easynav_system
+      - easynav_tools
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/EasyNavigation/EasyNavigation-release.git
+      version: 0.1.4-1
+    source:
+      type: git
+      url: https://github.com/EasyNavigation/EasyNavigation.git
+      version: jazzy
+    status: developed
   SMACC2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `EasyNavigation` to `0.1.4-1`:

- upstream repository: https://github.com/EasyNavigation/EasyNavigation.git
- release repository: https://github.com/EasyNavigation/EasyNavigation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## easynav

```
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_common

```
* Fix compilation errors in jazzy
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_controller

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_core

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_interfaces

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_localizer

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_maps_manager

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_planner

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_sensors

```
* Fix compilation errors in jazzy
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_support_py

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_system

```
* Fix compilation errors in jazzy
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```

## easynav_tools

```
* Merge kilted version bump into rolling
* Merge kilted into rolling. Update version to 0.1.3
* Contributors: Francisco Miguel Moreno
```
