### PR TITLE
rosbridge_suite: 2.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9722,7 +9722,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.0.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-1`

## rosapi

```
* chore: Update pre-commit hooks (backport #1090 <https://github.com/RobotWebTools/rosbridge_suite/issues/1090>) (#1100 <https://github.com/RobotWebTools/rosbridge_suite/issues/1100>)
* feat: Add type annotations, new parameter handling (backport #1069 <https://github.com/RobotWebTools/rosbridge_suite/issues/1069>, #1060 <https://github.com/RobotWebTools/rosbridge_suite/issues/1060>) (#1098 <https://github.com/RobotWebTools/rosbridge_suite/issues/1098>)
* fix: Change warn to warning (#1068 <https://github.com/RobotWebTools/rosbridge_suite/issues/1068>)
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* feat: Add action type and details services to rosapi (#1065 <https://github.com/RobotWebTools/rosbridge_suite/issues/1065>)
* refactor: Enable ruff and ament_mypy checks and fix lint errors (#1063 <https://github.com/RobotWebTools/rosbridge_suite/issues/1063>)
* chore: Use ruff to replace other linters used in pre-commit hook (#1062 <https://github.com/RobotWebTools/rosbridge_suite/issues/1062>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1057 <https://github.com/RobotWebTools/rosbridge_suite/issues/1057>)
* fix: Clean up package dependencies (#1054 <https://github.com/RobotWebTools/rosbridge_suite/issues/1054>)
* Contributors: Błażej Sowa, Sebastian Castro, davidfernandez, Scott Bell, MNV Chaitanya Kumar, pascalauroboa
```

## rosapi_msgs

```
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* feat: Add action type and details services to rosapi (#1065 <https://github.com/RobotWebTools/rosbridge_suite/issues/1065>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1057 <https://github.com/RobotWebTools/rosbridge_suite/issues/1057>)
* fix: Clean up package dependencies (#1054 <https://github.com/RobotWebTools/rosbridge_suite/issues/1054>)
* Contributors: Błażej Sowa, Sebastian Castro, davidfernandez, Scott Bell, MNV Chaitanya Kumar
```

## rosbridge_library

```
* chore: Update pre-commit hooks (backport #1090 <https://github.com/RobotWebTools/rosbridge_suite/issues/1090>) (#1100 <https://github.com/RobotWebTools/rosbridge_suite/issues/1100>)
* Fix mypy errors (backport #1084 <https://github.com/RobotWebTools/rosbridge_suite/issues/1084>) (#1099 <https://github.com/RobotWebTools/rosbridge_suite/issues/1099>)
* feat: Add type annotations, new parameter handling (backport #1069 <https://github.com/RobotWebTools/rosbridge_suite/issues/1069>, #1060 <https://github.com/RobotWebTools/rosbridge_suite/issues/1060>) (#1098 <https://github.com/RobotWebTools/rosbridge_suite/issues/1098>)
* fix: Change warn to warning (#1068 <https://github.com/RobotWebTools/rosbridge_suite/issues/1068>)
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* refactor: Enable ruff and ament_mypy checks and fix lint errors (#1063 <https://github.com/RobotWebTools/rosbridge_suite/issues/1063>)
* chore: Use ruff to replace other linters used in pre-commit hook (#1062 <https://github.com/RobotWebTools/rosbridge_suite/issues/1062>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1057 <https://github.com/RobotWebTools/rosbridge_suite/issues/1057>)
* fix: Clean up package dependencies (#1054 <https://github.com/RobotWebTools/rosbridge_suite/issues/1054>)
* fix: Correct JSON serialization in PNG compression and update tests (#1045 <https://github.com/RobotWebTools/rosbridge_suite/issues/1045>)
* fix: Support remapping service names (#1042 <https://github.com/RobotWebTools/rosbridge_suite/issues/1042>)
* Contributors: Błażej Sowa, Juan David Vergara, Sebastian Castro, pascalauroboa
```

## rosbridge_msgs

```
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1057 <https://github.com/RobotWebTools/rosbridge_suite/issues/1057>)
* fix: Clean up package dependencies (#1054 <https://github.com/RobotWebTools/rosbridge_suite/issues/1054>)
* Contributors: Błażej Sowa, Sebastian Castro
```

## rosbridge_server

```
* chore: Update pre-commit hooks (backport #1090 <https://github.com/RobotWebTools/rosbridge_suite/issues/1090>) (#1100 <https://github.com/RobotWebTools/rosbridge_suite/issues/1100>)
* Fix mypy errors (backport #1084 <https://github.com/RobotWebTools/rosbridge_suite/issues/1084>) (#1099 <https://github.com/RobotWebTools/rosbridge_suite/issues/1099>)
* feat: Add type annotations, new parameter handling (backport #1069 <https://github.com/RobotWebTools/rosbridge_suite/issues/1069>, #1060 <https://github.com/RobotWebTools/rosbridge_suite/issues/1060>) (#1098 <https://github.com/RobotWebTools/rosbridge_suite/issues/1098>)
* fix: Change warn to warning (#1068 <https://github.com/RobotWebTools/rosbridge_suite/issues/1068>)
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* fix: rosbridge_websocket cooperative shutdown (#1064 <https://github.com/RobotWebTools/rosbridge_suite/issues/1064>)
* refactor: Enable ruff and ament_mypy checks and fix lint errors (#1063 <https://github.com/RobotWebTools/rosbridge_suite/issues/1063>)
* chore: Use ruff to replace other linters used in pre-commit hook (#1062 <https://github.com/RobotWebTools/rosbridge_suite/issues/1062>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1057 <https://github.com/RobotWebTools/rosbridge_suite/issues/1057>)
* fix: Clean up package dependencies (#1054 <https://github.com/RobotWebTools/rosbridge_suite/issues/1054>)
* Contributors: Błażej Sowa, Sebastian Castro, cyan-at, pascalauroboa
```

## rosbridge_suite

```
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* Add pydocstyle lint checks and fix rosdoc2 warnings (#1057 <https://github.com/RobotWebTools/rosbridge_suite/issues/1057>)
* Contributors: Błażej Sowa, Sebastian Castro
```

## rosbridge_test_msgs

```
* chore: Update maintainers (#1066 <https://github.com/RobotWebTools/rosbridge_suite/issues/1066>)
* fix: Clean up package dependencies (#1054 <https://github.com/RobotWebTools/rosbridge_suite/issues/1054>)
* Contributors: Błażej Sowa
```
