### PR TITLE
rviz: 15.1.12-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8470,7 +8470,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.11-1
+      version: 15.1.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.12-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.11-1`

## rviz2

- No changes

## rviz_common

```
* Cleanup deprecated code (#1619 <https://github.com/ros2/rviz//issues/1619>)
* Removed support for yaml-cpp lower than 0.5 (#1605 <https://github.com/ros2/rviz//issues/1605>)
* Removed duplicated forward class declaration (#1602 <https://github.com/ros2/rviz//issues/1602>)
* resolved TODO in visualization manager (#1603 <https://github.com/ros2/rviz//issues/1603>)
* Contributors: Alejandro Hernández Cordero, mini-1235
```

## rviz_default_plugins

```
* Removed already done TODO (#1604 <https://github.com/ros2/rviz//issues/1604>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed unused files (#1600 <https://github.com/ros2/rviz//issues/1600>)
* Contributors: mosfet80
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
