### PR TITLE
control_toolbox: 5.8.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1286,7 +1286,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.8.2-1
+      version: 5.8.3-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.8.3-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.8.2-1`

## control_toolbox

```
* Replace deprecated rclcpp::spin_some() (#541 <https://github.com/ros-controls/control_toolbox/issues/541>) (#542 <https://github.com/ros-controls/control_toolbox/issues/542>)
* Contributors: mergify[bot]
```
