### PR TITLE
omni_base_navigation: 2.19.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6626,7 +6626,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_navigation-release.git
-      version: 2.18.0-1
+      version: 2.19.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_navigation` to `2.19.1-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_navigation.git
- release repository: https://github.com/pal-gbp/omni_base_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.18.0-1`

## omni_base_2dnav

- No changes

## omni_base_laser_sensors

- No changes

## omni_base_navigation

- No changes

## omni_base_rgbd_sensors

```
* removed camera namespace from realsense driver
* Contributors: martinaannicelli
```
