### PR TITLE
qml6_ros2_plugin: 2.25.120-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5975,6 +5975,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: rolling
     status: maintained
+  qml6_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: rolling
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
+      version: 2.25.120-1
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: rolling
+    status: developed
   qml_ros2_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `2.25.120-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## qml6_ros2_plugin

```
* Initial release.
* Contributors: Stefan Fabian
```
