### PR TITLE
ros2cli: 0.40.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7304,7 +7304,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.40.1-1
+      version: 0.40.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.40.2-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.40.1-1`

## ros2action

- No changes

## ros2cli

```
* add verbose in service-info verb (#916 <https://github.com/ros2/ros2cli//issues/916>)
* Fix handling of empty ROS_DOMAIN_ID in ros2cli (#1112 <https://github.com/ros2/ros2cli//issues/1112>)
* Contributors: Minju, Lee, Scott K Logan
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Add error handling when parsing package locally (#1108 <https://github.com/ros2/ros2cli//issues/1108>)
* Contributors: mini-1235
```

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* add mypy (#1109 <https://github.com/ros2/ros2cli//issues/1109>)
* Contributors: Michael Carlstrom
```

## ros2run

- No changes

## ros2service

```
* add verbose in service-info verb (#916 <https://github.com/ros2/ros2cli//issues/916>)
* Contributors: Minju, Lee
```

## ros2topic

- No changes
