### PR TITLE
ros2cli: 0.18.15-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9466,7 +9466,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.18.14-1
+      version: 0.18.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.18.15-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.18.14-1`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

```
* Updated wording in list.py (#775 <https://github.com/ros2/ros2cli//issues/775>) (#1111 <https://github.com/ros2/ros2cli//issues/1111>)
* Contributors: Eric Su
```

## ros2param

- No changes

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
