### PR TITLE
rosbridge_suite: 2.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9773,7 +9773,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.0.4-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.3-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Apply service timeout parameter correctly (backport #1125 <https://github.com/RobotWebTools/rosbridge_suite/issues/1125>) (#1130 <https://github.com/RobotWebTools/rosbridge_suite/issues/1130>)
  Co-authored-by: Mike Lanighan <mailto:45465435+mlanighan@users.noreply.github.com>
* Contributors: Błażej Sowa
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Use correct type for delay_between_messages parameter in launch file (backport #1126 <https://github.com/RobotWebTools/rosbridge_suite/issues/1126>) (#1132 <https://github.com/RobotWebTools/rosbridge_suite/issues/1132>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
