### PR TITLE
graph_monitor: 0.2.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2463,7 +2463,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/graph_monitor-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_monitor` to `0.2.2-1`:

- upstream repository: https://github.com/ros-tooling/graph-monitor.git
- release repository: https://github.com/ros2-gbp/graph_monitor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-2`

## rmw_stats_shim

- No changes

## rosgraph_monitor

```
* Fix release builds (#36 <https://github.com/ros-tooling/graph-monitor/issues/36>)
  * don't depend on ROS_DISTRO environment variable, instead use detected package versions
* Contributors: Emerson Knapp
```

## rosgraph_monitor_msgs

```
* Fix release builds (#36 <https://github.com/ros-tooling/graph-monitor/issues/36>)
  * add missing dependencies in package.xml
* Contributors: Emerson Knapp
```
