### PR TITLE
Enable key-ordering check in yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,20 +2,24 @@
 extends:
   default
 
+ignore: |
+  .venv
+
 rules:
   document-start:
     ignore: |
       releases/*.yaml
       rosdep/*.yaml
   indentation:
-    spaces: consistent
     indent-sequences: false
+    spaces: consistent
   key-duplicates: enable
+  key-ordering:
+    ignore: |
+      .github/
+      test/rosdep_repo_check/config.yaml
   line-length:
-    max: 125
     allow-non-breakable-words: true
     ignore: |
       rosdep/*.yaml
-
-ignore: |
-  .venv
+    max: 125


### PR DESCRIPTION
By enabling this check here, tools which integrate with yamllint will be aware of the constraint and (hopefully) surface it to the developer prior to submitting the PR. The automated rosdistro-reviewer will also surface ordering violations as part of the automated review.

I re-ordered the keys in the `.yamllint` file itself to conform. There were several files in the `.github` directory where it doesn't make sense to require ordering, as with the `rosdep_repo_check` config. These paths are specifically omitted from this rule.

Cross-link to ros-infrastructure/rosdistro-reviewer#46