### PR TITLE
launch: 3.8.5-3 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3509,7 +3509,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.4-1
+      version: 3.8.5-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.8.5-3`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.4-1`

## launch

```
* Fix all/any in xml and yaml launch files (backport #906 <https://github.com/ros2/launch/issues/906>) (#911 <https://github.com/ros2/launch/issues/911>)
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Fix all/any in xml and yaml launch files (backport #906 <https://github.com/ros2/launch/issues/906>) (#911 <https://github.com/ros2/launch/issues/911>)
* Contributors: mergify[bot]
```

## launch_yaml

```
* Fix all/any in xml and yaml launch files (backport #906 <https://github.com/ros2/launch/issues/906>) (#911 <https://github.com/ros2/launch/issues/911>)
* Contributors: mergify[bot]
```
