### PR TITLE
autoware_lanelet2_extension: 0.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1034,7 +1034,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.8.0-1
+      version: 0.10.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `0.10.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.8.0-1`

## autoware_lanelet2_extension

```
* chore: add build option -Wno-error=maybe-uninitialized (#79 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/79>)
  build::jazzy-porting::add build option -Wno-error=maybe-uninitialized to surpress compile error caused by boost-geometry library, v0.0
* fix: combineLaneletsShape duplicated point (#77 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/77>)
  * fix: combineLaneletsShape duplicated point
  * check distance
  style(pre-commit): autofix
  style(pre-commit): autofix
  ---------
* Contributors: Kosuke Takeuchi, 心刚
```

## autoware_lanelet2_extension_python

```
* feat(lanelet2_extension_python): add bindings for fromBinMsg (#80 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/80>)
* Contributors: Maxime CLEMENT
```
