### PR TITLE
mola: 2.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5510,7 +5510,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Publish to ROS all map types implementing getAsSimplePointsMap()
* format
* FIX: ROS2 bridge must use timestamps for map updates to publish maps and deskewed clouds
* Support publishing several maps from the same source per iteration to ROS
* clang-format
* Make use of ConstPtr across API
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_lidar_bin_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_input_video

- No changes

## mola_kernel

```
* Send sensor_rate_decimation to Viz
* interfaces/MapSourceBase: Add keep_last_one_only property
* Make use of ConstPtr across API
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

```
* Fix formatting
* Implement getAsSimplePointsMap()
* KeyframePointCloudMap: Fix class must be copy-constructible
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* FIX: Show correct sensor rate in Hz when visualizing with a decimation
* Fix clang-tidy warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
