### PR TITLE
Add qml6_ros2_plugin to distribution.yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6900,6 +6900,16 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: jazzy
     status: maintained
+  qml6_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: jazzy
+    status: maintained
   qml_ros2_plugin:
     doc:
       type: git


### PR DESCRIPTION
Added qml6_ros2_plugin with its source and documentation details. This is the Qt6 version of the QML ROS 2 module.

Please add the following dependency to the rosdep database.

## Package name:

qml6_ros2_plugin

## Package Upstream Source:

https://github.com/StefanFabian/qml6_ros2_plugin

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
