### PR TITLE
Added hebi_hardware to humble, jazzy, kilted, and rolling distributions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3753,6 +3753,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
     status: maintained
+  hebi_hardware:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_hardware.git
+      version: main
+    status: maintained
   heightmap_spawner:
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3566,6 +3566,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
     status: maintained
+  hebi_hardware:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_hardware.git
+      version: main
+    status: maintained
   hector_rviz_overlay:
     source:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2995,6 +2995,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
     status: maintained
+  hebi_hardware:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_hardware.git
+      version: main
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2925,6 +2925,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
       version: ros2
     status: maintained
+  hebi_hardware:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_hardware.git
+      version: main
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.
humble
jazzy
kilted
rolling

# The source is here:
https://github.com/HebiRobotics/hebi_hardware.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
