### PR TITLE
realtime_tools: 4.7.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6524,7 +6524,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.7.0-1
+      version: 4.7.1-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.7.1-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.7.0-1`

## realtime_tools

```
* Replace deprecated spin_some in realtime_tools (backport #448 <https://github.com/ros-controls/realtime_tools/issues/448>) (#451 <https://github.com/ros-controls/realtime_tools/issues/451>)
* Contributors: mergify[bot]
```
