### PR TITLE
geometry2: 0.45.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2347,7 +2347,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.45.0-1
+      version: 0.45.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.45.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.45.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

```
* Removed orocos kdl vendor dependency (#826 <https://github.com/ros2/geometry2/issues/826>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_geometry_msgs

```
* Removed orocos kdl vendor dependency (#826 <https://github.com/ros2/geometry2/issues/826>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_kdl

```
* Removed orocos kdl vendor dependency (#826 <https://github.com/ros2/geometry2/issues/826>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Removed deprecation rclcpp::spin_some(node) (#824 <https://github.com/ros2/geometry2/issues/824>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

```
* Removed orocos kdl vendor dependency (#826 <https://github.com/ros2/geometry2/issues/826>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_tools

- No changes
