### PR TITLE
rclpy: 10.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6214,7 +6214,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.0-1
+      version: 10.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.0.0-1`

## rclpy

```
* remove unused 'param_type' (#1524 <https://github.com/ros2/rclpy/issues/1524>)
* Fixes Action.*_async futures never complete (#1308 <https://github.com/ros2/rclpy/issues/1308>)
* add spinning state for the Executor classes. (#1510 <https://github.com/ros2/rclpy/issues/1510>)
* EventsExecutor: Handle async callbacks for services and subscriptions (#1478 <https://github.com/ros2/rclpy/issues/1478>)
* Added lock to protect futures for multithreaded executor (#1477 <https://github.com/ros2/rclpy/issues/1477>)
* Add content-filtered-topic interfaces (#1506 <https://github.com/ros2/rclpy/issues/1506>)
* Fix warnings from gcc. (#1501 <https://github.com/ros2/rclpy/issues/1501>)
* Feature: expose event callback setter in subscription, service, client and timer (#1496 <https://github.com/ros2/rclpy/issues/1496>)
* Feature: add executor.create_future() (#1495 <https://github.com/ros2/rclpy/issues/1495>)
* Add More Test Typings (#1472 <https://github.com/ros2/rclpy/issues/1472>)
* Use pybind11 from deb or pixi (#1497 <https://github.com/ros2/rclpy/issues/1497>)
* Do not execute the timer if call_timer_with_info() fails (#1488 <https://github.com/ros2/rclpy/issues/1488>)
* Fix msbuild warnings on operator== deprecation for pybind11 >=2.2 (#1483 <https://github.com/ros2/rclpy/issues/1483>)
* Cleanup the rclpy dependencies. (#1482 <https://github.com/ros2/rclpy/issues/1482>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Brad Martin, Brennan Miller-Klugman, Chris Lalancette, Christian Rauch, Clara Berendsen, Jonathan, Michael Carlstrom, Nadav Elkabets, Tomoya Fujita
```
