### PR TITLE
ros2cli_common_extensions: 0.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9613,7 +9613,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
-      version: 0.1.1-4
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli_common_extensions` to `0.1.2-1`:

- upstream repository: https://github.com/ros2/ros2cli_common_extensions.git
- release repository: https://github.com/ros2-gbp/ros2cli_common_extensions-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.1-4`

## ros2cli_common_extensions

```
* Add dependency on ros2plugin in package.xml (#13 <https://github.com/ros2/ros2cli_common_extensions/issues/13>) (#16 <https://github.com/ros2/ros2cli_common_extensions/issues/16>)
  (cherry picked from commit 213e52a9e28de35f9879e48f75fe556d362e74ef)
  Co-authored-by: Maurice Alexander Purnawan <mailto:mauricepurnawan@gmail.com>
* Contributors: mergify[bot]
```
