### PR TITLE
ros2_eventdispatch: 0.2.26-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8425,7 +8425,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_eventdispatch-release.git
-      version: 0.2.25-4
+      version: 0.2.26-1
     source:
       type: git
       url: https://github.com/cyan-at/ros2_eventdispatch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_eventdispatch` to `0.2.26-1`:

- upstream repository: https://github.com/cyan-at/ros2_eventdispatch.git
- release repository: https://github.com/ros2-gbp/ros2_eventdispatch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.25-4`

## eventdispatch_python

```
* ROSEvents msg / srv
* Contributors: Charlie Yan
```

## eventdispatch_ros2

```
* ROSEvents msg / srv
* Contributors: Charlie Yan
```

## eventdispatch_ros2_interfaces

```
* ROSEvents msg / srv
* Contributors: Charlie Yan
```
