### PR TITLE
rviz: 11.2.23-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10493,7 +10493,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.22-1
+      version: 11.2.23-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.23-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `11.2.22-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Removed duplicated forward class declaration (#1602 <https://github.com/ros2/rviz//issues/1602>) (#1614 <https://github.com/ros2/rviz//issues/1614>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Removed already done TODO (#1604 <https://github.com/ros2/rviz//issues/1604>) (#1611 <https://github.com/ros2/rviz//issues/1611>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Removed unused files (#1600 <https://github.com/ros2/rviz//issues/1600>) (#1608 <https://github.com/ros2/rviz//issues/1608>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
