### PR TITLE
pluginlib: 5.6.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5672,7 +5672,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.6.1-1
+      version: 5.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.6.2-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.6.1-1`

## pluginlib

- No changes

## ros2plugin

```
* Improve logging when unable to parse the plugin (#285 <https://github.com/ros/pluginlib/issues/285>) (#286 <https://github.com/ros/pluginlib/issues/286>)
* Contributors: mergify[bot]
```
