### PR TITLE
examples: 0.19.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2474,7 +2474,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/examples-release.git
-      version: 0.19.6-1
+      version: 0.19.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `examples` to `0.19.7-1`:

- upstream repository: https://github.com/ros2/examples.git
- release repository: https://github.com/ros2-gbp/examples-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.19.6-1`

## examples_rclcpp_async_client

- No changes

## examples_rclcpp_cbg_executor

- No changes

## examples_rclcpp_minimal_action_client

- No changes

## examples_rclcpp_minimal_action_server

- No changes

## examples_rclcpp_minimal_client

- No changes

## examples_rclcpp_minimal_composition

- No changes

## examples_rclcpp_minimal_publisher

- No changes

## examples_rclcpp_minimal_service

- No changes

## examples_rclcpp_minimal_subscriber

- No changes

## examples_rclcpp_minimal_timer

- No changes

## examples_rclcpp_multithreaded_executor

- No changes

## examples_rclcpp_wait_set

- No changes

## examples_rclpy_executors

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_guard_conditions

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_action_client

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_action_server

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_client

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_publisher

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_service

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_minimal_subscriber

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## examples_rclpy_pointcloud_publisher

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```

## launch_testing_examples

```
* Fix setuptools deprecations (backport #421 <https://github.com/ros2/examples//issues/421>) (#425 <https://github.com/ros2/examples//issues/425>)
* Contributors: mergify[bot]
```
