### PR TITLE
foxglove-sdk: 3.2.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2233,7 +2233,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.2.1-1
+      version: 3.2.2-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.2.2-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.1-1`

## foxglove_bridge

```
* Fix publishing from Foxglove 3D panel (#716 <https://github.com/foxglove/foxglove-sdk/pull/716>)
* Contributors: Bryan Fox
```

## foxglove_msgs

```
* Update documentation for various schemas
* Contributors: James Smith, Jeff Rouleau
```
