### PR TITLE
Add autoapms to rosdistro

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -647,6 +647,16 @@ repositories:
       url: https://github.com/ma-shangao/at_sonde_ros_driver.git
       version: main
     status: developed
+  autoapms:
+    doc:
+      type: git
+      url: https://github.com/AutoAPMS/auto-apms.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AutoAPMS/auto-apms.git
+      version: master
+    status: developed
   automatika_embodied_agents:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -583,6 +583,16 @@ repositories:
       url: https://github.com/hatchbed/asyncapi_gencpp.git
       version: main
     status: developed
+  autoapms:
+    doc:
+      type: git
+      url: https://github.com/AutoAPMS/auto-apms.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AutoAPMS/auto-apms.git
+      version: master
+    status: developed
   automatika_embodied_agents:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -630,6 +630,16 @@ repositories:
       url: https://github.com/ma-shangao/at_sonde_ros_driver.git
       version: main
     status: developed
+  autoapms:
+    doc:
+      type: git
+      url: https://github.com/AutoAPMS/auto-apms.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/AutoAPMS/auto-apms.git
+      version: master
+    status: developed
   automatika_embodied_agents:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

**autoapms**

AutoAPMS is a collection of packages for creating robot behaviors using behavior trees in any ROS 2 workspace.

# The source is here:

https://github.com/AutoAPMS/auto-apms.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
