### PR TITLE
rclpy: 3.3.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8369,7 +8369,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.18-1
+      version: 3.3.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.19-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.18-1`

## rclpy

```
* Remove accidental tuple (#1542 <https://github.com/ros2/rclpy/issues/1542>) (#1545 <https://github.com/ros2/rclpy/issues/1545>)
* Remove duplicate future handling from send_goal_async (#1532 <https://github.com/ros2/rclpy/issues/1532>) (#1537 <https://github.com/ros2/rclpy/issues/1537>)
* Contributors: Nathan Wiebe Neufeldt, mergify[bot]
```
