### PR TITLE
hitch_estimation_apriltag_array: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3756,6 +3756,21 @@ repositories:
       version: humble-devel
     status: end-of-life
     status_description: Deprecated by package pal_hey5_description
+  hitch_estimation_apriltag_array:
+    doc:
+      type: git
+      url: https://github.com/li9i/hitch-estimation-apriltag-array.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/li9i/hitch-estimation-apriltag-array.git
+      version: humble-devel
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hitch_estimation_apriltag_array` to `0.0.1-1`:

- upstream repository: https://github.com/li9i/hitch-estimation-apriltag-array.git
- release repository: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
