### PR TITLE
py_trees_ros_tutorials: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6775,7 +6775,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.4.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## py_trees_ros_tutorials

```
* [readme] Remove annoying period (#55 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/55>)
* [readme] Fix repo URLs too
* Contributors: Sebastian Castro
```
