### PR TITLE
mocap4r2_msgs: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4881,6 +4881,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mocap4r2_msgs:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
+      version: jazzy
+    status: developed
   mocap_optitrack:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2_msgs` to `0.1.0-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## mocap4r2_msgs

```
* Packaging for Jazzy
* Contributors: Francisco Martín Rico, José Miguel Guerrero
```
