### PR TITLE
Add sources and doc for pal_sea_arm related repositories

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7038,6 +7038,26 @@ repositories:
       url: https://github.com/pal-robotics/pal_sea_arm.git
       version: humble-devel
     status: developed
+  pal_sea_arm_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git
+      version: humble-devel
+    status: developed
+  pal_sea_arm_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_sea_arm_simulation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_sea_arm_simulation.git
+      version: humble-devel
+    status: developed
   pal_statistics:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The sources are here:

- https://github.com/pal-robotics/pal_sea_arm_moveit_config
- https://github.com/pal-robotics/pal_sea_arm_simulation

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro: **Need some previous releases, but yes**
