### PR TITLE
tinyxml2_vendor: 0.7.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11732,7 +11732,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
-      version: 0.7.6-1
+      version: 0.7.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tinyxml2_vendor` to `0.7.7-1`:

- upstream repository: https://github.com/ros2/tinyxml2_vendor.git
- release repository: https://github.com/ros2-gbp/tinyxml2_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.6-1`
