### PR TITLE
smacc2: Fix entry and update to 3.0.1-1 in jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -31,23 +31,6 @@ repositories:
       url: https://github.com/EasyNavigation/NavMap.git
       version: jazzy
     status: developed
-  SMACC2:
-    doc:
-      type: git
-      url: https://github.com/robosoft-ai/SMACC2.git
-      version: rolling
-    release:
-      packages:
-      - smacc2
-      - smacc2_msgs
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/SMACC2-release.git
-    source:
-      type: git
-      url: https://github.com/robosoft-ai/SMACC2.git
-      version: rolling
-    status: developed
   acado_vendor:
     release:
       tags:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10010,6 +10010,24 @@ repositories:
       url: https://github.com/oKermorgant/slider_publisher.git
       version: ros2
     status: maintained
+  smacc2:
+    doc:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: jazzy
+    release:
+      packages:
+      - smacc2
+      - smacc2_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/robosoft-ai/SMACC2-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/robosoft-ai/SMACC2.git
+      version: jazzy
+    status: maintained
   smach:
     doc:
       type: git


### PR DESCRIPTION
 Description:
  This PR fixes the SMACC2 entry in the jazzy distribution and updates to
  version 3.0.1-1.

  ## Changes
  - Corrected package key from `SMACC2` to `smacc2` (lowercase, consistent
  with ROS conventions)
  - Updated doc/source version from `rolling` to `jazzy`
  - Added missing `version: 3.0.1-1` field under `release:`
  - Corrected release repository from `ros2-gbp/SMACC2-release` to
  `robosoft-ai/SMACC2-release`

  ## Validation
  - YAML syntax validated
  - Structure matches humble/distribution.yaml format

  Replaces #48651 & #48720
