### PR TITLE
rosbridge_suite: 3.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7638,7 +7638,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.3.0-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `3.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## rosapi

```
* chore: Update pre-commit hooks (#1090 <https://github.com/RobotWebTools/rosbridge_suite/issues/1090>)
* Fix mypy errors (#1084 <https://github.com/RobotWebTools/rosbridge_suite/issues/1084>)
* refactor: Add type annotations to all functions and methods (#1069 <https://github.com/RobotWebTools/rosbridge_suite/issues/1069>)
* fix: Change warn to warning (#1067 <https://github.com/RobotWebTools/rosbridge_suite/issues/1067>)
* refactor: Enable various ruff checks and fix lint errors (#1059 <https://github.com/RobotWebTools/rosbridge_suite/issues/1059>)
* chore: Use ruff to replace other linters used in pre-commit hook (#1058 <https://github.com/RobotWebTools/rosbridge_suite/issues/1058>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1056 <https://github.com/RobotWebTools/rosbridge_suite/issues/1056>)
* fix: Clean up package dependencies (#1053 <https://github.com/RobotWebTools/rosbridge_suite/issues/1053>)
* feat: Add interface and service for retrieving action type (#1046 <https://github.com/RobotWebTools/rosbridge_suite/issues/1046>)
* fix: ament_mypy errors (#1039 <https://github.com/RobotWebTools/rosbridge_suite/issues/1039>)
* Contributors: Błażej Sowa, MNV Chaitanya Kumar, pascalauroboa
```

## rosapi_msgs

```
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1056 <https://github.com/RobotWebTools/rosbridge_suite/issues/1056>)
* fix: Clean up package dependencies (#1053 <https://github.com/RobotWebTools/rosbridge_suite/issues/1053>)
* feat: Add interface and service for retrieving action type (#1046 <https://github.com/RobotWebTools/rosbridge_suite/issues/1046>)
* Contributors: Błażej Sowa, MNV Chaitanya Kumar
```

## rosbridge_library

```
* chore: Update pre-commit hooks (#1090 <https://github.com/RobotWebTools/rosbridge_suite/issues/1090>)
* Fix mypy errors (#1084 <https://github.com/RobotWebTools/rosbridge_suite/issues/1084>)
* feat: New parameter and cli arguments handling  (#1060 <https://github.com/RobotWebTools/rosbridge_suite/issues/1060>)
* refactor: Add type annotations to all functions and methods (#1069 <https://github.com/RobotWebTools/rosbridge_suite/issues/1069>)
* fix: Add delays to tests after subscribing/unsubscribing topics (#1071 <https://github.com/RobotWebTools/rosbridge_suite/issues/1071>)
* fix: Change warn to warning (#1067 <https://github.com/RobotWebTools/rosbridge_suite/issues/1067>)
* refactor: Enable various ruff checks and fix lint errors (#1059 <https://github.com/RobotWebTools/rosbridge_suite/issues/1059>)
* chore: Use ruff to replace other linters used in pre-commit hook (#1058 <https://github.com/RobotWebTools/rosbridge_suite/issues/1058>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1056 <https://github.com/RobotWebTools/rosbridge_suite/issues/1056>)
* fix: Clean up package dependencies (#1053 <https://github.com/RobotWebTools/rosbridge_suite/issues/1053>)
* fix: Correct JSON serialization in PNG compression and update tests (#1044 <https://github.com/RobotWebTools/rosbridge_suite/issues/1044>)
* fix: Support remapping service names (#1041 <https://github.com/RobotWebTools/rosbridge_suite/issues/1041>)
* fix: ament_mypy errors (#1039 <https://github.com/RobotWebTools/rosbridge_suite/issues/1039>)
* Contributors: Błażej Sowa, Juan David Vergara, pascalauroboa, Sebastian Castro
```

## rosbridge_msgs

```
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1056 <https://github.com/RobotWebTools/rosbridge_suite/issues/1056>)
* fix: Clean up package dependencies (#1053 <https://github.com/RobotWebTools/rosbridge_suite/issues/1053>)
* Contributors: Błażej Sowa, Sebastian Castro
```

## rosbridge_server

```
* chore: Update pre-commit hooks (#1090 <https://github.com/RobotWebTools/rosbridge_suite/issues/1090>)
* Fix mypy errors (#1084 <https://github.com/RobotWebTools/rosbridge_suite/issues/1084>)
* feat: New parameter and cli arguments handling  (#1060 <https://github.com/RobotWebTools/rosbridge_suite/issues/1060>)
* refactor: Add type annotations to all functions and methods (#1069 <https://github.com/RobotWebTools/rosbridge_suite/issues/1069>)
* fix: Change warn to warning (#1067 <https://github.com/RobotWebTools/rosbridge_suite/issues/1067>)
* refactor: Enable various ruff checks and fix lint errors (#1059 <https://github.com/RobotWebTools/rosbridge_suite/issues/1059>)
* fix: rosbridge_websocket cooperative shutdown (#1048 <https://github.com/RobotWebTools/rosbridge_suite/issues/1048>)
* chore: Use ruff to replace other linters used in pre-commit hook (#1058 <https://github.com/RobotWebTools/rosbridge_suite/issues/1058>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1056 <https://github.com/RobotWebTools/rosbridge_suite/issues/1056>)
* fix: Clean up package dependencies (#1053 <https://github.com/RobotWebTools/rosbridge_suite/issues/1053>)
* fix: ament_mypy errors (#1039 <https://github.com/RobotWebTools/rosbridge_suite/issues/1039>)
* Contributors: Błażej Sowa, cyan-at, pascalauroboa, Sebastian Castro
```

## rosbridge_suite

```
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1056 <https://github.com/RobotWebTools/rosbridge_suite/issues/1056>)
* Contributors: Błażej Sowa, Sebastian Castro
```

## rosbridge_test_msgs

```
* fix: Clean up package dependencies (#1053 <https://github.com/RobotWebTools/rosbridge_suite/issues/1053>)
* Contributors: Błażej Sowa
```
