### PR TITLE
py_trees_ros: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7753,7 +7753,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.4.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros
- release repository: https://github.com/ros2-gbp/py_trees_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## py_trees_ros

```
* [readme] Remove ROS 1 from, add ROS 2 Kilted to, README (#242 <https://github.com/splintered-reality/py_trees_ros/issues/242>)
* [behaviours] Fix callback group parameter consistency and remove (most) old-school type hints (#241 <https://github.com/splintered-reality/py_trees_ros/issues/241>)
* [behaviours] Support setting callback group for service and action clients (#240 <https://github.com/splintered-reality/py_trees_ros/issues/240>)
* [behaviours] Add FromCallback service and action client behaviors (#238 <https://github.com/splintered-reality/py_trees_ros/issues/238>)
* [behaviours] Avoid silent failure on service and action client FromBlackboard (#236 <https://github.com/splintered-reality/py_trees_ros/issues/236>) (#239 <https://github.com/splintered-reality/py_trees_ros/issues/239>)
* [behaviours] Add convenience version of FromBlackboard service that creates a request with fields read from BB (#235 <https://github.com/splintered-reality/py_trees_ros/issues/235>)
* [behaviours] Add convenience version of FromBlackboard action that creates a goal with fields read from BB (#232 <https://github.com/splintered-reality/py_trees_ros/issues/232>)
* [behaviours] Fix feedback message args in docs action_clients.py (#231 <https://github.com/splintered-reality/py_trees_ros/issues/231>)
* [behaviours] fixes AttributeError when a goal callback does not return before the update() method of FromBlackboard. (#229 <https://github.com/splintered-reality/py_trees_ros/issues/229>)
* [readme] Update README to latest ROS versions (#227 <https://github.com/splintered-reality/py_trees_ros/issues/227>)
* Contributors: Jorge Santos Simón, Sebastian Castro, Thomas Cameron, tanneguy
```
