### PR TITLE
rqt: 1.9.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7932,7 +7932,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.9.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.9.1-1`

## rqt

```
* fix setuptools deprecations (#329 <https://github.com/ros-visualization/rqt/issues/329>) (#330 <https://github.com/ros-visualization/rqt/issues/330>)
* Contributors: mergify[bot]
```

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
