### PR TITLE
Add px4_msgs dependency to distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7745,6 +7745,11 @@ repositories:
       url: https://github.com/clearpathrobotics/puma_motor_driver.git
       version: foxy-devel
     status: maintained
+  px4_msgs:
+    doc:
+      type: git
+      url: https://github.com/PX4/px4_msgs
+      version: main
   py_binding_tools:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7748,8 +7748,14 @@ repositories:
   px4_msgs:
     doc:
       type: git
-      url: https://github.com/PX4/px4_msgs
+      url: https://github.com/PX4/px4_msgs.git
       version: main
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/PX4/px4_msgs.git
+      version: main
+    status: maintained
   py_binding_tools:
     release:
       tags:


### PR DESCRIPTION
<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

px4_msgs

# The source is here:

 https://github.com/PX4/px4_msgs

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

This package is part of the newer releases, but building .deb package with this dependency for ROS Humble fails, because it cannot find the dependency.
