### PR TITLE
NavMap: 0.2.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -25,7 +25,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/EasyNavigation/NavMap-release.git
-      version: 0.2.4-2
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/EasyNavigation/NavMap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `NavMap` to `0.2.5-1`:

- upstream repository: https://github.com/EasyNavigation/NavMap.git
- release repository: https://github.com/EasyNavigation/NavMap-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.4-2`

## navmap_core

- No changes

## navmap_examples

- No changes

## navmap_ros

```
* Fix pcl_conversions build
* Contributors: Francisco Martín Rico
```

## navmap_ros_interfaces

- No changes

## navmap_rviz_plugin

- No changes
