### PR TITLE
ros2ai: 0.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7347,6 +7347,11 @@ repositories:
       version: rolling
     status: developed
   ros2ai:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2ai-release.git
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/fujitatomoya/ros2ai.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2ai` to `0.1.3-1`:

- upstream repository: https://github.com/fujitatomoya/ros2ai.git
- release repository: https://github.com/ros2-gbp/ros2ai-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ros2ai

```
* remove Ollama dependency. (#78 <https://github.com/fujitatomoya/ros2ai/issues/78>)
* Correct the name of a dependent package (#77 <https://github.com/fujitatomoya/ros2ai/issues/77>)
```
