### PR TITLE
mola_state_estimation: 1.11.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5589,7 +5589,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.11.0-1
+      version: 1.11.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `1.11.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.11.0-1`

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Update to build against MOLA>=2.1.0 with ConstPtr API
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Update to build against MOLA>=2.1.0 with ConstPtr API
* Contributors: Jose Luis Blanco-Claraco
```
