### PR TITLE
play_motion_builder: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5466,6 +5466,15 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/play_motion_builder.git
       version: humble-devel
+    release:
+      packages:
+      - play_motion_builder
+      - play_motion_builder_msgs
+      - rqt_play_motion_builder
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/play_motion_builder-release.git
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion_builder.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion_builder` to `1.4.0-1`:

- upstream repository: https://github.com/pal-robotics/play_motion_builder.git
- release repository: https://github.com/ros2-gbp/play_motion_builder-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## play_motion_builder

```
* Fix ament_auto warning about headers install destination
* Contributors: Noel Jimenez
```

## play_motion_builder_msgs

- No changes

## rqt_play_motion_builder

```
* Fix ament_auto warning about headers install destination
* Contributors: Noel Jimenez
```
