### PR TITLE
ur_description: 3.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11044,7 +11044,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `3.5.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.0-1`

## ur_description

```
* Add effort command interface to all joints (backport of #302 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/302>) (#351 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/351>)
* Auto-update pre-commit hooks (backport of #347 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/347>) (#349 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/349>)
* Contributors: mergify[bot]
```
