### PR TITLE
[Rolling] Add cras_ros_utils package to distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1350,6 +1350,16 @@ repositories:
       url: https://github.com/PickNikRobotics/cpp_polyfills.git
       version: main
     status: maintained
+  cras_ros_utils:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/ros-utils.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/ctu-vras/ros-utils.git
+      version: ros2
+    status: developed
   crazyflie:
     source:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

cras_ros_utils

# The source is here:

https://github.com/ctu-vras/ros-utils/tree/ros2

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
