### PR TITLE
replay_testing: 0.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8423,6 +8423,11 @@ repositories:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/replay_testing-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `replay_testing` to `0.0.3-1`:

- upstream repository: https://github.com/polymathrobotics/replay_testing.git
- release repository: https://github.com/ros2-gbp/replay_testing-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## replay_testing

```
* Added new --analyze [RUN_ID] for rerunning @analyze without re-executing the full replay.
* Moved McapFixture to LocalFixture
* Remove mcap-ros2-support dependency
* Contributors: Troy Gibb, Emerson Knapp
```
