### PR TITLE
Add python3-fastapi for OpenEmbedded

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6029,6 +6029,7 @@ python3-fastapi:
         packages: [fastapi]
   fedora: [python-fastapi]
   nixos: [python3Packages.fastapi]
+  openembedded: [python3-fastapi@meta-python]
   ubuntu:
     '*': [python3-fastapi]
     bionic:


### PR DESCRIPTION
The recipe is moved from meta-ros to meta-openembedded [1].

[1]: https://github.com/openembedded/meta-openembedded/commit/cc274558bdbb709522e880b52f6c94c71cddce01

@robwoolley: could you review?  Once added I will send a PR to remove it from meta-ros