### PR TITLE
Update t64 package renames

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -827,11 +827,16 @@ cvs:
   nixos: [cvs]
   ubuntu: [cvs]
 cwiid:
-  debian: [libcwiid1]
+  debian:
+    '*': [libcwiid1t64]
+    bookworm: [libcwiid1]
   gentoo: [app-misc/cwiid]
   nixos: [cwiid]
   opensuse: [libcwiid1]
-  ubuntu: [libcwiid1]
+  ubuntu:
+    '*': [libcwiid1t64]
+    focal: [libcwiid1]
+    jammy: [libcwiid1]
 cwiid-dev:
   debian: [libcwiid-dev]
   gentoo: [app-misc/cwiid]
@@ -2634,10 +2639,15 @@ leveldb:
   rhel: [leveldb-devel]
   ubuntu: [libleveldb-dev]
 lib32asound2:
-  debian: [lib32asound2]
+  debian:
+    '*': [libasound2t64]
+    bookworm: [libasound2]
   fedora: ['alsa-lib(%{__isa_name}-32)', alsa-lib]
   gentoo: [media-libs/alsa-lib]
-  ubuntu: [lib32asound2]
+  ubuntu:
+    '*': [libasound2t64]
+    focal: [libasound2]
+    jammy: [libasound2]
 libabsl-dev:
   arch: [abseil-cpp]
   debian:
@@ -2883,7 +2893,7 @@ libboost-chrono:
     bionic: [libboost-chrono1.65.1]
     focal: [libboost-chrono1.71.0]
     jammy: [libboost-chrono1.74.0]
-    noble: [libboost-chrono1.83.0]
+    noble: [libboost-chrono1.83.0t64]
 libboost-chrono-dev:
   arch: [boost]
   debian: [libboost-chrono-dev]
@@ -3478,13 +3488,18 @@ libcunit-dev:
 libcurl:
   alpine: [libcurl]
   arch: [curl]
-  debian: [libcurl4]
+  debian:
+    '*': [libcurl4t64]
+    bookworm: [libcurl4]
   fedora: [libcurl]
   gentoo: [net-misc/curl]
   nixos: [curl]
   opensuse: [curl]
   rhel: [libcurl]
-  ubuntu: [libcurl4]
+  ubuntu:
+    '*': [libcurl4t64]
+    focal: [libcurl4]
+    jammy: [libcurl4]
 libcurl-dev:
   alpine: [curl-dev]
   arch: [curl]
@@ -4154,10 +4169,15 @@ libglui-dev:
   fedora: [glui-devel]
   ubuntu: [libglui-dev]
 libglw1-mesa:
-  debian: [libglw1-mesa]
+  debian:
+    '*': [libglw1t64-mesa]
+    bookworm: [libglw1-mesa]
   fedora: [mesa-libGLw]
   gentoo: [x11-libs/libGLw]
-  ubuntu: [libglw1-mesa]
+  ubuntu:
+    '*': [libglw1t64-mesa]
+    focal: [libglw1-mesa]
+    jammy: [libglw1-mesa]
 libgmock-dev:
   alpine: [gmock]
   arch: [gtest]
@@ -4629,20 +4649,32 @@ libjsoncpp-dev:
   rhel: [jsoncpp-devel]
   ubuntu: [libjsoncpp-dev]
 libjsonrpccpp-client0:
-  debian: [libjsonrpccpp-client0]
-  ubuntu: [libjsonrpccpp-client0]
+  debian:
+    '*': [libjsonrpccpp-client0t64]
+    bookworm: [libjsonrpccpp-client0]
+  ubuntu:
+    '*': [libjsonrpccpp-client0t64]
+    focal: [libjsonrpccpp-client0]
+    jammy: [libjsonrpccpp-client0]
 libjsonrpccpp-common0:
-  debian: [libjsonrpccpp-common0]
-  ubuntu: [libjsonrpccpp-common0]
+  debian:
+    '*': [libjsonrpccpp-common0t64]
+    bookworm: [libjsonrpccpp-common0]
+  ubuntu:
+    '*': [libjsonrpccpp-common0t64]
+    focal: [libjsonrpccpp-common0]
+    jammy: [libjsonrpccpp-common0]
 libjsonrpccpp-dev:
   debian: [libjsonrpccpp-dev]
   ubuntu: [libjsonrpccpp-dev]
 libjsonrpccpp-server0:
