### PR TITLE
Add qml6-module-qt-labs-qmlmodels

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8766,6 +8766,17 @@ qml6-module-qt-labs-platform:
   ubuntu:
     '*': [qml6-module-qt-labs-platform]
     'focal': null
+qml6-module-qt-labs-qmlmodels:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qt-labs-qmlmodels]
+  fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qt-labs-qmlmodels]
+    'focal': null
 qml6-module-qt-labs-settings:
   arch: [qt6-declarative]
   debian: [qml6-module-qt-labs-settings]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

qml6-module-qt-labs-qmlmodels

## Purpose of using this:

This dependency provides several useful model implementations, such as a TableModel for Qt6 QML applications.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/qml6-module-qt-labs-qmlmodels
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/qml6-module-qt-labs-qmlmodels
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtdeclarative/qt6-qtdeclarative/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt6-declarative/
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Can't find it in the search anymore, but multiple web sources refer to it, and it's already added for some of the other modules. It can still be removed if not wanted.
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/qt6-qtdeclarative-6.6.2-1.el9.x86_64.rpm.html
 