### PR TITLE
ros2_control: 5.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7091,7 +7091,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.7.0-1
+      version: 5.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7074,7 +7074,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: kilted
     release:
       packages:
       - controller_interface
@@ -7095,7 +7095,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git
-      version: master
+      version: kilted
     status: developed
   ros2_control_cmake:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.7.0-1`

## controller_interface

```
* Add magnetic_field_sensor semantic component (#2627 <https://github.com/ros-controls/ros2_control/issues/2627>) (#2656 <https://github.com/ros-controls/ros2_control/issues/2656>)
* Fix -Wreturn-local-addr compiler warning (#2628 <https://github.com/ros-controls/ros2_control/issues/2628>) (#2632 <https://github.com/ros-controls/ros2_control/issues/2632>)
* [Controllers] Set async thread properties via parameters (#2613 <https://github.com/ros-controls/ros2_control/issues/2613>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## controller_manager

```
* Deactivate the whole controller chain if one of the update results in ERROR (#2681 <https://github.com/ros-controls/ros2_control/issues/2681>) (#2744 <https://github.com/ros-controls/ros2_control/issues/2744>)
* Deactivate the controller chain upon failed group activation (#2669 <https://github.com/ros-controls/ros2_control/issues/2669>) (#2738 <https://github.com/ros-controls/ros2_control/issues/2738>)
* Fix concurrent spinning of the test_node (backport #2721 <https://github.com/ros-controls/ros2_control/issues/2721>) (#2728 <https://github.com/ros-controls/ros2_control/issues/2728>)
* [Spawner] Fix failing makedirs on multiple spawners at startup (#2698 <https://github.com/ros-controls/ros2_control/issues/2698>) (#2700 <https://github.com/ros-controls/ros2_control/issues/2700>)
* [Spawner] Create the FileLock in the ROS_HOME location (#2677 <https://github.com/ros-controls/ros2_control/issues/2677>) (#2686 <https://github.com/ros-controls/ros2_control/issues/2686>)
* Fix the same hardware component node naming issue with multiple controller managers setup (#2657 <https://github.com/ros-controls/ros2_control/issues/2657>) (#2667 <https://github.com/ros-controls/ros2_control/issues/2667>)
* Move clock availability check to controller manager thread (#2654 <https://github.com/ros-controls/ros2_control/issues/2654>) (#2661 <https://github.com/ros-controls/ros2_control/issues/2661>)
* increase tolerance of the controller manager tests (#2629 <https://github.com/ros-controls/ros2_control/issues/2629>) (#2637 <https://github.com/ros-controls/ros2_control/issues/2637>)
* [Controllers] Set async thread properties via parameters (#2613 <https://github.com/ros-controls/ros2_control/issues/2613>)
* Contributors: Sai Kishor Kothakota, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Deactivate the controller chain upon failed group activation (#2669 <https://github.com/ros-controls/ros2_control/issues/2669>) (#2738 <https://github.com/ros-controls/ros2_control/issues/2738>)
* Cleanup GenericSystem component code :broom:  (#2706 <https://github.com/ros-controls/ros2_control/issues/2706>) (#2715 <https://github.com/ros-controls/ros2_control/issues/2715>)
* [GenericSystem] Initialize joint_control_mode_ in on_configure (#2693 <https://github.com/ros-controls/ros2_control/issues/2693>) (#2696 <https://github.com/ros-controls/ros2_control/issues/2696>)
* Fix dynamics calculation of GenericSystem component (#2705 <https://github.com/ros-controls/ros2_control/issues/2705>) (#2707 <https://github.com/ros-controls/ros2_control/issues/2707>)
* Prepare GenericSystem for other interface data types (#2571 <https://github.com/ros-controls/ros2_control/issues/2571>) (#2697 <https://github.com/ros-controls/ros2_control/issues/2697>)
* Add has_state and has_command methods to hardware_component_interface (#2701 <https://github.com/ros-controls/ros2_control/issues/2701>) (#2703 <https://github.com/ros-controls/ros2_control/issues/2703>)
* Fix the same hardware component node naming issue with multiple controller managers setup (#2657 <https://github.com/ros-controls/ros2_control/issues/2657>) (#2667 <https://github.com/ros-controls/ros2_control/issues/2667>)
* Add magnetic_field_sensor semantic component (#2627 <https://github.com/ros-controls/ros2_control/issues/2627>) (#2656 <https://github.com/ros-controls/ros2_control/issues/2656>)
* Fix RCLCPP_WARN_ONCE within handle (#2630 <https://github.com/ros-controls/ros2_control/issues/2630>) (#2643 <https://github.com/ros-controls/ros2_control/issues/2643>)
* Fix warnings of uninitialized registry in GenericSystem tests (#2635 <https://github.com/ros-controls/ros2_control/issues/2635>) (#2642 <https://github.com/ros-controls/ros2_control/issues/2642>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* [Transmission] Fix the differential transmission configure checks (#2682 <https://github.com/ros-controls/ros2_control/issues/2682>) (#2688 <https://github.com/ros-controls/ros2_control/issues/2688>)
* [Transmissions] Add force  interface (backport #2588 <https://github.com/ros-controls/ros2_control/issues/2588>) (#2679 <https://github.com/ros-controls/ros2_control/issues/2679>)
* Contributors: mergify[bot]
```
