### PR TITLE
rclcpp: 30.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6198,7 +6198,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 30.1.1-1
+      version: 30.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `30.1.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `30.1.1-1`

## rclcpp

```
* clear handles before node destruction in test_memory_strategy. (#2969 <https://github.com/ros2/rclcpp/issues/2969>)
* Added static assert asserting custom types have no overloaded operator new (#2954 <https://github.com/ros2/rclcpp/issues/2954>)
* Store graph listener inside the context instead of the node graph (#2952 <https://github.com/ros2/rclcpp/issues/2952>)
* Reapply "Catch the exception from rate.sleep() if the context is invalid. (#2956 <https://github.com/ros2/rclcpp/issues/2956>)" (#2963 <https://github.com/ros2/rclcpp/issues/2963>) (#2964 <https://github.com/ros2/rclcpp/issues/2964>)
* Revert "Catch the exception from rate.sleep() if the context is invalid. (#2956 <https://github.com/ros2/rclcpp/issues/2956>)" (#2963 <https://github.com/ros2/rclcpp/issues/2963>)
* Catch the exception from rate.sleep() if the context is invalid. (#2956 <https://github.com/ros2/rclcpp/issues/2956>)
* update Time documentation (#2955 <https://github.com/ros2/rclcpp/issues/2955>)
* Contributors: Ilario A. Azzollini, Ivo Ivanov, Skyler Medeiros, Tomoya Fujita
```

## rclcpp_action

```
* it misses the iterator second to lock the weakptr. (#2958 <https://github.com/ros2/rclcpp/issues/2958>)
* try aborting before canceling 1st on dtor of ServerGoalHandle. (#2953 <https://github.com/ros2/rclcpp/issues/2953>)
* Contributors: Tomoya Fujita
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
