### PR TITLE
urdfdom: 5.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9886,7 +9886,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 5.0.2-1
+      version: 5.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `5.0.3-1`:

- upstream repository: https://github.com/ros/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.2-1`

## urdfdom

```
* Quaternion in urdf (PR123 new attempt) (#194 <https://github.com/ros/urdfdom/issues/194>)
* Removed tinyxml2_vendor dependency (#225 <https://github.com/ros/urdfdom/issues/225>)
* Contributors: Alejandro Hernández Cordero, Guillaume Doisy
```
