### PR TITLE
rmw_zenoh: 0.10.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6953,7 +6953,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.10.1-1
+      version: 0.10.2-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.10.2-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.10.1-1`

## rmw_zenoh_cpp

```
* Add rmw_get_clients_info_by_service and rmw_get_servers_info_by_service (#679 <https://github.com/ros2/rmw_zenoh/issues/679>)
* Fix REP url locations (#858 <https://github.com/ros2/rmw_zenoh/issues/858>)
* Contributors: Minju, Lee, Tim Clephas
```

## zenoh_cpp_vendor

```
* Fix REP url locations (#858 <https://github.com/ros2/rmw_zenoh/issues/858>)
* Contributors: Tim Clephas
```

## zenoh_security_tools

- No changes
