### PR TITLE
rosidl_dynamic_typesupport_fastrtps: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7731,7 +7731,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport_fastrtps` to `0.5.1-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.0-1`

## rosidl_dynamic_typesupport_fastrtps

```
* Merge pull request #11 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/11> from mosfet80/patch-1
* Don't automatically enable verbose makefiles. (#9 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/9>)
* Contributors: Chris Lalancette, mosfet80
```
