### PR TITLE
control_toolbox: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1330,7 +1330,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 6.0.0-1
+      version: 6.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `6.1.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.0-1`

## control_toolbox

```
* Exponantial filter refactoring (#493 <https://github.com/ros-controls/control_toolbox/issues/493>)
* Replace deprecated rclcpp::spin_some() (#541 <https://github.com/ros-controls/control_toolbox/issues/541>)
* No need for the specialization of update() (#509 <https://github.com/ros-controls/control_toolbox/issues/509>)
* Contributors: Abdullah, Christoph Fröhlich, silanus
```
