### PR TITLE
launch: 3.8.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3509,7 +3509,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.5-3
+      version: 3.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.8.6-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.5-3`

## launch

```
* [backport kilted] Make the directory-finding substitutions into a PathSubstitution for / operator (backport #914 <https://github.com/ros2/launch//issues/914>) (#919 <https://github.com/ros2/launch//issues/919>)
* Contributors: mergify[bot]
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
