### PR TITLE
rclpy: 10.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6295,7 +6295,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.1-1
+      version: 10.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.2-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.0.1-1`

## rclpy

```
* add : get clients, servers info (#1307 <https://github.com/ros2/rclpy/issues/1307>)
* Allow action servers without execute callback (#1219 <https://github.com/ros2/rclpy/issues/1219>)
* Remove accidental tuple (#1542 <https://github.com/ros2/rclpy/issues/1542>)
* fix(test_events_executor): destroy all nodes before shutdown (#1538 <https://github.com/ros2/rclpy/issues/1538>)
* Remove duplicate future handling from send_goal_async (#1532 <https://github.com/ros2/rclpy/issues/1532>)
* Contributors: Michael Carlstrom, Minju, Lee, Nathan Wiebe Neufeldt, Tim Clephas, Yuyuan Yuan
```
