### PR TITLE
apriltag_hitch_estimation: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -584,6 +584,21 @@ repositories:
       url: https://github.com/ros-misc-utilities/apriltag_detector.git
       version: release
     status: developed
+  apriltag_hitch_estimation:
+    doc:
+      type: git
+      url: https://github.com/li9i/apriltag-hitch-estimation.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/li9i/apriltag-hitch-estimation-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/li9i/apriltag-hitch-estimation.git
+      version: humble-devel
+    status: maintained
   apriltag_mit:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_hitch_estimation` to `0.0.1-1`:

- upstream repository: https://github.com/li9i/apriltag-hitch-estimation.git
- release repository: https://github.com/li9i/apriltag-hitch-estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
