### PR TITLE
aruco_opencv: 2.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -673,7 +673,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `2.4.1-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## aruco_opencv

```
* fix: Resolve redeclaration of IDs in make_grid_board function (#62 <https://github.com/fictionlab/ros_aruco_opencv/issues/62>) (#63 <https://github.com/fictionlab/ros_aruco_opencv/issues/63>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
