### PR TITLE
ros2_control: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7148,7 +7148,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.1.0-1
+      version: 6.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.0-1`

## controller_interface

```
* Fix the blocking calls of lifecycle_state in the real-time loop (#2884 <https://github.com/ros-controls/ros2_control/issues/2884>)
* Fix platform-dependent warning in controller_interface_base.cpp using fmt::format (#2880 <https://github.com/ros-controls/ros2_control/issues/2880>)
* Contributors: Dhruv Patel, Sai Kishor Kothakota
```

## controller_manager

```
* Fix the blocking calls of lifecycle_state in the real-time loop (#2884 <https://github.com/ros-controls/ros2_control/issues/2884>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* [Handle] Add support to more data types (#2879 <https://github.com/ros-controls/ros2_control/issues/2879>)
* Fix rst syntax (#2892 <https://github.com/ros-controls/ros2_control/issues/2892>)
* Fix the blocking calls of lifecycle_state in the real-time loop (#2884 <https://github.com/ros-controls/ros2_control/issues/2884>)
* remove unused async components header (#2885 <https://github.com/ros-controls/ros2_control/issues/2885>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Fix the blocking calls of lifecycle_state in the real-time loop (#2884 <https://github.com/ros-controls/ros2_control/issues/2884>)
* Contributors: Sai Kishor Kothakota
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
