### PR TITLE
sbg_driver: 3.2.1-2 in 'noetic/distribution.yaml' [bloom]

### DIFF
--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -11339,7 +11339,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 3.2.0-1
+      version: 3.2.1-2
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.2.1-2`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros_driver.git
- release repository: https://github.com/SBG-Systems/sbg_ros_driver-release.git
- distro file: `noetic/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.2.0-1`

## sbg_driver

```
* Add End of Life notice
* Handle INS internal clock rollover
* Fix timestamp computation for out-of-order messages
* Backport from ROS2 driver: Use imu_short to populate standard topics
* Fix typo sbg_ekf_ruler_pub_ instead of sbg_ekf_euler_pub_
* Contributors: Samuel Toledano
```
