### PR TITLE
qml6_ros2_plugin: 3.25.121-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6031,7 +6031,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 2.25.120-1
+      version: 3.25.121-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `3.25.121-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.25.120-1`

## qml6_ros2_plugin

```
* Added encoding information to ImageTransportSubscription and fixed conversion from float to Y16.
  In accordance with depth image standards in ROS 16UC1 is interpreted as mm whereas float is in m. The conversion now respects that.
* Contributors: Stefan Fabian
```
