### PR TITLE
tiago_pro_robot: 1.32.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11612,7 +11612,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_pro_robot-release.git
-      version: 1.32.0-1
+      version: 1.32.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_robot` to `1.32.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_robot.git
- release repository: https://github.com/pal-gbp/tiago_pro_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.32.0-1`

## tiago_pro_bringup

- No changes

## tiago_pro_controller_configuration

- No changes

## tiago_pro_description

```
* Fix humble tests excluding allegro hand end-effector
* Contributors: Noel Jimenez
```

## tiago_pro_robot

- No changes
