### PR TITLE
ros2_canopen: 0.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8136,7 +8136,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.2-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## canopen

- No changes

## canopen_402_driver

```
* Fix configuration parsing and logging
* add pdo 6077 torque actual value to the joint state interface as effort (#316 <https://github.com/ros-industrial/ros2_canopen/issues/316>)
* Contributors: ipa-vsp, synsi23b
```

## canopen_base_driver

```
* #379 <https://github.com/ros-industrial/ros2_canopen/issues/379>: Fix data conversion in the Lely Bridge to enable more data types and proper handling of Emcy in ros2_control
* Fixed types handling in canopen_ros2_control.
* #376 <https://github.com/ros-industrial/ros2_canopen/issues/376>: increase boot timout
* Contributors: Dr. Denis Stogl, Vishnuprasad Prachandabhanu
```

## canopen_core

- No changes

## canopen_fake_slaves

```
* #400 <https://github.com/ros-industrial/ros2_canopen/issues/400>: Update controllers for ROS Rolling API changes and fix fake slave type handling
* Refactor GetValue method to use std::type_index for type comparisons
* motion_generator as shared library (#295 <https://github.com/ros-industrial/ros2_canopen/issues/295>)
* Enhance SimpleSlave class with vendor ID parsing and adjust bus configuration timeouts
* Multiple SDO types for slaves (#278 <https://github.com/ros-industrial/ros2_canopen/issues/278>)
  Co-authored-by: Kurtis Thrush <mailto:kthrush@jlg.com>
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
* Contributors: Christoph Hellmann Santos, Patrick Roncagliolo, Vishnuprasad Prachandabhanu
```

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

```
* #379 <https://github.com/ros-industrial/ros2_canopen/issues/379>: Fix data conversion in the Lely Bridge to enable more data types and proper handling of Emcy in ros2_control
* Fixed types handling in canopen_ros2_control.
* Optimize debug output.
* Contributors: Dr. Denis Stogl, Vishnuprasad Prachandabhanu
```

## canopen_ros2_control

```
* add pdo 6077 torque actual value to the joint state interface as effort (#316 <https://github.com/ros-industrial/ros2_canopen/issues/316>)
  Co-authored-by: Vishnuprasad Prachandabhanu <mailto:32260301+ipa-vsp@users.noreply.github.com>
* Refactor on_init method for improved readability and consistency
* Fix deprecated hardware_interface API (#386 <https://github.com/ros-industrial/ros2_canopen/issues/386>)
* Fix typos in warning messages and comments for clarity
* #379 <https://github.com/ros-industrial/ros2_canopen/issues/379>: Fix data conversion in the Lely Bridge to enable more data types and proper handling of Emcy in ros2_control
* Return error on Emcy.
* Add correct data conversion for Emcy.
* Fixed types handling in canopen_ros2_control.
* Optimize debug output.
* Fixed sending values.
* Contributors: Christoph Fröhlich, Dr. Denis Stogl, Vishnuprasad Prachandabhanu, synsi23b
```

## canopen_ros2_controllers

```
* Merge pull request #400 <https://github.com/ros-industrial/ros2_canopen/issues/400> from ros-industrial/fix/proxy_controller
  Update controllers for ROS Rolling API changes and fix fake slave type handling
* Enhance command interface error handling and feedback reporting in CanopenProxyController
* Contributors: Vishnuprasad Prachandabhanu
```

## canopen_tests

```
* Enhance SimpleSlave class with vendor ID parsing and adjust bus configuration timeouts
* Multiple SDO types for slaves (#278 <https://github.com/ros-industrial/ros2_canopen/issues/278>)
  Co-authored-by: Kurtis Thrush <mailto:kthrush@jlg.com>
  Co-authored-by: Christoph Hellmann Santos <mailto:christoph.hellmann.santos@ipa.fraunhofer.de>
* Contributors: Christoph Hellmann Santos
```

## canopen_utils

```
* Enhance SimpleSlave class with vendor ID parsing and adjust bus configuration timeouts
* Contributors: ipa-vsp
```

## lely_core_libraries

- No changes
