### PR TITLE
kinematics_interface: 2.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3412,10 +3412,11 @@ repositories:
       packages:
       - kinematics_interface
       - kinematics_interface_kdl
+      - kinematics_interface_pinocchio
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.4.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## kinematics_interface

```
* Add pinocchio plugin (#199 <https://github.com/ros-controls/kinematics_interface/issues/199>)
* Add a test template for plugin implementations (#211 <https://github.com/ros-controls/kinematics_interface/issues/211>)
* Refactor and extend tests (#210 <https://github.com/ros-controls/kinematics_interface/issues/210>)
* Update maintainers (#198 <https://github.com/ros-controls/kinematics_interface/issues/198>)
* Contributors: Christoph Fröhlich
```

## kinematics_interface_kdl

```
* Add a test template for plugin implementations (#211 <https://github.com/ros-controls/kinematics_interface/issues/211>)
* Refactor and extend tests (#210 <https://github.com/ros-controls/kinematics_interface/issues/210>)
* Update maintainers (#198 <https://github.com/ros-controls/kinematics_interface/issues/198>)
* Contributors: Christoph Fröhlich
```

## kinematics_interface_pinocchio

```
* Add pinocchio plugin (#199 <https://github.com/ros-controls/kinematics_interface/issues/199>)
* Contributors: Christoph Fröhlich
```
