### PR TITLE
talos_simulation: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11324,7 +11324,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_simulation-release.git
-      version: 2.0.0-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/talos_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_simulation` to `2.0.3-1`:

- upstream repository: https://github.com/pal-robotics/talos_simulation.git
- release repository: https://github.com/pal-gbp/talos_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## talos_gazebo

```
* Merge branch 'increase/clock/rate' into 'humble-devel'
  Increase the clock_rate for TALOS simulation
  See merge request robots/talos_simulation!26
* Increase the clock_rate for TALOS simulation
* Contributors: Sai Kishor Kothakota
```