-  debian: [libjsonrpccpp-server0]
-  ubuntu: [libjsonrpccpp-server0]
-libjsonrpccpp-stub0:
-  debian: [libjsonrpccpp-stub0]
-  ubuntu: [libjsonrpccpp-stub0]
+  debian:
+    '*': [libjsonrpccpp-server0t64]
+    bookworm: [libjsonrpccpp-server0]
+  ubuntu: [libjsonrpccpp-server0t64]
+    '*': [libjsonrpccpp-server0t64]
+    focal: [libjsonrpccpp-server0]
+    jammy: [libjsonrpccpp-server0]
 libjsonrpccpp-tools:
   debian: [libjsonrpccpp-tools]
   ubuntu: [libjsonrpccpp-tools]
@@ -4821,10 +4853,15 @@ libmodbus5:
   ubuntu: [libmodbus5]
 libmongoc-1.0-0:
   arch: [mongo-c-driver]
-  debian: [libmongoc-1.0-0]
+  debian:
+    '*': [libmongoc-1.0-0t64]
+    bookworm: [libmongoc-1.0-0]
   gentoo: [dev-libs/mongo-c-driver]
   nixos: [mongoc]
-  ubuntu: [libmongoc-1.0-0]
+  ubuntu:
+    '*': [libmongoc-1.0-0t64]
+    focal: [libmongoc-1.0-0]
+    jammy: [libmongoc-1.0-0]
 libmongoc-dev:
   arch: [mongo-c-driver]
   debian: [libmongoc-dev]
@@ -4883,9 +4920,12 @@ libmysql++-dev:
   ubuntu: [libmysql++-dev]
 libmysql++3v5:
   arch: [mysql++]
-  debian: [libmysql++3v5]
+  debian:
+    '*': [libmysql++3t64]
+    bookworm: [libmysql++3v5]
   fedora: [mysql++]
   ubuntu:
+    '*': [libmysql++3t64]
     focal: [libmysql++3v5]
     jammy: [libmysql++3v5]
 libmysqlclient-dev:
@@ -5042,7 +5082,10 @@ libogre:
   openembedded: [ogre@meta-ros-common]
   opensuse: [ogre-devel]
   slackware: [ogre]
-  ubuntu: [libogre-1.9.0v5]
+  ubuntu:
+    '*': [libogre-1.9.0t64]
+    focal: [libogre-1.9.0v5]
+    jammy: [libogre-1.9.0v5]
 libogre-1.12-dev:
   debian:
     bullseye: [libogre-1.12-dev]
@@ -5216,6 +5259,7 @@ libopenvdb:
     bionic: [libopenvdb5.0]
     focal: [libopenvdb6.2]
     jammy: [libopenvdb8.1]
+    noble: [libopenvdb10.0t64]
 libopenvdb-dev:
   arch: [openvdb]
   debian: [libopenvdb-dev, libilmbase-dev]
@@ -5837,6 +5881,8 @@ libpqxx:
   ubuntu:
     bionic: [libpqxx-4.0v5]
     focal: [libpqxx-6.4]
+    jammy: [libpqxx-6.4]
+    noble: [libpqxx-7.8t64]
 libpqxx-dev:
   arch: [libpqxx]
   debian: [libpqxx-dev]
@@ -5925,14 +5971,19 @@ libqglviewer-qt4-dev:
   ubuntu:
     bionic: [libqglviewer-dev-qt4]
 libqglviewer2-qt5:
-  debian: [libqglviewer2-qt5]
+  debian:
+    '*': [libqglviewer2-qt5t64]
+    bookworm: [libqglviewer2-qt5]
   fedora: [libQGLViewer-qt5]
   gentoo: [x11-libs/libQGLViewer]
   nixos: [libsForQt5.libqglviewer]
   rhel:
     '*': [libQGLViewer-qt5]
     '7': null
