### PR TITLE
rosbridge_suite: 2.4.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8727,7 +8727,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.4.1-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Don't add rosapi services to glob patterns if we pass empty services_glob parameter (backport #1115 <https://github.com/RobotWebTools/rosbridge_suite/issues/1115>) (#1116 <https://github.com/RobotWebTools/rosbridge_suite/issues/1116>)
* feat: Allow importing action feedback message types (backport #1108 <https://github.com/RobotWebTools/rosbridge_suite/issues/1108>) (#1111 <https://github.com/RobotWebTools/rosbridge_suite/issues/1111>)
* feat: Replace cbor with cbor2 library, remove inline implementation (backport #1107 <https://github.com/RobotWebTools/rosbridge_suite/issues/1107>) (#1109 <https://github.com/RobotWebTools/rosbridge_suite/issues/1109>)
* Contributors: Błażej Sowa
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Don't add rosapi services to glob patterns if we pass empty services_glob parameter (backport #1115 <https://github.com/RobotWebTools/rosbridge_suite/issues/1115>) (#1116 <https://github.com/RobotWebTools/rosbridge_suite/issues/1116>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
