### PR TITLE
update source/doc branches for ros-event-camera and ros-misc-utilitie…

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1795,7 +1795,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1804,13 +1804,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git
-      version: rolling
+      version: release
     status: developed
   event_camera_msgs:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1819,7 +1819,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git
-      version: rolling
+      version: release
     status: developed
   event_camera_py:
     doc:
@@ -1840,7 +1840,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1849,7 +1849,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git
-      version: rolling
+      version: release
     status: developed
   example_interfaces:
     doc:
@@ -3648,7 +3648,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3657,13 +3657,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git
-      version: rolling
+      version: release
     status: developed
   libcaer_vendor:
     doc:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: rolling
+      version: release
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3672,7 +3672,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_vendor.git
-      version: rolling
+      version: release
     status: developed
   libcamera:
     doc:


### PR DESCRIPTION
This PR updates source and doc branches for various repos owned by ros-event-camera and ros-misc-utilities to point to "release" instead of "rolling". This is necessary because the "rolling" branches are no longer maintained.

