### PR TITLE
ros_babel_fish: 3.25.11-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7357,7 +7357,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 3.25.2-1
+      version: 3.25.11-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `3.25.11-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.25.2-1`

## ros_babel_fish

```
* Added documentation and fixed tiny memory leak.
* Added convenience methods to message introspection wrapper.
* Fixed waiting indefinitely if topic is namespaced and added test case.
* Print warning when waiting for more than 3 seconds for topic.
* Updated CMake project version.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes
