### PR TITLE
clearpath_common: 2.8.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1285,7 +1285,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.8.2-2
+      version: 2.8.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.8.3-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.2-2`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

```
* Fix: Generic (#280 <https://github.com/clearpathrobotics/clearpath_common/issues/280>)
  * Check for generic before creating drivetrain parameters
  * Add teleop_joy default parameter file for generic robot
  * Generic teleop values
  * Generic control file without a controller
  * Generic empty robot
  * Update path to cvontrol in empty generic URDF
* Contributors: luis-camero
```

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

```
* Fix: Generic (#280 <https://github.com/clearpathrobotics/clearpath_common/issues/280>)
  * Check for generic before creating drivetrain parameters
  * Add teleop_joy default parameter file for generic robot
  * Generic teleop values
  * Generic control file without a controller
  * Generic empty robot
  * Update path to cvontrol in empty generic URDF
* Contributors: luis-camero
```

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

- No changes

## clearpath_mounts_description

- No changes

## clearpath_platform_description

```
* Add missing Gazebo IMU topic tags for omnidirectional platforms (#286 <https://github.com/clearpathrobotics/clearpath_common/issues/286>)
  * Add missing Gazebo IMU topic tags for omnidirectional platforms
  Fixes missing <topic> tag in IMU sensor definitions for R100, DO100,
  and DO150 platforms. Without this tag, Gazebo publishes IMU data on
  default topic names instead of the namespace-aware topics expected by
  ros_gz_bridge, causing IMU data to not reach ROS 2 in simulation.
  This issue only affected omnidirectional platforms (mecanum wheel
  configurations). Differential drive platforms (J100, W200, DD100, DD150)
  were already fixed in v0.2.10.
  Tested on R100 platform with Gazebo Harmonic and ROS 2 Jazzy.
  IMU data now successfully bridges to /r100_0000/sensors/imu_0/data_raw
  and is consumed by ekf_localization_node for sensor fusion.
  * Fixed indent.
  ---------
  Co-authored-by: Michael Wescott <mailto:Michael.E.Wescott@Spiritaero.com>
* Replaced ignition references with gz (#283 <https://github.com/clearpathrobotics/clearpath_common/issues/283>)
* Fix: Generic (#280 <https://github.com/clearpathrobotics/clearpath_common/issues/280>)
  * Check for generic before creating drivetrain parameters
  * Add teleop_joy default parameter file for generic robot
  * Generic teleop values
  * Generic control file without a controller
  * Generic empty robot
  * Update path to cvontrol in empty generic URDF
* Contributors: Roni Kreinin, Tony Baltovski, luis-camero
```

## clearpath_sensors_description

```
* Fix: Ouster URDF (#281 <https://github.com/clearpathrobotics/clearpath_common/issues/281>)
* Contributors: luis-camero
```
