### PR TITLE
gz_transport_vendor: 0.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3466,7 +3466,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_transport_vendor-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_transport_vendor` to `0.0.7-1`:

- upstream repository: https://github.com/gazebo-release/gz_transport_vendor.git
- release repository: https://github.com/ros2-gbp/gz_transport_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.6-1`

## gz_transport_vendor

```
* Bump version to 13.5.0 (#16 <https://github.com/gazebo-release/gz_transport_vendor/issues/16>)
* Contributors: Addisu Z. Taddese
```
