### PR TITLE
event_camera_codecs: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2607,7 +2607,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_codecs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_codecs.git
- release repository: https://github.com/ros2-gbp/event_camera_codecs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## event_camera_codecs

```
* added getNumberOfBytesUsed() top api
* more documentation and tests
* Fix: (void) unused paras for successful build
* Fix: Enable successful build on macOS (AppleClang)
* fix bug in libcaer timeMult
* Contributors: Bernd Pfrommer, Dhruv Patel
```
