### PR TITLE
pal_gripper: 3.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6927,7 +6927,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.6.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.0-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

```
* Merge branch 'tpe/add_open_loop' into 'humble-devel'
  Add openloop to controllers
  See merge request robots/pal_gripper!40
* Add openloop to controllers
* Contributors: thomas.peyrucain, thomaspeyrucain
```

## pal_gripper_description

- No changes

## pal_gripper_simulation

- No changes
