### PR TITLE
realtime_tools: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6436,7 +6436,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 5.0.0-1
+      version: 5.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `5.1.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.0-1`

## realtime_tools

```
* Mark msg_ variable in RT publisher as private (#423 <https://github.com/ros-controls/realtime_tools/issues/423>)
* Replace deprecated spin_some in realtime_tools (#448 <https://github.com/ros-controls/realtime_tools/issues/448>)
* Contributors: Abdullah, Christoph Fröhlich
```
