### PR TITLE
control_toolbox: 5.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1309,7 +1309,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: master
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1318,7 +1318,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: master
     status: maintained
   cpp_polyfills:
     release:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1314,7 +1314,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.8.1-1
+      version: 5.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.9.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.8.1-1`

## control_toolbox

```
* Add test for trc if i-gain is zero (#526 <https://github.com/ros-controls/control_toolbox/issues/526>)
* Fix calculation of tracking time constant (#511 <https://github.com/ros-controls/control_toolbox/issues/511>)
* Remove duplicate storage of limits (#512 <https://github.com/ros-controls/control_toolbox/issues/512>)
* Improve PID parameter validation (#510 <https://github.com/ros-controls/control_toolbox/issues/510>)
* [PidROS] Change args to const reference (#513 <https://github.com/ros-controls/control_toolbox/issues/513>)
* Fix -Wunused-result (#506 <https://github.com/ros-controls/control_toolbox/issues/506>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, bijoua29
```
