### PR TITLE
Add qml6-module-qtmultimedia to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8831,6 +8831,17 @@ qml6-module-qtcore:
   ubuntu:
     '*': [qml6-module-qtcore]
     'focal': null
+qml6-module-qtmultimedia:
+  arch: [qt6-declarative]
+  debian: [qml6-module-qtmultimedia]
+  fedora: [qt6-qtdeclarative]
+  nixos: [qt6.qtdeclarative]
+  rhel:
+    '*': [qt6-qtdeclarative]
+    '8': null
+  ubuntu:
+    '*': [qml6-module-qtmultimedia]
+    'focal': null
 qml6-module-qtpositioning:
   arch: [qt6-declarative]
   debian: [qml6-module-qtpositioning]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8832,12 +8832,12 @@ qml6-module-qtcore:
     '*': [qml6-module-qtcore]
     'focal': null
 qml6-module-qtmultimedia:
-  arch: [qt6-declarative]
+  arch: [qt6-declarative, qt6-multimedia]
   debian: [qml6-module-qtmultimedia]
-  fedora: [qt6-qtdeclarative]
-  nixos: [qt6.qtdeclarative]
+  fedora: [qt6-qtdeclarative,  qt6-qtmultimedia]
+  nixos: [qt6.qtdeclarative, qt6.qtmultimedia]
   rhel:
-    '*': [qt6-qtdeclarative]
+    '*': [qt6-qtdeclarative, qt6-multimedia]
     '8': null
   ubuntu:
     '*': [qml6-module-qtmultimedia]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8834,7 +8834,7 @@ qml6-module-qtcore:
 qml6-module-qtmultimedia:
   arch: [qt6-declarative, qt6-multimedia]
   debian: [qml6-module-qtmultimedia]
-  fedora: [qt6-qtdeclarative,  qt6-qtmultimedia]
+  fedora: [qt6-qtdeclarative, qt6-qtmultimedia]
   nixos: [qt6.qtdeclarative, qt6.qtmultimedia]
   rhel:
     '*': [qt6-qtdeclarative, qt6-multimedia]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8837,7 +8837,7 @@ qml6-module-qtmultimedia:
   fedora: [qt6-qtdeclarative, qt6-qtmultimedia]
   nixos: [qt6.qtdeclarative, qt6.qtmultimedia]
   rhel:
-    '*': [qt6-qtdeclarative, qt6-multimedia]
+    '*': [qt6-qtdeclarative, qt6-qtmultimedia]
     '8': null
   ubuntu:
     '*': [qml6-module-qtmultimedia]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

qml6-module-qtmultimedia

## Purpose of using this:

Required for multimedia in QML applications. E.g. to display camera streams.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/qml6-module-qtmultimedia
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/qml6-module-qtmultimedia
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtdeclarative/qt6-qtdeclarative/
  - https://packages.fedoraproject.org/pkgs/qt6-qtmultimedia/qt6-qtmultimedia/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt6-declarative/
  - https://archlinux.org/packages/extra/x86_64/qt6-multimedia/
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Can't find it in the search anymore, but multiple web sources refer to it, and it's already added for some of the other modules. It can still be removed if not wanted.
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/qt6-qtdeclarative-6.6.2-1.el9.x86_64.rpm.html
  - https://rhel.pkgs.org/9/epel-x86_64/qt6-qtmultimedia-6.6.2-1.el9.x86_64.rpm.html
 
