### PR TITLE
rmw_connextdds: 1.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6819,7 +6819,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.3-1
+      version: 1.2.4-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.4-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.3-1`

## rmw_connextdds

```
* add : get clients,servers info (#154 <https://github.com/ros2/rmw_connextdds/issues/154>)
* fix: remove superflous buildtool_export_depend (#206 <https://github.com/ros2/rmw_connextdds/issues/206>)
* Contributors: Bas Zalmstra, Minju, Lee
```

## rmw_connextdds_common

```
* add : get clients,servers info (#154 <https://github.com/ros2/rmw_connextdds/issues/154>)
* Contributors: Minju, Lee
```

## rti_connext_dds_cmake_module

- No changes
