### PR TITLE
synchros2: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10218,6 +10218,21 @@ repositories:
       url: https://github.com/synapticon/synapticon_ros2_control.git
       version: main
     status: maintained
+  synchros2:
+    doc:
+      type: git
+      url: https://github.com/bdaiinstitute/synchros2.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/bdaiinstitute/synchros2-release.git
+      version: 1.0.2-1
+    source:
+      type: git
+      url: https://github.com/bdaiinstitute/synchros2.git
+      version: main
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `synchros2` to `1.0.2-1`:

- upstream repository: https://github.com/bdaiinstitute/synchros2.git
- release repository: https://github.com/bdaiinstitute/synchros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## synchros2

```
* [SW-2822] Rename repository to synchros2 (#180 <https://github.com/bdaiinstitute/ros_utilities/issues/180>)
* Contributors: Michel Hidalgo
```
