### PR TITLE
event_camera_py: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1830,7 +1830,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_py-release.git
-      version: 2.0.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_py.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_py` to `3.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_py.git
- release repository: https://github.com/ros2-gbp/event_camera_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-1`

## event_camera_py

```
* eventExtTrigger() returns true now
* get_start_time() returns None if sensor does not support abs time stamps
* Contributors: Bernd Pfrommer
```
