### PR TITLE
add event_camera_tools repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2677,6 +2677,16 @@ repositories:
       url: https://github.com/ros-event-camera/event_camera_renderer.git
       version: release
     status: developed
+  event_camera_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    status: developed
   event_image_reconstruction_fibar:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2437,6 +2437,16 @@ repositories:
       url: https://github.com/ros-event-camera/event_camera_renderer.git
       version: release
     status: developed
+  event_camera_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    status: developed
   event_image_reconstruction_fibar:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1919,6 +1919,16 @@ repositories:
       url: https://github.com/ros-event-camera/event_camera_renderer.git
       version: release
     status: developed
+  event_camera_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    status: developed
   event_image_reconstruction_fibar:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1851,6 +1851,16 @@ repositories:
       url: https://github.com/ros-event-camera/event_camera_renderer.git
       version: release
     status: developed
+  event_camera_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/event_camera_tools.git
+      version: release
+    status: developed
   event_image_reconstruction_fibar:
     doc:
       type: git


### PR DESCRIPTION
# Please add event_camera_tools to be indexed for humble, jazzy, kilted, rolling

Humble
Jazzy
Kilted
Rolling

I could not come up with a better name than "tools" for this hodgepodge of little utilities
that help with converting and debugging event camera data.

# The source is here:

https://github.com/ros-event-camera/event_camera_tools/

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
