### PR TITLE
topic_based_hardware_interfaces: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9274,6 +9274,7 @@ repositories:
       version: main
     release:
       packages:
+      - cm_topic_hardware_component
       - joint_state_topic_hardware_interface
       tags:
         release: release/rolling/{package}/{version}


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_hardware_interfaces` to `0.2.1-1`:

- upstream repository: https://github.com/ros-controls/topic_based_hardware_interfaces.git
- release repository: https://github.com/ros2-gbp/topic_based_hardware-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`
