### PR TITLE
ros2_planning_system: 3.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7415,7 +7415,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_planning_system-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/PlanSys2/ros2_planning_system.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_planning_system` to `3.0.2-1`:

- upstream repository: https://github.com/PlanSys2/ros2_planning_system.git
- release repository: https://github.com/ros2-gbp/ros2_planning_system-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.1-1`

## plansys2

```
* Remove nav2_common dependency
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo
```

## plansys2_bringup

```
* Set C++23 as default
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_bt_actions

```
* Set C++23 as default
* Fix cancel handle
* Add tf2_geometry_msgs to plansys2_bt_actions package.xml
* More improvments in BTActionNode
* Fix default  server_timeout
* Fix Groot2 monitor format
* Fix tests
* Added callback group executor
* Return to IDLE when finished
* Add tf2_geometry_msgs to plansys2_bt_actions package.xml.
  tf2_geometry_msgs is required to build plansys2_bt_actions
* Use geometry_msgs::msg::Pose as Pose2D is now in vision_msgs
* Improvements on BTAction
* Fix BTService and BT-JSON
* Update BTServiceNode.hpp
* Added a BT for services
* Added JSON utils
* Revert lifecycle
* Added deprecated constructor
* Merge branch 'PlanSys2:rolling' into fix_predicate_parsing
* Added spin to test
* Added bt_loop_duration to the blackboard
* Remove rate of ActionExecutorClient constructor and set as default parameter
* Added wait_for_service_timeout param and blackboard
* Added server_timeout as parameter and blackboard
* Doc for bt actions
* Added Groot2 monitor
* Minor fix
* Update Readme
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_core

```
* Set C++23 as default
* Add function to print predicates for debugging
* Allow rolling to build against ROS Jazzy
* core: tests use std::fs, so include it
* improve documentation State and DerivedResolutionGraph
* rm old ActionVariant from ActionExecutor and adjust code
* 🎨 fix code style
* add State class
* add DerivedResolutionGraph
* add NodeVariant class
* add Action class
* add Derived class and hashes
* add == operator to Instance and Predicate
* Improve doxygen documentation
* Improve doc for core
* Doc for core
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, gavanderhoorn
```

## plansys2_domain_expert

```
* Set C++23 as default
* Plansys2 domain expert
* fix code style
* change variable name in getDerivedFromDomain
* include DerivedResolutionGraph.hpp in DomainExpert.hpp
* merge plansys2_domain_expert pkg from rezenders/new_evaluationwq
* Improve doxygen documentation
* Improve doc for domain and problem
* Improve doc for Domain
* Doc for domain expert
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_executor

```
* Fix orphan thread bug in ExecutorNode
* Set C++23 as default
* Use std::string for BT API
* Remove Eigen dependency export
* adjust simple_btbuilder_tests.cpp
* include Action.hpp in BTBuilder.hpp
* More improvments in BTActionNode
* Fix Groot2 monitor format
* Added BTUtils and JSONUtils to ComputeBT and ExecutorNode
* Added blackboard keys for compatibility with other nodes
* Fix formats
* rm old ActionVariant from ActionExecutor and adjust code
* add plansys2::SequentialBTBuilder plugin
* Improvements to pddl parser utils
* Improvements on BTAction
* add plansys2::SequentialBTBuilder plugin
* Added deprecated constructor
* Minor fixes
* Added explicit to constructor
* Remove rate of ActionExecutorClient constructor and set as default parameter
* Improve doxygen documentation
* Added Groot2 monitor
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_lifecycle_manager

```
* Set C++23 as default
* Improve doxygen documentation
* Doc for lifecycle
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_msgs

```
* Set C++23 as default
* add State.msg
* Contributors: Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_pddl_parser

```
* Set C++23 as default
* Improvements to parser
* add more tests to parser
* fix Ground PDDLPrint for constant
* fix node name parsing in Expression.hpp
* Improvements to pddl parser utils
* add new helper functions
* add check_var_params to checkParamEquality
* small improvements to getPredicates and getFunctions
* improvments to fromStringPredicate
* fix toString exists when negated
* fix toString when node_type is Parameter
* fix Exists parse
* Fix string predicate parsing to handle cases with no parameters
* more fixes
* added test case for no arg predicates
* fromString works for Parameter
* getNodeType works with parameters
* fix bug in getSubExpr
* add parser::pddl::removeOperatorBeforeParenthesis
* getExpr fix parsing for words with hyphen
* Fix string predicate parsing to handle cases with no parameters
* Fixing bug #329 <https://github.com/PlanSys2/ros2_planning_system/issues/329>
* Contributors: Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, eshan-savla
```

## plansys2_planner

```
* Set C++23 as default
* Improve doxygen documentation
* Doc for planner
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_popf_plan_solver

```
* Set C++23 as default
* Improve doxygen documentation
* Doc for popf plan solver
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_problem_expert

```
* Set C++23 as default
* derived_name.name -> derived_name.predicate.name
* Improvements to pddl parser utils
* fix evaluate_not test
* Improve doxygen documentation
* Added optional dependency
* Improve doc for domain and problem
* Doc for problem expert
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_support_py

```
* Fix logging in python support
* Improve python package
* Added some tests
* Fix format
* Added planner in python
* Convert to fully python package
* Added execute_plan to executor
* Added parser, format and lint
* Update logs and parser
* Implement new classes in python
* Implement DomainExpertClient, ExecutorClient, PlannerClient, PlannerClient and ProblemExpertClient
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_terminal

```
* Fix orphan thread bug in ExecutorNode
* Set C++23 as default
* derived_name.name -> derived_name.predicate.name
* Improvements on BTAction
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende
```

## plansys2_tests

```
* Set C++23 as default
* Improvements on BTAction
* added test case for no arg predicates
* Fix explicit in test
* Contributors: Alberto Tudela, Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, eshan-savla
```

## plansys2_tools

```
* Set C++23 as default
* Allow rolling to build against ROS Jazzy
* tools: conditionally include .hpp (vs .h)
  Headers have been renamed in Rolling & Kilted.
* Contributors: Eshan Savla, Francisco Martín Rico, Gustavo, Gustavo Rezende, gavanderhoorn
```
