### PR TITLE
play_motion2: 1.8.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7360,7 +7360,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 1.8.1-1
+      version: 1.8.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.8.2-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/pal-gbp/play_motion2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.8.1-1`

## play_motion2

```
* Changes for hardware_interface new API
* Contributors: Noel Jimenez
```

## play_motion2_cli

```
* Log an error when a motion fails
* Contributors: Isaac Acevedo
```

## play_motion2_msgs

- No changes
