### PR TITLE
ublox_dgnss: 0.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11007,7 +11007,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.6.1-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.7.0-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.1-1`

## ntrip_client_node

```
* Merge pull request #50 <https://github.com/aussierobots/ublox_dgnss/issues/50> from ahcorde/ahcorde/rolling/libcurl
  Replaced libcurl_vendor package with deb or pixi
* Replaced libcurl_vendor package with deb or pixi
* Contributors: Alejandro Hernandez Cordero, Nick Hortovanyi
```

## ublox_dgnss

```
* Merge pull request #49 <https://github.com/aussierobots/ublox_dgnss/issues/49> from aussierobots/X20P
  Add X20P device family support with USB architecture adaptation
* commented out uart1 and uart2 cfg items
* 
  
    * Add clear error message directing users to main interface (0x01ab)
    * Update documentation with interface limitations and GitHub Issue #48 <https://github.com/aussierobots/ublox_dgnss/issues/48>
    * Comment out experimental header stripping code
    * Add X20P configuration parameters to launch files
  
* added new device family for X20P
* Contributors: Nick Hortovanyi
```

## ublox_dgnss_node

```
* Merge pull request #49 <https://github.com/aussierobots/ublox_dgnss/issues/49> from aussierobots/X20P
  Add X20P device family support with USB architecture adaptation
* 
  
    * Add clear error message directing users to main interface (0x01ab)
    * Update documentation with interface limitations and GitHub Issue #48 <https://github.com/aussierobots/ublox_dgnss/issues/48>
    * Comment out experimental header stripping code
    * Add X20P configuration parameters to launch files
  
* Documentation updates to match code
* added new device family for X20P
* Added support for X20P and changed USB connection to support USB UARTs
* added new device family to add X20P
* Contributors: Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
