### PR TITLE
autoware_cmake: 1.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -716,7 +716,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.0.2-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.1.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-1`

## autoware_cmake

```
* feat: add autoware_ament_auto_package() macro (#37 <https://github.com/autowarefoundation/autoware_cmake/issues/37>)
* feat: jazzy-porting, add jazzy distro condition for jazzy related compiling (#35 <https://github.com/autowarefoundation/autoware_cmake/issues/35>)
  cmake env::jazzy-porting::add jazzy distro condition for jazzy related compiling
* fix: when using CMake >= 3.24 use CMAKE_COMPILE_WARNING_AS_ERROR variable instead of setting -Werror directly (#33 <https://github.com/autowarefoundation/autoware_cmake/issues/33>)
* Contributors: Silvio Traversaro, Yutaka Kondo, 心刚
```

## autoware_lint_common

- No changes
