### PR TITLE
mola_lidar_odometry: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4193,7 +4193,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `1.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## mola_lidar_odometry

```
* Docs: describe the new GICP and LIO pipelines
* Update rviz settings
* Prefer to publish deskewed clouds in 'map' frame
* FIX: ROS2 interface must use correct cloud and pose timestamps
* Update and fix LIO ROS2 launch demo and docs
* ROS: support rendering deskewed clouds
* Replace deprecated ament_target_dependencies() with pure cmake
* Publish deskewed scans for ROS visualization
* Make use of ConstPtr for processing incoming observations
* Code clean up: remove macros for building against very old mola_kernel versions
* ros2 launch: add argument 'mola_tf_base_link'
* Contributors: Jose Luis Blanco-Claraco
```
