### PR TITLE
clearpath_config: 2.8.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1300,7 +1300,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.8.1-1
+      version: 2.8.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.8.2-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.1-1`

## clearpath_config

```
* Fix reading arm_id (#204 <https://github.com/clearpathrobotics/clearpath_config/issues/204>)
* 2.8.1
* Changes.
* Fix: Ewellix Parameters (#203 <https://github.com/clearpathrobotics/clearpath_config/issues/203>)
  Add mount parameter and remove redefinition of urdf functions
* 2.8.0
* Changes.
* Add a new platform.wireless section to config (#201 <https://github.com/clearpathrobotics/clearpath_config/issues/201>)
  * Add a new platform.wireless section to contain router, base station, wireless_watcher parameters
  * Fixed linting.
  ---------
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Replace assert with raise + relevant Exception (#200 <https://github.com/clearpathrobotics/clearpath_config/issues/200>)
  * Raise a FileNotFound exception instead of an assertion error if the middleware config path doesn't exist; this makes it easier to catch those exceptions in CI tests. Fix a bug where setting the extra launch to None raises an unintended exception
  * Start replacing all assert CONDITION[, 'error message'] instances with if + raise with more precise exceptions (generally PermissionError, FileNotFoundError, ValueError, or TypeError)
  * Replace more asserts
  * Replace asserts in username. Don't allow underscores; these are not valid in Linux usernames. Verify that the first character is not a digit or hyphen
  * More asserts
  * More asserts
  * More asserts
  * More asserts
  * Fix length check
  * id -> _id
  * .config -> .control
  * UR_TYPE -> UR_TYPES
  * More asserts
  * Finish first pass removing all asserts
  * Missing negative sign
  * Fix wonky indent
  * Fix formatting issues
* Fix: OakD Parameters (#202 <https://github.com/clearpathrobotics/clearpath_config/issues/202>)
  - Use empty strings as defaults
* Raise a FileNotFound exception instead of an assertion error if the middleware config path doesn't exist; this makes it easier to catch those exceptions in CI tests. Fix a bug where setting the extra launch to None raises an unintended exception (#199 <https://github.com/clearpathrobotics/clearpath_config/issues/199>)
* Add system.bash support (#196 <https://github.com/clearpathrobotics/clearpath_config/issues/196>)
  * Add system.bash section to robot.yaml with source and env sub-fields for adding additional bash sources and envars
  * Add new envar to Flir camera sample
* Allow multiple launch files to be listed in platform.extras.launch, add launch arguments field (#197 <https://github.com/clearpathrobotics/clearpath_config/issues/197>)
* Add support for automatic discovery range (#191 <https://github.com/clearpathrobotics/clearpath_config/issues/191>)
  * Add ROS_STATIC_PEERS and ROS_AUTOMATIC_DISCOVERY_RANGE setters to middleware
  * Add middleware samples
* Rename oakd namespace in robot.yaml to luxonis_oakd (#192 <https://github.com/clearpathrobotics/clearpath_config/issues/192>)
* Contributors: Chris Iverach-Brereton, Tony Baltovski, luis-camero
```
