### PR TITLE
turtlebot3: 2.3.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9693,7 +9693,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot3-release.git
-      version: 2.3.4-1
+      version: 2.3.6-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/turtlebot3.git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot3` to `2.3.6-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/turtlebot3.git
- release repository: https://github.com/ros2-gbp/turtlebot3-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.4-1`

## turtlebot3

```
* Fixed an issue where the reset trigger did not work correctly
* Contributors: Hyungyu Kim
```

## turtlebot3_bringup

```
* None
```

## turtlebot3_cartographer

```
* None
```

## turtlebot3_description

```
* None
```

## turtlebot3_example

```
* None
```

## turtlebot3_navigation2

```
* None
```

## turtlebot3_node

```
* Fixed an issue where the reset trigger did not work correctly
* Contributors: Hyungyu Kim
```

## turtlebot3_teleop

```
* None
```
