### PR TITLE
behaviortree_cpp_v4: 4.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -904,7 +904,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.8.0-1
+      version: 4.8.2-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.8.2-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.8.0-1`

## behaviortree_cpp

```
* Merge pull request #996 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/996> from EnjoyRobotics/make-sequence-node-inheritable
* Merge branch 'master' of github.com:BehaviorTree/BehaviorTree.CPP
* fix issue #1034 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1034>
* Merge pull request #1030 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1030> from pleemann/tree_wake_up
  Event-based tree ticking
* force tinyxml2_vendor in ROS2. See #1033 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1033> and #1028 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1028>
* added Tree::emitWakeUpSignal
* Lint
* Propagate node config to parent
* Make tick method protected
* Contributors: Davide Faconti, pleemann, redvinaa
```
