### PR TITLE
ur_robot_driver: 3.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11081,7 +11081,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.5.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* Add support for UR18 (backport of #1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>) (#1526 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1526>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Add missing update_rate config files for UR7e and UR12e (backport #1544 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1544>) (#1548 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1548>)
* Specify that only PS5 needs the option of remote control explicitly enabled (backport of #1530 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1530>) (#1534 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1534>)
* Add missing dependency to effort_controllers (backport of #1531 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1531>) (#1532 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1532>)
* Add effort command interface to hardware interface (backport of #1411 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1411>) (#1529 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1529>)
* Trajectory until node (backport #1461 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1461>) (#1523 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1523>)
* Add support for UR18 (backport of #1524 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1524>) (#1526 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1526>)
* Wait for used controllers in test setup (backport of #1519 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1519>) (#1521 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1521>)
* Running integration tests with mock hardware (#1226 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1226>) (#1509 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1509>)
* Add test for hardware component lifecycle (backport #1476 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1476>) (#1507 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1507>)
* Contributors: mergify[bot]
```
