### PR TITLE
Revert "gtsam: 4.3.0-3 in 'rolling/distribution.yaml' [bloom]"

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2569,7 +2569,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gtsam-release.git
-      version: 4.3.0-3
+      version: 4.3.0-2
     source:
       type: git
       url: https://github.com/borglab/gtsam.git


### PR DESCRIPTION
Reverts ros/rosdistro#48704 for reasons described in https://github.com/ros/rosdistro/pull/48843