### PR TITLE
dbw_ros: 2.3.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1825,7 +1825,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.6-1
+      version: 2.3.9-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.9-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.6-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2025/10/24 release package
* Improve compiler portability for CAN message C++ header
* Add gear command return-to-park flag
* Use ros2_socketcan launch.xml instead of internal copies of launch.py
* Add option to send/receive CAN messages with socketCAN instead of ROS topics
* Remove invalid null characters from EcuInfo message strings
* Fix firmware build date in EcuInfo message
* Add system reasons for driver seat-belt and driver door open event
* Contributors: Gabriel Oetjens, Kevin Hallenbeck, Micho Radovnikovich
```

## ds_dbw_joystick_demo

```
* Add option to send/receive CAN messages with socketCAN instead of ROS topics
* Document additional launch args
* Contributors: Kevin Hallenbeck, Micho Radovnikovich
```

## ds_dbw_msgs

```
* Add gear command return-to-park flag
* Contributors: Gabe
```
