### PR TITLE
foxglove_sdk_vendor: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2824,6 +2824,13 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
+  foxglove_sdk_vendor:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/jlack1987/foxglove_sdk_vendor-release.git
+      version: 0.1.0-1
+    status: maintained
   frame_editor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_sdk_vendor` to `0.1.0-1`:

- upstream repository: https://gitlab.com/jlack/foxglove_sdk_vendor.git
- release repository: https://github.com/jlack1987/foxglove_sdk_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
