### PR TITLE
control_toolbox: 5.8.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1257,7 +1257,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.8.1-1
+      version: 5.8.2-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1252,7 +1252,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1261,7 +1261,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: ros2-master
+      version: kilted
     status: maintained
   cpp_polyfills:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.8.2-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.8.1-1`

## control_toolbox

```
* Add test for trc if i-gain is zero (#526 <https://github.com/ros-controls/control_toolbox/issues/526>) (#529 <https://github.com/ros-controls/control_toolbox/issues/529>)
* Fix calculation of tracking time constant (#511 <https://github.com/ros-controls/control_toolbox/issues/511>) (#525 <https://github.com/ros-controls/control_toolbox/issues/525>)
* Improve PID parameter validation (#510 <https://github.com/ros-controls/control_toolbox/issues/510>)
* [PidROS] Change args to const reference (#513 <https://github.com/ros-controls/control_toolbox/issues/513>)
* Fix -Wunused-result (#506 <https://github.com/ros-controls/control_toolbox/issues/506>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, mergify[bot]
```
