### PR TITLE
rqt_console: 2.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9321,7 +9321,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.2.1-3
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.2.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-3`

## rqt_console

```
* fix setuptools deprecations (backport #50 <https://github.com/ros-visualization/rqt_console/issues/50>) (#52 <https://github.com/ros-visualization/rqt_console/issues/52>)
* Remove CODEOWNERS and mirror-rolling-to-main workflow (backport #46 <https://github.com/ros-visualization/rqt_console/issues/46>) (#47 <https://github.com/ros-visualization/rqt_console/issues/47>)
* Contributors: mergify[bot]
```
