### PR TITLE
rosidl_typesupport: 3.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7699,7 +7699,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 3.4.0-1
+      version: 3.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `3.4.1-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.0-1`

## rosidl_typesupport_c

- No changes

## rosidl_typesupport_cpp

```
* Remove deprecated rosidl_typesupport_cpp/type_support_map.h (#167 <https://github.com/ros2/rosidl_typesupport/issues/167>)
* Contributors: Christophe Bedard
```
