### PR TITLE
ros2_control: 2.53.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9209,7 +9209,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.52.2-1
+      version: 2.53.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.53.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.52.2-1`

## controller_interface

- No changes

## controller_manager

```
* Fix dependencies of controller_manager (backport #2836 <https://github.com/ros-controls/ros2_control/issues/2836>) (#2837 <https://github.com/ros-controls/ros2_control/issues/2837>)
* Update CPU affinity parameter to be able to set multiple CPUs (backport #1915 <https://github.com/ros-controls/ros2_control/issues/1915>, #2509 <https://github.com/ros-controls/ros2_control/issues/2509>) (#2823 <https://github.com/ros-controls/ros2_control/issues/2823>)
* [Docs] Update determinism section (#2131 <https://github.com/ros-controls/ros2_control/issues/2131>) (#2785 <https://github.com/ros-controls/ros2_control/issues/2785>)
* Remove Realtime Kernel Check (#2777 <https://github.com/ros-controls/ros2_control/issues/2777>)
* Contributors: Brian Jin, mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

- No changes

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
