### PR TITLE
rmw_zenoh: 0.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8985,7 +8985,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.1.7-1
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.1.8-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.7-1`

## rmw_zenoh_cpp

```
* Fix typo in 'triggered' (#848 <https://github.com/ros2/rmw_zenoh/issues/848>)
* Log details at SHM creation (alloc and threshold sizes) (#838 <https://github.com/ros2/rmw_zenoh/issues/838>)
* Contributors: Alejandro Hernandez Cordero, Christophe Bedard, Julien Enoch
```

## zenoh_cpp_vendor

```
* Bump zenoh to 1.6.2 (#851 <https://github.com/ros2/rmw_zenoh/issues/851>)
* Contributors: Julien Enoch
```

## zenoh_security_tools

- No changes
