### PR TITLE
rmw_connextdds: 0.22.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7794,7 +7794,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.22.1-1
+      version: 0.22.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.22.2-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.22.1-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* [rmw_connextdds_common]: Remove <member_of_group>rosidl_interface_packages (#202 <https://github.com/ros2/rmw_connextdds/issues/202>) (#204 <https://github.com/ros2/rmw_connextdds/issues/204>)
* Contributors: mergify[bot]
```

## rti_connext_dds_cmake_module

- No changes
