### PR TITLE
launch: 3.9.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3478,7 +3478,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.4-1
+      version: 3.9.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.5-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.4-1`

## launch

```
* Make the directory-finding substitutions into a PathSubstitution for / operator (#914 <https://github.com/ros2/launch//issues/914>)
* Expose StringJoinSubstitution to frontend (#857 <https://github.com/ros2/launch//issues/857>)
* Contributors: Christian Ruf, Emerson Knapp
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Expose StringJoinSubstitution to frontend (#857 <https://github.com/ros2/launch//issues/857>)
* Contributors: Christian Ruf
```

## launch_yaml

```
* Expose StringJoinSubstitution to frontend (#857 <https://github.com/ros2/launch//issues/857>)
* Contributors: Christian Ruf
```
