### PR TITLE
mavros: 2.13.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5318,12 +5318,13 @@ repositories:
       packages:
       - libmavconn
       - mavros
+      - mavros_examples
       - mavros_extras
       - mavros_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mavros-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       type: git
       url: https://github.com/mavlink/mavros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mavros` to `2.13.0-1`:

- upstream repository: https://github.com/mavlink/mavros.git
- release repository: https://github.com/ros2-gbp/mavros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.12.0-1`

## libmavconn

- No changes

## mavros

```
* Uncrustify
* Fix overflow in uas_timesync.cpp synchronise_stamp
* Add test for synchronise_stamp overflow
* examples: fix doc strings, add types
* update packages to format 3
* docs: update installation guide
* regenerate all with cogall.sh, apply ament_uncrustify
* Contributors: Paul Erik Frivold, Vladimir Ermakov
```

## mavros_examples

```
* examples: disable copyright check
* examples: add copyright headers
* examples: fix package.xml lint
* examples: fix doc strings, add types
* examples: isort + ruff format
* examples: add sample setup.py
* update packages to format 3
* modifying package.xml file.
* setting mavros_examples for draft pr
* adding mavros_examples
* Contributors: Haroon Rasheed, Vladimir Ermakov, haroon
```

## mavros_extras

```
* extras landing_target: fix #2080 <https://github.com/mavlink/mavros/issues/2080> fov vector init
* update packages to format 3
* added brief documentation
* whitespace lint check
* char count p line change
* added support for SIM_STATE message
* Fixing TF timestamps to use system time in landing_target plugin
* extras: fix cpplint by dropping unneded comment
* regenerate all with cogall.sh, apply ament_uncrustify
* fixes #2070 <https://github.com/mavlink/mavros/issues/2070>: adding support for OBSTACLE_DISTANCE_3D message (#2071 <https://github.com/mavlink/mavros/issues/2071>)
  * feat: add Obstacle Distance 3D plugin
  - Introduced a new plugin obstacle_distance_3d to handle 3D obstacle distance data.
  - Subscribes to a custom ROS 2 message Obstacle3D and sends corresponding MAVLink messages.
  - Updated CMakeLists.txt and package.xml to include dependencies for the new plugin.
  * add native message support
  * clean up changes
  * removed redundant time param in the message, and changed default logging to debug
  ---------
  Co-authored-by: zekesarosi <mailto:zsarosi@flyseneca.com>
* Contributors: Gus Meyer, Vladimir Ermakov, Zeke Sarosi, zekesarosi
```

## mavros_msgs

```
* update packages to format 3
* regenerate all with cogall.sh, apply ament_uncrustify
* fixes #2070 <https://github.com/mavlink/mavros/issues/2070>: adding support for OBSTACLE_DISTANCE_3D message (#2071 <https://github.com/mavlink/mavros/issues/2071>)
  * feat: add Obstacle Distance 3D plugin
  - Introduced a new plugin obstacle_distance_3d to handle 3D obstacle distance data.
  - Subscribes to a custom ROS 2 message Obstacle3D and sends corresponding MAVLink messages.
  - Updated CMakeLists.txt and package.xml to include dependencies for the new plugin.
  * add native message support
  * clean up changes
  * removed redundant time param in the message, and changed default logging to debug
  ---------
  Co-authored-by: zekesarosi <mailto:zsarosi@flyseneca.com>
* Contributors: Vladimir Ermakov, Zeke Sarosi
```
