### PR TITLE
Add python3-huggingface-hub

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6833,6 +6833,9 @@ python3-httpx:
     focal:
       pip:
         packages: [httpx]
+python3-huggingface-hub-pip:
+  '*':
+    pip: [huggingface_hub]
 python3-hydra-core-pip:
   '*':
     pip: [hydra-core]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`huggingface_hub`

## Package Upstream Source:

[PyPI - huggingface-hub](https://pypi.org/project/huggingface-hub/)

## Purpose of using this:

The huggingface_hub library allows you to interact with the [Hugging Face Hub](https://huggingface.co/), a platform democratizing open-source Machine Learning for creators and collaborators. Discover pre-trained models and datasets for your projects or play with the thousands of machine learning apps hosted on the Hub. You can also create and share your own models, datasets and demos with the community. The huggingface_hub library provides a simple way to do all these things with Python.

I saw that the `transformers` package is available via rosdep but not the hub so it will be nice to have it as it allows to save custom torch/jax models that are used a lot in robotics nowadays.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF Available areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - Its from PyPi
- Ubuntu: https://packages.ubuntu.com/
  - Its from PyPi
- Fedora: https://packages.fedoraproject.org/
  - Int available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available