### PR TITLE
clearpath_config: 2.8.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1290,7 +1290,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.8.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.0-1`

## clearpath_config

```
* Fix: Ewellix Parameters (#203 <https://github.com/clearpathrobotics/clearpath_config/issues/203>)
  Add mount parameter and remove redefinition of urdf functions
* Contributors: luis-camero
```
