### PR TITLE
point_cloud_transport: 5.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5585,7 +5585,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.3.1-1
+      version: 5.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.3.2-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.3.1-1`

## point_cloud_transport

```
* Fix duplicate component registration for Republisher (#142 <https://github.com/ros-perception/point_cloud_transport/issues/142>)
* Removed outdated comment (#138 <https://github.com/ros-perception/point_cloud_transport/issues/138>)
* Contributors: Alejandro Hernández Cordero, mini-1235
```

## point_cloud_transport_py

- No changes
