### PR TITLE
mrpt_sensors: 0.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5893,7 +5893,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.2.3-1
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.2.4-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.2.3-1`

## mrpt_generic_sensor

```
* Replace deprecated ament_target_dependencies() with standard cmake
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_bumblebee_stereo

```
* Replace deprecated ament_target_dependencies() with standard cmake
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_nmea

```
* Replace deprecated ament_target_dependencies() with standard cmake
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_novatel

```
* Replace deprecated ament_target_dependencies() with standard cmake
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_imu_taobotics

```
* Replace deprecated ament_target_dependencies() with standard cmake
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* Replace deprecated ament_target_dependencies() with standard cmake
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

```
* package.xml: update license tag to BSD-3-Clause
* Contributors: Jose Luis Blanco-Claraco
```
