### PR TITLE
rcutils: 7.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6473,7 +6473,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.0.4-1
+      version: 7.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.0.5-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.0.4-1`

## rcutils

```
* Check SIZE_MAX for array initialization. (#527 <https://github.com/ros2/rcutils/issues/527>)
* Do not export dl in rcutils_LIBRARIES (#522 <https://github.com/ros2/rcutils/issues/522>)
* Contributors: Shane Loretz, Tomoya Fujita
```
