### PR TITLE
control_msgs: 5.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1623,7 +1623,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.5.0-1
+      version: 5.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.6.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.5.0-1`

## control_msgs

```
* Add Keys and Float64Values messages (#273 <https://github.com/ros-controls/control_msgs/issues/273>) (#281 <https://github.com/ros-controls/control_msgs/issues/281>)
* Let's not lint generated code please (#238 <https://github.com/ros-controls/control_msgs/issues/238>) (#239 <https://github.com/ros-controls/control_msgs/issues/239>)
* Contributors: mergify[bot]
```
