### PR TITLE
rosidl_typesupport_fastrtps: 3.8.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7902,7 +7902,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.8.1-1
+      version: 3.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.8.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.1-1`

## rosidl_typesupport_fastrtps_c

```
* Switch ament_index_python and rosidl_cli to exec_depend. (#137 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/137>) (#139 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/139>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_fastrtps_cpp

```
* Switch ament_index_python and rosidl_cli to exec_depend. (#137 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/137>) (#139 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/139>)
  They are both Python libraries, so they are really only
  needed at exec time.
  (cherry picked from commit db528f13225c23f3f04a97500279f9171611da22)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
