### PR TITLE
Add RHEL rule for 'python3-networkx'

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7761,6 +7761,7 @@ python3-networkx:
   debian: [python3-networkx]
   fedora: [python3-networkx]
   nixos: [python3Packages.networkx]
+  rhel: [python3-networkx]
   ubuntu: [python3-networkx]
 python3-nlopt:
   arch: [nlopt]


### PR DESCRIPTION
For both RHEL 8 and 9, this package is part of the AppStream repository.

RHEL 8: https://mirrors.bmcc.edu/alma/8.10/AppStream/x86_64/os/Packages/python3-networkx-1.11-16.1.el8.noarch.rpm
RHEL 9: https://mirrors.bmcc.edu/alma/9.6/AppStream/x86_64/os/Packages/python3-networkx-2.6.2-2.el9.noarch.rpm