### PR TITLE
mrpt_ros_bridge: 3.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4565,7 +4565,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.0.1-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.0-1`

## mrpt_libros_bridge

```
* Fix package.xml so packages downstream install the required dependencies
* Finer grained dependencies on the part of mrpt that is really used
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

```
* Fix package.xml so packages downstream install the required dependencies
* Contributors: Jose Luis Blanco-Claraco
```
