### PR TITLE
Index mrpt_ros_bridge sources

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4529,6 +4529,16 @@ repositories:
       url: https://github.com/MRPT/mrpt_ros.git
       version: main
     status: developed
+  mrpt_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros_bridge.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros_bridge.git
+      version: ros2
+    status: developed
   mrpt_sensors:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/MRPT/mrpt_ros_bridge

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
