### PR TITLE
point_cloud_transport: 4.0.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6480,7 +6480,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 4.0.5-1
+      version: 4.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.6-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.5-1`

## point_cloud_transport

```
* Fix duplicate component registration for Republisher (#142 <https://github.com/ros-perception/point_cloud_transport/issues/142>) (#144 <https://github.com/ros-perception/point_cloud_transport/issues/144>)
* Removed outdated comment (#138 <https://github.com/ros-perception/point_cloud_transport/issues/138>) (#140 <https://github.com/ros-perception/point_cloud_transport/issues/140>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

- No changes
