### PR TITLE
Update release repository for play_motion2

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7393,7 +7393,7 @@ repositories:
       - play_motion2_msgs
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/play_motion2-release.git
+      url: https://github.com/ros2-gbp/play_motion2-release.git
       version: 1.8.2-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6411,7 +6411,7 @@ repositories:
       - play_motion2_msgs
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/pal-gbp/play_motion2-release.git
+      url: https://github.com/ros2-gbp/play_motion2-release.git
       version: 1.8.0-1
     source:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5595,7 +5595,7 @@ repositories:
       - play_motion2_msgs
       tags:
         release: release/kilted/{package}/{version}
-      url: https://github.com/pal-gbp/play_motion2-release.git
+      url: https://github.com/ros2-gbp/play_motion2-release.git
       version: 1.8.0-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5502,7 +5502,7 @@ repositories:
       - play_motion2_msgs
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/pal-gbp/play_motion2-release.git
+      url: https://github.com/ros2-gbp/play_motion2-release.git
       version: 1.8.0-1
     source:
       type: git


### PR DESCRIPTION
This PR updates the release repository for `play_motion2`, which is now hosted under the `ros2-gbp` github organization.

Added on https://github.com/ros2-gbp/ros2-gbp-github-org/issues/891.