### PR TITLE
moveit: 2.12.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5143,7 +5143,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.12.3-1
+      version: 2.12.4-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit` to `2.12.4-1`:

- upstream repository: https://github.com/moveit/moveit2.git
- release repository: https://github.com/ros2-gbp/moveit2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.12.3-1`

## chomp_motion_planner

- No changes

## moveit

- No changes

## moveit_common

- No changes

## moveit_configs_utils

- No changes

## moveit_core

```
* Fix seg fault with attached objects during motion execution (#3466 <https://github.com/moveit/moveit2/issues/3466>) (#3470 <https://github.com/moveit/moveit2/issues/3470>)
```

## moveit_hybrid_planning

- No changes

## moveit_kinematics

- No changes

## moveit_planners

- No changes

## moveit_planners_chomp

- No changes

## moveit_planners_ompl

```
* Update ompl_interface with latest version of OMPL (#2994 <https://github.com/moveit/moveit2/issues/2994>) (#3600 <https://github.com/moveit/moveit2/issues/3600>)
* [OMPL] also check constraints in StateValidityCallback (#3586 <https://github.com/moveit/moveit2/issues/3586>) (#3611 <https://github.com/moveit/moveit2/issues/3611>)
```

## moveit_planners_stomp

- No changes

## moveit_plugins

- No changes

## moveit_py

```
* Python PlanningScene API: add set_current_state() (#3481 <https://github.com/moveit/moveit2/issues/3481>)
* Allow conversion rclpy.Time <-> rclcpp::Time (#3453 <https://github.com/moveit/moveit2/issues/3453>) (#3455 <https://github.com/moveit/moveit2/issues/3455>)
```

## moveit_resources_prbt_ikfast_manipulator_plugin

- No changes

## moveit_resources_prbt_moveit_config

- No changes

## moveit_resources_prbt_pg70_support

- No changes

## moveit_resources_prbt_support

- No changes

## moveit_ros

- No changes

## moveit_ros_benchmarks

- No changes

## moveit_ros_control_interface

- No changes

## moveit_ros_move_group

- No changes

## moveit_ros_occupancy_map_monitor

- No changes

## moveit_ros_perception

- No changes

## moveit_ros_planning

```
* PSM: finish thread on rclcpp::shutdown (#3484 <https://github.com/moveit/moveit2/issues/3484>) (#3486 <https://github.com/moveit/moveit2/issues/3486>)
* Fix seg fault with attached objects during motion execution (#3466 <https://github.com/moveit/moveit2/issues/3466>) (#3470 <https://github.com/moveit/moveit2/issues/3470>)
```

## moveit_ros_planning_interface

- No changes

## moveit_ros_robot_interaction

- No changes

## moveit_ros_tests

- No changes

## moveit_ros_trajectory_cache

- No changes

## moveit_ros_visualization

- No changes

## moveit_ros_warehouse

- No changes

## moveit_runtime

- No changes

## moveit_servo

```
* Fix severe warning from class loader in servo (#3577 <https://github.com/moveit/moveit2/issues/3577>) (#3598 <https://github.com/moveit/moveit2/issues/3598>)
```

## moveit_setup_app_plugins

- No changes

## moveit_setup_assistant

- No changes

## moveit_setup_controllers

- No changes

## moveit_setup_core_plugins

- No changes

## moveit_setup_framework

- No changes

## moveit_setup_srdf_plugins

- No changes

## moveit_simple_controller_manager

- No changes

## pilz_industrial_motion_planner

- No changes

## pilz_industrial_motion_planner_testutils

- No changes
