### PR TITLE
geometry2: 0.36.15-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2977,7 +2977,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.14-1
+      version: 0.36.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.15-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.36.14-1`

## examples_tf2_py

```
* Fix Setuptools deprecations (#809 <https://github.com/ros2/geometry2/issues/809>) (#830 <https://github.com/ros2/geometry2/issues/830>)
* Contributors: mergify[bot]
```

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

```
* Fix Setuptools deprecations (#809 <https://github.com/ros2/geometry2/issues/809>) (#830 <https://github.com/ros2/geometry2/issues/830>)
* Contributors: mergify[bot]
```
