### PR TITLE
Changed owner of rplidar_ros repository for jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8965,6 +8965,10 @@ repositories:
       version: master
     status: maintained
   rplidar_ros:
+    doc:
+      type: git
+      url: https://github.com/Slamtec/rplidar_ros.git
+      version: ros2
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -8973,7 +8977,7 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/allenh1/rplidar_ros.git
+      url: https://github.com/Slamtec/rplidar_ros.git
       version: ros2
     status: developed
   rpyutils:


### PR DESCRIPTION
## Purpose
The purpose of this PR is to update the ownership of the rplidar_ros repository from an out of date version originally maintained by @allenh1 to the more up to date repository maintained by a @deyouslamtec, a commercial representative from [Slamtec](https://www.slamtec.com/). The maintainer has been made aware #https://github.com/Slamtec/rplidar_ros/issues/164 but has not initiated any change yet.

## My Issue
My personal issue is that the current repo does not have support for the C1 Lidar for ros2, while the official one does.

## Relevant distro's
For me this issue primarily concerns jazzy, because that is the distro I am actively using for my project. However since I am not fully aware of how  this chance fits into the distrobution release cycles I am open to guidance on this.

#### The original repository
https://github.com/allenh1/rplidar_ros
#### The updated repository
https://github.com/Slamtec/rplidar_ros




