### PR TITLE
Add ros2ai to rosdistro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9398,6 +9398,12 @@ repositories:
       url: https://github.com/ros-acceleration/ros2acceleration.git
       version: rolling
     status: developed
+  ros2ai:
+      source:
+        type: git
+        url: https://github.com/fujitatomoya/ros2ai.git
+        version: rolling
+      status: developed
   ros2caret:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9399,11 +9399,11 @@ repositories:
       version: rolling
     status: developed
   ros2ai:
-      source:
-        type: git
-        url: https://github.com/fujitatomoya/ros2ai.git
-        version: rolling
-      status: developed
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2ai.git
+      version: rolling
+    status: developed
   ros2caret:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8344,6 +8344,12 @@ repositories:
       url: https://github.com/ros-acceleration/ros2acceleration.git
       version: rolling
     status: developed
+  ros2ai:
+      source:
+        type: git
+        url: https://github.com/fujitatomoya/ros2ai.git
+        version: rolling
+      status: developed
   ros2cli:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8345,11 +8345,11 @@ repositories:
       version: rolling
     status: developed
   ros2ai:
-      source:
-        type: git
-        url: https://github.com/fujitatomoya/ros2ai.git
-        version: rolling
-      status: developed
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2ai.git
+      version: rolling
+    status: developed
   ros2cli:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7309,11 +7309,11 @@ repositories:
       version: rolling
     status: developed
   ros2ai:
-      source:
-        type: git
-        url: https://github.com/fujitatomoya/ros2ai.git
-        version: rolling
-      status: developed
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2ai.git
+      version: rolling
+    status: developed
   ros2cli:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7308,6 +7308,12 @@ repositories:
       url: https://github.com/ros-acceleration/ros2acceleration.git
       version: rolling
     status: developed
+  ros2ai:
+      source:
+        type: git
+        url: https://github.com/fujitatomoya/ros2ai.git
+        version: rolling
+      status: developed
   ros2cli:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7256,11 +7256,11 @@ repositories:
       version: rolling
     status: developed
   ros2ai:
-      source:
-        type: git
-        url: https://github.com/fujitatomoya/ros2ai.git
-        version: rolling
-      status: developed
+    source:
+      type: git
+      url: https://github.com/fujitatomoya/ros2ai.git
+      version: rolling
+    status: developed
   ros2cli:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7255,6 +7255,12 @@ repositories:
       url: https://github.com/ros-acceleration/ros2acceleration.git
       version: rolling
     status: developed
+  ros2ai:
+      source:
+        type: git
+        url: https://github.com/fujitatomoya/ros2ai.git
+        version: rolling
+      status: developed
   ros2cli:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ros2ai

# The source is here:

https://github.com/fujitatomoya/ros2ai.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
