### PR TITLE
launch_ros: 0.29.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3528,7 +3528,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.3-4
+      version: 0.29.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.29.4-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.29.3-4`

## launch_ros

```
* Make FindPackage substitutions a Path to get operator / (#494 <https://github.com/ros2/launch_ros/issues/494>)
* Expose lifecycle_node (#327 <https://github.com/ros2/launch_ros/issues/327>) (with test) (#482 <https://github.com/ros2/launch_ros/issues/482>)
* Contributors: Emerson Knapp, Jasper van Brakel
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
