### PR TITLE
ros2_control: 5.10.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7251,7 +7251,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.9.0-1
+      version: 5.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.10.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.9.0-1`

## controller_interface

```
* Fix the blocking calls of lifecycle_state in the real-time loop (backport #2884 <https://github.com/ros-controls/ros2_control/issues/2884>) (#2891 <https://github.com/ros-controls/ros2_control/issues/2891>)
* Fix platform-dependent warning in controller_interface_base.cpp using fmt::format (#2880 <https://github.com/ros-controls/ros2_control/issues/2880>) (#2881 <https://github.com/ros-controls/ros2_control/issues/2881>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Fix the blocking calls of lifecycle_state in the real-time loop (backport #2884 <https://github.com/ros-controls/ros2_control/issues/2884>) (#2891 <https://github.com/ros-controls/ros2_control/issues/2891>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [Handle] Add support to more data types (#2879 <https://github.com/ros-controls/ros2_control/issues/2879>) (#2897 <https://github.com/ros-controls/ros2_control/issues/2897>)
* Fix the blocking calls of lifecycle_state in the real-time loop (backport #2884 <https://github.com/ros-controls/ros2_control/issues/2884>) (#2891 <https://github.com/ros-controls/ros2_control/issues/2891>)
* Fix rst syntax (#2892 <https://github.com/ros-controls/ros2_control/issues/2892>) (#2894 <https://github.com/ros-controls/ros2_control/issues/2894>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix the blocking calls of lifecycle_state in the real-time loop (backport #2884 <https://github.com/ros-controls/ros2_control/issues/2884>) (#2891 <https://github.com/ros-controls/ros2_control/issues/2891>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
