### PR TITLE
event_camera_tools: 3.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2442,6 +2442,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/event_camera_tools.git
       version: release
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/event_camera_tools-release.git
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_tools` to `3.1.0-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_tools.git
- release repository: https://github.com/ros2-gbp/event_camera_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## event_camera_tools

```
* first release
* Contributors: Bernd Pfrommer, Dhruv Patel, YLFeng
```
