### PR TITLE
add fibar_lib repository to ROS distro

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2875,6 +2875,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
       version: release
     status: developed
+  fibar_lib:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    status: developed
   fields2cover:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2589,6 +2589,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
       version: release
     status: developed
+  fibar_lib:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    status: developed
   fields2cover:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2028,6 +2028,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
       version: release
     status: developed
+  fibar_lib:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    status: developed
   fields2cover:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2007,6 +2007,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_tools.git
       version: release
     status: developed
+  fibar_lib:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/fibar_lib.git
+      version: release
+    status: developed
   fields2cover:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME: humble, jazzy, kilted, rolling

This package is a plain cmake package that has the base library for reconstructing a brightness image from event camera events using the FIBAR method. This package is a dependency of an upcoming ROS package that supports FIBAR reconstruction in the ROS ecosystem.

# The source is here:
https://github.com/ros-event-camera/fibar_lib

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
