### PR TITLE
demos: 0.37.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1431,7 +1431,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.37.3-1
+      version: 0.37.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.37.4-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.37.3-1`

## action_tutorials_cpp

- No changes

## action_tutorials_py

- No changes

## composition

```
* Log message for linktime composition on Windows (#640 <https://github.com/ros2/demos/issues/640>)
* Contributors: yadunund
```

## demo_nodes_cpp

```
* Update subscription callback signatures (#754 <https://github.com/ros2/demos/issues/754>)
* Contributors: mini-1235
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

```
* Added README.md for dummy_robot_bringup. (#574 <https://github.com/ros2/demos/issues/574>)
* Contributors: Gary Bey
```

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

- No changes

## lifecycle

```
* r-simonelli/demos-lifecycle (#750 <https://github.com/ros2/demos/issues/750>)
* Contributors: r-simonelli
```

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

```
* Update subscription callback signatures (#754 <https://github.com/ros2/demos/issues/754>)
* Contributors: mini-1235
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
