### PR TITLE
easynav: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2106,6 +2106,34 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/dynamixel-workbench-msgs.git
       version: ros2
     status: maintained
+  easynav:
+    doc:
+      type: git
+      url: https://github.com/EasyNavigation/EasyNavigation.git
+      version: jazzy
+    release:
+      packages:
+      - easynav
+      - easynav_common
+      - easynav_controller
+      - easynav_core
+      - easynav_interfaces
+      - easynav_localizer
+      - easynav_maps_manager
+      - easynav_planner
+      - easynav_sensors
+      - easynav_support_py
+      - easynav_system
+      - easynav_tools
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/EasyNavigation/EasyNavigation-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/EasyNavigation/EasyNavigation.git
+      version: jazzy
+    status: developed
   ecal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav` to `0.2.0-1`:

- upstream repository: https://github.com/EasyNavigation/EasyNavigation.git
- release repository: https://github.com/EasyNavigation/EasyNavigation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## easynav

```
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico
```

## easynav_common

```
* Merge rolling into jazzy
* Add vision_msgs/msg/Detection3DArray perception
* Cleanup unused headers
* Reshape execution and sensor handling
* Finished collision checker
* Optimize pointperceptionview
* Option to non-lazy ops
* Optimize filter and collapse
* Optimized downsample and delete risky constructors
* Lazy update in PointPerceptions
* Allow using yaets tracing macros from outside the easynav namespace
* Add namespace to yaets tracing macro
* GNSS Support
* Add missing dependencies
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_controller

```
* Cleanup unused headers
* Reshape execution and sensor handling
* Make dummies' fake processing time independent from clock source
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_core

```
* Add README.md with base classes description
* Remove unused include and random
* Set collision checker disabled by default
* Cleanup unused headers
* Add warning when exceeding the target cycle time
* Finished collision checker
* Reset method execution time when triggered
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_interfaces

```
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico
```

## easynav_localizer

```
* Cleanup unused headers
* Make dummies' fake processing time independent from clock source
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_maps_manager

```
* Cleanup unused headers
* Make dummies' fake processing time independent from clock source
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_planner

```
* Cleanup unused headers
* Make dummies' fake processing time independent from clock source
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_sensors

```
* Add vision_msgs/msg/Detection3DArray perception
* Cleanup unused headers
* Finished collision checker
* Lazy update in PointPerceptions
* Refactor set_by_group to avoid runtime lookups
* GNSS Support
* Fix TF compilation warnings
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## easynav_support_py

```
* Add feedback case in sent goal state to avoid unknown msg error
* small fixes in py goal manager client
* Contributors: Esther Aguado, Francisco Martín Rico, estherag
```

## easynav_system

```
* Remove unused include and random
* Set collision checker disabled by default
* Cleanup unused headers
* Add feedback case in sent goal state to avoid unknown msg error
* Change spin_some to spin_all. Add param for max spin time
* Dedicated thread for TF updates
* Fix TF compilation warnings
* GoalManager: Split position tolerance into x/y and height
* Remove use_sim_time param from tf node left in #59 <https://github.com/Butakus/EasyNavigation/issues/59>
* Contributors: Esther Aguado, Francisco Martín Rico, Francisco Miguel Moreno, estherag
```

## easynav_tools

```
* Add missing dependencies
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```
