### PR TITLE
topic_based_hardware_interfaces: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10549,11 +10549,12 @@ repositories:
       version: main
     release:
       packages:
+      - cm_topic_hardware_component
       - joint_state_topic_hardware_interface
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_hardware-release.git
-      version: 0.2.1-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_hardware_interfaces` to `1.0.0-1`:

- upstream repository: https://github.com/ros-controls/topic_based_hardware_interfaces.git
- release repository: https://github.com/ros2-gbp/topic_based_hardware-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`

## cm_topic_hardware_component

```
* Add cast to boolean for cm_topic component (#64 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/64>)
* Add controller manager introspection topic system (#33 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/33>)
* Contributors: Christoph Fröhlich
```

## joint_state_topic_hardware_interface

```
* Rewrite resource storage and add mimic test (#44 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/44>)
* Fix integration test (#42 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/42>)
* Rename shadowed variables (#37 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/37>)
* Contributors: Christoph Fröhlich
```
