### PR TITLE
ur_description: 2.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12459,7 +12459,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.8.0-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.9.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.0-1`

## ur_description

```
* Replace argument replacements with properties (#368 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/368>)
* Do not add effort command interface for GZ sim (#355 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/355>)
* Add effort command interface to all joints (#350 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/350>)
* Contributors: Felix Exner, mergify[bot]
```
