### PR TITLE
mola: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5054,7 +5054,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Import all pcd fields from ros2 messages using CGenericPointsMap
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

```
* Fix build against mrpt>=2.15.3
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

- No changes

## mola_input_lidar_bin_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* Import all pcd fields from ros2 messages using CGenericPointsMap
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

- No changes

## mola_kernel

- No changes

## mola_launcher

- No changes

## mola_metric_maps

```
* KF metric map: change heuristic to select nearby KFs for NN matching taking into account the orientation
* KeyFramePointCloudMap: new rendering option to show XYZ axes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* Fix: missing uint fields stats in PCD preview GUI in mola_viz
* mola-viz: fix NaNs in range of each point channel preview window
* Viz: Fix handling multi-line messages in the UI terminal
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
