### PR TITLE
automatika_embodied_agents: 0.4.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -592,7 +592,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_embodied_agents` to `0.4.3-1`:

- upstream repository: https://github.com/automatika-robotics/ros-agents.git
- release repository: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.4.2-1`

## automatika_embodied_agents

```
* (docs) Adds instructions for using the dynamic web UI
* (chore) Removes tiny web client
* (fix) Removes StreamingString as input option for LLM/MLLM
* (feature) Adds logging output from StreamingString in the UI
* (chore) Adds warning for using templates with StreamingString
* (chore) Adds alias VLM for MLLM component
* (fix) Adds detections as handled output in mllm component
* (feature) Adds callback for points of interest msg
* (feature) Adds ui callback for rgbd images
* (docs) Updates docs for planning model example
* (fix) Fixes publishing images as part of detection msgs
* (refactor) Updates callbacks for video and rgbd type messages
* (feature) Adds handling of additional types from other sugar derived packages in agent's components
* (feature) Adds UI element definitions for custom types
* (feature) Adds ui callbacks for Detections and DetectionsMultiSource
* (feature) Adds utility for drawing images with bounding boxes
* (fix) Fixes passing topic from sugar derived packages to agents components
* (feature) Adds Detection2D as allowed input in map encoding component
* (feature) Adds callback for Detections2D and their use in llm/mllm components
  - Streamlines names of detection msgs
  - Streamlines names of tracking msgs
* (fix) Gets raw msg data in execution step to avoid calling get_output twice
* (chore) Adds websockets as an explicit dependency
* Contributors: ahr, mkabtoul
```
