### PR TITLE
clearpath_common: 2.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1275,7 +1275,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.7.4-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.8.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.4-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

```
* Put the router & base station diagnostics into Networking (#272 <https://github.com/clearpathrobotics/clearpath_common/issues/272>)
  * Put the router & base station diagnostics into Networking, update the wireless watcher to use the correct flag
  * Update the new diagnostic names
* Add dependency on python3-apt (#273 <https://github.com/clearpathrobotics/clearpath_common/issues/273>)
* Replace assertions in clearpath_generator_common with specific exceptions. Include error messages (#271 <https://github.com/clearpathrobotics/clearpath_common/issues/271>)
* Catch FileNotFound exceptions when loading the samples and ignore them
  Some samples have /path/to/... placeholders, which will never load correctly (#270 <https://github.com/clearpathrobotics/clearpath_common/issues/270>)
* Add system.bash support (#268 <https://github.com/clearpathrobotics/clearpath_common/issues/268>)
  * Add the ability to specify additional BASH sources & envars directly from robot.yaml. Put quotation marks around exports (required if the value contains whitespace). Add comments to the bash file for clarity
* Add support for automatic discovery range (#262 <https://github.com/clearpathrobotics/clearpath_common/issues/262>)
  * Write the ROS_AUTOMATIC_DISCOVERY_RANGE and ROS_STATIC_PEERS envars
  * Unset ROS_STATIC_PEERS if there are no peers, rather than setting an empty string
* Contributors: Chris Iverach-Brereton
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
