### PR TITLE
Add python3-cbor2 for RHEL

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5379,6 +5379,7 @@ python3-cbor2:
   osx:
     pip:
       packages: [cbor2]
+  rhel: [python3-cbor2]
   ubuntu:
     '*': [python3-cbor2]
     bionic:


### PR DESCRIPTION
Need this to release ROSbridge after it added this dependency