### PR TITLE
pal_maps: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6993,7 +6993,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_maps-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_maps` to `0.2.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_maps.git
- release repository: https://github.com/pal-gbp/pal_maps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-1`

## pal_maps

```
* fix pgm names
* added maps for new controller server tests worlds
* Contributors: martinaannicelli
```
