### PR TITLE
ros2_control: 6.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7075,7 +7075,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.0.1-1
+      version: 6.0.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.0.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.1-1`

## controller_interface

```
* Extend the reasoning for the capacity mismatch (#2723 <https://github.com/ros-controls/ros2_control/issues/2723>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* Avoid deadlocks for failed command switching (#2774 <https://github.com/ros-controls/ros2_control/issues/2774>)
* Fix ANSI escape code pollution in log output (#2741 <https://github.com/ros-controls/ros2_control/issues/2741>)
* Contributors: Sai Kishor Kothakota, sauman raaj
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Auto-set joint state interfaces to zero in MockHardware (#2788 <https://github.com/ros-controls/ros2_control/issues/2788>)
* Rename hardware descriptions (#2787 <https://github.com/ros-controls/ros2_control/issues/2787>)
* Don't update MockComponent's state interfaces if command interfaces are not finite (#2786 <https://github.com/ros-controls/ros2_control/issues/2786>)
* Contributors: Christoph Fröhlich
```

## hardware_interface_testing

```
* Avoid deadlocks for failed command switching (#2774 <https://github.com/ros-controls/ros2_control/issues/2774>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
