### PR TITLE
rclcpp: 30.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6279,7 +6279,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 30.1.2-1
+      version: 30.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `30.1.3-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `30.1.2-1`

## rclcpp

```
* correct test function descriptions (#2970 <https://github.com/ros2/rclcpp/issues/2970>)
* add : get clients, servers info (#2569 <https://github.com/ros2/rclcpp/issues/2569>)
* Fix REP url locations (#2987 <https://github.com/ros2/rclcpp/issues/2987>)
* Contributors: Minju, Lee, Tim Clephas, Yuchen966
```

## rclcpp_action

```
* Fix REP url locations (#2987 <https://github.com/ros2/rclcpp/issues/2987>)
* Contributors: Tim Clephas
```

## rclcpp_components

```
* Fix REP url locations (#2987 <https://github.com/ros2/rclcpp/issues/2987>)
* Contributors: Tim Clephas
```

## rclcpp_lifecycle

```
* add : get clients, servers info (#2569 <https://github.com/ros2/rclcpp/issues/2569>)
* Fix REP url locations (#2987 <https://github.com/ros2/rclcpp/issues/2987>)
* Add get_parameter_or overload returning value or alternative (#2973 <https://github.com/ros2/rclcpp/issues/2973>)
* Contributors: Minju, Lee, Tim Clephas, Zheng Qu
```
