### PR TITLE
mujoco_vendor: 0.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6045,6 +6045,11 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git
       version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mujoco_vendor-release.git
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.0.5-1`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## mujoco_vendor

```
* Merge branch 'sma/add_install_simulate_project' into 'master'
  Add install rule for simulate folder
  See merge request third-party/mujoco_vendor!4
* Add install rule for simulate folder
* Contributors: Sai Kishor Kothakota, sergiacosta
```
