### PR TITLE
fibar_lib: 1.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2114,7 +2114,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fibar_lib-release.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/fibar_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fibar_lib` to `1.0.2-1`:

- upstream repository: https://github.com/ros-event-camera/fibar_lib.git
- release repository: https://github.com/ros2-gbp/fibar_lib-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## fibar_lib

```
* added buildtool_depend on cmake
* Contributors: Bernd Pfrommer
```
