### PR TITLE
ros2cli_common_extensions: 0.5.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7383,7 +7383,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.5.2-1`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.1-1`

## ros2cli_common_extensions

```
* Add dependency on ros2plugin in package.xml (#13 <https://github.com/ros2/ros2cli_common_extensions/issues/13>)
* Contributors: Maurice Alexander Purnawan
```
