### PR TITLE
rmw_fastrtps: 9.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6899,7 +6899,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.3-1
+      version: 9.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.4-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.4.3-1`

## rmw_fastrtps_cpp

```
* add : get clients, servers info (#771 <https://github.com/ros2/rmw_fastrtps/issues/771>)
* Contributors: Minju, Lee
```

## rmw_fastrtps_dynamic_cpp

```
* add : get clients, servers info (#771 <https://github.com/ros2/rmw_fastrtps/issues/771>)
* Contributors: Minju, Lee
```

## rmw_fastrtps_shared_cpp

```
* add : get clients, servers info (#771 <https://github.com/ros2/rmw_fastrtps/issues/771>)
* Refs #23861 <https://github.com/ros2/rmw_fastrtps/issues/23861>. Use key annotation in TypeObject build (#849 <https://github.com/ros2/rmw_fastrtps/issues/849>)
* Contributors: Miguel Company, Minju, Lee
```
