### PR TITLE
autoware_internal_msgs: 1.12.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -756,7 +756,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.10.0-1
+      version: 1.12.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.12.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.10.0-1`

## autoware_internal_debug_msgs

- No changes

## autoware_internal_localization_msgs

- No changes

## autoware_internal_metric_msgs

- No changes

## autoware_internal_msgs

- No changes

## autoware_internal_perception_msgs

- No changes

## autoware_internal_planning_msgs

```
* chore(autoware_internal_planning_msgs): unifiy module load srv (#76 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/76>)
* Contributors: Yuki TAKAGI
```
