### PR TITLE
robot_state_publisher: 3.5.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6912,7 +6912,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.5.2-1
+      version: 3.5.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.5.3-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.2-1`

## robot_state_publisher

```
* Add functionality to read description from a topic instead of a parameter (#234 <https://github.com/ros/robot_state_publisher/issues/234>)
* Removed tf2_ros warning (#239 <https://github.com/ros/robot_state_publisher/issues/239>)
* fix cmake deprecation (#232 <https://github.com/ros/robot_state_publisher/issues/232>)
* Removed tf2_ros warning (#238 <https://github.com/ros/robot_state_publisher/issues/238>)
* Removed orocos kdl vendor dependency (#237 <https://github.com/ros/robot_state_publisher/issues/237>)
* Removed warnings in geometry2 (#236 <https://github.com/ros/robot_state_publisher/issues/236>)
* Contributors: Alejandro Hernández Cordero, Kenji Brameld (TRACLabs), mosfet80
```
