### PR TITLE
pal_urdf_utils: 2.3.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7065,7 +7065,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_urdf_utils-release.git
-      version: 2.2.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_urdf_utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_urdf_utils` to `2.3.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_urdf_utils.git
- release repository: https://github.com/pal-gbp/pal_urdf_utils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## pal_urdf_utils

```
* Typo in t265 urdf
* Contributors: antoniobrandi
```
