### PR TITLE
frequency_cam: 3.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3254,6 +3254,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/frequency_cam.git
       version: release
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/frequency_cam-release.git
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/ros-event-camera/frequency_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frequency_cam` to `3.1.0-1`:

- upstream repository: https://github.com/ros-event-camera/frequency_cam.git
- release repository: https://github.com/ros2-gbp/frequency_cam-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## frequency_cam

```
* first release
* Contributors: Bernd Pfrommer
```
