### PR TITLE
ros_babel_fish: 0.25.120-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9627,7 +9627,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.25.2-1
+      version: 0.25.120-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `0.25.120-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.25.2-1`

## ros_babel_fish

```
* Wrap exceptions when creating service or action client with invalid topic as BabelFishException.
* Fixed ament package not found error not being caught and wrapped as TypeSupportException / BabelFishException.
* Added a get method for CompoundArrayMessage to obtain element as shared_ptr.
* Added documentation and fixed tiny memory leak.
* Added convenience methods to message introspection wrapper.
* Fixed waiting indefinitely if topic is namespaced and added test case.
* Print warning when waiting for more than 3 seconds for topic.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes
