### PR TITLE
mrpt_ros: 2.15.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5306,7 +5306,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.1-2
+      version: 2.15.2-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.2-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.15.1-2`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

```
* mrpt::maps::CGenericPointsMap now supports fields of type double too.
* Merge pull request #5 <https://github.com/MRPT/mrpt_ros/issues/5> from wentasah/readd-octomap
  libmaps: Depend on liboctomap-dev
* libmaps: Depend on liboctomap-dev
  Dependency on liboctomap-dev was removed in commit e94c04e ("Remove
  deps on ROS message packages, following the removal of mrpt-ros bridge
  into its own repository", 2025-10-23), but libmaps needs octomap to
  build. Otherwise, the following error message is printed:
  /build/mrpt-build/src/mrpt/libs/maps/src/maps/COctoMap.cpp:18:10:
  fatal error: octomap/OcTree.h: No such file or directory
* Contributors: Jose Luis Blanco-Claraco, Michal Sojka
```

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
