### PR TITLE
image_pipeline: 3.0.9-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4155,7 +4155,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 3.0.8-1
+      version: 3.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `3.0.9-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.8-1`

## camera_calibration

```
* [backport humble] fix threading shutdown (#1122 <https://github.com/ros-perception/image_pipeline//issues/1122>)
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: jangeliniara, mergify[bot]
```

## depth_image_proc

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## image_pipeline

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## image_proc

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## image_publisher

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## image_rotate

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## image_view

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## stereo_image_proc

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline//issues/1101>) (#1105 <https://github.com/ros-perception/image_pipeline//issues/1105>)
* Contributors: mergify[bot]
```

## tracetools_image_pipeline

- No changes
