### PR TITLE
ur_robot_driver: 3.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11180,7 +11180,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.6.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.0-1`

## ur

- No changes

## ur_calibration

```
* Explicitly state PolyScope X compatibility (backport #1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>) (#1568 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1568>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* Explicitly state PolyScope X compatibility (backport #1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>) (#1568 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1568>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

```
* Explicitly state PolyScope X compatibility (backport #1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>) (#1568 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1568>)
* Contributors: mergify[bot]
```

## ur_moveit_config

```
* Explicitly state PolyScope X compatibility (backport #1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>) (#1568 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1568>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Docs: Corrects forward hardware interfaces & Contributing.md (backport #1569 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1569>) (#1570 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1570>)
* Explicitly state PolyScope X compatibility (backport #1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>) (#1568 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1568>)
* Fix flaky tests (backport #1559 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1559>) (#1567 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1567>)
* Dashboard client polyscopex (backport #1546 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1546>) (#1561 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1561>)
* Fix syntax for link to robot_manual (backport of #1558 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1558>) (#1560 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1560>)
* Temporarily deactivate one testcase in controller_switch_test (backport #1553 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1553>) (#1554 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1554>)
* Contributors: mergify[bot]
```
