### PR TITLE
sbg_driver: 3.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10571,7 +10571,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros2-release.git
-      version: 3.3.0-1
+      version: 3.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.3.1-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros2.git
- release repository: https://github.com/SBG-Systems/sbg_ros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.0-1`

## sbg_driver

```
* fix: removed usage of deprecated tf2 C header
* Contributors: Fabian Freihube
```
