### PR TITLE
control_toolbox: 4.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1597,7 +1597,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.8.1-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.9.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.8.1-1`

## control_toolbox

```
* Add test for trc if i-gain is zero (#526 <https://github.com/ros-controls/control_toolbox/issues/526>) (#528 <https://github.com/ros-controls/control_toolbox/issues/528>)
* Fix calculation of tracking time constant (#511 <https://github.com/ros-controls/control_toolbox/issues/511>) (#524 <https://github.com/ros-controls/control_toolbox/issues/524>)
* Improve PID parameter validation (#510 <https://github.com/ros-controls/control_toolbox/issues/510>) (#515 <https://github.com/ros-controls/control_toolbox/issues/515>)
* [PidROS] Change args to const reference (#513 <https://github.com/ros-controls/control_toolbox/issues/513>) (#514 <https://github.com/ros-controls/control_toolbox/issues/514>)
* Remove deprecation of i_min/i_max  PID parameters (#507 <https://github.com/ros-controls/control_toolbox/issues/507>)
* Fix -Wunused-result of rcutils_logging (#506 <https://github.com/ros-controls/control_toolbox/issues/506>) (#508 <https://github.com/ros-controls/control_toolbox/issues/508>)
* Contributors: Christoph Fröhlich, mergify[bot]
```
