### PR TITLE
Add nanovdb

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4970,6 +4970,10 @@ libnanopb-dev:
   ubuntu:
     '*': [libnanopb-dev]
     bionic: null
+libnanovdb-dev:
+  debian: [libnanovdb-dev]
+  fedora: [openvdb-nanovdb]
+  ubuntu: [libnanovdb-dev]
 libncurses:
   arch: [ncurses]
   debian: [libncurses6]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4972,6 +4972,10 @@ libnanopb-dev:
     bionic: null
 libnanovdb-dev:
   debian: [libnanovdb-dev]
+  fedora:
+    '*': [openvdb-nanovdb-devel]
+    '41': null
+    '42': null
   ubuntu:
     '*': [libnanovdb-dev]
     'focal': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4972,8 +4972,10 @@ libnanopb-dev:
     bionic: null
 libnanovdb-dev:
   debian: [libnanovdb-dev]
-  fedora: [openvdb-nanovdb]
-  ubuntu: [libnanovdb-dev]
+  ubuntu:
+    '*': [libnanovdb-dev]
+    'focal': null
+    'jammy': null
 libncurses:
   arch: [ncurses]
   debian: [libncurses6]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

Nanovdb

## Package Upstream Source:

https://github.com/AcademySoftwareFoundation/openvdb


## Purpose of using this:

For research purposes, this library is similar to OpenVDB, which is already listed in rosdep

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libnanovdb-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libnanovdb-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/openvdb/openvdb-nanovdb/
- Arch: https://www.archlinux.org/packages/
  - skipped
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - skipped
- NixOS/nixpkgs: https://search.nixos.org/packages
  - skipped
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - skipped
