### PR TITLE
ros2_controllers: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7154,7 +7154,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.0.0-1
+      version: 6.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.1.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.0-1`

## ackermann_steering_controller

```
* Rename Odometry Class to SteeringKinematics (#1996 <https://github.com/ros-controls/ros2_controllers/issues/1996>)
* Rename joint_reference_interfaces to reference_interface_names (#2008 <https://github.com/ros-controls/ros2_controllers/issues/2008>)
* Contributors: Sanjeev, Surya!
```

## admittance_controller

- No changes

## bicycle_steering_controller

```
* Rename Odometry Class to SteeringKinematics (#1996 <https://github.com/ros-controls/ros2_controllers/issues/1996>)
* Rename joint_reference_interfaces to reference_interface_names (#2008 <https://github.com/ros-controls/ros2_controllers/issues/2008>)
* Contributors: Sanjeev, Surya!
```

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Update odometry implementation in diff_drive (#1854 <https://github.com/ros-controls/ros2_controllers/issues/1854>)
* Contributors: Aarav Gupta
```

## effort_controllers

```
* Deprecate forward_command_controller specializations (#1913 <https://github.com/ros-controls/ros2_controllers/issues/1913>)
* Contributors: Christoph Fröhlich
```

## force_torque_sensor_broadcaster

```
* Add utility node to transform wrench messages for a list of frames (#2021 <https://github.com/ros-controls/ros2_controllers/issues/2021>)
* Contributors: Julia Jia
```

## forward_command_controller

```
* Deprecate forward_command_controller specializations (#1913 <https://github.com/ros-controls/ros2_controllers/issues/1913>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Refactor interpolation_method class (#2019 <https://github.com/ros-controls/ros2_controllers/issues/2019>)
* Contributors: Surya!
```

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

- No changes

## pid_controller

```
* Remove parameter_traits dependency (#2022 <https://github.com/ros-controls/ros2_controllers/issues/2022>)
* Contributors: Christoph Fröhlich
```

## pose_broadcaster

- No changes

## position_controllers

```
* Deprecate forward_command_controller specializations (#1913 <https://github.com/ros-controls/ros2_controllers/issues/1913>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Rename Odometry Class to SteeringKinematics (#1996 <https://github.com/ros-controls/ros2_controllers/issues/1996>)
* Rename joint_reference_interfaces to reference_interface_names (#2008 <https://github.com/ros-controls/ros2_controllers/issues/2008>)
* Contributors: Sanjeev, Surya!
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Rename Odometry Class to SteeringKinematics (#1996 <https://github.com/ros-controls/ros2_controllers/issues/1996>)
* Rename joint_reference_interfaces to reference_interface_names (#2008 <https://github.com/ros-controls/ros2_controllers/issues/2008>)
* Contributors: Sanjeev, Surya!
```

## velocity_controllers

```
* Deprecate forward_command_controller specializations (#1913 <https://github.com/ros-controls/ros2_controllers/issues/1913>)
* Contributors: Christoph Fröhlich
```
