### PR TITLE
service_load_balancing: 0.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8547,7 +8547,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/service_load_balancing-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `service_load_balancing` to `0.1.3-1`:

- upstream repository: https://github.com/Barry-Xu-2018/ros2_service_load_balancing.git
- release repository: https://github.com/ros2-gbp/service_load_balancing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.2-1`

## service_load_balancing

```
* Replace deprecated interface rclcpp::spin_some
```
