### PR TITLE
Fedora 41 is EOL, long live Fedora 43

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -66,8 +66,8 @@ supported_versions:
   debian:
   - bookworm
   fedora:
-  - '41'
   - '42'
+  - '43'
   opensuse:
   - '15.2'
   openembedded:
@@ -100,9 +100,9 @@ supported_arches:
 
 name_replacements:
   fedora:
-    '41':
-      '%{__isa_name}': 'x86'
     '42':
+      '%{__isa_name}': 'x86'
+    '43':
       '%{__isa_name}': 'x86'
   openembedded:
     master:


### PR DESCRIPTION
EOL announcement: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/UX72XERVTHJWFOVD7X4LUZ6EJDTEO5TJ/

With Fedora 43, we're going from 61 incorrect rules to 77. Here are the new rules which are no longer correct:
- Package bandit for rosdep key bandit
- Package dlib-devel for rosdep key libdlib-dev
- Package libdxflib-devel for rosdep key libdxflib-dev
- Package mesa-libOSMesa-devel for rosdep key libosmesa6-dev
- Package nbtscan for rosdep key nbtscan
- Package python-GeographicLib for rosdep key python-geographiclib
- Package python-docx for rosdep key python-docx
- Package python-nose for rosdep key python-nose
- Package python-statsd for rosdep key python-statsd
- Package python3-GeographicLib for rosdep key python3-geographiclib
- Package python3-nose for rosdep key python3-nose
- Package python3-retrying for rosdep key python3-retrying
- Package python3-uvloop for rosdep key python3-uvloop
- Package python3-whichcraft for rosdep key python3-whichcraft
- Package python3-yappi for rosdep key python3-yappi
- Package tweeny-devel for rosdep key libtweeny-dev

(as a frame of reference, we currently have 354 incorrect Ubuntu Noble rules)