### PR TITLE
jrl_cmakemodules: 1.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3950,7 +3950,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
Increasing version of package(s) in repository `jrl_cmakemodules` to `1.1.2-1`:

- upstream repository: https://github.com/jrl-umi3218/jrl-cmakemodules
- release repository: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.1.1-1`
