### PR TITLE
locator_ros_bridge: 2.1.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4999,7 +4999,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/locator_ros_bridge-release.git
-      version: 2.1.14-1
+      version: 2.1.15-1
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `locator_ros_bridge` to `2.1.15-1`:

- upstream repository: https://github.com/boschglobal/locator_ros_bridge.git
- release repository: https://github.com/ros2-gbp/locator_ros_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.1.14-1`

## bosch_locator_bridge

```
* Update to Locator 2.0 #74 <https://github.com/boschglobal/locator_ros_bridge/issues/74> from boschglobal/humble-v2.0
* Contributors: Sheung Ying Yuen-Wille
```

## bosch_locator_bridge_utils

- No changes
