### PR TITLE
event_camera_renderer: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2431,7 +2431,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_renderer-release.git
-      version: 2.0.1-2
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_renderer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_renderer` to `3.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_renderer.git
- release repository: https://github.com/ros2-gbp/event_camera_renderer-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-2`

## event_camera_renderer

```
* updated license string in package.xml
* better error message when no events are received
* need include for queue
* removed remaining ROS1 stuff (except for ros_compat)
* handle arbitrarily fine time slices now
* eventExtTrigger() returns true now
* This pull request resolves a build failure caused by an invalid-constexpr error on modern compilers (like AppleClang).
* Contributors: Bernd Pfrommer, Dhruv Patel
```
