### PR TITLE
added frequency_cam repository

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3239,6 +3239,16 @@ repositories:
       url: https://github.com/frankaemika/franka_ros2.git
       version: humble
     status: developed
+  frequency_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    status: developed
   game_controller_spl:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2895,6 +2895,16 @@ repositories:
       url: https://github.com/ipa320/rqt_frame_editor_plugin.git
       version: jazzy-devel
     status: maintained
+  frequency_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    status: developed
   fuse:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2331,6 +2331,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
+  frequency_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    status: developed
   fuse:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2263,6 +2263,16 @@ repositories:
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
       version: release
     status: developed
+  frequency_cam:
+    doc:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    source:
+      type: git
+      url: https://github.com/ros-event-camera/frequency_cam.git
+      version: release
+    status: developed
   fuse:
     doc:
       type: git


### PR DESCRIPTION
# Please add the frequency\_cam package to be indexed in the rosdistro.

ROS distros:   humble, jazzy, kilted, rolling

# The source is [here](https://github.com/ros-event-camera/frequency_cam)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
