### PR TITLE
rosidl: 5.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7633,7 +7633,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.1.0-1
+      version: 5.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.1.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.0-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

```
* Add BaseImpl (#912 <https://github.com/ros2/rosidl/issues/912>)
* Contributors: Michael Carlstrom
```

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
