### PR TITLE
Remove kinematics_interface_pinocchio

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4071,21 +4071,6 @@ repositories:
       url: https://github.com/ros-controls/kinematics_interface.git
       version: jazzy
     status: developed
-  kinematics_interface_pinocchio:
-    doc:
-      type: git
-      url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: ros-jazzy
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/justagist/kinematics_interface_pinocchio-release.git
-      version: 0.0.1-1
-    source:
-      type: git
-      url: https://github.com/justagist/kinematics_interface_pinocchio.git
-      version: ros-jazzy
-    status: maintained
   kobuki_core:
     doc:
       type: git


### PR DESCRIPTION
Because we moved that upstream to [kinematics_interface](https://github.com/ros-controls/kinematics_interface.git) repository and blocks bloom-release.

https://github.com/justagist/kinematics_interface_pinocchio/issues/11#issuecomment-3364774671
@justagist 