### PR TITLE
point_cloud_transport: 1.0.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7483,7 +7483,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 1.0.19-1
+      version: 1.0.20-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.20-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.19-1`

## point_cloud_transport

```
* Fix duplicate component registration for Republisher (#142 <https://github.com/ros-perception/point_cloud_transport/issues/142>) (#145 <https://github.com/ros-perception/point_cloud_transport/issues/145>)
* Removed outdated comment (#138 <https://github.com/ros-perception/point_cloud_transport/issues/138>) (#141 <https://github.com/ros-perception/point_cloud_transport/issues/141>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

- No changes
