### PR TITLE
rosidl: 4.9.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7830,7 +7830,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.9.5-1
+      version: 4.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.9.6-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.9.5-1`

## rosidl_adapter

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>) (#879 <https://github.com/ros2/rosidl/issues/879>)
* Contributors: mergify[bot]
```

## rosidl_cli

```
* remove importlib-metadata (#917 <https://github.com/ros2/rosidl/issues/917>) (#919 <https://github.com/ros2/rosidl/issues/919>)
* fix setuptools deprecations (#877 <https://github.com/ros2/rosidl/issues/877>) (#895 <https://github.com/ros2/rosidl/issues/895>)
* Contributors: mergify[bot]
```

## rosidl_cmake

```
* Add rosidl_auto_generate_inetrfaces function (#918 <https://github.com/ros2/rosidl/issues/918>) (#920 <https://github.com/ros2/rosidl/issues/920>)
* Contributors: mergify[bot]
```

## rosidl_generator_c

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>) (#879 <https://github.com/ros2/rosidl/issues/879>)
* Contributors: mergify[bot]
```

## rosidl_generator_cpp

```
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>) (#899 <https://github.com/ros2/rosidl/issues/899>)
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>) (#879 <https://github.com/ros2/rosidl/issues/879>)
* Contributors: mergify[bot]
```

## rosidl_generator_type_description

```
* Add missing dependency on ament_cmake_pytest (#914 <https://github.com/ros2/rosidl/issues/914>) (#915 <https://github.com/ros2/rosidl/issues/915>)
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>) (#879 <https://github.com/ros2/rosidl/issues/879>)
* Contributors: mergify[bot]
```

## rosidl_parser

- No changes

## rosidl_pycommon

```
* fix setuptools deprecation (#880 <https://github.com/ros2/rosidl/issues/880>) (#892 <https://github.com/ros2/rosidl/issues/892>)
* Contributors: mergify[bot]
```

## rosidl_runtime_c

```
* Fix copy/paste errors in type support docs (#906 <https://github.com/ros2/rosidl/issues/906>) (#907 <https://github.com/ros2/rosidl/issues/907>)
* Contributors: mergify[bot]
```

## rosidl_runtime_cpp

```
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>) (#899 <https://github.com/ros2/rosidl/issues/899>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>) (#879 <https://github.com/ros2/rosidl/issues/879>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_introspection_cpp

```
* Uniform cmake minVersion (#849 <https://github.com/ros2/rosidl/issues/849>) (#879 <https://github.com/ros2/rosidl/issues/879>)
* Contributors: mergify[bot]
```
