### PR TITLE
dynamixel_hardware_interface: 1.5.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2330,7 +2330,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
-      version: 1.5.0-1
+      version: 1.5.0-2
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware_interface` to `1.5.0-2`:

- upstream repository: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.0-1`

## dynamixel_hardware_interface

```
* Added comm_id/id concept for virtual_* devices.
* Added unit info system for Unified unit conversion logic.
* Added sequential initialization logic.
* Fixed memory leak of matrix malloc.
* Refactored every type info based unit conversion to unit info based system.
* Contributors: Woojin Wie
```
