### PR TITLE
ros2_control: 4.39.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8114,7 +8114,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.38.0-1
+      version: 4.39.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.39.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.38.0-1`

## controller_interface

```
* Add magnetic_field_sensor semantic component (#2627 <https://github.com/ros-controls/ros2_control/issues/2627>) (#2655 <https://github.com/ros-controls/ros2_control/issues/2655>)
* Fix -Wreturn-local-addr compiler warning (#2628 <https://github.com/ros-controls/ros2_control/issues/2628>) (#2631 <https://github.com/ros-controls/ros2_control/issues/2631>)
* [Controllers] Set async thread properties via parameters (#2613 <https://github.com/ros-controls/ros2_control/issues/2613>) (#2614 <https://github.com/ros-controls/ros2_control/issues/2614>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Deactivate the whole controller chain if one of the update results in ERROR (#2681 <https://github.com/ros-controls/ros2_control/issues/2681>) (#2743 <https://github.com/ros-controls/ros2_control/issues/2743>)
* Deactivate the controller chain upon failed group activation (#2669 <https://github.com/ros-controls/ros2_control/issues/2669>) (#2737 <https://github.com/ros-controls/ros2_control/issues/2737>)
* Fix concurrent spinning of the test_node (backport #2721 <https://github.com/ros-controls/ros2_control/issues/2721>) (#2727 <https://github.com/ros-controls/ros2_control/issues/2727>)
* [Spawner] Fix failing makedirs on multiple spawners at startup (#2698 <https://github.com/ros-controls/ros2_control/issues/2698>) (#2699 <https://github.com/ros-controls/ros2_control/issues/2699>)
* [Spawner] Create the FileLock in the ROS_HOME location (#2677 <https://github.com/ros-controls/ros2_control/issues/2677>) (#2685 <https://github.com/ros-controls/ros2_control/issues/2685>)
* Fix the same hardware component node naming issue with multiple controller managers setup (#2657 <https://github.com/ros-controls/ros2_control/issues/2657>) (#2666 <https://github.com/ros-controls/ros2_control/issues/2666>)
* Move clock availability check to controller manager thread (#2654 <https://github.com/ros-controls/ros2_control/issues/2654>) (#2660 <https://github.com/ros-controls/ros2_control/issues/2660>)
* increase tolerance of the controller manager tests (#2629 <https://github.com/ros-controls/ros2_control/issues/2629>) (#2636 <https://github.com/ros-controls/ros2_control/issues/2636>)
* [Controllers] Set async thread properties via parameters (#2613 <https://github.com/ros-controls/ros2_control/issues/2613>) (#2614 <https://github.com/ros-controls/ros2_control/issues/2614>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Deactivate the controller chain upon failed group activation (#2669 <https://github.com/ros-controls/ros2_control/issues/2669>) (#2737 <https://github.com/ros-controls/ros2_control/issues/2737>)
* Cleanup GenericSystem component code :broom:  (#2706 <https://github.com/ros-controls/ros2_control/issues/2706>) (#2714 <https://github.com/ros-controls/ros2_control/issues/2714>)
* [GenericSystem] Initialize joint_control_mode_ in on_configure (#2693 <https://github.com/ros-controls/ros2_control/issues/2693>) (#2695 <https://github.com/ros-controls/ros2_control/issues/2695>)
* Fix dynamics calculation of GenericSystem component (#2705 <https://github.com/ros-controls/ros2_control/issues/2705>) (#2709 <https://github.com/ros-controls/ros2_control/issues/2709>)
* Prepare GenericSystem for other interface data types (#2571 <https://github.com/ros-controls/ros2_control/issues/2571>) (#2708 <https://github.com/ros-controls/ros2_control/issues/2708>)
* Add has_state and has_command methods to hardware_component_interface (#2701 <https://github.com/ros-controls/ros2_control/issues/2701>) (#2702 <https://github.com/ros-controls/ros2_control/issues/2702>)
* Fix runtime variant access bug in HardwareComponentInterface::get_command helper method (#2491 <https://github.com/ros-controls/ros2_control/issues/2491>) (#2704 <https://github.com/ros-controls/ros2_control/issues/2704>)
* Fix the same hardware component node naming issue with multiple controller managers setup (#2657 <https://github.com/ros-controls/ros2_control/issues/2657>) (#2666 <https://github.com/ros-controls/ros2_control/issues/2666>)
* Enable logger service for hardware component node (#2503 <https://github.com/ros-controls/ros2_control/issues/2503>) (#2668 <https://github.com/ros-controls/ros2_control/issues/2668>)
* Remove deprecation warning for kilted now (#2645 <https://github.com/ros-controls/ros2_control/issues/2645>)
* Add magnetic_field_sensor semantic component (#2627 <https://github.com/ros-controls/ros2_control/issues/2627>) (#2655 <https://github.com/ros-controls/ros2_control/issues/2655>)
* Fix warnings of uninitialized registry in GenericSystem tests (#2635 <https://github.com/ros-controls/ros2_control/issues/2635>) (#2641 <https://github.com/ros-controls/ros2_control/issues/2641>)
* Fix the variant access in the hardware component interface (#2626 <https://github.com/ros-controls/ros2_control/issues/2626>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* [Transmission] Fix the differential transmission configure checks (#2682 <https://github.com/ros-controls/ros2_control/issues/2682>) (#2687 <https://github.com/ros-controls/ros2_control/issues/2687>)
* [Transmissions] Add force  interface (backport #2588 <https://github.com/ros-controls/ros2_control/issues/2588>) (#2678 <https://github.com/ros-controls/ros2_control/issues/2678>)
* Contributors: mergify[bot]
```
