### PR TITLE
ros2_eventdispatch: 0.2.25-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8350,6 +8350,19 @@ repositories:
       version: jazzy
     status: developed
   ros2_eventdispatch:
+    doc:
+      type: git
+      url: https://github.com/cyan-at/ros2_eventdispatch.git
+      version: 0.2.25
+    release:
+      packages:
+      - eventdispatch_python
+      - eventdispatch_ros2
+      - eventdispatch_ros2_interfaces
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_eventdispatch-release.git
+      version: 0.2.25-2
     source:
       type: git
       url: https://github.com/cyan-at/ros2_eventdispatch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_eventdispatch` to `0.2.25-2`:

- upstream repository: https://github.com/cyan-at/ros2_eventdispatch.git
- release repository: https://github.com/ros2-gbp/ros2_eventdispatch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
