### PR TITLE
aruco_opencv: 6.1.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -541,7 +541,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.0.2-1
+      version: 6.1.0-2
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `6.1.0-2`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.2-1`

## aruco_opencv

```
* refactor: Move parameter handling to different file (#57 <https://github.com/fictionlab/ros_aruco_opencv/issues/57>)
* feat: Add pose selection strategies (#56 <https://github.com/fictionlab/ros_aruco_opencv/issues/56>)
* refactor: Split implementation into helper classes/functions (#55 <https://github.com/fictionlab/ros_aruco_opencv/issues/55>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
