### PR TITLE
tinyxml2_vendor: 0.10.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9309,7 +9309,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.10.0-2
+      version: 0.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.10.1-1`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.10.0-2`

## tinyxml2_vendor

```
* fix: use path to tinyxml2 if it's the only item in TINYXML2_LIBRARY (#29 <https://github.com/ros2/tinyxml2_vendor//issues/29>)
* Fix CMake deprecation (#24 <https://github.com/ros2/tinyxml2_vendor//issues/24>) (#25 <https://github.com/ros2/tinyxml2_vendor//issues/25>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#20 <https://github.com/ros2/tinyxml2_vendor//issues/20>)
* Contributors: Chris Lalancette, Esteve Fernandez, mergify[bot]
```
