### PR TITLE
clearpath_common: 2.8.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1275,7 +1275,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.8.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.0-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Add guard to include zed only once
* Contributors: Luis Camero
```

## clearpath_sensors_description

```
* Add guard to include zed only once
* Contributors: Luis Camero
```
