### PR TITLE
raph_robot: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7108,6 +7108,18 @@ repositories:
       version: jazzy
     status: maintained
   raph_robot:
+    doc:
+      type: git
+      url: https://github.com/RaphRover/raph_robot.git
+      version: main
+    release:
+      packages:
+      - raph_bringup
+      - raph_robot
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/raph_robot-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/RaphRover/raph_robot.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7123,7 +7123,7 @@ repositories:
     source:
       type: git
       url: https://github.com/RaphRover/raph_robot.git
-      version: jazzy
+      version: main
     status: maintained
   raspimouse2:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `raph_robot` to `1.0.0-1`:

- upstream repository: https://github.com/RaphRover/raph_robot
- release repository: https://github.com/ros2-gbp/raph_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## raph_bringup

```
* feat: Add box filter to rplidar scans (#6 <https://github.com/Rapha-Rover/rapha_robot/issues/6>)
* feat: Improve Oak configuration (#5 <https://github.com/Rapha-Rover/rapha_robot/issues/5>)
* Add rosbridge and web_video_server to raph_bringup
* Update raph_system script, add get_os_version service
* Change all names to Raph (#4 <https://github.com/Rapha-Rover/rapha_robot/issues/4>)
* Contributors: Błażej Sowa, Jan Hernas
```

## raph_robot

```
* Change all names to Raph (#4 <https://github.com/Rapha-Rover/rapha_robot/issues/4>)
* Contributors: Jan Hernas
```
