### PR TITLE
octomap_ros: 0.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4985,7 +4985,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_ros-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_ros` to `0.4.5-1`:

- upstream repository: https://github.com/OctoMap/octomap_ros.git
- release repository: https://github.com/ros2-gbp/octomap_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.4-1`

## octomap_ros

```
* chore: update headers for tf2, update CI
* Contributors: wep21
```
