### PR TITLE
Add entries for astrometry and photutils

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,7 +29,7 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
-astrometry:
+astrometry-pip:
   debian:
     pip:
       packages: [astrometry]
@@ -356,7 +356,7 @@ paramiko:
   rhel:
     '7': [python-paramiko]
   ubuntu: [python-paramiko]
-photutils:
+photutils-pip:
   debian:
     pip:
       packages: [photutils]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -29,6 +29,16 @@ adafruit-pca9685-pip:
   ubuntu:
     pip:
       packages: [adafruit-pca9685]
+astrometry:
+  debian:
+    pip:
+      packages: [astrometry]
+  fedora:
+    pip:
+      packages: [astrometry]
+  ubuntu:
+    pip:
+      packages: [astrometry]
 autograd-pip:
   debian:
     pip:
@@ -346,6 +356,16 @@ paramiko:
   rhel:
     '7': [python-paramiko]
   ubuntu: [python-paramiko]
+photutils:
+  debian:
+    pip:
+      packages: [photutils]
+  fedora:
+    pip:
+      packages: [photutils]
+  ubuntu:
+    pip:
+      packages: [photutils]
 pi-ina219-pip:
   debian:
     pip:
@@ -644,6 +664,16 @@ python-astor-pip:
   ubuntu:
     pip:
       packages: [astor]
+python-astrometry-pip: &migrate_eol_2025_04_30_python3_astrometry_pip
+  debian:
+    pip:
+      packages: [astrometry]
+  fedora:
+    pip:
+      packages: [astrometry]
+  ubuntu:
+    pip:
+      packages: [astrometry]
 python-attrs:
   debian:
     buster: [python-attr]
@@ -2834,6 +2864,16 @@ python-pexpect:
   debian: [python-pexpect]
   gentoo: [dev-python/pexpect]
   ubuntu: [python-pexpect]
+python-photutils-pip: &migrate_eol_2025_04_30_python3_photutils_pip
+  debian:
+    pip:
+      packages: [photutils]
+  fedora:
+    pip:
+      packages: [photutils]
+  ubuntu:
+    pip:
+      packages: [photutils]
 python-pip:
   arch: [python2-pip]
   debian: [python-pip]
@@ -4965,6 +5005,7 @@ python3-asn1tools-pip:
   '*':
     pip:
       packages: [asn1tools]
+python3-astrometry-pip: *migrate_eol_2025_04_30_python3_astrometry_pip
 python3-astropy-pip:
   debian:
     pip:
@@ -8194,6 +8235,7 @@ python3-pexpect:
   opensuse: [python3-pexpect]
   rhel: ['python%{python3_pkgversion}-pexpect']
   ubuntu: [python3-pexpect]
+python3-photutils-pip: *migrate_eol_2025_04_30_python3_photutils_pip
 python3-pickleDB-pip:
   debian:
     pip:


### PR DESCRIPTION
…ING.md

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependencies to the rosdep database.

## Package name:
astrometry

## Package Upstream Source:
- PyPI: https://pypi.org/project/astrometry
- Source repository: https://github.com/neuromorphicsystems/astrometry.git

## Purpose of using this:
Used by downstream packages that perform astrometric plate solving and image-based WCS solutions. This rosdep rule allows those ROS packages and CI to install the dependency via pip on platforms where no native distro package exists.

Distro packaging links:
- Debian: not available (pip-only)
- Ubuntu: not available (pip-only)
- Fedora: not available (pip-only)
- Arch: not available (pip-only)
- Gentoo: not available (pip-only)
- macOS (homebrew): not available (pip-only)
- Alpine: not available (pip-only)

---

## Package name:
photutils

## Package Upstream Source:
- PyPI: https://pypi.org/project/photutils
- Source repository: https://github.com/astropy/photutils

## Purpose of using this:
Provides photometry tools used by downstream image-processing code to detect and measure sources in astronomical images. Adding this rosdep rule ensures the Python dependency can be installed in CI and on developer machines where a distro package is not available.

Distro packaging links:
- Debian: not available (pip-only)
- Ubuntu: not available (pip-only)
- Fedora: not available (pip-only)
- Arch: not available (pip-only)
- Gentoo: not available (pip-only)
- macOS (homebrew): not available (pip-only)
- Alpine: not available (pip-only)

---

Distro packaging notes
- Both packages are pip-only on common distributions at time of writing. The proposed rosdep entries add pip fallbacks for Debian/Ubuntu/Fedora per repository conventions.
- If native distro packages become available later, distro-specific mappings can be added and the pip fallback adjusted/removed.

Testing performed
- Updated local rosdep (used local rosdep/python.yaml for testing):
  - ROSDEP_YAML="$(pwd)/rosdep/python.yaml" rosdep resolve python3-astrometry-pip --os=ubuntu:22.04
  - ROSDEP_YAML="$(pwd)/rosdep/python.yaml" rosdep resolve python3-photutils-pip --os=debian:bookworm
  - ROSDEP_YAML="$(pwd)/rosdep/python.yaml" rosdep resolve photutils --os=ubuntu:22.04
- Repository formatting checks:
  - pytest -q test/rosdep_formatting_test.py::test — PASS

License information
- Please verify upstream license metadata:
  - astrometry: check PyPI page (GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007 at time of this PR)
  - photutils: check PyPI page (BSD-3-Clause license at time of this PR)

Checks
 - [ ] All packages have a declared license in the package.xml  (N/A — these are pip-only rosdep rules)
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro (validated via rosdep resolve + formatting test and pip install checks)

Notes for reviewers
- If maintainers prefer a different EOL date or anchor placement, I can update the change.
