### PR TITLE
omni_base_robot: 2.14.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6646,7 +6646,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_robot-release.git
-      version: 2.12.0-1
+      version: 2.14.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.14.1-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/pal-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.12.0-1`

## omni_base_bringup

- No changes

## omni_base_controller_configuration

- No changes

## omni_base_description

```
* Update 2 files
  - /omni_base_description/urdf/cameras_add_on/camera_horizon_add_on.urdf.xacro
  - /omni_base_description/urdf/cameras_add_on/cameras.urdf.xacro
* Contributors: antoniobrandi
```

## omni_base_robot

- No changes
