### PR TITLE
launch: 1.0.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4622,7 +4622,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 1.0.11-1
+      version: 1.0.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `1.0.12-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.11-1`

## launch

```
* Fix all/any in xml and yaml launch files (backport #906 <https://github.com/ros2/launch/issues/906>) (#913 <https://github.com/ros2/launch/issues/913>)
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Fix all/any in xml and yaml launch files (backport #906 <https://github.com/ros2/launch/issues/906>) (#913 <https://github.com/ros2/launch/issues/913>)
* Contributors: mergify[bot]
```

## launch_yaml

```
* Fix all/any in xml and yaml launch files (backport #906 <https://github.com/ros2/launch/issues/906>) (#913 <https://github.com/ros2/launch/issues/913>)
* Contributors: mergify[bot]
```
