### PR TITLE
proto2ros: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7626,7 +7626,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/bdaiinstitute/proto2ros-release.git
-      version: 1.0.0-3
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/bdaiinstitute/proto2ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `proto2ros` to `1.0.1-1`:

- upstream repository: https://github.com/bdaiinstitute/proto2ros.git
- release repository: https://github.com/bdaiinstitute/proto2ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-3`

## proto2ros

```
* Add Jazzy support (#13 <https://github.com/bdaiinstitute/proto2ros/issues/13>)
* Change to new RAI Institute copyright (#12 <https://github.com/bdaiinstitute/proto2ros/issues/12>)
* Fix proto2ros C++ conversions template (#11 <https://github.com/bdaiinstitute/proto2ros/issues/11>)
* Trim trailing whitespace (#10 <https://github.com/bdaiinstitute/proto2ros/issues/10>)
* Have proto2ros mypy checks follow imports silently (#8 <https://github.com/bdaiinstitute/proto2ros/issues/8>)
* Contributors: Ben Axelrod, Michel Hidalgo
```
