### PR TITLE
Switch python3-bson to pymongo for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5191,7 +5191,7 @@ python3-bson:
   debian: [python3-bson]
   fedora: [python3-bson]
   gentoo: [dev-python/pymongo]
-  nixos: [python3Packages.bson]
+  nixos: [python3Packages.pymongo]
   openembedded: [python3-pymongo@meta-python]
   osx:
     pip:


### PR DESCRIPTION
Other distributions already use BSON module from pymongo. Even [NixOS switched to pymongo, for Python 2](https://github.com/ros/rosdistro/blob/d6139fae2a7010a786bd527303d0c96eeee74d29/rosdep/python.yaml#L819), but the Python 3 version remained unchanged.

Related to https://github.com/lopsided98/nix-ros-overlay/issues/728.