-  ubuntu: [libqglviewer2-qt5]
+  ubuntu:
+    '*': [libqglviewer2-qt5t64]
+    focal: [libqglviewer2-qt5]
+    jammy: [libqglviewer2-qt5]
 libqhull:
   arch: [qhull]
   debian: [libqhull-dev]
@@ -6020,7 +6071,9 @@ libqt5-charts-dev:
   ubuntu: [libqt5charts5-dev]
 libqt5-concurrent:
   arch: [qt5-base]
-  debian: [libqt5concurrent5]
+  debian:
+    '*': [libqt5concurrent5t64]
+    bookworm: [libqt5concurrent5]
   fedora: [qt5-qtbase]
   gentoo: ['dev-qt/qtconcurrent:5']
   nixos: [qt5.qtbase]
@@ -6028,11 +6081,16 @@ libqt5-concurrent:
   opensuse: [libQt5Concurrent5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
-  ubuntu: [libqt5concurrent5]
+  ubuntu:
+    '*': [libqt5concurrent5t64]
+    focal: [libqt5concurrent5]
+    jammy: [libqt5concurrent5]
 libqt5-core:
   alpine: [qt5-qtbase]
   arch: [qt5-base]
-  debian: [libqt5core5a]
+  debian:
+    '*': [libqt5core5t64]
+    bookworm: [libqt5core5a]
   fedora: [qt5-qtbase]
   freebsd: [qt5-core]
   gentoo: ['dev-qt/qtcore:5']
@@ -6051,7 +6109,9 @@ libqt5-gstreamer-dev:
 libqt5-gui:
   alpine: [qt5-qtbase]
   arch: [qt5-base]
-  debian: [libqt5gui5]
+  debian:
+    '*': [libqt5gui5t64]
+    bookworm: [libqt5gui5]
   fedora: [qt5-qtbase-gui]
   freebsd: [qt5-gui]
   gentoo: ['dev-qt/qtgui:5']
@@ -6073,18 +6133,25 @@ libqt5-multimedia:
   ubuntu: [libqt5multimedia5]
 libqt5-network:
   arch: [qt5-base]
-  debian: [libqt5network5]
+  debian:
+    '*': [libqt5network5t64]
+    bookworm: [libqt5network5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-network]
   gentoo: ['dev-qt/qtnetwork:5']
   nixos: [qt5.qtbase]
   openembedded: [qtbase@meta-qt5]
   opensuse: [libQt5Network5]
-  ubuntu: [libqt5network5]
+  ubuntu:
+    '*': [libqt5network5t64]
+    focal: [libqt5network5]
+    jammy: [libqt5network5]
 libqt5-opengl:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]
-  debian: [libqt5opengl5]
+  debian:
+    '*': [libqt5opengl5t64]
+    bookworm: [libqt5opengl5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-opengl]
   gentoo: ['dev-qt/qtopengl:5']
@@ -6093,7 +6160,10 @@ libqt5-opengl:
   opensuse: [libQt5OpenGL5]
   rhel: [qt5-qtbase]
   slackware: [qt5]
-  ubuntu: [libqt5opengl5]
+  ubuntu:
+    '*': [libqt5opengl5t64]
+    focal: [libqt5opengl5]
+    jammy: [libqt5opengl5]
 libqt5-opengl-dev:
   arch: [qt5-base]
   debian: [libqt5opengl5-dev]
@@ -6108,12 +6178,17 @@ libqt5-opengl-dev:
   ubuntu: [libqt5opengl5-dev]
 libqt5-printsupport:
   arch: [qt5-base]
-  debian: [libqt5printsupport5]
+  debian:
+    '*': [libqt5printsupport5t64]
+    bookworm: [libqt5printsupport5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-printsupport]
   gentoo: ['dev-qt/qtprintsupport:5']
   nixos: [qt5.qtbase]
-  ubuntu: [libqt5printsupport5]
+  ubuntu:
+    '*': [libqt5printsupport5t64]
+    focal: [libqt5printsupport5]
+    jammy: [libqt5printsupport5]
 libqt5-qml:
   arch: [qt5-declarative]
   debian: [libqt5qml5]
@@ -6151,13 +6226,16 @@ libqt5-serialport-dev:
 libqt5-sql:
   arch: [qt5-base]
   debian:
