### PR TITLE
point_cloud_transport_plugins: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5625,7 +5625,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 5.0.2-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `6.0.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.2-1`

## draco_point_cloud_transport

```
* Correctly export dependencies for downstream packages (#70 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/70>)
* Contributors: Albers Franz
```

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

```
* Correctly export dependencies for downstream packages (#70 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/70>)
* Contributors: Albers Franz
```

## zstd_point_cloud_transport

```
* Correctly export dependencies for downstream packages (#70 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/70>)
* Contributors: Albers Franz
```
