### PR TITLE
rosbridge_suite: 2.4.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8752,7 +8752,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.4.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.1-1`

## rosapi

```
* fix: Invert success check for set_param function (backport #1133 <https://github.com/RobotWebTools/rosbridge_suite/issues/1133>) (#1134 <https://github.com/RobotWebTools/rosbridge_suite/issues/1134>)
* Contributors: Błażej Sowa
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Apply service timeout parameter correctly (backport #1125 <https://github.com/RobotWebTools/rosbridge_suite/issues/1125>) (#1129 <https://github.com/RobotWebTools/rosbridge_suite/issues/1129>)
  Co-authored-by: Mike Lanighan <mailto:45465435+mlanighan@users.noreply.github.com>
* Contributors: Błażej Sowa
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Use correct type for delay_between_messages parameter in launch file (backport #1126 <https://github.com/RobotWebTools/rosbridge_suite/issues/1126>) (#1131 <https://github.com/RobotWebTools/rosbridge_suite/issues/1131>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
