### PR TITLE
Remove kinematics_interface_pinocchio

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3420,21 +3420,6 @@ repositories:
       url: https://github.com/ros-controls/kinematics_interface.git
       version: master
     status: developed
-  kinematics_interface_pinocchio:
-    doc:
-      type: git
-      url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: ros-rolling
-    release:
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/kinematics_interface_pinocchio-release.git
-      version: 0.0.1-2
-    source:
-      type: git
-      url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: ros-rolling
-    status: maintained
   kobuki_core:
     doc:
       type: git


### PR DESCRIPTION
Because we moved that upstream to [kinematics_interface](https://github.com/ros-controls/kinematics_interface.git) repository and blocks bloom-release.

https://github.com/justagist/kinematics_interface_pinocchio/issues/11#issuecomment-3364774671
@justagist 