### PR TITLE
synchros2: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11286,6 +11286,21 @@ repositories:
       url: https://github.com/Tacha-S/sync_parameter_server.git
       version: main
     status: developed
+  synchros2:
+    doc:
+      type: git
+      url: https://github.com/bdaiinstitute/synchros2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/bdaiinstitute/synchros2-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/bdaiinstitute/synchros2.git
+      version: main
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `synchros2` to `1.0.2-1`:

- upstream repository: https://github.com/bdaiinstitute/synchros2.git
- release repository: https://github.com/bdaiinstitute/synchros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## synchros2

```
* [SW-2822] Rename repository to synchros2 (#180 <https://github.com/bdaiinstitute/ros_utilities/issues/180>)
* Contributors: Michel Hidalgo
```
