### PR TITLE
mola: 2.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4908,7 +4908,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.2.1-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* BridgeROS2: more debug traces in map publishing
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_lidar_bin_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_input_video

- No changes

## mola_kernel

- No changes

## mola_launcher

```
* Fix embedded FindFilesystem.cmake to avoid cmake warnings
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Metric maps: implement missing loading 'color.A' from config files
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

```
* Fix embedded FindFilesystem.cmake to avoid cmake warnings
* Contributors: Jose Luis Blanco-Claraco
```
