### PR TITLE
Added rosbot_ros to humble and jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9699,6 +9699,12 @@ repositories:
       url: https://github.com/fictionlab/rosbag2_to_video.git
       version: ros2
     status: maintained
+  rosbot_ros:
+    source:
+      type: git
+      url: https://github.com/husarion/rosbot_ros.git
+      version: humble
+    status: developed
   rosbridge_suite:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8648,6 +8648,12 @@ repositories:
       url: https://github.com/fictionlab/rosbag2_to_video.git
       version: ros2
     status: maintained
+  rosbot_ros:
+    source:
+      type: git
+      url: https://github.com/husarion/rosbot_ros.git
+      version: jazzy
+    status: developed
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

rosbot_ros

## Package Upstream Source:

https://github.com/husarion/rosbot_ros

## Purpose of using this:

Driver of a popular educational robotics platform

Distro packaging links:
- [humble](https://github.com/husarion/rosbot_ros/tree/humble)
- [jazzy](https://github.com/husarion/rosbot_ros/tree/jazzy)

