### PR TITLE
rmw_dds_common: 4.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6766,7 +6766,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 4.0.0-1
+      version: 4.0.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `4.0.1-2`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.0-1`

## rmw_dds_common

```
* Remove deprecated GraphCache methods without type hash (#83 <https://github.com/ros2/rmw_dds_common/issues/83>)
* Contributors: Christophe Bedard
```
