### PR TITLE
laser_filters: 2.2.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3446,11 +3446,15 @@ repositories:
       version: master
     status: maintained
   laser_filters:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/laser_filters.git
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/laser_filters-release.git
-      version: 2.2.0-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/ros-perception/laser_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filters` to `2.2.3-1`:

- upstream repository: https://github.com/ros-perception/laser_filters.git
- release repository: https://github.com/ros2-gbp/laser_filters-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## laser_filters

```
* Parameter for chaning history depth of filtered scan publisher
* Binning filter
* Fix compile warning in speckle filter
* Added readonly = false to reconfigurable parameters
* Run CI on kilted branch
* Contributors: Anthony Goeckner, Griffin Tabor, Guillaume Doisy, Jeanine van Bruggen, Tatsuro Sakaguchi
```
