### PR TITLE
tiago_robot: 4.22.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11629,7 +11629,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.18.0-1
+      version: 4.22.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.22.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.18.0-1`

## tiago_bringup

- No changes

## tiago_controller_configuration

```
* Merge branch 'tpe/add_open_loop' into 'humble-devel'
  Add openloop to controllers
  See merge request robots/tiago_robot!361
* Add openloop to controllers + remove impedance controller
* Contributors: thomas.peyrucain, thomaspeyrucain
```

## tiago_description

- No changes

## tiago_robot

- No changes
