### PR TITLE
automatika_ros_sugar: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -654,7 +654,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.4.2-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## automatika_ros_sugar

```
* (docs) Adds robot plugins tutorial to docs
* (feature) Adds publish pre processors to robot plugin client
* (feature) Adds robot plugin client and enable using plugins in components and launcher
* (fix) Fixes publishing occupancy grid (humble)
* (fix) Fixes conversion between Vector3 and Point
* Contributors: ahr, mkabtoul
```
