### PR TITLE
class_loader: 2.8.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1034,7 +1034,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.8.0-2
+      version: 2.8.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.8.1-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.0-2`

## class_loader

```
* Update cmake requirement (#222 <https://github.com/ros/class_loader/issues/222>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#215 <https://github.com/ros/class_loader/issues/215>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```
