### PR TITLE
pluginlib: 5.4.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6495,7 +6495,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.4.3-1
+      version: 5.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.4.4-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.4.3-1`

## pluginlib

- No changes

## ros2plugin

```
* Improve logging when unable to parse the plugin (#285 <https://github.com/ros/pluginlib/issues/285>) (#287 <https://github.com/ros/pluginlib/issues/287>)
* Contributors: mergify[bot]
```
