### PR TITLE
cloudini: 0.10.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1694,6 +1694,25 @@ repositories:
       url: https://github.com/carologistics/clips_vendor.git
       version: main
     status: maintained
+  cloudini:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/cloudini.git
+      version: main
+    release:
+      packages:
+      - cloudini_lib
+      - cloudini_ros
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/facontidavide/cloudini-release.git
+      version: 0.10.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/facontidavide/cloudini.git
+      version: main
+    status: developed
   coal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `0.10.1-1`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
