### PR TITLE
pal_sea_arm: 1.21.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7040,7 +7040,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_sea_arm-release.git
-      version: 1.20.1-1
+      version: 1.21.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm` to `1.21.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm.git
- release repository: https://github.com/pal-gbp/pal_sea_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.20.1-1`

## pal_sea_arm

- No changes

## pal_sea_arm_bringup

- No changes

## pal_sea_arm_controller_configuration

```
* Merge branch 'tpe/add_open_loop' into 'humble-devel'
  Add back openloop to controller
  See merge request robots/pal_sea_arm!99
* Add back openloop to controller
* Contributors: thomas.peyrucain, thomaspeyrucain
```

## pal_sea_arm_description

- No changes
