### PR TITLE
synchros2: 1.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11305,7 +11305,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/bdaiinstitute/synchros2-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/bdaiinstitute/synchros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `synchros2` to `1.0.3-1`:

- upstream repository: https://github.com/bdaiinstitute/synchros2.git
- release repository: https://github.com/bdaiinstitute/synchros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-1`

## synchros2

```
* [N/A] Add missing synchros2 deps (#183 <https://github.com/bdaiinstitute/ros_utilities/issues/183>)
* [SW-3983] Define outcome for actionables (#179 <https://github.com/bdaiinstitute/ros_utilities/issues/179>)
* Contributors: Michel Hidalgo
```
