### PR TITLE
[Jazzy] Add cras_ros_utils to distribution.yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1669,6 +1669,16 @@ repositories:
       url: https://github.com/rt-net/crane_plus.git
       version: master
     status: maintained
+  cras_ros_utils:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/ros-utils.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/ctu-vras/ros-utils.git
+      version: ros2
+    status: developed
   crazyflie:
     source:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

cras_ros_utils

# The source is here:

https://github.com/ctu-vras/ros-utils/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
