### PR TITLE
event_camera_codecs: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1800,7 +1800,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_codecs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_codecs.git
- release repository: https://github.com/ros2-gbp/event_camera_codecs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-2`

## event_camera_codecs

```
* added getNumberOfBytesUsed() top api
* more documentation and tests
* Fix: (void) unused paras for successful build
* Fix: Enable successful build on macOS (AppleClang)
* fix bug in libcaer timeMult
* Contributors: Bernd Pfrommer, Dhruv Patel
```
