### PR TITLE
Fix qml6-module-qtquick entry for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8845,7 +8845,7 @@ qml6-module-qtquick:
   arch: [qt6-declarative]
   debian: [qml6-module-qtquick]
   fedora: [qt6-qtdeclarative]
-  nixos: [qt6.qtquickcontrols]
+  nixos: [qt6.qtdeclarative]
   rhel:
     '*': [qt6-qtdeclarative]
     '8': null


### PR DESCRIPTION
The `qml6-module-qtquick` entry for NixOS is incorrect. `qt6` package set doesn't have `qtquickcontrols` attribute [1]. QtQuick module is declared in `qt6.qtdeclarative` [2].

[1]: https://search.nixos.org/packages?channel=unstable&query=qtquickcontrols
[2]: https://github.com/NixOS/nixpkgs/blob/8e087d5ea60a39676587983dc5829a3346f18c37/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix

