### PR TITLE
event_camera_codecs: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2386,7 +2386,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 2.0.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_codecs` to `3.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_codecs.git
- release repository: https://github.com/ros2-gbp/event_camera_codecs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-1`

## event_camera_codecs

```
* updated license string in package.xml
* fix broken tests and README
* returning false from eventExtTrigger() will now interrupt decode()
* do not bomb out on padding code 9
* Contributors: Bernd Pfrommer
```
