### PR TITLE
Update release repositories for tiago-pro related repositories

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4743,7 +4743,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/launch_pal-release.git
+      url: https://github.com/ros2-gbp/launch_pal-release.git
       version: 0.19.0-1
     source:
       type: git
@@ -7103,7 +7103,7 @@ repositories:
       - pal_pro_gripper_wrapper
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_pro_gripper-release.git
+      url: https://github.com/ros2-gbp/pal_pro_gripper-release.git
       version: 1.8.0-1
     source:
       type: git
@@ -7142,7 +7142,7 @@ repositories:
       - pal_sea_arm_description
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_sea_arm-release.git
+      url: https://github.com/ros2-gbp/pal_sea_arm-release.git
       version: 1.21.0-1
     source:
       type: git
@@ -7157,7 +7157,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_sea_arm_moveit_config-release.git
+      url: https://github.com/ros2-gbp/pal_sea_arm_moveit_config-release.git
       version: 1.0.5-1
     source:
       type: git
@@ -7175,7 +7175,7 @@ repositories:
       - pal_sea_arm_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_sea_arm_simulation-release.git
+      url: https://github.com/ros2-gbp/pal_sea_arm_simulation-release.git
       version: 1.0.4-1
     source:
       type: git
@@ -7208,7 +7208,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_urdf_utils-release.git
+      url: https://github.com/ros2-gbp/pal_urdf_utils-release.git
       version: 2.3.3-1
     source:
       type: git
@@ -11724,7 +11724,7 @@ repositories:
       - tiago_pro_head_robot
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_pro_head_robot-release.git
+      url: https://github.com/ros2-gbp/tiago_pro_head_robot-release.git
       version: 1.7.0-1
     source:
       type: git
@@ -11742,7 +11742,7 @@ repositories:
       - tiago_pro_head_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_pro_head_simulation-release.git
+      url: https://github.com/ros2-gbp/tiago_pro_head_simulation-release.git
       version: 1.0.2-1
     source:
       type: git
@@ -11757,7 +11757,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_pro_moveit_config-release.git
+      url: https://github.com/ros2-gbp/tiago_pro_moveit_config-release.git
       version: 1.3.2-1
     source:
       type: git
@@ -11777,7 +11777,7 @@ repositories:
       - tiago_pro_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_pro_navigation-release.git
+      url: https://github.com/ros2-gbp/tiago_pro_navigation-release.git
       version: 2.13.3-1
     source:
       type: git
@@ -11797,7 +11797,7 @@ repositories:
       - tiago_pro_robot
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_pro_robot-release.git
+      url: https://github.com/ros2-gbp/tiago_pro_robot-release.git
       version: 1.32.1-1
     source:
       type: git
@@ -11815,7 +11815,7 @@ repositories:
       - tiago_pro_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_pro_simulation-release.git
+      url: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
       version: 1.12.2-1
     source:
       type: git


### PR DESCRIPTION
This PR updates the release repositories for TIAGo Pro related repositories, which are now hosted under the `ros2-gbp` GitHub organization.

Added on https://github.com/ros2-gbp/ros2-gbp-github-org/issues/896.