### PR TITLE
rcl_logging: 3.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6220,7 +6220,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.3.1-1
+      version: 3.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.3.2-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.1-1`

## rcl_logging_interface

```
* Fix cmake deprecation (#133 <https://github.com/ros2/rcl_logging/issues/133>)
* Contributors: mosfet80
```

## rcl_logging_noop

```
* Fix cmake deprecation (#133 <https://github.com/ros2/rcl_logging/issues/133>)
* Contributors: mosfet80
```

## rcl_logging_spdlog

```
* Fix cmake deprecation (#133 <https://github.com/ros2/rcl_logging/issues/133>)
* Contributors: mosfet80
```
