### PR TITLE
tango_icons_vendor: 0.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9039,11 +9039,15 @@ repositories:
       version: kilted
     status: developed
   tango_icons_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/tango_icons_vendor.git
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.4.0-2
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.4.1-1`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-2`

## tango_icons_vendor

```
* fix cmake deprecation (#15 <https://github.com/ros-visualization/tango_icons_vendor/issues/15>) (#16 <https://github.com/ros-visualization/tango_icons_vendor/issues/16>)
* Remove the mirror-rolling-to-master workflow. (#12 <https://github.com/ros-visualization/tango_icons_vendor/issues/12>)
* Remove CODEOWNERS (#11 <https://github.com/ros-visualization/tango_icons_vendor/issues/11>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, mergify[bot]
```
