### PR TITLE
metavision_driver: 3.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4131,7 +4131,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/metavision_driver-release.git
-      version: 2.0.1-2
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/metavision_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metavision_driver` to `3.0.0-1`:

- upstream repository: https://github.com/ros-event-camera/metavision_driver.git
- release repository: https://github.com/ros2-gbp/metavision_driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-2`

## metavision_driver

```
* updated license string in package.xml
* improved launch files
* updated banner image
* documented settings param and save_settings service call
* add options to invoke renderer and fibar for stereo cam
* updated launch file for ids cameras, not loading triggers
* support init of bias params, loading/saving of camera settings
* added commented-out lines for libasan compilation
* added bias file for ids xcpe camera
* fix broken ROI feature and support RONI
* added instructions for IDS camera, removed ROS1 documentation
* remove bad format parameter in driver_node launch script
* set camera encoding format
* Contributors: Bernd Pfrommer
```
