### PR TITLE
rclcpp: 16.0.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8353,7 +8353,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.15-1
+      version: 16.0.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.16-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `16.0.15-1`

## rclcpp

```
* Fix REP url locations (backport #2987 <https://github.com/ros2/rclcpp/issues/2987>) (#2991 <https://github.com/ros2/rclcpp/issues/2991>)
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Fix REP url locations (backport #2987 <https://github.com/ros2/rclcpp/issues/2987>) (#2991 <https://github.com/ros2/rclcpp/issues/2991>)
* Contributors: mergify[bot]
```

## rclcpp_components

```
* Fix REP url locations (backport #2987 <https://github.com/ros2/rclcpp/issues/2987>) (#2991 <https://github.com/ros2/rclcpp/issues/2991>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

```
* Fix REP url locations (backport #2987 <https://github.com/ros2/rclcpp/issues/2987>) (#2991 <https://github.com/ros2/rclcpp/issues/2991>)
* Add get_parameter_or overload returning value or alternative (#2973 <https://github.com/ros2/rclcpp/issues/2973>) (#2978 <https://github.com/ros2/rclcpp/issues/2978>)
* Contributors: mergify[bot]
```
