### PR TITLE
rko_lio: 0.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6585,7 +6585,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rko_lio-release.git
-      version: 0.1.6-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/PRBonn/rko_lio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.2.0-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.6-1`

## rko_lio

```
* Fix (core): log proper pose for the first frame if init. phase is on (#89 <https://github.com/PRBonn/rko_lio/issues/89>)
* chore: bump FetchContent Eigen to 5.0.1 (#88 <https://github.com/PRBonn/rko_lio/issues/88>)
  Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
* core: minimize TimestampProcessingConfig (#87 <https://github.com/PRBonn/rko_lio/issues/87>)
  * remove the configs for start and end time thresholds that can be satisfied much simpler by just forcing relative or absolute overrides
* python: remove unnecessary scan viz (#85 <https://github.com/PRBonn/rko_lio/issues/85>)
* remove pytest as optional dep, added toml based config (#83 <https://github.com/PRBonn/rko_lio/issues/83>)
* Rename published_deskewed_cloud to publish_deskewed_scan (#81 <https://github.com/PRBonn/rko_lio/issues/81>)
* Fix: core - proper second frame pose if initialization off (#77 <https://github.com/PRBonn/rko_lio/issues/77>)
  * move preproc to its own file and fix the non intialization behaviour
  * better (but not cross platform-worthy) identity registration testing
* Update accelerometer data expectation in docs. Clarified accelerometer assumptions
* core: Configurable lidar timestamp processing (#74 <https://github.com/PRBonn/rko_lio/issues/74>)
  * thresholds and timestamp processing behaviour is configurable
  * config modifications to the python side
  * ros side launch config modified to have more params
  * docs additions and cleanup
  * fix the py tests since the api changed
* update installation instructions and badge formatting. Updated README.md to improve formatting and clarity of installation instructions and dependencies.
* More CLI options, profiles stats has variance, dumping deskewed scans (#73 <https://github.com/PRBonn/rko_lio/issues/73>)
  * add the modifications needed to dump the plys when running
  * add variance to profile stats
  * python: pybind interval stats, and imu logging in rerun
  * more cli options, viz improvements a bit
  * update the cli for dumping deskewed
  * update the rbl
* Update README.md. Add ros source build details
* Folder reorganisation and docs update (#69 <https://github.com/PRBonn/rko_lio/issues/69>)
  * flatten the directories. massive renaming across the board
  * docs rework
  * docs updates
  * rename the config file so its explicit
  * fix workflows
* Core/move logging to wrappers (#68 <https://github.com/PRBonn/rko_lio/issues/68>)
  * remove logging from core. improve docs
  * python side now does its own config and traj dumping
  * nlohmann json is no longer a core requirement. ros only
  * result dumping on ros side now
  * make result logging on ros optional. and add launch config for that
  * use a shutdown callback for ros to dump results
* Contributors: Anthony Bisulco, Meher Malladi, dependabot[bot]
```
