### PR TITLE
mrpt_ros_bridge: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5277,6 +5277,24 @@ repositories:
       url: https://github.com/MRPT/mrpt_ros.git
       version: main
     status: developed
+  mrpt_ros_bridge:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros_bridge.git
+      version: ros2
+    release:
+      packages:
+      - mrpt_libros_bridge
+      - rosbag2rawlog
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt_ros_bridge.git
+      version: ros2
+    status: developed
   mrpt_sensors:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.0.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mrpt_libros_bridge

```
* Release as independent repository. Moved out from the MRPT/mrpt repository.
```

## rosbag2rawlog

```
* Release as independent repository. Moved out from the mrpt_navigation repository.
```
