### PR TITLE
launch_ros: 0.26.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4249,7 +4249,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.9-1
+      version: 0.26.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.10-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.9-1`

## launch_ros

```
* Make FindPackage substitutions a Path to get operator / (#494 <https://github.com/ros2/launch_ros/issues/494>) (#497 <https://github.com/ros2/launch_ros/issues/497>)
* Contributors: mergify[bot]
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
