### PR TITLE
fibar_lib: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2032,6 +2032,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/fibar_lib.git
       version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/fibar_lib-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/fibar_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fibar_lib` to `1.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/fibar_lib.git
- release repository: https://github.com/ros2-gbp/fibar_lib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## fibar_lib

```
* more templating to make spatial filter optional
* better error message for hot pixels
* Contributors: Bernd Pfrommer
```
