### PR TITLE
foxglove_sdk_vendor: 0.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2312,13 +2312,18 @@ repositories:
   foxglove_sdk_vendor:
     doc:
       type: git
-      url: https://gitlab.com/jlack/foxglove_sdk_vendor
+      url: https://gitlab.com/jlack/foxglove_sdk_vendor.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/foxglove_sdk_vendor-release.git
+      version: 0.2.0-2
     source:
       type: git
-      url: https://gitlab.com/jlack/foxglove_sdk_vendor
+      url: https://gitlab.com/jlack/foxglove_sdk_vendor.git
       version: main
-    status: maintained
+    status: developed
   frequency_cam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_sdk_vendor` to `0.2.0-2`:

- upstream repository: https://gitlab.com/jlack/foxglove_sdk_vendor.git
- release repository: https://github.com/ros2-gbp/foxglove_sdk_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
