### PR TITLE
synchros2: 1.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10243,6 +10243,21 @@ repositories:
       url: https://github.com/synapticon/synapticon_ros2_control.git
       version: main
     status: maintained
+  synchros2:
+    doc:
+      type: git
+      url: https://github.com/bdaiinstitute/synchros2.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/bdaiinstitute/synchros2-release.git
+      version: 1.0.3-1
+    source:
+      type: git
+      url: https://github.com/bdaiinstitute/synchros2.git
+      version: main
+    status: developed
   system_fingerprint:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `synchros2` to `1.0.3-1`:

- upstream repository: https://github.com/bdaiinstitute/synchros2.git
- release repository: https://github.com/bdaiinstitute/synchros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## synchros2

```
* [N/A] Add missing synchros2 deps (#183 <https://github.com/bdaiinstitute/ros_utilities/issues/183>)
* [SW-3983] Define outcome for actionables (#179 <https://github.com/bdaiinstitute/ros_utilities/issues/179>)
* Contributors: Michel Hidalgo
```
