### PR TITLE
rslidar_msg: 0.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8363,6 +8363,21 @@ repositories:
       url: https://github.com/PickNikRobotics/RSL.git
       version: main
     status: developed
+  rslidar_msg:
+    doc:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+      version: master
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/rslidar_msg-release.git
+      version: 0.0.0-1
+    source:
+      type: git
+      url: https://github.com/RoboSense-LiDAR/rslidar_msg.git
+      version: master
+    status: maintained
   rt_manipulators_cpp:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rslidar_msg` to `0.0.0-1`:

- upstream repository: https://github.com/RoboSense-LiDAR/rslidar_msg.git
- release repository: https://github.com/ros2-gbp/rslidar_msg-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
