### PR TITLE
open_manipulator: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5066,7 +5066,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 4.0.7-1
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.1.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.7-1`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* None
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Support OMX-F GUI
* Support OMX-F Keyboard Teleop
* Contributors: Heewon Lee
```

## open_manipulator_bringup

```
* None
```

## open_manipulator_collision

```
* None
```

## open_manipulator_description

```
* None
```

## open_manipulator_gui

```
* Support OMX-F GUI
* Contributors: Heewon Lee
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* Support OMX-F Keyboard Teleop
* Contributors: Heewon Lee
```
