### PR TITLE
aruco_opencv: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -661,7 +661,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 2.3.1-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `2.4.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.1-1`

## aruco_opencv

```
* refactor: Move parameter handling to different file (backport #57 <https://github.com/fictionlab/ros_aruco_opencv/issues/57>) (#60 <https://github.com/fictionlab/ros_aruco_opencv/issues/60>)
* feat: Add pose selection strategies (backport #56 <https://github.com/fictionlab/ros_aruco_opencv/issues/56>) (#59 <https://github.com/fictionlab/ros_aruco_opencv/issues/59>)
* refactor: Split implementation into helper classes/functions (backport #55 <https://github.com/fictionlab/ros_aruco_opencv/issues/55>) (#58 <https://github.com/fictionlab/ros_aruco_opencv/issues/58>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
