### PR TITLE
rviz: 15.0.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8454,7 +8454,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.7-1
+      version: 15.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.8-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.7-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fixed issue 1593 (#1598 <https://github.com/ros2/rviz/issues/1598>) (#1599 <https://github.com/ros2/rviz/issues/1599>)
  (cherry picked from commit ef84b87fefe4e8fd81b170ce12d41094d1bc44d9)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
