### PR TITLE
omni_base_simulation: 2.10.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6664,7 +6664,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/omni_base_simulation-release.git
-      version: 2.9.0-1
+      version: 2.10.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_simulation` to `2.10.1-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_simulation.git
- release repository: https://github.com/pal-gbp/omni_base_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.0-1`

## omni_base_gazebo

```
* added missing dep for public sim
* Contributors: andreacapodacqua
```

## omni_base_simulation

- No changes
