### PR TITLE
ros2_controllers: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7144,7 +7144,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.8.0-1
+      version: 6.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.8.0-1`

## ackermann_steering_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## admittance_controller

```
* Use NodeInterfaces for TransformBroadcaster construction (#1981 <https://github.com/ros-controls/ros2_controllers/issues/1981>)
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## bicycle_steering_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## chained_filter_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## diff_drive_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Don't use msg_ field of realtime publisher (#1947 <https://github.com/ros-controls/ros2_controllers/issues/1947>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## effort_controllers

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## force_torque_sensor_broadcaster

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Don't use msg_ field of realtime publisher (#1947 <https://github.com/ros-controls/ros2_controllers/issues/1947>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## forward_command_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## gpio_controllers

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Fix integer literal for size_t (#1986 <https://github.com/ros-controls/ros2_controllers/issues/1986>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## gps_sensor_broadcaster

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## imu_sensor_broadcaster

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## joint_state_broadcaster

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Fix integer literal for size_t (#1986 <https://github.com/ros-controls/ros2_controllers/issues/1986>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## joint_trajectory_controller

```
* Add missing dependency rclcpp_action (#1992 <https://github.com/ros-controls/ros2_controllers/issues/1992>)
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Add time_from_start to action feedback and state message (cherry-pick #1755 <https://github.com/ros-controls/ros2_controllers/issues/1755>) (#1820 <https://github.com/ros-controls/ros2_controllers/issues/1820>)
* Fix integer literal for size_t (#1986 <https://github.com/ros-controls/ros2_controllers/issues/1986>)
* memo
  
  Add disclaimer on missing trajectory replacement implementation (#1978)
* Fix JTC crashing when shutdown while executing (#1960 <https://github.com/ros-controls/ros2_controllers/issues/1960>)
* Remove unused get_state_msg method (#1949 <https://github.com/ros-controls/ros2_controllers/issues/1949>)
* Don't use msg_ field of realtime publisher (#1947 <https://github.com/ros-controls/ros2_controllers/issues/1947>)
* Contributors: Anand Vardhan, Bence Magyar, Christoph Fröhlich, Marq Rasmussen, Noel Jiménez García
```

## mecanum_drive_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## motion_primitives_controllers

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Fix integer literal for size_t (#1986 <https://github.com/ros-controls/ros2_controllers/issues/1986>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## omni_wheel_drive_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## parallel_gripper_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## pid_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## pose_broadcaster

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## position_controllers

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## range_sensor_broadcaster

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* fix issue of not listing new JTCs (#1891 <https://github.com/ros-controls/ros2_controllers/issues/1891>)
* Contributors: Peter Mitrano (AR)
```

## steering_controllers_library

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## tricycle_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Don't use msg_ field of realtime publisher (#1947 <https://github.com/ros-controls/ros2_controllers/issues/1947>)
* Contributors: Anand Vardhan, Christoph Fröhlich
```

## tricycle_steering_controller

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```

## velocity_controllers

```
* Controller interface api update to ros2_controller packages (#1973 <https://github.com/ros-controls/ros2_controllers/issues/1973>)
* Contributors: Anand Vardhan
```
