### PR TITLE
aruco_opencv: 6.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -509,7 +509,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.1.0-1
+      version: 6.1.1-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `6.1.1-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.0-1`

## aruco_opencv

```
* fix: Resolve redeclaration of IDs in make_grid_board function (#62 <https://github.com/fictionlab/ros_aruco_opencv/issues/62>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
