### PR TITLE
rcl: 10.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6092,7 +6092,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.2.4-1
+      version: 10.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.2.5-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.2.4-1`

## rcl

```
* rcl_logging_allocator_initialize() support. (#1049 <https://github.com/ros2/rcl/issues/1049>)
* Contributors: Sai Kishor Kothakota, Tomoya Fujita
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Fix param file parsing failure with wildcards due to ordering (#1253 <https://github.com/ros2/rcl/issues/1253>)
* Contributors: Barry Xu
```
