### PR TITLE
rosbridge_suite: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7603,7 +7603,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `3.0.1-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.0-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Don't add rosapi services to glob patterns if we pass empty services_glob parameter (#1115 <https://github.com/RobotWebTools/rosbridge_suite/issues/1115>)
* feat: Allow importing action feedback message types (#1108 <https://github.com/RobotWebTools/rosbridge_suite/issues/1108>)
* feat: Replace cbor with cbor2 library, remove inline implementation (#1107 <https://github.com/RobotWebTools/rosbridge_suite/issues/1107>)
* Contributors: Błażej Sowa
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Don't add rosapi services to glob patterns if we pass empty services_glob parameter (#1115 <https://github.com/RobotWebTools/rosbridge_suite/issues/1115>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
