### PR TITLE
rviz_satellite: 4.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9582,7 +9582,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/nobleo/rviz_satellite-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.3.0-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/nobleo/rviz_satellite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.0-1`

## rviz_satellite

```
* added generic utm rotation calculation based on only latitude and longitude
* added property to visualize in utm frame, if activated utm_rotation factor will be calculated to correct position and orientation of tiles
* Add exception handling for the shiftMap error
* Contributors: Florian, junhee.lee
```
