### PR TITLE
orbbec_camera_v2: 2.5.4-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6049,6 +6049,19 @@ repositories:
       version: ros2
     status: developed
   orbbec_camera_v2:
+    doc:
+      type: git
+      url: https://github.com/orbbec/OrbbecSDK_ROS2.git
+      version: v2-main
+    release:
+      packages:
+      - orbbec_camera
+      - orbbec_camera_msgs
+      - orbbec_description
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/orbbec/orbbec_camera_v2-release.git
+      version: 2.5.4-2
     source:
       type: git
       url: https://github.com/orbbec/OrbbecSDK_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orbbec_camera_v2` to `2.5.4-2`:

- upstream repository: https://github.com/orbbec/OrbbecSDK_ROS2.git
- release repository: https://github.com/orbbec/orbbec_camera_v2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
