### PR TITLE
ros2_fmt_logger: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8180,7 +8180,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/nobleo/ros2_fmt_logger.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_fmt_logger` to `1.0.2-1`:

- upstream repository: https://github.com/nobleo/ros2_fmt_logger.git
- release repository: https://github.com/ros2-gbp/ros2_fmt_logger-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`

## ros2_fmt_logger

```
* Create intermediate string to support for fmt>=10.1.1
* Fix some small clang-tidy issues
* Contributors: Ramon Wijnands, Tim Clephas
```
