### PR TITLE
Add crccheck package for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1167,6 +1167,7 @@ python-crccheck-pip:
   fedora:
     pip:
       packages: [crccheck]
+  nixos: [python3Packages.crccheck]
   osx:
     pip:
       packages: [crccheck]


### PR DESCRIPTION
This package is already in the rosdep database, but is missing a link to its location in nixpkgs.

## Package name:

python-crccheck-pip

## Links to Distribution Packages

- NixOS/nixpkgs: https://search.nixos.org/packages
  - python3Packages.crccheck
