### PR TITLE
rcl_logging: 3.2.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6270,7 +6270,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.2.3-4
+      version: 3.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.2.4-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.3-4`

## rcl_logging_interface

```
* Fix cmake deprecation (#133 <https://github.com/ros2/rcl_logging/issues/133>) (#134 <https://github.com/ros2/rcl_logging/issues/134>)
* Contributors: mergify[bot]
```

## rcl_logging_noop

```
* Fix cmake deprecation (#133 <https://github.com/ros2/rcl_logging/issues/133>) (#134 <https://github.com/ros2/rcl_logging/issues/134>)
* Contributors: mergify[bot]
```

## rcl_logging_spdlog

```
* Fix cmake deprecation (#133 <https://github.com/ros2/rcl_logging/issues/133>) (#134 <https://github.com/ros2/rcl_logging/issues/134>)
* Contributors: mergify[bot]
```
