### PR TITLE
geometry2: 0.36.17-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2994,7 +2994,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.16-1
+      version: 0.36.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.17-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.36.16-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Fix various documentation errors in tf2 (backport #857 <https://github.com/ros2/geometry2/issues/857>) (#864 <https://github.com/ros2/geometry2/issues/864>)
* Fix REP url locations (#847 <https://github.com/ros2/geometry2/issues/847>) (#849 <https://github.com/ros2/geometry2/issues/849>)
* Contributors: mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

```
* Add fromMsg for converting from Accel to Eigen (#844 <https://github.com/ros2/geometry2/issues/844>) (#859 <https://github.com/ros2/geometry2/issues/859>)
* Contributors: mergify[bot]
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Prevent log spam from tf2_ros message_filter (backport #851 <https://github.com/ros2/geometry2/issues/851>) (#853 <https://github.com/ros2/geometry2/issues/853>)
* Contributors: mergify[bot]
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
