### PR TITLE
jrl_cmakemodules: 1.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3220,7 +3220,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jrl_cmakemodules` to `1.1.2-1`:

- upstream repository: https://github.com/jrl-umi3218/jrl-cmakemodules.git
- release repository: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`
