### PR TITLE
bcr_bot: 2.0.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -927,6 +927,21 @@ repositories:
       url: https://github.com/blackcoffeerobotics/bcr_arm.git
       version: ros2
     status: developed
+  bcr_bot:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros2-jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros2-jazzy
+    status: developed
   beckhoff_ads_driver:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_bot` to `2.0.0-2`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_bot.git
- release repository: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## bcr_bot

```
* Update package for ROS 2 Jazzy support
* Update Nav2 configuration parameters to run Navigation2 on Jazzy
```
