### PR TITLE
example_interfaces: 0.13.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1881,7 +1881,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.13.0-2
+      version: 0.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `example_interfaces` to `0.13.1-1`:

- upstream repository: https://github.com/ros2/example_interfaces.git
- release repository: https://github.com/ros2-gbp/example_interfaces-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.13.0-2`

## example_interfaces

```
* fix cmake deprecation (#23 <https://github.com/ros2/example_interfaces/issues/23>) (#24 <https://github.com/ros2/example_interfaces/issues/24>)
* remove .github/ISSUE_TEMPLATE.md (old version of templates) (#21 <https://github.com/ros2/example_interfaces/issues/21>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#19 <https://github.com/ros2/example_interfaces/issues/19>)
* Contributors: Chris Lalancette, Tomoya Fujita, mergify[bot]
```
