### PR TITLE
kinematics_interface: 1.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4063,10 +4063,11 @@ repositories:
       packages:
       - kinematics_interface
       - kinematics_interface_kdl
+      - kinematics_interface_pinocchio
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.6.0-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.7.0-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-1`

## kinematics_interface

```
* Add a test template for plugin implementations (backport #211 <https://github.com/ros-controls/kinematics_interface/issues/211>) (#223 <https://github.com/ros-controls/kinematics_interface/issues/223>)
* Refactor and extend tests (backport #210 <https://github.com/ros-controls/kinematics_interface/issues/210>) (#219 <https://github.com/ros-controls/kinematics_interface/issues/219>)
* Update maintainers (backport #198 <https://github.com/ros-controls/kinematics_interface/issues/198>) (#201 <https://github.com/ros-controls/kinematics_interface/issues/201>)
* Contributors: mergify[bot]
```

## kinematics_interface_kdl

```
* Add a test template for plugin implementations (backport #211 <https://github.com/ros-controls/kinematics_interface/issues/211>) (#223 <https://github.com/ros-controls/kinematics_interface/issues/223>)
* Refactor and extend tests (backport #210 <https://github.com/ros-controls/kinematics_interface/issues/210>) (#219 <https://github.com/ros-controls/kinematics_interface/issues/219>)
* Update maintainers (backport #198 <https://github.com/ros-controls/kinematics_interface/issues/198>) (#201 <https://github.com/ros-controls/kinematics_interface/issues/201>)
* Contributors: mergify[bot]
```

## kinematics_interface_pinocchio

```
* Add pinocchio plugin (backport #199 <https://github.com/ros-controls/kinematics_interface/issues/199>) (#225 <https://github.com/ros-controls/kinematics_interface/issues/225>)
* Contributors: mergify[bot]
```
