### PR TITLE
ardrone_ros: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -505,7 +505,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ardrone_ros-release.git
-      version: 1.1.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/vtalpaert/ardrone-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_ros` to `2.0.2-1`:

- upstream repository: https://github.com/vtalpaert/ardrone-ros2.git
- release repository: https://github.com/ros2-gbp/ardrone_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.0-1`

## ardrone_sdk

```
* change libncurses to libncurses-dev since we not build full sdk
* Contributors: Victor Talpaert
```

## ardrone_sumo

- No changes
