### PR TITLE
proto2ros: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6633,6 +6633,21 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  proto2ros:
+    doc:
+      type: git
+      url: https://github.com/bdaiinstitute/proto2ros.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/bdaiinstitute/proto2ros-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/bdaiinstitute/proto2ros.git
+      version: main
+    status: developed
   protobuf_comm:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `proto2ros` to `1.0.1-1`:

- upstream repository: https://github.com/bdaiinstitute/proto2ros.git
- release repository: https://github.com/bdaiinstitute/proto2ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## proto2ros

```
* Add Jazzy support (#13 <https://github.com/bdaiinstitute/proto2ros/issues/13>)
* Change to new RAI Institute copyright (#12 <https://github.com/bdaiinstitute/proto2ros/issues/12>)
* Fix proto2ros C++ conversions template (#11 <https://github.com/bdaiinstitute/proto2ros/issues/11>)
* Trim trailing whitespace (#10 <https://github.com/bdaiinstitute/proto2ros/issues/10>)
* Have proto2ros mypy checks follow imports silently (#8 <https://github.com/bdaiinstitute/proto2ros/issues/8>)
* Contributors: Ben Axelrod, Michel Hidalgo
```
