### PR TITLE
rviz: 15.0.10-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8584,7 +8584,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.9-1
+      version: 15.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.10-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.9-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

- No changes

## rviz_default_plugins

```
* Fix Translation Issue in XYOrbitViewController (#1630 <https://github.com/ros2/rviz/issues/1630>) (#1631 <https://github.com/ros2/rviz/issues/1631>)
* Overcome 16384 size limit (#1622 <https://github.com/ros2/rviz/issues/1622>) (#1627 <https://github.com/ros2/rviz/issues/1627>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
