### PR TITLE
rosdep: Added python3-overpy

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8138,17 +8138,16 @@ python3-overpy:
       packages: [overpy]
   debian: [python3-overpy]
   fedora: [python3-overpy]
-  gentoo:
-    pip:
-      packages: [overpy]
   nixos: [python3Packages.overpy]
   opensuse:
     pip:
-      packages: [mercurial]
+      packages: [overpy]
   osx:
     pip:
       packages: [overpy]
-  rhel: [python3-overpy]
+  rhel:
+    pip:
+      packages: [overpy]
   ubuntu: [python3-overpy]
 python3-overrides:
   arch: [python-overrides]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8131,6 +8131,25 @@ python3-osrf-pycommon:
   nixos: [python3Packages.osrf-pycommon]
   rhel: [python3-osrf-pycommon]
   ubuntu: [python3-osrf-pycommon]
+python3-overpy:
+  alpine: [py3-overpy]
+  arch:
+    pip:
+      packages: [overpy]
+  debian: [python3-overpy]
+  fedora: [python3-overpy]
+  gentoo:
+    pip:
+      packages: [overpy]
+  nixos: [python3Packages.overpy]
+  opensuse:
+    pip:
+      packages: [mercurial]
+  osx:
+    pip:
+      packages: [overpy]
+  rhel: [python3-overpy]
+  ubuntu: [python3-overpy]
 python3-overrides:
   arch: [python-overrides]
   debian:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-overpy

## Package Upstream Source:

https://github.com/DinoTools/python-overpy

## Purpose of using this:

Library for using Overpass API (access to OpenStreetMap data).

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/stable/python/python3-overpy
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/questing/python3-overpy
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-overpy/python3-overpy/
  - IF AVAILABLE
- Arch: via pip
  - IF AVAILABLE
- Gentoo: via pip
  - IF AVAILABLE
- macOS: via pip
  - IF AVAILABLE
- Alpine: https://alpine.pkgs.org/3.23/alpine-community-aarch64/py3-overpy-0.7-r1.apk.html
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.11&query=overpy
  - OPTIONAL
- openSUSE: via pip
  - IF AVAILABLE
- rhel: via pip
  - IF AVAILABLE
