### PR TITLE
robot_state_publisher: 3.4.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6976,7 +6976,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.4.2-2
+      version: 3.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.4.3-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.2-2`

## robot_state_publisher

```
* fix cmake deprecation (#232 <https://github.com/ros/robot_state_publisher/issues/232>) (#240 <https://github.com/ros/robot_state_publisher/issues/240>)
* Contributors: mergify[bot]
```
