### PR TITLE
Add source and doc for tiago_pro repositories

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11513,6 +11513,46 @@ repositories:
       url: https://github.com/pal-robotics/tiago_pro_head_simulation.git
       version: humble-devel
     status: developed
+  tiago_pro_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_moveit_config.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_moveit_config.git
+      version: humble-devel
+    status: developed
+  tiago_pro_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_navigation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_navigation.git
+      version: humble-devel
+    status: developed
+  tiago_pro_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_robot.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_robot.git
+      version: humble-devel
+    status: developed
+  tiago_pro_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_simulation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_pro_simulation.git
+      version: humble-devel
+    status: developed
   tiago_robot:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The sources are here:

- https://github.com/pal-robotics/tiago_pro_moveit_config.git
- https://github.com/pal-robotics/tiago_pro_navigation.git
- https://github.com/pal-robotics/tiago_pro_robot.git
- https://github.com/pal-robotics/tiago_pro_simulation.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro: **Need some previous releases (and https://github.com/ros/rosdistro/pull/48188), but yes**
