### PR TITLE
add ros2tree to humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13217,5 +13217,11 @@ repositories:
       url: https://github.com/tier4/zmqpp_vendor.git
       version: main
     status: developed
+  ros2tree:
+    source:
+      type: git
+      url: https://github.com/ishaanbhimwal/ros2tree.git
+      version: humble
+    status: developed
 type: distribution
 version: 2

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9517,6 +9517,12 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros2tree:
+    source:
+      type: git
+      url: https://github.com/ishaanbhimwal/ros2tree.git
+      version: main
+    status: developed
   ros_babel_fish:
     doc:
       type: git
@@ -13216,12 +13222,6 @@ repositories:
       type: git
       url: https://github.com/tier4/zmqpp_vendor.git
       version: main
-    status: developed
-  ros2tree:
-    source:
-      type: git
-      url: https://github.com/ishaanbhimwal/ros2tree.git
-      version: humble
     status: developed
 type: distribution
 version: 2

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9536,12 +9536,6 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
-  ros2tree:
-    source:
-      type: git
-      url: https://github.com/ishaanbhimwal/ros2tree.git
-      version: main
-    status: developed
   ros_babel_fish:
     doc:
       type: git
@@ -11893,6 +11887,12 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
+      version: main
+    status: developed
+  tree:
+    source:
+      type: git
+      url: https://github.com/ishaanbhimwal/ros2tree.git
       version: main
     status: developed
   tsid:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9557,6 +9557,12 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros2tree:
+    source:
+      type: git
+      url: https://github.com/ishaanbhimwal/ros2tree.git
+      version: main
+    status: developed
   ros_babel_fish:
     doc:
       type: git
@@ -11908,12 +11914,6 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
-      version: main
-    status: developed
-  tree:
-    source:
-      type: git
-      url: https://github.com/ishaanbhimwal/ros2tree.git
       version: main
     status: developed
   tsid:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

tree

## Package Upstream Source:

[source repository](https://github.com/ishaanbhimwal/ros2tree/tree/humble)

## Purpose of using this:

This is useful for better visualizing node/topic info. Also I working to provide the name of the package a node spawns from as additional info for debugging.

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

humble

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
