### PR TITLE
rosidl_rust: 0.4.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7802,7 +7802,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_rust-release.git
-      version: 0.4.8-1
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros2-rust/rosidl_rust.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_rust` to `0.4.9-1`:

- upstream repository: https://github.com/ros2-rust/rosidl_rust.git
- release repository: https://github.com/ros2-gbp/rosidl_rust-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.8-1`

## rosidl_generator_rs

```
* fix: update rosidl_runtime_rs dependency version to 0.5 (#11 <https://github.com/ros2-rust/rosidl_rust/issues/11>)
* Contributors: Esteve Fernandez
```
