### PR TITLE
cloudini: 0.11.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/facontidavide/cloudini-release.git
-      version: 0.10.1-1
+      version: 0.11.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `0.11.1-2`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.10.1-1`

## cloudini_lib

```
* fix ROS compilation
* Contributors: Davide Faconti
```

## cloudini_ros

```
* try fixing build in ROS
* Contributors: Davide Faconti
```
