### PR TITLE
scenario_execution: 1.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9703,17 +9703,20 @@ repositories:
       - scenario_execution
       - scenario_execution_control
       - scenario_execution_coverage
+      - scenario_execution_dataops
       - scenario_execution_gazebo
       - scenario_execution_interfaces
       - scenario_execution_nav2
+      - scenario_execution_network
       - scenario_execution_os
       - scenario_execution_ros
       - scenario_execution_rviz
+      - scenario_execution_sim
       - scenario_execution_x11
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
-      version: 1.3.0-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/IntelLabs/scenario_execution.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scenario_execution` to `1.4.0-1`:

- upstream repository: https://github.com/cps-test-lab/scenario-execution.git
- release repository: https://github.com/ros2-gbp/scenario_execution-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.0-1`

## scenario_execution

```
* Add external interface
* support creating override template
* Fix overriding list parameters
* Allow overriding non-initialized parameters
* add ability to set snapshot period
* add post command execution
* Add directory getters
```

## scenario_execution_control

- No changes

## scenario_execution_coverage

- No changes

## scenario_execution_dataops

```
* Add dataops library
```

## scenario_execution_gazebo

```
* gazebo: fix spawning from xacro without arguments
* Support xacro for path-defined gazebo models
* add action spawn_multiple
```

## scenario_execution_interfaces

- No changes

## scenario_execution_nav2

- No changes

## scenario_execution_network

```
* Add network lib
```

## scenario_execution_os

```
* add check_process_running
```

## scenario_execution_ros

```
* rosbag_record: report missing topics
* add post command execution
* ros2: bag_record is able to remove previous bag directory
* ros_launch: support launch file without package
* fix nav_through_poses
```

## scenario_execution_rviz

- No changes

## scenario_execution_sim

```
* Initial creation
```

## scenario_execution_x11

```
* Support webm in capture_screen
```
