### PR TITLE
pluginlib: 5.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7442,7 +7442,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.1.2-1
+      version: 5.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.1.3-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.2-1`

## pluginlib

- No changes

## ros2plugin

```
* Improve logging when unable to parse the plugin (#285 <https://github.com/ros/pluginlib/issues/285>) (#288 <https://github.com/ros/pluginlib/issues/288>)
* Contributors: mergify[bot]
```
