### PR TITLE
rosidl_typesupport_fastrtps: 2.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9911,7 +9911,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `2.2.4-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.3-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* Switch ament_index_python and rosidl_cli to exec_depend. (backport #137 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/137>) (#141 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/141>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_fastrtps_cpp

```
* Switch ament_index_python and rosidl_cli to exec_depend. (backport #137 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/137>) (#141 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/141>)
* Contributors: mergify[bot]
```
