### PR TITLE
generate_parameter_library: 0.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2395,17 +2395,13 @@ repositories:
       version: main
     release:
       packages:
-      - cmake_generate_parameter_module_example
       - generate_parameter_library
-      - generate_parameter_library_example
-      - generate_parameter_library_example_external
       - generate_parameter_library_py
-      - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.6.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.0-1`

## generate_parameter_library

```
* Update maintainers for GBP release team (#282 <https://github.com/PickNikRobotics/generate_parameter_library/issues/282>)
* Contributors: Nathan Brooks
```

## generate_parameter_library_py

```
* Use templated NodeT in c++ constructor  (#274 <https://github.com/PickNikRobotics/generate_parameter_library/issues/274>)
* Update pre-commit hooks (#288 <https://github.com/PickNikRobotics/generate_parameter_library/issues/288>)
* Improve logging message when a parameter is not set (#279 <https://github.com/PickNikRobotics/generate_parameter_library/issues/279>)
* Account for nested map params (#277 <https://github.com/PickNikRobotics/generate_parameter_library/issues/277>) (#280 <https://github.com/PickNikRobotics/generate_parameter_library/issues/280>)
* Update maintainers for GBP release team (#282 <https://github.com/PickNikRobotics/generate_parameter_library/issues/282>)
* fix setuptools deprecations (#268 <https://github.com/PickNikRobotics/generate_parameter_library/issues/268>)
* Contributors: Ander González Tomé, Christoph Fröhlich, Gaël Écorchard, Nathan Brooks, Russ, mosfet80
```

## parameter_traits

```
* Update pre-commit hooks (#288 <https://github.com/PickNikRobotics/generate_parameter_library/issues/288>)
* Update maintainers for GBP release team (#282 <https://github.com/PickNikRobotics/generate_parameter_library/issues/282>)
* Contributors: Christoph Fröhlich, Nathan Brooks
```
