### PR TITLE
rclpy: 9.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6349,7 +6349,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 9.1.2-1
+      version: 9.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `9.1.3-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.1.2-1`

## rclpy

```
* Remove accidental tuple (#1542 <https://github.com/ros2/rclpy/issues/1542>) (#1543 <https://github.com/ros2/rclpy/issues/1543>)
* fix(test_events_executor): destroy all nodes before shutdown (#1538 <https://github.com/ros2/rclpy/issues/1538>) (#1539 <https://github.com/ros2/rclpy/issues/1539>)
* Remove duplicate future handling from send_goal_async (#1532 <https://github.com/ros2/rclpy/issues/1532>) (#1534 <https://github.com/ros2/rclpy/issues/1534>)
* Contributors: mergify[bot]
```
