### PR TITLE
ros2_control: 4.40.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8164,7 +8164,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.39.2-1
+      version: 4.40.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.40.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.39.2-1`

## controller_interface

```
* Add tf prefix helper and test (#2803 <https://github.com/ros-controls/ros2_control/issues/2803>) (#2866 <https://github.com/ros-controls/ros2_control/issues/2866>)
* Use fmt for correct int64_t format specifier across platforms (#2817 <https://github.com/ros-controls/ros2_control/issues/2817>) (#2840 <https://github.com/ros-controls/ros2_control/issues/2840>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Fix the CM statistics async publish placement (#2865 <https://github.com/ros-controls/ros2_control/issues/2865>) (#2868 <https://github.com/ros-controls/ros2_control/issues/2868>)
* Fix failing controller switch when using ::ALL command interface configuration (#2856 <https://github.com/ros-controls/ros2_control/issues/2856>) (#2858 <https://github.com/ros-controls/ros2_control/issues/2858>)
* Add handle_exceptions parameter to controller manager (#2807 <https://github.com/ros-controls/ros2_control/issues/2807>) (#2849 <https://github.com/ros-controls/ros2_control/issues/2849>)
* Fix dependencies of controller_manager (backport #2836 <https://github.com/ros-controls/ros2_control/issues/2836>) (#2838 <https://github.com/ros-controls/ros2_control/issues/2838>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [HardwareComponentInterface] Add get state and command interface handle methods (backport #2831 <https://github.com/ros-controls/ros2_control/issues/2831>) (#2876 <https://github.com/ros-controls/ros2_control/issues/2876>)
* Use proper hardware component logger for async components (#2860 <https://github.com/ros-controls/ros2_control/issues/2860>) (#2861 <https://github.com/ros-controls/ros2_control/issues/2861>)
* Publish all castable data types to pal_statistics (backport #2633 <https://github.com/ros-controls/ros2_control/issues/2633>) (#2855 <https://github.com/ros-controls/ros2_control/issues/2855>)
* Add handle_exceptions parameter to controller manager (#2807 <https://github.com/ros-controls/ros2_control/issues/2807>) (#2849 <https://github.com/ros-controls/ros2_control/issues/2849>)
* Avoid C++20 structured binding capture (#2832 <https://github.com/ros-controls/ros2_control/issues/2832>) (#2834 <https://github.com/ros-controls/ros2_control/issues/2834>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Publish all castable data types to pal_statistics (backport #2633 <https://github.com/ros-controls/ros2_control/issues/2633>) (#2855 <https://github.com/ros-controls/ros2_control/issues/2855>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Improving differential_transmission configure checks (#2812 <https://github.com/ros-controls/ros2_control/issues/2812>) (#2814 <https://github.com/ros-controls/ros2_control/issues/2814>)
* Contributors: mergify[bot]
```
