### PR TITLE
ur_robot_driver: 4.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9777,7 +9777,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.3.0-1
+      version: 4.4.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.4.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.3.0-1`

## ur

- No changes

## ur_calibration

```
* Explicitly state PolyScope X compatibility (#1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>)
* Implement motion_primitive interface in hardware interface (#1341 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1341>)
  With this it is possible to use motion_primitives to command the robot's motion.
* Add migration notes to individual packages (#1545 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1545>)
  * Add migration notes to packages.
  Also added a GitHub action to build the Sphinx documentation.
  * Add conf.py to moveit_config package
  * Suppress reference warnings when building package docs individually
  * Apply suggestions from code review
  ---------
  Co-authored-by: Felix Exner <mailto:feex@universal-robots.com>
* Contributors: Felix Exner, Mathias Fuhrer, URJala
```

## ur_controllers

```
* Explicitly state PolyScope X compatibility (#1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>)
* Add migration notes to individual packages (#1545 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1545>)
* Contributors: Felix Exner, URJala
```

## ur_dashboard_msgs

```
* Explicitly state PolyScope X compatibility (#1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>)
* Contributors: Felix Exner
```

## ur_moveit_config

```
* Explicitly state PolyScope X compatibility (#1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>)
* Add migration notes to individual packages (#1545 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1545>)
* Contributors: Felix Exner, URJala
```

## ur_robot_driver

```
* Docs: Corrects forward hardware interfaces & Contributing.md (#1569 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1569>)
* Explicitly state PolyScope X compatibility (#1563 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1563>)
* Fix flaky tests (#1559 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1559>)
* Increase default dashboard client timeout to 2 seconds (#1564 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1564>)
* Dashboard client polyscopex (#1546 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1546>)
* Implement motion_primitive interface in hardware interface (#1341 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1341>)
* Fix syntax for link to robot_manual (#1558 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1558>)
* Temporarily deactivate one testcase in controller_switch_test (#1553 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1553>)
* Add missing update_rate config files for UR7e and UR12e (#1544 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1544>)
* Add migration notes to individual packages (#1545 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1545>)
* Specify that only PolyScope 5 needs the option of remote control explicitly e… (#1530 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1530>)
* Contributors: Felix Exner, Mathias Fuhrer, Matthias Mayr, URJala
```
