### PR TITLE
qml6_ros2_plugin: 2.25.121-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6081,6 +6081,21 @@ repositories:
       url: https://github.com/ros-visualization/python_qt_binding.git
       version: kilted
     status: maintained
+  qml6_ros2_plugin:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: kilted
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
+      version: 2.25.121-1
+    source:
+      type: git
+      url: https://github.com/StefanFabian/qml6_ros2_plugin.git
+      version: kilted
+    status: developed
   qml_ros2_plugin:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `2.25.121-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## qml6_ros2_plugin

```
* Backport for kilted.
* Contributors: Stefan Fabian
```
