### PR TITLE
event_camera_msgs: 2.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1883,7 +1883,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_msgs-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_msgs.git
- release repository: https://github.com/ros2-gbp/event_camera_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## event_camera_msgs

```
* fixed license string in package.xml
* Contributors: Bernd Pfrommer
```
