### PR TITLE
play_motion2: 1.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7302,11 +7302,12 @@ repositories:
     release:
       packages:
       - play_motion2
+      - play_motion2_cli
       - play_motion2_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.7.0-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.8.0-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.0-1`

## play_motion2

```
* Remove unused ordering of interfaces for passthrough_controller
* Add -Wno-cpp to ignore warnings from dependencies
* Replace ament_target_dependencies with target_link_libraries
* Add condition for using services QoS
* Use move_group_interface.hpp header instead of .h
* Fix linters for jazzy
* Add support for jazzy
* Contributors: Noel Jimenez, Sai Kishor Kothakota
```

## play_motion2_cli

```
* Start zenoh router if rmw_implementation is rmw_zenoh_cpp
* Fix linters for rolling
* Fix linters for jazzy
* Fix motion_name argument and motion validation
* Rename function for clarity
* Add play_motion2 exec_depend and remove unused test_depend
* Remove dead code in run verb result handling
* Simplify CLI verbs with context manager and shared motion_name argument
* Unify CLI options, fix typos, and update package format
* Update ClI examples
* Remove unused data from setup
* Simplify CLI using PlayMotion2ClientPy class
* Add play_motion2 CLI
* Contributors: Isaac Acevedo, Noel Jimenez
```

## play_motion2_msgs

- No changes
