### PR TITLE
sick_scan_xd: 3.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10696,7 +10696,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sick_scan_xd-release.git
-      version: 3.7.0-7
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_scan_xd` to `3.8.0-1`:

- upstream repository: https://github.com/SICKAG/sick_scan_xd.git
- release repository: https://github.com/ros2-gbp/sick_scan_xd-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.7.0-7`

## sick_scan_xd

```
* Release v3.8.0
  * add: Extra frameid for IMU message, #471
  * add: ROS2 kilted support
  * update: Fix code block indentation in README
  * update: README — add layer suffixes explanation and general improvements
  * update: Optimized CMakeLists.txt (ROS2 distros as list)
  * fix: Relaxed required field test
  * fix: ASCII parsing for TiM240, #478
```
