### PR TITLE
tiago_pro_navigation: 2.13.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11565,6 +11565,16 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_navigation.git
       version: humble-devel
+    release:
+      packages:
+      - tiago_pro_2dnav
+      - tiago_pro_laser_sensors
+      - tiago_pro_navigation
+      - tiago_pro_rgbd_sensors
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/tiago_pro_navigation-release.git
+      version: 2.13.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_navigation` to `2.13.3-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_navigation.git
- release repository: https://github.com/pal-gbp/tiago_pro_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## tiago_pro_2dnav

- No changes

## tiago_pro_laser_sensors

- No changes

## tiago_pro_navigation

- No changes

## tiago_pro_rgbd_sensors

```
* removed camera namespace from realsense driver
* Contributors: martinaannicelli
```
