### PR TITLE
fibar_lib: 1.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2644,7 +2644,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/fibar_lib-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/fibar_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fibar_lib` to `1.0.2-1`:

- upstream repository: https://github.com/ros-event-camera/fibar_lib.git
- release repository: https://github.com/ros2-gbp/fibar_lib-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## fibar_lib

```
* added buildtool_depend on cmake
* Contributors: Bernd Pfrommer
```
