### PR TITLE
mocap4r2_msgs: 0.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4161,6 +4161,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mocap4r2_msgs:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
+      version: kilted
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
+      version: kilted
+    status: developed
   mola:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mocap4r2_msgs` to `0.2.0-1`:

- upstream repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs.git
- release repository: https://github.com/MOCAP4ROS2-Project/mocap4r2_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## mocap4r2_msgs

```
* Packaging for Kilted
* Contributors: Francisco Martín Rico, José Miguel Guerrero
```
