### PR TITLE
ros2_control: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7042,7 +7042,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.7.0-1
+      version: 6.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.7.0-1`

## controller_interface

```
* Add magnetic_field_sensor semantic component (#2627 <https://github.com/ros-controls/ros2_control/issues/2627>)
* Fix -Wreturn-local-addr compiler warning (#2628 <https://github.com/ros-controls/ros2_control/issues/2628>)
* [Controllers] Set async thread properties via parameters (#2613 <https://github.com/ros-controls/ros2_control/issues/2613>)
* Contributors: Aarav Gupta, Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager

```
* Switch the default strictness to STRICT (#2742 <https://github.com/ros-controls/ros2_control/issues/2742>)
* Deactivate the whole controller chain if one of the update results in ERROR (#2681 <https://github.com/ros-controls/ros2_control/issues/2681>)
* Deactivate the controller chain upon failed group activation (#2669 <https://github.com/ros-controls/ros2_control/issues/2669>)
* Add test_test_utils to CMakeLists (#2729 <https://github.com/ros-controls/ros2_control/issues/2729>)
* Fix concurrent spinning of the test_node (#2721 <https://github.com/ros-controls/ros2_control/issues/2721>)
* [Spawner] Fix failing makedirs on multiple spawners at startup (#2698 <https://github.com/ros-controls/ros2_control/issues/2698>)
* [Spawner] Create the FileLock in the ROS_HOME location (#2677 <https://github.com/ros-controls/ros2_control/issues/2677>)
* Fix the same hardware component node naming issue with multiple controller managers setup (#2657 <https://github.com/ros-controls/ros2_control/issues/2657>)
* Move clock availability check to controller manager thread (#2654 <https://github.com/ros-controls/ros2_control/issues/2654>)
* increase tolerance of the controller manager tests (#2629 <https://github.com/ros-controls/ros2_control/issues/2629>)
* [Controllers] Set async thread properties via parameters (#2613 <https://github.com/ros-controls/ros2_control/issues/2613>)
* Contributors: Christoph Fröhlich, Erik Holum, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Deactivate the controller chain upon failed group activation (#2669 <https://github.com/ros-controls/ros2_control/issues/2669>)
* Cleanup GenericSystem component code :broom:  (#2706 <https://github.com/ros-controls/ros2_control/issues/2706>)
* Fix dynamics calculation of GenericSystem component (#2705 <https://github.com/ros-controls/ros2_control/issues/2705>)
* Add has_state and has_command methods to hardware_component_interface (#2701 <https://github.com/ros-controls/ros2_control/issues/2701>)
* [GenericSystem] Initialize joint_control_mode_ in on_configure (#2693 <https://github.com/ros-controls/ros2_control/issues/2693>)
* Cleanup deprecations (#2589 <https://github.com/ros-controls/ros2_control/issues/2589>)
* Prepare GenericSystem for other interface data types (#2571 <https://github.com/ros-controls/ros2_control/issues/2571>)
* Fix the same hardware component node naming issue with multiple controller managers setup (#2657 <https://github.com/ros-controls/ros2_control/issues/2657>)
* Deprecate thread_priority again (#2644 <https://github.com/ros-controls/ros2_control/issues/2644>)
* Add magnetic_field_sensor semantic component (#2627 <https://github.com/ros-controls/ros2_control/issues/2627>)
* Fix RCLCPP_WARN_ONCE within handle (#2630 <https://github.com/ros-controls/ros2_control/issues/2630>)
* Fix warnings of uninitialized registry in GenericSystem tests (#2635 <https://github.com/ros-controls/ros2_control/issues/2635>)
* Contributors: Aarav Gupta, Christoph Fröhlich, Felix Exner, Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Added view_hardware_status ros2cli verb (#2495 <https://github.com/ros-controls/ros2_control/issues/2495>)
* Contributors: Soham Patil
```

## rqt_controller_manager

- No changes

## transmission_interface

```
* [Transmission] Fix the differential transmission configure checks (#2682 <https://github.com/ros-controls/ros2_control/issues/2682>)
* [Transmissions] Add force  interface (#2588 <https://github.com/ros-controls/ros2_control/issues/2588>)
* Contributors: Jordan Palacios, Sai Kishor Kothakota
```
