### PR TITLE
Remove orbbec_camera_v1 entries from jazzy & humble distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6755,25 +6755,6 @@ repositories:
       url: https://github.com/ros-drivers/openni2_camera.git
       version: iron
     status: maintained
-  orbbec_camera_v1:
-    doc:
-      type: git
-      url: https://github.com/orbbec/OrbbecSDK_ROS2.git
-      version: main
-    release:
-      packages:
-      - orbbec_camera
-      - orbbec_camera_msgs
-      - orbbec_description
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/orbbec/orbbec_camera_v1-release.git
-      version: 1.5.14-1
-    source:
-      type: git
-      url: https://github.com/orbbec/OrbbecSDK_ROS2.git
-      version: main
-    status: maintained
   orbbec_camera_v2:
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6048,25 +6048,6 @@ repositories:
       url: https://github.com/hatchbed/opensw_ros.git
       version: ros2
     status: developed
-  orbbec_camera_v1:
-    doc:
-      type: git
-      url: https://github.com/orbbec/OrbbecSDK_ROS2.git
-      version: main
-    release:
-      packages:
-      - orbbec_camera
-      - orbbec_camera_msgs
-      - orbbec_description
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/orbbec/orbbec_camera_v1-release.git
-      version: 1.5.14-1
-    source:
-      type: git
-      url: https://github.com/orbbec/OrbbecSDK_ROS2.git
-      version: main
-    status: maintained
   orbbec_camera_v2:
     source:
       type: git


### PR DESCRIPTION
This PR removes all `orbbec_camera_v1` entries from the `jazzy/distribution.yaml` and `humble/distribution.yaml`.

The reason for this change is that our `main` branch (which corresponds to `orbbec_camera_v1`) has package name conflicts with the newer `v2-main` branch (which corresponds to `orbbec_camera_v2`) . Since the `main` branch is gradually being deprecated and will no longer be maintained, we have decided to stop releasing packages from `main` and continue maintenance and releases only for the `v2-main` branch moving forward.

