### PR TITLE
Add modemmanager to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7806,6 +7806,12 @@ mkdocs-bootswatch:
   gentoo: [dev-python/mkdocs-bootswatch]
   ubuntu:
     bionic: [mkdocs-bootswatch]
+modemmanager:
+  debian: [modemmanager]
+  fedora: [ModemManager]
+  opensuse: [ModemManager]
+  rhel: [ModemManager]
+  ubuntu: [modemmanager]
 mongodb:
   gentoo: [dev-db/mongodb]
   nixos: [mongodb]


### PR DESCRIPTION
## Package name:

Modemmanager

## Package Upstream Source:

https://modemmanager.org

## Purpose of using this:

I want to develop a ROS package using modemmanager

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/modemmanager
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/questing/modemmanager
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/ModemManager/ModemManager/
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/ModemManager
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=modemmanager

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->