### PR TITLE
gz_ogre_next_vendor: 0.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2763,7 +2763,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
-      version: 0.1.0-2
+      version: 0.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.1.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-2`

## gz_ogre_next_vendor

```
* Kilted: 0.1.1 - gz_cmake as build_dep and libatomic as dep (#11 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/11>)
  * Kilted: gz_cmake as build_dep and libatomic as dep
* Fix use of gz-cmake vendor package (#6 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/6>)
  This ensures that this works with gz-cmake4 as well
* Add check for system installed ogre-next (#5 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/5>)
  * Check for system installed ogre-next first.
  * Add exact/relaxed version matching
  * Revert change to github url
* Contributors: Rhys Mainwaring, Addisu Z. Taddese, Jose Luis Rivero, Øystein Sture
```
