### PR TITLE
Add libxcursor-devel for RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7327,6 +7327,7 @@ libxcursor-dev:
   fedora: [libXcursor-devel]
   nixos: [xorg.libXcursor]
   openembedded: [libxcursor@openembedded-core]
+  rhel: [libXcursor-devel]
   ubuntu: [libxcursor-dev]
 libxenomai-dev:
   debian:


### PR DESCRIPTION
Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/libXcursor-devel

I need this to release mujoco_vendor package
