### PR TITLE
ros2_control: 4.39.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8131,7 +8131,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.39.1-1
+      version: 4.39.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.39.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.39.1-1`

## controller_interface

- No changes

## controller_manager

```
* Avoid deadlocks for failed command switching (#2774 <https://github.com/ros-controls/ros2_control/issues/2774>) (#2796 <https://github.com/ros-controls/ros2_control/issues/2796>)
* Fix ANSI escape code pollution in log output (backport #2741 <https://github.com/ros-controls/ros2_control/issues/2741>) (#2783 <https://github.com/ros-controls/ros2_control/issues/2783>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Auto-set joint state interfaces to zero in MockHardware (#2788 <https://github.com/ros-controls/ros2_control/issues/2788>) (#2794 <https://github.com/ros-controls/ros2_control/issues/2794>)
* Don't update MockComponent's state interfaces if command interfaces are not finite (#2786 <https://github.com/ros-controls/ros2_control/issues/2786>) (#2790 <https://github.com/ros-controls/ros2_control/issues/2790>)
* Rename hardware descriptions (#2787 <https://github.com/ros-controls/ros2_control/issues/2787>) (#2792 <https://github.com/ros-controls/ros2_control/issues/2792>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Avoid deadlocks for failed command switching (#2774 <https://github.com/ros-controls/ros2_control/issues/2774>) (#2796 <https://github.com/ros-controls/ros2_control/issues/2796>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
