### PR TITLE
rosidl: 4.6.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8880,7 +8880,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.6.6-1
+      version: 4.6.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.6.7-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.6.6-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* fix setuptools deprecations (#877 <https://github.com/ros2/rosidl/issues/877>) (#896 <https://github.com/ros2/rosidl/issues/896>)
* Contributors: mergify[bot]
```

## rosidl_cmake

```
* Add rosidl_auto_generate_inetrfaces function (#918 <https://github.com/ros2/rosidl/issues/918>) (#921 <https://github.com/ros2/rosidl/issues/921>)
* Contributors: mergify[bot]
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>) (#900 <https://github.com/ros2/rosidl/issues/900>)
* Contributors: mergify[bot]
```

## rosidl_generator_type_description

```
* Add missing dependency on ament_cmake_pytest (#914 <https://github.com/ros2/rosidl/issues/914>) (#916 <https://github.com/ros2/rosidl/issues/916>)
* Contributors: mergify[bot]
```

## rosidl_parser

- No changes

## rosidl_pycommon

```
* fix setuptools deprecation (#880 <https://github.com/ros2/rosidl/issues/880>) (#893 <https://github.com/ros2/rosidl/issues/893>)
* Contributors: mergify[bot]
```

## rosidl_runtime_c

```
* Fix copy/paste errors in type support docs (backport #906 <https://github.com/ros2/rosidl/issues/906>) (#908 <https://github.com/ros2/rosidl/issues/908>)
* Contributors: mergify[bot]
```

## rosidl_runtime_cpp

```
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>) (#900 <https://github.com/ros2/rosidl/issues/900>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
