### PR TITLE
skai_edge_perception: 1.0.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10872,6 +10872,12 @@ repositories:
       url: https://github.com/snt-arg/situational_graphs_wrapper.git
       version: develop
     status: maintained
+  skai_edge_perception:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/valteq/skai-edge-release.git
+      version: 1.0.15-1
   slam_toolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `skai_edge_perception` to `1.0.15-1`:

- upstream repository: https://github.com/valteq/skai-edge.git
- release repository: https://github.com/valteq/skai-edge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
