### PR TITLE
pal_sea_arm: 1.20.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7033,6 +7033,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm.git
       version: humble-devel
+    release:
+      packages:
+      - pal_sea_arm
+      - pal_sea_arm_bringup
+      - pal_sea_arm_controller_configuration
+      - pal_sea_arm_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_sea_arm-release.git
+      version: 1.20.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm` to `1.20.1-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm.git
- release repository: https://github.com/pal-gbp/pal_sea_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## pal_sea_arm

- No changes

## pal_sea_arm_bringup

- No changes

## pal_sea_arm_controller_configuration

- No changes

## pal_sea_arm_description

```
* Add condition for allegro_hand dependencies
* Contributors: Noel Jimenez
```
