### PR TITLE
rmw_connextdds: 1.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6733,7 +6733,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.3-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.2-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* [rmw_connextdds_common]: Remove <member_of_group>rosidl_interface_packages (#202 <https://github.com/ros2/rmw_connextdds/issues/202>)
* Correctly calculate the size of a serialized key (#200 <https://github.com/ros2/rmw_connextdds/issues/200>)
* Contributors: Chris Lalancette, Francisco Gallego Salido
```

## rti_connext_dds_cmake_module

- No changes
