### PR TITLE
mocap4r2_msgs: 0.0.6-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5465,7 +5465,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
-      version: 0.0.5-1
+      version: 0.0.6-2
     source:
       type: git
       url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2_msgs` to `0.0.6-2`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.5-1`

## mocap4r2_msgs

```
* Rename mocap_ to mocap4r2_ to meet with REP 144
* new message for multiple rigid bodies
* Fix Markers -> Marker
* Proposal for definitive format
* Add Rigid Body description
* Change idx (int) to name (string)
* Add markers indexes
* Contributors: Francisco Martín Rico, José Miguel Guerrero
```
