### PR TITLE
Replace pip installations with native packages for Python deps on newer Debian/Ubuntu distros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7543,8 +7543,7 @@ python3-mock:
   rhel: ['python%{python3_pkgversion}-mock']
   ubuntu: [python3-mock]
 python3-mongomock:
-  debian:
-    '*': [python3-mongomock]
+  debian: [python3-mongomock]
   ubuntu:
     '*': [python3-mongomock]
     focal:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4041,11 +4041,16 @@ python-sphinx-rtd-theme:
     bionic: [python-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
-    pip:
-      packages: [spidev]
+    '*':
+      pip:
+        packages: [spidev]
+    bookworm: [python3-spidev]
   ubuntu:
-    pip:
-      packages: [spidev]
+    '*':
+      pip:
+        packages: [spidev]
+    jammy: [python3-spidev]
+    noble: [python3-spidev]
 python-sqlalchemy:
   debian: [python-sqlalchemy]
   fedora: [python-sqlalchemy]
@@ -4876,14 +4881,18 @@ python3-ahrs-pip:
       packages: [ahrs]
 python3-aio-pika-pip:
   debian:
-    pip:
-      packages: [aio-pika]
+    '*':
+      pip:
+        packages: [aio-pika]
+    bookworm: [python3-aio-pika]
   fedora:
     pip:
       packages: [aio-pika]
   ubuntu:
-    pip:
-      packages: [aio-pika]
+    '*':
+      pip:
+        packages: [aio-pika]
+    noble: [python3-aio-pika]
 python3-aiohttp:
   arch: [python-aiohttp]
   debian: [python3-aiohttp]
@@ -4951,14 +4960,19 @@ python3-alsaaudio:
   ubuntu: [python3-alsaaudio]
 python3-ansible-runner-pip:
   debian:
-    pip:
-      packages: [ansible-runner]
+    '*':
+      pip:
+        packages: [ansible-runner]
+    bookworm: [python3-ansible-runner]
   fedora:
     pip:
       packages: [ansible-runner]
   ubuntu:
-    pip:
-      packages: [ansible-runner]
+    '*':
+      pip:
+        packages: [ansible-runner]
+    jammy: [python3-ansible-runner]
+    noble: [python3-ansible-runner]
 python3-antlr4:
   debian: [python3-antlr4]
   nixos: [python3Packages.antlr4-python3-runtime]
@@ -5074,8 +5088,10 @@ python3-backoff-pip:
     pip:
       packages: [backoff]
   debian:
-    pip:
-      packages: [backoff]
+    '*':
+      pip:
+        packages: [backoff]
+    bookworm: [python3-backoff]
   fedora:
     pip:
       packages: [backoff]
@@ -5086,8 +5102,11 @@ python3-backoff-pip:
     pip:
       packages: [backoff]
   ubuntu:
-    pip:
-      packages: [backoff]
+    '*':
+      pip:
+        packages: [backoff]
+    jammy: [python3-backoff]
+    noble: [python3-backoff]
 python3-bcrypt:
   debian: [python3-bcrypt]
   fedora: [python3-bcrypt]
@@ -6019,11 +6038,16 @@ python3-fastapi:
         packages: [fastapi]
 python3-fasteners-pip:
   debian:
-    pip:
-      packages: [fasteners]
+    '*':
+      pip:
+        packages: [fasteners]
+    bookworm: [python3-fasteners]
   ubuntu:
-    pip:
-      packages: [fasteners]
+    '*':
+      pip:
+        packages: [fasteners]
+    jammy: [python3-fasteners]
+    noble: [python3-fasteners]
 python3-fastjsonschema:
   debian: [python3-fastjsonschema]
   fedora: [python3-fastjsonschema]
@@ -6123,8 +6147,10 @@ python3-flake8-black:
     pip:
       packages: [flake8-black]
   ubuntu:
-    pip:
-      packages: [flake8-black]
+    '*':
+      pip:
+        packages: [flake8-black]
+    noble: [python3-flake8-black]
 python3-flake8-blind-except:
   debian:
     '*': [python3-flake8-blind-except]
@@ -6443,8 +6469,10 @@ python3-fpdf2-pip:
     pip:
       packages: [fpdf2]
   ubuntu:
-    pip:
-      packages: [fpdf2]
+    '*':
+      pip:
+        packages: [fpdf2]
+    noble: [python3-fpdf]
 python3-freezegun:
   debian: [python3-freezegun]
   fedora: [python3-freezegun]
@@ -7241,11 +7269,15 @@ python3-libtmux:
   ubuntu: [python3-libtmux]
 python3-lingua-franca-pip:
   debian:
-    pip:
-      packages: [lingua-franca]
+    '*':
+      pip:
+        packages: [lingua-franca]
+    bookworm: [python3-lingua-franca]
   ubuntu:
-    pip:
-      packages: [lingua-franca]
+    '*':
+      pip:
+        packages: [lingua-franca]
+    noble: [python3-lingua-franca]
 python3-lockfile:
   alpine: [py3-lockfile]
   arch: [python-lockfile]
@@ -7305,14 +7337,18 @@ python3-mako:
   ubuntu: [python3-mako]
 python3-mapbox-earcut-pip:
   debian:
-    pip:
-      packages: [mapbox-earcut]
+    '*':
+      pip:
+        packages: [mapbox-earcut]
+    bookworm: [python3-mapbox-earcut]
   fedora:
     pip:
       packages: [mapbox-earcut]
   ubuntu:
-    pip:
-      packages: [mapbox-earcut]
+    '*':
+      pip:
+        packages: [mapbox-earcut]
+    noble: [python3-mapbox-earcut]
 python3-mapnik:
   debian: [python3-mapnik]
   fedora: [python3-mapnik]
@@ -7343,8 +7379,10 @@ python3-marshmallow:
   ubuntu: [python3-marshmallow]
 python3-marshmallow-dataclass-pip:
   ubuntu:
-    pip:
-      packages: [marshmallow-dataclass]
+    '*':
+      pip:
+        packages: [marshmallow-dataclass]
+    noble: [python3-marshmallow-dataclass]
 python3-matplotlib:
   alpine: [py3-matplotlib]
   arch: [python-matplotlib]
@@ -7507,9 +7545,6 @@ python3-mock:
 python3-mongomock:
   debian:
     '*': [python3-mongomock]
-    bookworm:
-      pip:
-        packages: [mongomock]
   ubuntu:
     '*': [python3-mongomock]
     focal:
@@ -8000,8 +8035,10 @@ python3-openai-pip:
     pip:
       packages: [openai]
   ubuntu:
-    pip:
-      packages: [openai]
+    '*':
+      pip:
+        packages: [openai]
+    noble: [python3-openai]
 python3-opencv:
   debian: [python3-opencv]
   fedora: [python3-opencv]
@@ -8140,8 +8177,11 @@ python3-padaos-pip:
     pip:
       packages: [padaos]
   ubuntu:
-    pip:
-      packages: [padaos]
+    '*':
+      pip:
+        packages: [padaos]
+    jammy: [python3-padaos]
+    noble: [python3-padaos]
 python3-padatious-pip:
   debian:
     pip:
@@ -10022,8 +10062,11 @@ python3-sense-hat-pip:
     pip:
       packages: [sense-hat]
   ubuntu:
-    pip:
-      packages: [sense-hat]
+    '*':
+      pip:
+        packages: [sense-hat]
+    jammy: [python3-sense-hat]
+    noble: [python3-sense-hat]
 python3-serial:
   debian: [python3-serial]
   fedora: [python3-pyserial]
@@ -11236,8 +11279,11 @@ python3-xmlschema:
   fedora: [python3-xmlschema]
   nixos: [python3Packages.xmlschema]
   ubuntu:
-    pip:
-      packages: [xmlschema]
+    '*':
+      pip:
+        packages: [xmlschema]
+    jammy: [python3-xmlschema]
+    noble: [python3-xmlschema]
 python3-xmltodict:
   alpine: [py3-xmltodict]
   arch: [python-xmltodict]


### PR DESCRIPTION
As mentioned in #48237 , a bunch of packages from PyPI have been added as native system libraries in Ubuntu and Debian, this pr updates the corresponding entries to make them available on the build farm and avoid shadowing problems.