### PR TITLE
rclpy: 7.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7275,7 +7275,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.1.5-1
+      version: 7.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.6-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.1.5-1`

## rclpy

```
* remove unused 'param_type' (#1524 <https://github.com/ros2/rclpy/issues/1524>) (#1526 <https://github.com/ros2/rclpy/issues/1526>)
* Fixes Action.*_async futures never complete (#1308 <https://github.com/ros2/rclpy/issues/1308>) (#1517 <https://github.com/ros2/rclpy/issues/1517>)
* Feature: add executor.create_future() (backport #1495 <https://github.com/ros2/rclpy/issues/1495>) (#1500 <https://github.com/ros2/rclpy/issues/1500>)
* Do not execute the timer if call_timer() fails (#1487 <https://github.com/ros2/rclpy/issues/1487>)
* Contributors: Barry Xu, Jonathan, mergify[bot]
```
