### PR TITLE
mrpt_ros: 2.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4537,7 +4537,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.0-1
+      version: 2.15.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.1-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.15.0-1`

## mrpt_apps

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libapps

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libbase

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libgui

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libhwdrivers

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libmaps

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libmath

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libnav

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libobs

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libopengl

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libposes

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libslam

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libtclap

```
* Remove obsolete BUILD_ros2bridge cmake variable
* Add missing opencv dependency after removal of cv_bridge
* Contributors: Jose Luis Blanco-Claraco
```
