### PR TITLE
Add libceres support to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3396,9 +3396,11 @@ libceres:
     bookworm: [libceres3]
     bullseye: [libceres1]
     trixie: [libceres4t64]
+  fedora: [ceres-solver]
   opensuse:
     leap: [libceres3]
     tumbleweed: [libceres4]
+  rhel: [ceres-solver]
   ubuntu:
     focal: null
     jammy: [libceres2]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3392,13 +3392,12 @@ libcereal-dev:
   openembedded: [libcereal@meta-oe]
   ubuntu: [libcereal-dev]
 libceres:
-  arch: [libceres]
   debian: [libceres4t64]
   opensuse: [libceres3]
   ubuntu:
-    '*': [libceres4t64]
+    noble: [libceres4t64]
+    jammy: [libceres3]
     focal: null
-    jammy: null
     bionic: null
 libceres-dev:
   arch: [ceres-solver]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3395,9 +3395,9 @@ libceres:
   debian: [libceres4t64]
   opensuse: [libceres3]
   ubuntu:
-    noble: [libceres4t64]
-    jammy: [libceres3]
     focal: null
+    jammy: [libceres3]
+    noble: [libceres4t64]
 libceres-dev:
   arch: [ceres-solver]
   debian: [libceres-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3391,6 +3391,15 @@ libcereal-dev:
   gentoo: [dev-libs/cereal]
   openembedded: [libcereal@meta-oe]
   ubuntu: [libcereal-dev]
+libceres:
+  arch: [libceres]
+  debian: [libceres4t64]
+  opensuse: [libceres3]
+  ubuntu:
+    '*': [libceres4t64]
+    focal: null
+    jammy: null
+    bionic: null
 libceres-dev:
   arch: [ceres-solver]
   debian: [libceres-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3398,7 +3398,6 @@ libceres:
     noble: [libceres4t64]
     jammy: [libceres3]
     focal: null
-    bionic: null
 libceres-dev:
   arch: [ceres-solver]
   debian: [libceres-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3392,7 +3392,10 @@ libcereal-dev:
   openembedded: [libcereal@meta-oe]
   ubuntu: [libcereal-dev]
 libceres:
-  debian: [libceres4t64]
+  debian: 
+    bookworm: [libceres3]
+    bullseye: [libceres1]
+    trixie: [libceres4t64]
   opensuse: [libceres3]
   ubuntu:
     focal: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3396,10 +3396,12 @@ libceres:
     bookworm: [libceres3]
     bullseye: [libceres1]
     trixie: [libceres4t64]
-  opensuse: [libceres3]
+  opensuse:
+    leap: [libceres3]
+    tumbleweed: [libceres4]
   ubuntu:
     focal: null
-    jammy: [libceres3]
+    jammy: [libceres2]
     noble: [libceres4t64]
 libceres-dev:
   arch: [ceres-solver]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3392,7 +3392,7 @@ libcereal-dev:
   openembedded: [libcereal@meta-oe]
   ubuntu: [libcereal-dev]
 libceres:
-  debian: 
+  debian:
     bookworm: [libceres3]
     bullseye: [libceres1]
     trixie: [libceres4t64]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`libceres`

## Package Upstream Source:

https://github.com/ceres-solver/ceres-solver

## Purpose of using this:

The runtime needed parts of `libceres-dev`. To shrink runtime needed dependencies

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libceres4t64
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libceres4t64
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libceres3
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE