### PR TITLE
olive-interfaces: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6721,6 +6721,23 @@ repositories:
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
       version: humble-devel
     status: maintained
+  olive-interfaces:
+    doc:
+      type: git
+      url: https://github.com/olive-robotics/olive-ros2-interfaces.git
+      version: humble
+    release:
+      packages:
+      - olive_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/olive-robotics/olive-ros2-interfaces-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/olive-robotics/olive-ros2-interfaces.git
+      version: humble
+    status: developed
   omni_base_navigation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `olive-interfaces` to `0.1.0-1`:

- upstream repository: https://github.com/olive-robotics/olive-ros2-interfaces.git
- release repository: https://github.com/olive-robotics/olive-ros2-interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
