### PR TITLE
rclcpp: 28.1.13-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7259,7 +7259,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.12-1
+      version: 28.1.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.13-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `28.1.12-1`

## rclcpp

- No changes

## rclcpp_action

```
* it misses the iterator second to lock the weakptr. (#2958 <https://github.com/ros2/rclcpp/issues/2958>) (#2960 <https://github.com/ros2/rclcpp/issues/2960>)
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
