### PR TITLE
ros2cli_common_extensions: 0.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7517,7 +7517,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.4.0-2
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.4.1-1`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-2`

## ros2cli_common_extensions

```
* Add dependency on ros2plugin in package.xml (#13 <https://github.com/ros2/ros2cli_common_extensions/issues/13>) (#14 <https://github.com/ros2/ros2cli_common_extensions/issues/14>)
* Update CMakeLists.txt (#11 <https://github.com/ros2/ros2cli_common_extensions/issues/11>) (#12 <https://github.com/ros2/ros2cli_common_extensions/issues/12>)
* Contributors: mergify[bot]
```
