### PR TITLE
rosidl_dynamic_typesupport_fastrtps: 0.4.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7813,7 +7813,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
-      version: 0.4.1-2
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_dynamic_typesupport_fastrtps` to `0.4.2-1`:

- upstream repository: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_dynamic_typesupport_fastrtps-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-2`

## rosidl_dynamic_typesupport_fastrtps

```
* Merge pull request #11 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/11> from mosfet80/patch-1 (#12 <https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/issues/12>)
* Contributors: mergify[bot]
```
