### PR TITLE
rosdep entry for libjson-c-dev and question for libjson0-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4631,6 +4631,16 @@ libjpeg:
   rhel: [libjpeg-turbo-devel]
   slackware: [libjpeg-turbo]
   ubuntu: [libjpeg-dev]
+libjson-c-dev:
+  alpine: [json-c-dev]
+  arch: [json-c]
+  debian: [libjson-c-dev]
+  fedora: [json-c-devel]
+  gentoo: ['dev-libs/json-c:0']
+  openembedded: [jsoncpp@meta-oe]
+  opensuse: [libjson-c-devel]
+  rhel: [json-c-devel]
+  ubuntu: [libjson-c-dev]
 libjson-glib:
   arch: [json-glib]
   debian: [libjson-glib-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libjson-c-dev

## Package Upstream Source:

https://github.com/json-c/json-c

## Purpose of using this:

The development headers for json-c are not available for Ubuntu in rosdep. The closest key is `libjson0-dev` but it does not correspond to an existing package for Ubuntu nor Debian. This last key is a mix of non existing packages with the real json-c-dev.

I leave to the reviewers the decision about `libjson0-dev`, which could be removed or updated to the json-c devel packages so that it is at least consistent among the distributions.

This PR adds a new key, `libjson-c-dev` with the packages as bellow :

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libjson-c-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/resolute/libjson-c-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/json-c/json-c-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/core/x86_64/json-c/ not sure if devel version
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-libs/json-c not sure if devel version
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/json-c#default not sure if devel version
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86_64/json-c-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.11&show=json_c&query=json-c not sure if devel version
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libjson-c-devel
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/json-c-devel
