### PR TITLE
rclpy: 9.1.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6291,7 +6291,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 9.1.1-1
+      version: 9.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `9.1.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.1.1-1`

## rclpy

```
* remove unused 'param_type' (#1524 <https://github.com/ros2/rclpy/issues/1524>) (#1525 <https://github.com/ros2/rclpy/issues/1525>)
* Fixes Action.*_async futures never complete (#1308 <https://github.com/ros2/rclpy/issues/1308>) (#1514 <https://github.com/ros2/rclpy/issues/1514>)
* Add content-filtered-topic interfaces (backport #1506 <https://github.com/ros2/rclpy/issues/1506>) (#1520 <https://github.com/ros2/rclpy/issues/1520>)
* EventsExecutor: Handle async callbacks for services and subscriptions (#1478 <https://github.com/ros2/rclpy/issues/1478>) (#1512 <https://github.com/ros2/rclpy/issues/1512>)
* Do not execute the timer if call_timer_with_info() fails (#1488 <https://github.com/ros2/rclpy/issues/1488>) (#1498 <https://github.com/ros2/rclpy/issues/1498>)
* Feature: add executor.create_future() (#1495 <https://github.com/ros2/rclpy/issues/1495>) (#1499 <https://github.com/ros2/rclpy/issues/1499>)
* Contributors: mergify[bot]
```
