### PR TITLE
rosidl_rust: 0.4.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7724,7 +7724,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_rust-release.git
-      version: 0.4.7-1
+      version: 0.4.8-1
     source:
       type: git
       url: https://github.com/ros2-rust/rosidl_rust.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_rust` to `0.4.8-1`:

- upstream repository: https://github.com/ros2-rust/rosidl_rust.git
- release repository: https://github.com/ros2-gbp/rosidl_rust-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.7-1`

## rosidl_generator_rs

```
* Fix use of serde (#9 <https://github.com/ros2-rust/rosidl_rust/issues/9>)
  * Fix use of serde
  * Include serde for services
  ---------
* Update to the latest version of Action trait (#7 <https://github.com/ros2-rust/rosidl_rust/issues/7>)
  * Update to the latest version of Action trait
  * Fix use of serde
  ---------
* fix cmake deprecation (#6 <https://github.com/ros2-rust/rosidl_rust/issues/6>)
  * fix cmake deprecation
  cmake version < then 3.10 is deprecated
  * Update CMakeLists.txt
* Contributors: Grey, mosfet80
```
