### PR TITLE
tiago_pro_head_simulation: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11529,6 +11529,14 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_head_simulation.git
       version: humble-devel
+    release:
+      packages:
+      - tiago_pro_head_gazebo
+      - tiago_pro_head_simulation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_pro_head_simulation-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_head_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_head_simulation` to `1.0.2-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_head_simulation.git
- release repository: https://github.com/pal-gbp/tiago_pro_head_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## tiago_pro_head_gazebo

```
* Remove controller_configuration dependency
* Contributors: Aina
```

## tiago_pro_head_simulation

- No changes
