### PR TITLE
Revert "gtsam: 4.3.0-3 in 'kilted/distribution.yaml' [bloom]"

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2639,7 +2639,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
-      version: 4.3.0-3
+      version: 4.3.0-2
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
This reverts #48703.

The 4.3.0-3 release, which is an update from 4.3.0-2, contains a [multitude of changes](https://github.com/ros2-gbp/gtsam-release/compare/release/kilted/gtsam/4.3.0-2..release/kilted/gtsam/4.3.0-3) which are not possible with only a debinc bump. For debian builds, such substantial changes to the underlying sources require a version bump of some kind.

Failing buildfarm job: https://build.ros2.org/view/Kbin_uN64/job/Ksrc_uN__gtsam__ubuntu_noble__source/4/

@jlblancoc FYI