### PR TITLE
geometry2: 0.45.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2383,7 +2383,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.45.2-1
+      version: 0.45.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.45.3-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.45.2-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Fix REP url locations (#847 <https://github.com/ros2/geometry2/issues/847>)
* Contributors: R Kent James, Tim Clephas
```

## tf2_bullet

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Contributors: R Kent James
```

## tf2_eigen

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Contributors: R Kent James
```

## tf2_eigen_kdl

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Cleanup mislabeled BSD license (#855 <https://github.com/ros2/geometry2/issues/855>)
* Contributors: Alejandro Hernández Cordero, R Kent James
```

## tf2_geometry_msgs

- No changes

## tf2_kdl

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Contributors: R Kent James
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Prevent log spam from tf2_ros message_filter (#851 <https://github.com/ros2/geometry2/issues/851>)
* Contributors: R Kent James, mini-1235
```

## tf2_ros_py

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (#856 <https://github.com/ros2/geometry2/issues/856>)
* Contributors: R Kent James
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
