### PR TITLE
yasmin: 4.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10376,7 +10376,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 4.0.1-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `4.0.2-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.1-1`

## yasmin

```
* fixing macros using pybind and setting EventsExecutor for Kilted and Rolling
* improving comments in C++
* removing directory in yasmin
* fixing comments in blackboard
* removing blackboard_value to simplify blackboard
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

```
* fixing python comments
* removing directory in yasmin
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_editor

```
* fixing python comments
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_factory

```
* fixing macros using pybind and setting EventsExecutor for Kilted and Rolling
* removing directory in yasmin
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* fixing macros using pybind and setting EventsExecutor for Kilted and Rolling
* fixing code format
* using macros for EventsExecutors
* fixing python comments
* improving comments in C++
* removing directory in yasmin
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

- No changes
