### PR TITLE
ur_client_library: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9636,7 +9636,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.5.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## ur_client_library

```
* Polyscopex dashboard client (#392 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/392>)
* Use enable_external_ft_sensor on old software versions (#395 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/395>)
* Rtde external ft (#388 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/388>)
* Fixed auto reconnection to the RTDE server. (#384 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/384>)
* Refactor Rtde client test (#389 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/389>)
* Add release.yml for auto-generated changelogs (#391 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/391>)
* Allow an empty input recipe to the RTDE client (#318 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/318>)
* Contributors: Felix Exner, Mads Holm Peters, URJala
```
