### PR TITLE
add easysnmp to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11366,7 +11366,7 @@ zulip-pip:
   ubuntu:
     pip:
       packages: [zulip]
-python3-easysnmp-pip:
+python3-easysnmp:
   ubuntu:
     noble: [python3-easysnmp]
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5795,6 +5795,11 @@ python3-easydict:
     focal:
       pip:
         packages: [easydict]
+python3-easysnmp:
+  ubuntu:
+    noble: [python3-easysnmp]
+    pip:
+      packages: [easysnmp]
 python3-einops-pip:
   debian:
     pip:
@@ -11373,8 +11378,3 @@ zulip-pip:
   ubuntu:
     pip:
       packages: [zulip]
-python3-easysnmp:
-  ubuntu:
-    noble: [python3-easysnmp]
-    pip:
-      packages: [easysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11368,5 +11368,6 @@ zulip-pip:
       packages: [zulip]
 python3-easysnmp-pip:
   ubuntu:
+    noble: [python3-easysnmp]
     pip:
       packages: [easysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11366,3 +11366,7 @@ zulip-pip:
   ubuntu:
     pip:
       packages: [zulip]
+python3-easysnmp-pip:
+  ubuntu:
+    pip:
+      packages: [easysnmp]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5838,9 +5838,13 @@ python3-easydict:
         packages: [easydict]
 python3-easysnmp:
   ubuntu:
-    noble: [python3-easysnmp]
-    pip:
-      packages: [easysnmp]
+    '*': [python3-easysnmp]
+    focal:
+      pip:
+        packages: [easysnmp]
+    jammy:
+      pip:
+        packages: [easysnmp]
 python3-einops-pip:
   debian:
     pip:


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name: 
easysnmp

## Package Upstream Source: 
https://github.com/easysnmp/easysnmp

## Purpose of using this:
easysnmp is a Python library that provides a simple interface for working with SNMP

Distro packaging links:

## Links to Distribution Packages
https://pypi.org/project/easysnmp/

