### PR TITLE
rclcpp: 29.5.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6275,7 +6275,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.5.3-1
+      version: 29.5.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.5.4-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `29.5.3-1`

## rclcpp

- No changes

## rclcpp_action

```
* it misses the iterator second to lock the weakptr. (#2958 <https://github.com/ros2/rclcpp/issues/2958>) (#2959 <https://github.com/ros2/rclcpp/issues/2959>)
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
