### PR TITLE
ur_client_library: 2.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9725,7 +9725,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.6.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.0-1`

## ur_client_library

```
* RTDEClient sendStart handle missed confirmation (#403 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/403>)
* Add enum value for 3PE input active to UrRtdeSafetyStatusBits (#401 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/401>)
* Save polyscope folder in local filesystem (#399 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/399>)
* Succeed power on command on PolyScope 5 when robot is running (#397 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/397>)
* Bump actions/upload-artifact from 4 to 5 (#398 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/398>)
* Contributors: Andrew C. Morrow, Felix Exner, dependabot[bot]
```
