### PR TITLE
orbbec_camera_v2: 2.5.5-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6796,7 +6796,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/orbbec/orbbec_camera_v2-release.git
-      version: 2.5.4-1
+      version: 2.5.5-2
     source:
       type: git
       url: https://github.com/orbbec/OrbbecSDK_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orbbec_camera_v2` to `2.5.5-2`:

- upstream repository: https://github.com/orbbec/OrbbecSDK_ROS2.git
- release repository: https://github.com/orbbec/orbbec_camera_v2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.4-1`
