### PR TITLE
rmw_zenoh: 0.6.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6979,7 +6979,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.6-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.5-1`

## rmw_zenoh_cpp

```
* Fix typo in 'triggered' (#846 <https://github.com/ros2/rmw_zenoh/issues/846>)
* Log details at SHM creation (alloc and threashold sizes) (#836 <https://github.com/ros2/rmw_zenoh/issues/836>)
* Contributors: Alejandro Hernandez Cordero, Christophe Bedard, Julien Enoch
```

## zenoh_cpp_vendor

```
* Bump zenoh to 1.6.2 (#849 <https://github.com/ros2/rmw_zenoh/issues/849>)
* Contributors: Julien Enoch
```

## zenoh_security_tools

- No changes
