### PR TITLE
geometry2: 0.45.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2383,7 +2383,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.45.3-1
+      version: 0.45.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.45.4-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.45.3-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Fix various documentation errors in tf2 (#857 <https://github.com/ros2/geometry2/issues/857>)
* Contributors: R Kent James
```

## tf2_bullet

- No changes

## tf2_eigen

```
* Add fromMsg for converting from Accel to Eigen (#844 <https://github.com/ros2/geometry2/issues/844>)
* Contributors: Alireza Moayyedi
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
