### PR TITLE
ros2_kortex: 0.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8455,6 +8455,7 @@ repositories:
       packages:
       - kinova_gen3_6dof_robotiq_2f_85_moveit_config
       - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_lite_moveit_config
       - kortex_api
       - kortex_bringup
       - kortex_description
@@ -8462,6 +8463,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
+      version: 0.2.4-1
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.4-1`:

- upstream repository: https://github.com/Kinovarobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* fixed gen3_lite moveit issues (#318 <https://github.com/Kinovarobotics/ros2_kortex/issues/318>)
* Remove Gazebo Classic support and Update for MoveIt Jazzy/Rolling (#228 <https://github.com/Kinovarobotics/ros2_kortex/issues/228>)
* Contributors: Abed Al Rahman Al Mrad
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* fixed gen3_lite moveit issues (#318 <https://github.com/Kinovarobotics/ros2_kortex/issues/318>)
* Remove Gazebo Classic support and Update for MoveIt Jazzy/Rolling (#228 <https://github.com/Kinovarobotics/ros2_kortex/issues/228>)
* Contributors: Abed Al Rahman Al Mrad
```

## kinova_gen3_lite_moveit_config

```
* fixed gen3_lite moveit issues (#318 <https://github.com/Kinovarobotics/ros2_kortex/issues/318>)
* Modifications to fix moveit issues while controlling Gen3_lite (#316 <https://github.com/Kinovarobotics/ros2_kortex/issues/316>)
* Remove Gazebo Classic support and Update for MoveIt Jazzy/Rolling (#228 <https://github.com/Kinovarobotics/ros2_kortex/issues/228>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_api

```
* modified the kortex trademark name (#305 <https://github.com/Kinovarobotics/ros2_kortex/issues/305>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_bringup

```
* Remove Gazebo Classic support and Update for MoveIt Jazzy/Rolling (#228 <https://github.com/Kinovarobotics/ros2_kortex/issues/228>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_description

```
* Update to parallel_gripper_controller (#324 <https://github.com/Kinovarobotics/ros2_kortex/issues/324>)
* fixed bringing up the Gen3 wo gripper issue (#321 <https://github.com/Kinovarobotics/ros2_kortex/issues/321>)
* fixed the gen3_lite fake_hardware issue (#319 <https://github.com/Kinovarobotics/ros2_kortex/issues/319>)
* fixed gen3_lite moveit issues (#318 <https://github.com/Kinovarobotics/ros2_kortex/issues/318>)
* Modifications to fix moveit issues while controlling Gen3_lite (#316 <https://github.com/Kinovarobotics/ros2_kortex/issues/316>)
* modified the kortex trademark name (#305 <https://github.com/Kinovarobotics/ros2_kortex/issues/305>)
* Fixed pi issue #295 (#296 <https://github.com/Kinovarobotics/ros2_kortex/issues/296>)
* Replaced file:// with package:// + Added temporary repositories as dependencies (#275 <https://github.com/Kinovarobotics/ros2_kortex/issues/275>)
* Remove Gazebo Classic support and Update for MoveIt Jazzy/Rolling (#228 <https://github.com/Kinovarobotics/ros2_kortex/issues/228>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_driver

```
* fix deprecated hardware_interface API (#327 <https://github.com/Kinovarobotics/ros2_kortex/issues/327>)
* Fixed pi issue #295 (#296 <https://github.com/Kinovarobotics/ros2_kortex/issues/296>)
* modified the kortex trademark name (#305 <https://github.com/Kinovarobotics/ros2_kortex/issues/305>)
* Contributors: Abed Al Rahman Al Mrad
```
