### PR TITLE
automatika_ros_sugar: 0.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -855,7 +855,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.4.1-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.0-1`

## automatika_ros_sugar

```
* (feature) Adds UI font files locally
* (fix) Fixes logging card scroll behavior
* (fix) Fixes drawing of output UI elements by filtering those that log
* (fix) Fixes setting id in divs added to logging card
* (fix) Clears last message when getting output for UI
* (feature) Adds method to augment exisiting text on logging card
* (fix) Fixes terminal scrolling behavior in UI
* (fix) Makes inputs/outputs displays conditional in UI
* (refactor) Moves logging card outputs to their own functions based on datatype
* Contributors: ahr, mkabtoul
```
