### PR TITLE
tiago_pro_head_robot: 1.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11497,7 +11497,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_pro_head_robot-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_head_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_head_robot` to `1.6.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_head_robot.git
- release repository: https://github.com/pal-gbp/tiago_pro_head_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-1`

## tiago_pro_head_bringup

- No changes

## tiago_pro_head_controller_configuration

- No changes

## tiago_pro_head_description

- No changes

## tiago_pro_head_robot

```
* Remove unused linters
* Contributors: Noel Jimenez
```
