### PR TITLE
mp2p_icp: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4404,7 +4404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## mp2p_icp

```
* Merge pull request #13 <https://github.com/MOLAorg/mp2p_icp/issues/13> from MOLAorg/fix/filterdecimate-bug
* Add unit test for FilterDecimateVoxel
* mm-viewer: ensure proper order of opengl object destruction
* Add more debug traces for Filters
* Generator: Add more info on layer contents in debug traces
* FIX: Avoid crash in FilterVoxelSlice if there are no points in the ROI
* Merge pull request #12 <https://github.com/MOLAorg/mp2p_icp/issues/12> from MOLAorg/feat/mls
  Implemented MLS filter
* Merge pull request #11 <https://github.com/MOLAorg/mp2p_icp/issues/11> from MOLAorg/feat/use-faster-insertion
  Use the faster insertion-with-context in MRPT 2.15.0
* Update to build using CGenericPointsMap in upcoming MRPT >=2.15
* Merge pull request #10 <https://github.com/MOLAorg/mp2p_icp/issues/10> from MOLAorg/fix/ci
* Upgrade CircleCI images to u24.04
* Fix build out of ROS and w/o IMU preintegration
* Update mola_common version
* Fix: Warning message missing new line
* FilterDecimateVoxels: add new parameter 'minimum_points_per_voxel'
* Fix docs typo
* Update docs for Deskew filter
* Update README.md badges
* Contributors: Jose Luis Blanco-Claraco
```
