### PR TITLE
rosidl: 3.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9928,7 +9928,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 3.1.7-1
+      version: 3.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `3.1.8-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.7-1`

## rosidl_adapter

- No changes

## rosidl_cli

```
* fix setuptools deprecations (#877 <https://github.com/ros2/rosidl/issues/877>) (#897 <https://github.com/ros2/rosidl/issues/897>)
* Contributors: mergify[bot]
```

## rosidl_cmake

```
* Add rosidl_auto_generate_inetrfaces function (#918 <https://github.com/ros2/rosidl/issues/918>) (#922 <https://github.com/ros2/rosidl/issues/922>)
* Contributors: mergify[bot]
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>) (#901 <https://github.com/ros2/rosidl/issues/901>)
* Contributors: mergify[bot]
```

## rosidl_parser

- No changes

## rosidl_runtime_c

```
* Fix copy/paste errors in type support docs (backport #906 <https://github.com/ros2/rosidl/issues/906>) (#909 <https://github.com/ros2/rosidl/issues/909>)
* Contributors: mergify[bot]
```

## rosidl_runtime_cpp

```
* Add missing cstdint include (#864 <https://github.com/ros2/rosidl/issues/864>) (#901 <https://github.com/ros2/rosidl/issues/901>)
* Contributors: mergify[bot]
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
