### PR TITLE
camera_ros: 0.5.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1100,7 +1100,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/camera_ros-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/christianrauch/camera_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_ros` to `0.5.2-1`:

- upstream repository: https://github.com/christianrauch/camera_ros.git
- release repository: https://github.com/ros2-gbp/camera_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.1-1`
