### PR TITLE
clearpath_common: 2.8.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1275,7 +1275,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.8.1-1
+      version: 2.8.2-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.8.2-2`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.1-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

```
* Fix: UR Parameter Generation (#277 <https://github.com/clearpathrobotics/clearpath_common/issues/277>)
  Use merge instead of update to prevent clobbering parameters
* Contributors: luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Fix: Ewellix Parameters (#278 <https://github.com/clearpathrobotics/clearpath_common/issues/278>)
  Add plate and mount parameters to URDF
* Contributors: luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

- No changes
