### PR TITLE
urdfdom_headers: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9902,7 +9902,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `2.0.1-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`
