### PR TITLE
mrpt_ros: 2.15.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5864,13 +5864,12 @@ repositories:
       - mrpt_libobs
       - mrpt_libopengl
       - mrpt_libposes
-      - mrpt_libros_bridge
       - mrpt_libslam
       - mrpt_libtclap
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.14.16-1
+      version: 2.15.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.14.16-1`

## mrpt_apps

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* RawLogViewer:  Show stats for mrpt::maps::CGenericPoinsMap. GUI options to colorize clouds by any point cloud field.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libapps

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libbase

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libgui

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libhwdrivers

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libmaps

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Add new mrpt::maps::CGenericPointsMap
* Refactor around mrpt::maps::CPointsMap for more efficient generic insertion of maps in others with arbitrary per-point fields.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libmath

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libnav

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libobs

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libopengl

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libposes

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libslam

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libtclap

```
* Remove deps on ROS message packages, following the removal of mrpt-ros bridge into its own repository
* Contributors: Jose Luis Blanco-Claraco
```
