### PR TITLE
Add python3-osrf-pycommon and python3-types-pyyaml entries for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8039,6 +8039,7 @@ python3-orjson:
 python3-osrf-pycommon:
   debian: [python3-osrf-pycommon]
   fedora: [python3-osrf-pycommon]
+  nixos: [python3Packages.osrf-pycommon]
   rhel: [python3-osrf-pycommon]
   ubuntu: [python3-osrf-pycommon]
 python3-overrides:
@@ -10807,6 +10808,7 @@ python3-typer:
 python3-types-pyyaml:
   debian: [python3-typeshed]
   fedora: [python3-types-pyyaml]
+  nixos: [python3Packages.types-pyyaml]
   rhel:
     '*': [python3-types-pyyaml]
     '8':


### PR DESCRIPTION
The first package is hosted in the [nix-ros-overlay repo](https://github.com/lopsided98/nix-ros-overlay/blob/d1b93bbb043cdcb15a10e801aa3aaf3a08d51a35/pkgs/default.nix#L148). The other in the [official nixpkgs repo](https://search.nixos.org/packages?channel=unstable&query=types-pyyaml).
