### PR TITLE
ros_babel_fish: 3.25.111-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7367,7 +7367,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 3.25.11-1
+      version: 3.25.111-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `3.25.111-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.25.11-1`

## ros_babel_fish

```
* Wrap exceptions when creating service or action client with invalid topic as BabelFishException.
* Fixed ament package not found error not being caught and wrapped as TypeSupportException / BabelFishException.
* Added a get method for CompoundArrayMessage to obtain element as shared_ptr.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes
