### PR TITLE
launch: 3.9.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3462,7 +3462,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.3-1
+      version: 3.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.4-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.3-1`

## launch

```
* Shared logic for substitutions (#769 <https://github.com/ros2/launch/issues/769>)
* Use yaml types (#781 <https://github.com/ros2/launch/issues/781>)
* Switch osrf_pycommon dependency to system package (#817 <https://github.com/ros2/launch/issues/817>)
* Fix all/any in xml and yaml launch files (#906 <https://github.com/ros2/launch/issues/906>)
* Contributors: Matthijs van der Burgh, Michael Carlstrom, Scott K Logan
```

## launch_pytest

```
* Switch osrf_pycommon dependency to system package (#817 <https://github.com/ros2/launch/issues/817>)
* Contributors: Scott K Logan
```

## launch_testing

```
* Switch osrf_pycommon dependency to system package (#817 <https://github.com/ros2/launch/issues/817>)
* Contributors: Scott K Logan
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Fix all/any in xml and yaml launch files (#906 <https://github.com/ros2/launch/issues/906>)
* Contributors: Matthijs van der Burgh
```

## launch_yaml

```
* Fix all/any in xml and yaml launch files (#906 <https://github.com/ros2/launch/issues/906>)
* Contributors: Matthijs van der Burgh
```
