### PR TITLE
Add `leo_examples` packages to jazzy, kilted and rolling distros

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4308,6 +4308,12 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop-ros2.git
       version: jazzy
     status: maintained
+  leo_examples:
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_examples-ros2.git
+      version: main
+    status: maintained
   leo_robot:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3658,6 +3658,12 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop-ros2.git
       version: ros2
     status: maintained
+  leo_examples:
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_examples-ros2.git
+      version: main
+    status: maintained
   leo_robot:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3604,6 +3604,12 @@ repositories:
       url: https://github.com/LeoRover/leo_desktop-ros2.git
       version: ros2
     status: maintained
+  leo_examples:
+    source:
+      type: git
+      url: https://github.com/LeoRover/leo_examples-ros2.git
+      version: main
+    status: maintained
   leo_robot:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Packages to be indexed in the rosdistro.
* leo_examples-ros2
  - leo_examples
  - leo_example_follow_aruco_marker
  - leo_example_line_follower
  - leo_example_object_detection

# The source is here:

https://github.com/LeoRover/leo_examples-ros2

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro