### PR TITLE
Update devel branch of ros2_controllers

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7142,7 +7142,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: kilted
     release:
       packages:
       - ackermann_steering_controller
@@ -7180,7 +7180,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git
-      version: master
+      version: kilted
     status: developed
   ros2_easy_test:
     doc:


### PR DESCRIPTION
I forgot to update the branches with https://github.com/ros/rosdistro/pull/48567, see changes in the release repo
https://github.com/ros2-gbp/ros2_controllers-release/commit/358a17797ab6e81b90b59ca0e1bb07420abd93b4