### PR TITLE
qml6_ros2_plugin: 0.25.120-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8040,6 +8040,21 @@ repositories:
       url: https://bitbucket.org/qbrobotics/qbshin-ros.git
       version: production-humble
     status: developed
+  qml6_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
+      version: 0.25.120-1
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: humble
+    status: developed
   qml_ros2_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `0.25.120-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## qml6_ros2_plugin

```
* Initial release.
* Contributors: Stefan Fabian
```
