### PR TITLE
Added hebi_msgs to humble, jazzy, kilted and rolling distributions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3759,6 +3759,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_hardware.git
       version: main
     status: maintained
+  hebi_msgs:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_msgs.git
+      version: main
+    status: maintained
   heightmap_spawner:
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3608,6 +3608,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_hardware.git
       version: main
     status: maintained
+  hebi_msgs:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_msgs.git
+      version: main
+    status: maintained
   hector_rviz_overlay:
     source:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3029,6 +3029,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_hardware.git
       version: main
     status: maintained
+  hebi_msgs:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_msgs.git
+      version: main
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2931,6 +2931,12 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_hardware.git
       version: main
     status: maintained
+  hebi_msgs:
+    source:
+      type: git
+      url: https://github.com/HebiRobotics/hebi_msgs.git
+      version: main
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.
humble
jazzy
kilted
rolling

# The source is here:
https://github.com/HebiRobotics/hebi_msgs.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
