### PR TITLE
rqt_console: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8116,7 +8116,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.4.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.1-1`

## rqt_console

```
* fixed copyright test (#57 <https://github.com/ros-visualization/rqt_console/issues/57>)
* added copyright header
* fixed flake8 (#56 <https://github.com/ros-visualization/rqt_console/issues/56>)
* fixed flake8
* remove residual imports in colored output test-file (#55 <https://github.com/ros-visualization/rqt_console/issues/55>)
* remove residual imports
* basic support for colors and bold/bright using ANSI escape codes (#54 <https://github.com/ros-visualization/rqt_console/issues/54>)
* replace colorama dependency with manual ansi codes
* add checkbox in the settings
* support more color codes
* basic support for colors and bold/bright
* Contributors: Arne Hitzmann, Peter, peter
```
