### PR TITLE
rosbridge_suite: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7613,7 +7613,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `3.0.2-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.1-1`

## rosapi

```
* fix: Invert success check for set_param function (#1133 <https://github.com/RobotWebTools/rosbridge_suite/issues/1133>)
* Contributors: Błażej Sowa
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Apply service timeout parameter correctly (#1125 <https://github.com/RobotWebTools/rosbridge_suite/issues/1125>)
* Contributors: Mike Lanighan
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Use correct type for delay_between_messages parameter in launch file (#1126 <https://github.com/RobotWebTools/rosbridge_suite/issues/1126>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
