### PR TITLE
smacc2: 2.3.20-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10943,7 +10943,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 2.3.18-1
+      version: 2.3.20-2
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `2.3.20-2`:

  - upstream repository: https://github.com/robosoft-ai/SMACC2.git
  - release repository: https://github.com/robosoft-ai/SMACC2-release.git
  - distro file: `humble/distribution.yaml`
  - bloom version: `0.13.0`
  - previous version for package: `2.3.18-1`

  ## Release Notes
  This release includes a critical fix for double onExit() calls in client behaviors (#556, #558) that caused deadlocks in user code. The bug affected all users installing from apt packages.

  ## Changes
  - Fixed double onExit() calls in client behaviors
  - Major refactoring of cl_nav2z, cl_ros2_timer, and cl_moveit2z
  - New cl_moveit2z client library
  - Component-based architecture updates

  Full changelog: https://github.com/robosoft-ai/SMACC2/blob/humble/smacc2/CHANGELOG.rst

