### PR TITLE
replay_testing: 0.0.3-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6428,6 +6428,21 @@ repositories:
       url: https://github.com/ros-controls/realtime_tools.git
       version: kilted
     status: maintained
+  replay_testing:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/replay_testing-release.git
+      version: 0.0.3-2
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/replay_testing.git
+      version: main
+    status: developed
   resource_retriever:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `replay_testing` to `0.0.3-2`:

- upstream repository: https://github.com/polymathrobotics/replay_testing.git
- release repository: https://github.com/ros2-gbp/replay_testing-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## replay_testing

```
* Added new --analyze [RUN_ID] for rerunning @analyze without re-executing the full replay.
* Moved McapFixture to LocalFixture
* Remove mcap-ros2-support dependency
* Contributors: Troy Gibb, Emerson Knapp
```
