### PR TITLE
pal_pro_gripper: 1.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7001,7 +7001,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_pro_gripper-release.git
-      version: 1.7.2-1
+      version: 1.8.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_pro_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_pro_gripper` to `1.8.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_pro_gripper.git
- release repository: https://github.com/pal-gbp/pal_pro_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.2-1`

## pal_pro_gripper

- No changes

## pal_pro_gripper_bringup

- No changes

## pal_pro_gripper_controller_configuration

- No changes

## pal_pro_gripper_description

```
* adding grasping frame
* Contributors: Matteo Villani
```

## pal_pro_gripper_wrapper

- No changes
