### PR TITLE
graph_monitor: 0.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3067,7 +3067,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/graph_monitor-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ros-tooling/graph-monitor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_monitor` to `0.2.3-1`:

- upstream repository: https://github.com/ros-tooling/graph-monitor.git
- release repository: https://github.com/ros2-gbp/graph_monitor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-1`

## rmw_stats_shim

```
* Fix circular dependency (#38 <https://github.com/ros-tooling/graph-monitor/issues/38>)
* Contributors: Emerson Knapp
```

## rosgraph_monitor

- No changes

## rosgraph_monitor_msgs

```
* Fix circular dependency (#38 <https://github.com/ros-tooling/graph-monitor/issues/38>)
* Contributors: Emerson Knapp
```
