### PR TITLE
gtsam: 4.3.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2569,7 +2569,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
-      version: 4.3.0-2
+      version: 4.3.0-3
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam` to `4.3.0-3`:

- upstream repository: https://github.com/borglab/gtsam.git
- release repository: https://github.com/ros2-gbp/gtsam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `4.3.0-2`
