### PR TITLE
ros2_control: 2.52.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9156,7 +9156,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.52.1-1
+      version: 2.52.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.52.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.52.1-1`

## controller_interface

- No changes

## controller_manager

```
* Fix concurrent spinning of the test_node (backport #2721 <https://github.com/ros-controls/ros2_control/issues/2721>) (#2726 <https://github.com/ros-controls/ros2_control/issues/2726>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
