### PR TITLE
mrpt_msgs: 0.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5799,7 +5799,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_msgs-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_msgs` to `0.6.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_msgs.git
- release repository: https://github.com/ros2-gbp/mrpt_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.0-1`

## mrpt_msgs

```
* Export mrpt_msgs::mrpt_msgs_library cmake target as ROS2 std packages
* Update README.md: Mark Noetic as EOL
* Readme: Update ROS badges
* Contributors: Jose Luis Blanco-Claraco
```
