### PR TITLE
Add ignition dependencies for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2331,6 +2331,7 @@ ignition-msgs7:
 ignition-msgs8:
   debian:
     buster: [libignition-msgs8-dev]
+  nixos: [ignition.msgs8]
   ubuntu:
     focal: [libignition-msgs8-dev]
     jammy: [libignition-msgs8-dev]
@@ -2403,6 +2404,7 @@ ignition-transport10:
 ignition-transport11:
   debian:
     buster: [libignition-transport11-dev]
+  nixos: [ignition.transport11]
   ubuntu:
     focal: [libignition-transport11-dev]
     jammy: [libignition-transport11-dev]


### PR DESCRIPTION
These are defined in `nix-ros-overlay`:  https://github.com/lopsided98/nix-ros-overlay/blob/8a927d104d10114d64528d3731eb7663bea5d843/pkgs/default.nix#L39-L62
