### PR TITLE
pal_sea_arm_moveit_config: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7051,6 +7051,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git
       version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_sea_arm_moveit_config-release.git
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm_moveit_config` to `1.0.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git
- release repository: https://github.com/pal-gbp/pal_sea_arm_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## pal_sea_arm_moveit_config

```
* Add coupler link on disable collision for allegro
* Add srdf for allegro
* Contributors: Aina
```
