### PR TITLE
pmb2_robot: 5.10.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7443,7 +7443,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.9.0-1
+      version: 5.10.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_robot` to `5.10.2-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_robot.git
- release repository: https://github.com/pal-gbp/pmb2_robot-gbp.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.9.0-1`

## pmb2_bringup

- No changes

## pmb2_controller_configuration

- No changes

## pmb2_description

```
* Merge branch 'tpe/update_wheel_max_vel' into 'humble-devel'
  Increase Wheel max velocity
  See merge request robots/pmb2_robot!167
* Remove params from ros2control
* Increase Wheel max velocity
* Contributors: thomas.peyrucain, thomaspeyrucain
```

## pmb2_robot

- No changes
