### PR TITLE
ros2_control: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7095,7 +7095,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.0.2-1
+      version: 6.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.2-1`

## controller_interface

```
* Add tf prefix helper and test (#2803 <https://github.com/ros-controls/ros2_control/issues/2803>)
* Calculate achievable update rate of controllers (#2828 <https://github.com/ros-controls/ros2_control/issues/2828>)
* Use fmt for correct int64_t format specifier across platforms (#2817 <https://github.com/ros-controls/ros2_control/issues/2817>)
* Contributors: Dhruv Patel, Ege Kural, Sai Kishor Kothakota
```

## controller_manager

```
* Fix the CM statistics async publish placement (#2865 <https://github.com/ros-controls/ros2_control/issues/2865>)
* Fix failing controller switch when using ::ALL command interface configuration (#2856 <https://github.com/ros-controls/ros2_control/issues/2856>)
* Add handle_exceptions parameter to controller manager (#2807 <https://github.com/ros-controls/ros2_control/issues/2807>)
* Calculate achievable update rate of controllers (#2828 <https://github.com/ros-controls/ros2_control/issues/2828>)
* Fix dependencies of controller_manager (#2836 <https://github.com/ros-controls/ros2_control/issues/2836>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [HardwareComponentInterface] Add get state and command interface handle methods (#2831 <https://github.com/ros-controls/ros2_control/issues/2831>)
* Use proper hardware component logger for async components (#2860 <https://github.com/ros-controls/ros2_control/issues/2860>)
* Publish all castable data types to pal_statistics (#2633 <https://github.com/ros-controls/ros2_control/issues/2633>)
* Add handle_exceptions parameter to controller manager (#2807 <https://github.com/ros-controls/ros2_control/issues/2807>)
* Avoid C++20 structured binding capture (#2832 <https://github.com/ros-controls/ros2_control/issues/2832>)
* Use tinyxml2 package instead of deprecated tinyxml2_vendor (#2833 <https://github.com/ros-controls/ros2_control/issues/2833>)
* Contributors: Christoph Fröhlich, James Cowsert, Noel Jiménez García, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Publish all castable data types to pal_statistics (#2633 <https://github.com/ros-controls/ros2_control/issues/2633>)
* Contributors: Christoph Fröhlich
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Improving differential_transmission configure checks (#2812 <https://github.com/ros-controls/ros2_control/issues/2812>)
* Contributors: Jordan Palacios
```
