### PR TITLE
ur_client_library: 2.6.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11173,7 +11173,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.6.0-1
+      version: 2.6.1-2
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.6.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.0-1`

## ur_client_library

```
* Ignore lists.apple link in link check (#411 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/411>)
* Bump actions/checkout from 5 to 6 (#412 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/412>)
* [Doc] Remove beta statement for External Control URCapX (#407 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/407>)
* Updated version check, as 5.23 has been released
* Initialize dashboard client for PolyScopeX version 10.11.0 and above (#409 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/409>)
* Explicitly list PolyScope X compatibility (#402 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/402>)
* Contributors: Felix Exner, Mads Holm Peters, dependabot[bot]
```
