### PR TITLE
rmf_simulation: 2.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6653,7 +6653,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.5.0-1
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_simulation` to `2.6.1-1`:

- upstream repository: https://github.com/open-rmf/rmf_simulation.git
- release repository: https://github.com/ros2-gbp/rmf_simulation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.5.0-1`

## rmf_building_sim_gz_plugins

```
* Qt5 and Qt6 compatibility (#157 <https://github.com/open-rmf/rmf_simulation/issues/157>)
* Migrate to target_link_libraries (#147 <https://github.com/open-rmf/rmf_simulation/issues/147>)
* Contributors: Luca Della Vedova
```

## rmf_robot_sim_common

```
* Fix reverse drive for slotcar (#150 <https://github.com/open-rmf/rmf_simulation/issues/150>)
* Migrate to target_link_libraries (#147 <https://github.com/open-rmf/rmf_simulation/issues/147>)
* Rotate directly towards the immediate target (#149 <https://github.com/open-rmf/rmf_simulation/issues/149>)
* Contributors: Grey, Luca Della Vedova
```

## rmf_robot_sim_gz_plugins

```
* Qt5 and Qt6 compatibility (#157 <https://github.com/open-rmf/rmf_simulation/issues/157>)
* Migrate to target_link_libraries (#147 <https://github.com/open-rmf/rmf_simulation/issues/147>)
* Contributors: Luca Della Vedova
```
