### PR TITLE
ur_robot_driver: 2.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12341,7 +12341,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.10.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.0-1`

## ur

- No changes

## ur_bringup

```
* Add support for UR18 (backport #1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>) (#1525 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1525>)
* Contributors: mergify[bot]
```

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for UR18 (backport #1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>) (#1525 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1525>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Add missing update_rate config files for UR7e and UR12e (backport of #1544 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1544>) (#1547 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1547>)
* Add support for UR18 (backport #1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>) (#1525 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1525>)
* Trajectory until node (backport of #1461 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1461>) (#1522 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1522>)
* Wait for used controllers in test setup (backport #1519 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1519>) (#1520 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1520>)
* Running integration tests with mock hardware (backport #1226 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1226>) (#1508 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1508>)
* Fix link to limits man page (#1518 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1518>)
* Add test for hardware component lifecycle (backport #1476 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1476>) (#1506 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1506>)
* Contributors: Felix Exner, mergify[bot]
```