### PR TITLE
dynamixel_hardware_interface: 1.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2037,7 +2037,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
-      version: 1.4.16-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `1.5.0-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.16-1`

## dynamixel_hardware_interface

```
* Added comm_id/id concept for virtual_* devices.
* Added unit info system for Unified unit conversion logic.
* Added sequential initialization logic.
* Fixed memory leak of matrix malloc.
* Refactored every type info based unit conversion to unit info based system.
* Contributors: Woojin Wie
```
