### PR TITLE
event_camera_tools: 3.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2686,7 +2686,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_tools-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_tools` to `3.1.1-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_tools.git
- release repository: https://github.com/ros2-gbp/event_camera_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.0-1`

## event_camera_tools

```
* Merge branch 'master' into release
* added opencv dependency to package file
* Contributors: Bernd Pfrommer
```
