### PR TITLE
rviz: 15.0.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8526,7 +8526,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.8-1
+      version: 15.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.9-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.8-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Removed duplicated forward class declaration (#1602 <https://github.com/ros2/rviz//issues/1602>) (#1612 <https://github.com/ros2/rviz//issues/1612>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Removed already done TODO (#1604 <https://github.com/ros2/rviz//issues/1604>) (#1609 <https://github.com/ros2/rviz//issues/1609>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed unused files (#1600 <https://github.com/ros2/rviz//issues/1600>) (#1606 <https://github.com/ros2/rviz//issues/1606>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
