### PR TITLE
Add qt6 opengl

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6427,6 +6427,19 @@ libqt6gui6t64:
     '*': [libqt6gui6t64]
     'focal': null
     'jammy': [libqt6gui6]
+libqt6opengl6t64:
+  alpine: [qt6-qtbase-dev]
+  arch: [qt6-base]
+  debian: [libqt6opengl6]
+  fedora: [qt6-qtbase]
+  nixos: [qt6.qtbase]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+  ubuntu:
+    '*': [libqt6opengl6t64]
+    'focal': null
+    'jammy': [libqt6opengl6]
 libqt6statemachine6:
   arch: [qt6-scxml]
   debian: [libqt6statemachine6]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6428,7 +6428,7 @@ libqt6gui6t64:
     'focal': null
     'jammy': [libqt6gui6]
 libqt6opengl6t64:
-  alpine: [qt6-qtbase-dev]
+  alpine: [qt6-qtbase]
   arch: [qt6-base]
   debian: [libqt6opengl6]
   fedora: [qt6-qtbase]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

- libqt6opengl6t64

## Package Upstream Source:

https://github.com/qt/qtbase

## Purpose of using this:

Needed in rviz

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libqt6opengl6
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qt6opengl&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/search?query=qt6-qtbase
- Arch: https://www.archlinux.org/packages/
  - skipped
- Gentoo: https://packages.gentoo.org/
  - skipped
- macOS: https://formulae.brew.sh/
  - skipped
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=qt6-qtbase
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?query=qt6.qtbase
- openSUSE: https://software.opensuse.org/package/
  - skipped
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=qt6-qtbase