### PR TITLE
mp2p_icp: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5786,7 +5786,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.1.2-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.1-1`

## mp2p_icp

```
* mm-viewer: Automatic retry to load maps if missing plugins, trying to reload with libmola_metric_maps.so
* Enable coverage run for noble docker image
* Add new unit tests
* docs: fix broken formatting of filters page
* Merge pull request #14 <https://github.com/MOLAorg/mp2p_icp/issues/14>
  deskew filter: refactoring to handle arbitrary point fields
* get code ready for API update in MRPT 2.15.3
* Fix build w/o imu library
* mm-viewer: add keystrokes shift+cursor arrows to move up/down
* Add Codecov badge to README
* MLS filter: add progress report logging
* Contributors: Jose Luis Blanco-Claraco
```