-    buster: [libqt5sql5]
-    stretch: [libqt5sql5]
+    '*': [libqt5sql5t64]
+    bookworm: [libqt5sql5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-sql]
   gentoo: ['dev-qt/qtsql:5']
   nixos: [qt5.qtbase]
-  ubuntu: [libqt5sql5]
+  ubuntu:
+    '*': [libqt5sql5t64]
+    focal: [libqt5sql5]
+    jammy: [libqt5sql5]
 libqt5-svg:
   arch: [qt5-svg]
   debian: [libqt5svg5]
@@ -6192,7 +6270,9 @@ libqt5-websockets-dev:
 libqt5-widgets:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]
-  debian: [libqt5widgets5]
+  debian:
+    '*': [libqt5widgets5t64]
+    bookworm: [libqt5widgets5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-widgets]
   gentoo: ['dev-qt/qtwidgets:5']
@@ -6207,7 +6287,9 @@ libqt5-widgets:
     jammy: [libqt5widgets5]
 libqt5-xml:
   arch: [qt5-base]
-  debian: [libqt5xml5]
+  debian:
+    '*': [libqt5xml5t64]
+    bookworm: [libqt5xml5]
   nixos: [qt5.qtbase]
   ubuntu:
     '*': [libqt5xml5t64]
@@ -6233,7 +6315,9 @@ libqt5x11extras5-dev:
 libqt6-core:
   alpine: [qt6-qtbase]
   arch: [qt6-base]
-  debian: [libqt6core6]
+  debian:
+    '*': [libqt6core6t64]
+    bookworm: [libqt6core6]
   fedora: [qt6-qtbase]
   gentoo: ['dev-qt/qtcore:6']
   nixos: [qt6.qtbase]
@@ -6591,12 +6675,17 @@ libssh-dev:
   ubuntu: [libssh-dev]
 libssh2:
   arch: [libssh2]
-  debian: [libssh2-1]
+  debian:
+    '*': [libssh2-1t64]
+    bookworm: [libssh2-1]
   fedora: [libssh2]
   gentoo: [net-libs/libssh2]
   nixos: [libssh2]
   openembedded: [libssh2@openembedded-core]
-  ubuntu: [libssh2-1]
+  ubuntu:
+    '*': [libssh2-1t64]
+    focal: [libssh2-1]
+    jammy: [libssh2-1]
 libssh2-dev:
   arch: [libssh2]
   debian: [libssh2-1-dev]
@@ -6760,8 +6849,13 @@ libtool:
   slackware: [libtool]
   ubuntu: [libtool, libltdl-dev, libtool-bin]
 libttspico:
-  debian: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
-  ubuntu: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
+  debian:
+    '*': [libttspico-dev, libttspico-data, libttspico-utils, libttspico0t64]
+    bookworm: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
+  ubuntu:
+    '*': [libttspico-dev, libttspico-data, libttspico-utils, libttspico0t64]
+    focal: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
+    jammy: [libttspico-dev, libttspico-data, libttspico-utils, libttspico0]
 libturbojpeg:
   arch: [libjpeg-turbo]
   debian:
@@ -8333,7 +8427,7 @@ protobuf:
     bionic: [libprotobuf10]
     focal: [libprotobuf17]
     jammy: [libprotobuf23]
-    noble: [libprotobuf32]
+    noble: [libprotobuf32t64]
 protobuf-compiler-grpc:
   arch: [grpc]
   debian: [protobuf-compiler-grpc]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4671,7 +4671,7 @@ libjsonrpccpp-server0:
   debian:
     '*': [libjsonrpccpp-server0t64]
     bookworm: [libjsonrpccpp-server0]
-  ubuntu: [libjsonrpccpp-server0t64]
+  ubuntu:
     '*': [libjsonrpccpp-server0t64]
     focal: [libjsonrpccpp-server0]
     jammy: [libjsonrpccpp-server0]


### PR DESCRIPTION
As mentioned in  #47577,  a bunch of packages in Ubuntu Noble and Debian Trixie have been renamed due to 64-bit time_t migration, this pr update their names to avoid future problems