### PR TITLE
kompass: 0.3.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3387,7 +3387,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.3.3-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.2-1`

## kompass

```
* (fix) Updates critical zone checker initialization to match kompass core
* (feature) Adds robot_plugin argument to launcher
* (fix) Fixes command publishing pre-processor
* (fix) Fixes topic update from file
* (feature) Enables using robot plugin in drive manager
* (fix) Fixes image size update in callback
* (fix) Moves external callbacks to new module and inherets from external callback classes
* (fix) Fixes update attribute name in BaseComponentConfig attrs class
* Contributors: ahr, mkabtoul
```

## kompass_interfaces

- No changes
