### PR TITLE
ardrone_ros: 2.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -511,6 +511,18 @@ repositories:
       url: https://github.com/ycheng517/ar4_ros_driver.git
       version: main
   ardrone_ros:
+    doc:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    release:
+      packages:
+      - ardrone_sdk
+      - ardrone_sumo
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ardrone_ros-release.git
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/vtalpaert/ardrone-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_ros` to `2.0.3-1`:

- upstream repository: https://github.com/vtalpaert/ardrone-ros2.git
- release repository: https://github.com/ros2-gbp/ardrone_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ardrone_sdk

```
* fix format-security warning since ROS build farm triggers a format-security error
* Contributors: Victor Talpaert
```

## ardrone_sumo

- No changes
