### PR TITLE
NavMap: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -25,7 +25,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/EasyNavigation/NavMap-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/EasyNavigation/NavMap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `NavMap` to `0.3.0-1`:

- upstream repository: https://github.com/EasyNavigation/NavMap.git
- release repository: https://github.com/EasyNavigation/NavMap-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.5-1`

## navmap_core

```
* Sppedup the navcel location
* Cleanup unused headers
* Fix potential linker error and warning
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## navmap_examples

```
* Cleanup unused headers
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## navmap_ros

```
* Cleanup unused headers
* Occupancy works
* Add occupancy grid constants
* Fix surface creation from points
* Remove unused field
* Remove some comments
* Final working version
* Acelerated respecting floors
* Working slow with many points
* Initial working version
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## navmap_ros_interfaces

```
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico
```

## navmap_rviz_plugin

```
* Cleanup unused headers
* NavMap Goal Pose
* Occupancy works
* FREE_SPACE as white
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```
