### PR TITLE
rosidl: 5.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7696,7 +7696,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.1.1-1
+      version: 5.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.1.2-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.1-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* remove importlib-metadata (#917 <https://github.com/ros2/rosidl/issues/917>)
* Contributors: Michael Carlstrom
```

## rosidl_cmake

```
* Add rosidl_auto_generate_interfaces function (#918 <https://github.com/ros2/rosidl/issues/918>)
* Contributors: Kotaro Yoshimoto
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

```
* Add missing dependency on ament_cmake_pytest (#914 <https://github.com/ros2/rosidl/issues/914>)
* Contributors: Scott K Logan
```

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
