### PR TITLE
rclpy: 7.1.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7352,7 +7352,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 7.1.6-1
+      version: 7.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `7.1.7-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.1.6-1`

## rclpy

```
* Remove accidental tuple (#1542 <https://github.com/ros2/rclpy/issues/1542>) (#1544 <https://github.com/ros2/rclpy/issues/1544>)
* fix(test_events_executor): destroy all nodes before shutdown (#1538 <https://github.com/ros2/rclpy/issues/1538>) (#1540 <https://github.com/ros2/rclpy/issues/1540>)
* Remove duplicate future handling from send_goal_async (#1532 <https://github.com/ros2/rclpy/issues/1532>) (#1536 <https://github.com/ros2/rclpy/issues/1536>)
* Contributors: Nathan Wiebe Neufeldt, mergify[bot]
```
