### PR TITLE
tinyxml2_vendor: 0.11.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9222,7 +9222,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.11.2-1
+      version: 0.11.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.11.3-1`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.11.2-1`

## tinyxml2_vendor

```
* Deprecation warning in package.xml (#26 <https://github.com/ros2/tinyxml2_vendor//issues/26>)
  Co-authored-by: Michal Sojka <mailto:michal.sojka@cvut.cz>
* Contributors: Alejandro Hernández Cordero
```
