### PR TITLE
rmw_implementation: 3.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6933,7 +6933,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 3.1.2-1
+      version: 3.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_implementation` to `3.1.3-1`:

- upstream repository: https://github.com/ros2/rmw_implementation.git
- release repository: https://github.com/ros2-gbp/rmw_implementation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.2-1`

## rmw_implementation

```
* Add rmw_get_clients_info_by_service , rmw_servers_clients_info_by_service (#238 <https://github.com/ros2/rmw_implementation/issues/238>)
* fix cmake deprecation (#267 <https://github.com/ros2/rmw_implementation/issues/267>)
* Explain rosidl_typesupport_{c,cpp} in rmw impl typesupport list (#265 <https://github.com/ros2/rmw_implementation/issues/265>)
* Contributors: Christophe Bedard, Minju, Lee, mosfet80
```
