### PR TITLE
rqt_console: 2.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8229,7 +8229,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.3.1-2
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.3.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.1-2`

## rqt_console

```
* fix setuptools deprecations (backport #50 <https://github.com/ros-visualization/rqt_console/issues/50>) (#51 <https://github.com/ros-visualization/rqt_console/issues/51>)
* Contributors: mergify[bot]
```
