### PR TITLE
ros2_kortex: 0.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7295,6 +7295,7 @@ repositories:
       packages:
       - kinova_gen3_6dof_robotiq_2f_85_moveit_config
       - kinova_gen3_7dof_robotiq_2f_85_moveit_config
+      - kinova_gen3_lite_moveit_config
       - kortex_api
       - kortex_bringup
       - kortex_description
@@ -7302,7 +7303,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.2-2
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.5-1`:

- upstream repository: https://github.com/Kinovarobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.2-2`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* No changes for this version
* Contributors: Abed Al Rahman Al Mrad
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* No changes for this version
* Contributors: Abed Al Rahman Al Mrad
```

## kinova_gen3_lite_moveit_config

```
* fixed gen3_lite moveit issues (#318 <https://github.com/Kinovarobotics/ros2_kortex/issues/318>)
* Modifications to fix moveit issues while controlling Gen3_lite (#316 <https://github.com/Kinovarobotics/ros2_kortex/issues/316>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_api

```
* No changes for this version
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_bringup

```
* added parallel gripper controller (#329 <https://github.com/Kinovarobotics/ros2_kortex/issues/329>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_description

```
* added parallel gripper controller (#329 <https://github.com/Kinovarobotics/ros2_kortex/issues/329>)
* fixed bringing up the Gen3 wo gripper issue (#321 <https://github.com/Kinovarobotics/ros2_kortex/issues/321>)
* fixed the gen3_lite fake_hardware issue (#319 <https://github.com/Kinovarobotics/ros2_kortex/issues/319>)
* fixed gen3_lite moveit issues (#318 <https://github.com/Kinovarobotics/ros2_kortex/issues/318>)
* Modifications to fix moveit issues while controlling Gen3_lite (#316 <https://github.com/Kinovarobotics/ros2_kortex/issues/316>)
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_driver

```
* Fix deprecated hardware_interface API (#309 <https://github.com/Kinovarobotics/ros2_kortex/issues/309>)
* Contributors: Abed Al Rahman Al Mrad
```
