### PR TITLE
image_pipeline: 7.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3088,7 +3088,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 7.1.2-1
+      version: 7.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `7.1.3-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.1.2-1`

## camera_calibration

- No changes

## depth_image_proc

```
* Fix incorrect plugin name for PointCloudXyzrgbRadialNode (#1120 <https://github.com/ros-perception/image_pipeline//issues/1120>)
* Contributors: mini-1235
```

## image_pipeline

- No changes

## image_proc

- No changes

## image_publisher

- No changes

## image_rotate

- No changes

## image_view

- No changes

## stereo_image_proc

- No changes

## tracetools_image_pipeline

- No changes
