### PR TITLE
realtime_tools: 3.10.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7504,7 +7504,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.10.0-1
+      version: 3.10.1-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.10.1-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.10.0-1`

## realtime_tools

```
* Replace deprecated spin_some in realtime_tools (backport #448 <https://github.com/ros-controls/realtime_tools/issues/448>) (#450 <https://github.com/ros-controls/realtime_tools/issues/450>)
* Contributors: mergify[bot]
```
