### PR TITLE
kdl_parser: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3219,7 +3219,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kdl_parser` to `3.0.1-1`:

- upstream repository: https://github.com/ros/kdl_parser.git
- release repository: https://github.com/ros2-gbp/kdl_parser-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.0-1`

## kdl_parser

```
* Removed kdl vendor dependency (#90 <https://github.com/ros/kdl_parser//issues/90>)
* Contributors: Alejandro Hernández Cordero
```
