### PR TITLE
rviz: 15.1.11-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8373,7 +8373,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.10-1
+      version: 15.1.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.11-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.10-1`

## rviz2

- No changes

## rviz_common

```
* Fix incorrect Qt signal connection in combo box (#1596 <https://github.com/ros2/rviz/issues/1596>)
* Removed tinyxml2_vendor dependency (#1591 <https://github.com/ros2/rviz/issues/1591>)
* Replace QRegExp with QRegularExpression to support Qt6 (#1592 <https://github.com/ros2/rviz/issues/1592>)
* Contributors: Alejandro Hernández Cordero, mini-1235
```

## rviz_default_plugins

```
* Fixed issue 1593 (#1598 <https://github.com/ros2/rviz/issues/1598>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
