### PR TITLE
beluga: 2.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -847,6 +847,25 @@ repositories:
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
       version: master
     status: developed
+  beluga:
+    doc:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    release:
+      packages:
+      - beluga
+      - beluga_amcl
+      - beluga_ros
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/beluga-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/Ekumen-OS/beluga.git
+      version: main
+    status: developed
   better_launch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `beluga` to `2.1.0-1`:

- upstream repository: https://github.com/Ekumen-OS/beluga.git
- release repository: https://github.com/ros2-gbp/beluga-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## beluga

```
* Beluga compiles with MSVC on Windows (#523 <https://github.com/Ekumen-OS/beluga/issues/523>)
* Add support for Bazel builds (#521 <https://github.com/Ekumen-OS/beluga/issues/521>)
* Expose model_unknown_space parameter to ROS2 (#448 <https://github.com/Ekumen-OS/beluga/issues/448>)
* Add likelihood prob sensor model and enable Beluga's flavour of clustering (#476 <https://github.com/Ekumen-OS/beluga/issues/476>)
* Add 2D state type to likelihood field sensor model for beluga_vdb (#480 <https://github.com/Ekumen-OS/beluga/issues/480>)
* Fix to likelihood map pre-calculation performance for large maps (#471 <https://github.com/Ekumen-OS/beluga/issues/471>)
* Contributors: Diego Palma, Gerardo Puga, Nahuel Espinosa, Pablo Vela, Florencia Battocchia
```

## beluga_amcl

```
* Beluga AMCL documentation update (#536 <https://github.com/Ekumen-OS/beluga/issues/536>)
* Deal with deprecated headers in Rolling (#531 <https://github.com/Ekumen-OS/beluga/issues/531>)
* Drop Noetic support (#520 <https://github.com/Ekumen-OS/beluga/issues/520>)
* Add support for point clouds in beluga_amcl (#491 <https://github.com/Ekumen-OS/beluga/issues/491>)
* Add support for ROS 2 nodes test isolation (#497 <https://github.com/Ekumen-OS/beluga/issues/497>)
* Add missing backtick in ROS 2 documentation (#495 <https://github.com/Ekumen-OS/beluga/issues/495>)
* Expose model_unknown_space parameter to ROS2 (#448 <https://github.com/Ekumen-OS/beluga/issues/448>)
* Add ROS Kilted Kaiju support (#485 <https://github.com/Ekumen-OS/beluga/issues/485>)
* Add likelihood prob sensor model and enable Beluga's flavour of clustering (#476 <https://github.com/Ekumen-OS/beluga/issues/476>)
* Add ros parameter for bond timeout (#473 <https://github.com/Ekumen-OS/beluga/issues/473>)
* Contributors: Andrés Brumovsky, Diego Palma, Gerardo Puga, Michel Hidalgo, Xavi Ruiz, Florencia Battocchia
```

## beluga_ros

```
* Remove ROS 1 references and documentation (#528 <https://github.com/Ekumen-OS/beluga/issues/528>)
* Drop Noetic support (#520 <https://github.com/Ekumen-OS/beluga/issues/520>)
* Add support for point clouds in beluga_amcl (#491 <https://github.com/Ekumen-OS/beluga/issues/491>)
* Add support for ROS 2 nodes test isolation (#497 <https://github.com/Ekumen-OS/beluga/issues/497>)
* Expose model_unknown_space parameter to ROS2 (#448 <https://github.com/Ekumen-OS/beluga/issues/448>)
* Add ROS Kilted Kaiju support (#485 <https://github.com/Ekumen-OS/beluga/issues/485>)
* Add likelihood prob sensor model and enable Beluga's flavour of clustering (#476 <https://github.com/Ekumen-OS/beluga/issues/476>)
* Contributors: Andrés Brumovsky, Diego Palma, Michel Hidalgo, Nahuel Espinosa, Xavi Ruiz, Florencia Battocchia
```
