### PR TITLE
rosdep: add some Qt6 deps on NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6418,6 +6418,7 @@ libqt6svg6:
   debian: [libqt6svg6]
   fedora: [qt6-qtsvg]
   gentoo: ['dev-qt/qtsvg:6']
+  nixos: [qt6.qtsvg]
   openembedded: [qtsvg@meta-qt6]
   rhel:
     '*': [qt6-qtsvg-devel]
@@ -8710,6 +8711,7 @@ qml6-module-qt-labs-folderlistmodel:
   arch: [qt6-declarative]
   debian: [qml6-module-qt-labs-folderlistmodel]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8720,6 +8722,7 @@ qml6-module-qt-labs-platform:
   arch: [qt6-declarative]
   debian: [qml6-module-qt-labs-platform]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8730,6 +8733,7 @@ qml6-module-qt-labs-settings:
   arch: [qt6-declarative]
   debian: [qml6-module-qt-labs-settings]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8740,6 +8744,7 @@ qml6-module-qt5compat-graphicaleffects:
   arch: [qt6-declarative]
   debian: [qml6-module-qt5compat-graphicaleffects]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8750,6 +8755,7 @@ qml6-module-qtcharts:
   arch: [qt6-declarative]
   debian: [qml6-module-qtcharts]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8760,6 +8766,7 @@ qml6-module-qtcore:
   arch: [qt6-declarative]
   debian: [qml6-module-qtcore]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8770,6 +8777,7 @@ qml6-module-qtpositioning:
   arch: [qt6-declarative]
   debian: [qml6-module-qtpositioning]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8780,6 +8788,7 @@ qml6-module-qtqml:
   arch: [qt6-declarative]
   debian: [qml6-module-qtqml]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8790,6 +8799,7 @@ qml6-module-qtqml-models:
   arch: [qt6-declarative]
   debian: [qml6-module-qtqml-models]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8800,6 +8810,7 @@ qml6-module-qtqml-workerscript:
   arch: [qt6-declarative]
   debian: [qml6-module-qtqml-workerscript]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8821,6 +8832,7 @@ qml6-module-qtquick-controls:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick-controls]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8831,6 +8843,7 @@ qml6-module-qtquick-dialogs:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick-dialogs]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8841,6 +8854,7 @@ qml6-module-qtquick-layouts:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick-layouts]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8851,6 +8865,7 @@ qml6-module-qtquick-templates:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick-templates]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8861,6 +8876,7 @@ qml6-module-qtquick-window:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick-window]
   fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null
@@ -8923,6 +8939,7 @@ qt6-5compat-dev:
   debian: [qt6-5compat-dev]
   fedora: [qt6-qt5compat]
   gentoo: ['dev-qt/qt5compat:6']
+  nixos: [qt6.qt5compat]
   openembedded: [qt5compat@meta-qt6]
   rhel:
     '*': [qt6-qt5compat-devel]
@@ -8955,6 +8972,7 @@ qt6-base-private-dev:
   debian: [qt6-base-private-dev]
   fedora: [qt6-qtbase-private-devel]
   gentoo: ['dev-qt/qtbase:6']
+  nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase-private-devel]
@@ -8993,6 +9011,7 @@ qt6-declarative-private-dev:
   debian: [qt6-declarative-private-dev]
   fedora: [qt6-qtdeclarative-devel]
   gentoo: ['dev-qt/qtdeclarative:6']
+  nixos: [qt6.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt6]
   rhel:
     '*': [qt6-qtdeclarative-private-devel]


### PR DESCRIPTION
Hi,

This add some rosdep keys for nixos:

- qtsvg: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/libraries/qt-6/modules/qtsvg.nix
- qt5compat: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/libraries/qt-6/modules/qt5compat.nix
- re-use qt6.qtdeclarative for some other keys
- re-use qt6.qtbase for some other keys