### PR TITLE
pal_sea_arm_simulation: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7066,6 +7066,14 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm_simulation.git
       version: humble-devel
+    release:
+      packages:
+      - pal_sea_arm_gazebo
+      - pal_sea_arm_simulation
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_sea_arm_simulation-release.git
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm_simulation` to `1.0.4-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm_simulation.git
- release repository: https://github.com/pal-gbp/pal_sea_arm_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## pal_sea_arm_gazebo

```
* Update 2 files
  - /pal_sea_arm_gazebo/package.xml
  - /pal_sea_arm_gazebo/launch/pal_sea_arm_gazebo.launch.py
* Contributors: davidterkuile
```

## pal_sea_arm_simulation

- No changes
