### PR TITLE
ardrone_ros: 2.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -626,6 +626,18 @@ repositories:
       version: master
     status: developed
   ardrone_ros:
+    doc:
+      type: git
+      url: https://github.com/vtalpaert/ardrone-ros2.git
+      version: main
+    release:
+      packages:
+      - ardrone_sdk
+      - ardrone_sumo
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ardrone_ros-release.git
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/vtalpaert/ardrone-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ardrone_ros` to `2.0.3-1`:

- upstream repository: https://github.com/vtalpaert/ardrone-ros2.git
- release repository: https://github.com/ros2-gbp/ardrone_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ardrone_sdk

```
* fix format-security warning since ROS build farm triggers a format-security error
* Contributors: Victor Talpaert
```

## ardrone_sumo

- No changes
