### PR TITLE
mp2p_icp: 2.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4430,7 +4430,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.1.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## mp2p_icp

```
* FIX: SanityCheck was triggering as errors optional pointcloud fields in XYZIRT clouds
* FIX: Throw exception instead of crashing if FilterDeskew is invoked with an empty local velocity buffer
* Fix yaml file for not using mola_yaml extensions
* Add more sm2mm demo pipelines
* Contributors: Jose Luis Blanco-Claraco
```
