### PR TITLE
point_cloud_transport: 5.1.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5630,7 +5630,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.1.4-1
+      version: 5.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.1.5-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.4-1`

## point_cloud_transport

```
* Fix duplicate component registration for Republisher (#142 <https://github.com/ros-perception/point_cloud_transport/issues/142>) (#143 <https://github.com/ros-perception/point_cloud_transport/issues/143>)
* Removed outdated comment (#138 <https://github.com/ros-perception/point_cloud_transport/issues/138>) (#139 <https://github.com/ros-perception/point_cloud_transport/issues/139>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

- No changes
