### PR TITLE
Remove foxglove_sdk_vendor from jazzy/distribution.yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2827,13 +2827,6 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
-  foxglove_sdk_vendor:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/jlack1987/foxglove_sdk_vendor-release.git
-      version: 0.2.0-1
-    status: maintained
   frame_editor:
     doc:
       type: git


### PR DESCRIPTION
This PR reverts https://github.com/ros/rosdistro/pull/48330. The source entry will be reviewed in https://github.com/ros/rosdistro/pull/48866 first. 