### PR TITLE
Add libmm-glib (dev/runtime) to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4836,6 +4836,14 @@ libmlpack-dev:
   debian: [libmlpack-dev]
   fedora: [mlpack-devel]
   ubuntu: [libmlpack-dev]
+libmm-glib-dev:
+  debian: [libmm-glib-dev]
+  fedora: [ModemManager-glib-devel]
+  ubuntu: [libmm-glib-dev]
+libmm-glib0:
+  debian: [libmm-glib0]
+  fedora: [ModemManager-glib]
+  ubuntu: [libmm-glib0]
 libmnl-dev:
   alpine: [libmnl-dev]
   arch: [libmnl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4840,10 +4840,13 @@ libmm-glib-dev:
   debian: [libmm-glib-dev]
   fedora: [ModemManager-glib-devel]
   ubuntu: [libmm-glib-dev]
+  rhel: [ModemManager-glib-devel]
 libmm-glib0:
   debian: [libmm-glib0]
   fedora: [ModemManager-glib]
   ubuntu: [libmm-glib0]
+  rhel: [ModemManager-glib]
+  opensuse: [libmm-glib0]
 libmnl-dev:
   alpine: [libmnl-dev]
   arch: [libmnl]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4839,14 +4839,14 @@ libmlpack-dev:
 libmm-glib-dev:
   debian: [libmm-glib-dev]
   fedora: [ModemManager-glib-devel]
-  ubuntu: [libmm-glib-dev]
   rhel: [ModemManager-glib-devel]
+  ubuntu: [libmm-glib-dev]
 libmm-glib0:
   debian: [libmm-glib0]
   fedora: [ModemManager-glib]
-  ubuntu: [libmm-glib0]
-  rhel: [ModemManager-glib]
   opensuse: [libmm-glib0]
+  rhel: [ModemManager-glib]
+  ubuntu: [libmm-glib0]
 libmnl-dev:
   alpine: [libmnl-dev]
   arch: [libmnl]


### PR DESCRIPTION
Reopen of https://github.com/ros/rosdistro/pull/48474

## Package name:

libmm-glib-dev
libmm-glib0

## Package Upstream Source:

https://www.freedesktop.org/wiki/Software/ModemManager/

## Purpose of using this:

I gonna create a package which handles LTE configuration. Which requires modem manager features. These packages provides functionality to do this.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libmm-glib-dev
  - https://packages.debian.org/trixie/libmm-glib0
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libmm-glib-dev
  - https://packages.ubuntu.com/jammy/libmm-glib0
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/ModemManager/ModemManager-glib-devel/
  - https://packages.fedoraproject.org/pkgs/ModemManager/ModemManager-glib/
- RHEL:
  - https://pkgs.org/search/?q=ModemManager-glib
- OpenSUSE:
  - https://software.opensuse.org/package/libmm-glib0 