### PR TITLE
mola_common: 0.5.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4184,7 +4184,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_common-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_common` to `0.5.2-1`:

- upstream repository: https://github.com/MOLAorg/mola_common.git
- release repository: https://github.com/ros2-gbp/mola_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.5.1-1`

## mola_common

```
* Removed leftover inclusion of old mola-version.cmake file
* Contributors: Jose Luis Blanco-Claraco
```
