### PR TITLE
gz_ogre_next_vendor: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2712,7 +2712,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.2.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-1`

## gz_ogre_next_vendor

```
* Bump minor for Rolling
* Mark gz_cmake_vendor as a build dependency #10
* Merge pull request #9 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/9> from gazebo-release/jrivero/missing_atomic
  * Missing atomic depends. 0.2.0
* Fix use of gz-cmake vendor package (#6 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/6>)
  This ensures that this works with gz-cmake4 as well
* Add check for system installed ogre-next (#5 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/5>)
  * Check for system installed ogre-next first.
  * Add exact/relaxed version matching
  * Revert change to github url
  ---------
  Co-authored-by: Rhys Mainwaring <mailto:rhys.mainwaring@me.com>
* Contributors: Addisu Z. Taddese, Jose Luis Rivero, Øystein Sture
```
