### PR TITLE
ur_robot_driver: 2.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12497,7 +12497,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.11.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.10.0-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

- No changes

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Dashboard client polyscopex (backport #1546 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1546>) (#1562 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1562>)
* Fix flaky tests (backport #1559 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1559>) (#1566 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1566>)
* Add effort command interface to hardware interface (backport #1411 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1411>) (#1528 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1528>)
* Contributors: mergify[bot]
```