### PR TITLE
gz_gui_vendor: 0.2.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2679,7 +2679,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_gui_vendor-release.git
-      version: 0.3.1-1
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_gui_vendor` to `0.2.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_gui_vendor.git
- release repository: https://github.com/ros2-gbp/gz_gui_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## gz_gui_vendor

```
* Merge pull request #9 <https://github.com/gazebo-release/gz_gui_vendor/issues/9> from gazebo-release/releasepy/kilted/9.0.2
  Bump version to 9.0.2
* Bump version to 9.0.2
* Contributors: Jose Luis Rivero
```
