### PR TITLE
launch_ros: 0.29.3-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3512,7 +3512,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.2-1
+      version: 0.29.3-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.29.3-4`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.29.2-1`

## launch_ros

```
* Expose composable_lifecycle_node in front-end (#480 <https://github.com/ros2/launch_ros/issues/480>)
* Switch osrf_pycommon dependency to system package (#431 <https://github.com/ros2/launch_ros/issues/431>)
* Fix SetUseSimTime for launch frontends (#488 <https://github.com/ros2/launch_ros/issues/488>)
* Contributors: Christophe Bedard, Jasper van Brakel, Scott K Logan
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
