### PR TITLE
yasmin: 3.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10137,7 +10137,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 3.5.0-1
+      version: 3.5.1-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `3.5.1-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.0-1`

## yasmin

```
* test exception messages in C++ tests
* creating C++ tests
* fixing python tests to run using colcon
* fixing exceptions in C++ version
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

- No changes

## yasmin_msgs

- No changes

## yasmin_ros

```
* renaming ROSCommunicationsCache to ROSClientsCache
* creating C++ tests
* fixing python tests to run using colcon
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

- No changes
