### PR TITLE
sbg_driver: 3.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8509,6 +8509,21 @@ repositories:
       url: https://github.com/PickNikRobotics/rviz_visual_tools.git
       version: ros2
     status: maintained
+  sbg_driver:
+    doc:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      version: 3.3.0-1
+    source:
+      type: git
+      url: https://github.com/SBG-Systems/sbg_ros2.git
+      version: master
+    status: developed
   sdformat_urdf:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.3.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros2.git
- release repository: https://github.com/SBG-Systems/sbg_ros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## sbg_driver

```
* Update README.md
* Don't apply scale factor on SbgImuData message, it already has the good unit
* Update sbgECom to latest stable
* Fix transformations to use correct parents and children frames
* Issue-35 Add Ellipse STL and URDF files
* fix lon&lat minutes snprintf format error in NMEA sentence for ntrip
* Update README
* uart: implement baudrate discovery mechanism
* Apply LSB on IMU messages
* Add file mode to replay sbgECom logs on the driver
* Provide /imu/data topic even if orientation is not available
* Handle INS internal clock rollover
* Fix timestamp computation for out-of-order messages
* Use cmake fetch content to get sbgECom, get the latest release and fix compilation issue
* Send odometry topic as soon as the solution mode is full navigation instead of waiting for position valid flag
* Use imu_short to populate standard topics
* Improved documentation
* Contributors: Christoph Gruber, Kaoutar Benmakhlouf, Samuel Toledano, djason-todd
```
