### PR TITLE
Add python3-pyzbar to rosdep

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9505,6 +9505,26 @@ python3-pyxdg-pip:
   ubuntu:
     pip:
       packages: [pyxdg]
+python3-pyzbar:
+  alpine: [py3-pyzbar]
+  arch:
+    pip:
+      packages: [pyzbar]
+  debian: [python3-pyzbar]
+  fedora:
+    pip:
+      packages: [pyzbar]
+  nixos: [python3Packages.pyzbar]
+  opensuse:
+    pip:
+      packages: [pyzbar]
+  osx:
+    pip:
+      packages: [pyzbar]
+  rhel:
+    pip:
+      packages: [pyzbar]
+  ubuntu: [python3-pyzbar]
 python3-qpsolvers-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9524,7 +9524,9 @@ python3-pyzbar:
   rhel:
     pip:
       packages: [pyzbar]
-  ubuntu: [python3-pyzbar]
+  ubuntu:
+    '*': [python3-pyzbar]
+    focal: null
 python3-qpsolvers-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-pyzbar

## Package Upstream Source:

https://github.com/NaturalHistoryMuseum/pyzbar/

## Purpose of using this:

Read 1-D and 2-D barcodes.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/sid/python3-pyzbar
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/questing/python3-pyzbar
  - REQUIRED
- Fedora: via pip
  - IF AVAILABLE
- Arch: via pip
  - IF AVAILABLE
- Gentoo: via pip
  - IF AVAILABLE
- macOS: via pip
  - IF AVAILABLE
- Alpine:  https://alpine.pkgs.org/3.23/alpine-community-aarch64/py3-pyzbar-0.1.9-r4.apk.html
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.11&show=python312Packages.pyzbar&query=pyzbar
  - OPTIONAL
- openSUSE: via pip
  - IF AVAILABLE
- rhel: via pip
  - IF AVAILABLE
