### PR TITLE
flexbe_behavior_engine: 4.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2108,7 +2108,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
-      version: 3.0.3-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_behavior_engine` to `4.0.2-1`:

- upstream repository: https://github.com/FlexBE/flexbe_behavior_engine.git
- release repository: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.3-1`

## flexbe_behavior_engine

```
* update test set up for colcon testing and build farm
```

## flexbe_core

```
* flake8 cleanup and CI badge update
* fixed state_logger and be_action_server for ros2
* clean warn --> warning
* clean of latest flake8 tests
* update test set up for colcon testing and build farm
* specify python3
* protect against package parsing errors
* add verify_action_status with timeout; clear status and other terms in remove_result
```

## flexbe_input

```
* clean of latest flake8 tests
* update test set up for colcon testing and build farm
* specify python3
```

## flexbe_mirror

```
* clean of latest flake8 tests
* update test set up for colcon testing and build farm
* specify python3
* reduce spam for potential (likely short lived) sync issues
```

## flexbe_msgs

- No changes

## flexbe_onboard

```
* clean warn --> warning
* clean of latest flake8 tests
* update test set up for colcon testing and build farm
* specify python3
```

## flexbe_states

```
* update test set up for colcon testing and build farm
* specify python3
```

## flexbe_testing

```
* flake8 cleanup and CI badge update
* update test set up for colcon testing and build farm
* specify python3
```

## flexbe_widget

```
* flake8 cleanup and CI badge update
* fixed state_logger and be_action_server for ros2
* clean of latest flake8 tests
* update test set up for colcon testing and build farm
* specify python3
```
