### PR TITLE
add source/doc info to foxglove_sdk_vendor jazzy yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2885,6 +2885,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
+  foxglove_sdk_vendor:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/foxglove_sdk_vendor
+      version: main
+    source:
+      type: git
+      url: https://gitlab.com/jlack/foxglove_sdk_vendor
+      version: main
+    status: maintained
   frame_editor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2268,6 +2268,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
+  foxglove_sdk_vendor:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/foxglove_sdk_vendor
+      version: main
+    source:
+      type: git
+      url: https://gitlab.com/jlack/foxglove_sdk_vendor
+      version: main
+    status: maintained
   frequency_cam:
     doc:
       type: git


### PR DESCRIPTION
As requested in [this comment](https://github.com/ros/rosdistro/pull/48814#pullrequestreview-3541523992) I have added source/doc info to the jazzy release entry for `foxglove_sdk_vendor`. Note that I do not have any personal affiliation to foxglove. Also in [this thread](https://github.com/foxglove/foxglove-sdk/issues/531) we discuss them potentially owning this package at some future date and I will work with them if they're interested in that.