### PR TITLE
mola_lidar_odometry: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5680,7 +5680,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 1.2.2-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `1.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.2-1`

## mola_lidar_odometry

```
* Add CI and documentation badges to README
  Added badges for CI build, clang-format, documentation, and code coverage.
* Add option 'use_imu_orientation' to disable using IMU orientation for initialization
* docs: add table clarifying localmap types
* Make it compatible with observations w/o cov
* Discard GPS readings with invalid cov matrix
* Add warning if sensor stamps go backwards in time
* Update usage instructions for mola_lo_apps.rst
  Added usage instructions for LIO with Ouster in mola_lo_apps.rst.
* Contributors: Jose Luis Blanco-Claraco
```
