### PR TITLE
depthai: 3.2.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1397,7 +1397,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 3.1.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `3.2.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.0-1`

## depthai

```
## Bug fixes
* [_RVC4_] Fix a regression for IMX586 only working with the 4000x3000 sensor config at 30 FPS
On the LuxonisOS 1.20.5 and newer, up to 240 FPS is now supported
```
