### PR TITLE
py_trees: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6711,7 +6711,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.4.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/ros2-gbp/py_trees-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## py_trees

```
* [code] Replace type checks with instance checks (#479 <https://github.com/splintered-reality/py_trees/issues/479>)
* [behaviours] Add ForEach decorator to iterate over a list (#476 <https://github.com/splintered-reality/py_trees/issues/476>)
* [code] Use typing.Any for type hints in kwargs (#475 <https://github.com/splintered-reality/py_trees/issues/475>)
* [behaviours] Add behavior CompareBlackboardVariables (#472 <https://github.com/splintered-reality/py_trees/issues/472>)
* [code] use generator expression in all() for short-circuit evaluation (#470 <https://github.com/splintered-reality/py_trees/issues/470>)
* [behaviours] Extend ComparisonExpression so we can get the value from a callable (#468 <https://github.com/splintered-reality/py_trees/issues/468>)
* [code] remove py package, no longer needed for pytest-benchmark (#466 <https://github.com/splintered-reality/py_trees/issues/466>)
* [docs] Update introduction.rst -fixed typo (#464 <https://github.com/splintered-reality/py_trees/issues/464>)
* [readme] Update README for version 2.3.x (#460 <https://github.com/splintered-reality/py_trees/issues/460>)
* [infra] Update Python package version to 2.3.0 (#461 <https://github.com/splintered-reality/py_trees/issues/461>)
* [infra] Use commas to separate multiple tox commands
* Contributors: FrankvVeelen, Jorge Santos Simón, Lei Zhang, Robert Tang-Kong, Sebastian Castro, Sid Sarasvati
```
