### PR TITLE
Update aiortc to support Ubuntu noble and later

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4872,6 +4872,9 @@ python3-aiortc:
       packages: [aiortc]
   ubuntu:
     '*': [python3-aiortc]
+    focal:
+      pip:
+        packages: [aortc]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4868,7 +4868,10 @@ python3-aiortc:
     pip:
       packages: [aiortc]
   ubuntu:
-    jammy: [python3-aiortc]
+    '*': [python3-aiortc]
+    bionic:
+      pip:
+        packages: [aortc]
 python3-albumentations-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4863,15 +4863,15 @@ python3-aiohttp-cors:
   ubuntu: [python3-aiohttp-cors]
 python3-aiortc:
   debian:
-    bookworm: [python3-aiortc]
+    '*': [python3-aiortc]
+    bullseye:
+      pip:
+        packages: [aiortc]
   osx:
     pip:
       packages: [aiortc]
   ubuntu:
     '*': [python3-aiortc]
-    bionic:
-      pip:
-        packages: [aortc]
 python3-albumentations-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-aiortc

## Package Upstream Source:

https://github.com/aiortc/aiortc

## Purpose of using this:

This package is available in Ubuntu 22.04 Jammy and later, but is restricted to Jammy in rosdistro.
This PR aims to make it available for Ubuntu 24.04 Noble and later.

refer to https://github.com/ros/rosdistro/pull/33726
> aiortc is a Python implementation of the WebRTC protocol, including support for DataChannels. Notably, it doesn't depend on the Chromium WebRTC project, hence avoiding issues such as https://github.com/RobotWebTools/webrtc_ros/issues/66. WebRTC is not only useful for sending video data to a browser from a robot, but also low latency realtime data via datachannels. Hence, I think it is valuable to add this to the index.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian:
  - https://pypi.org/project/aiortc/ or https://packages.debian.org/bookworm/python3-aiortc
- Ubuntu:
  - https://pypi.org/project/aiortc/ or https://packages.ubuntu.com/jammy/python3-aiortc

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ros 2 jazzy ( Ubuntu noble or later）

# The source is here:


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
