### PR TITLE
rcutils: 6.9.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6573,7 +6573,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.8-1
+      version: 6.9.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.9-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.9.8-1`

## rcutils

```
* Check SIZE_MAX for array initialization. (#527 <https://github.com/ros2/rcutils/issues/527>) (#529 <https://github.com/ros2/rcutils/issues/529>)
* Do not export dl in rcutils_LIBRARIES (#522 <https://github.com/ros2/rcutils/issues/522>) (#524 <https://github.com/ros2/rcutils/issues/524>)
* Export -latomic even if BUILD_TESTING is disabled. (backport #516 <https://github.com/ros2/rcutils/issues/516>) (#517 <https://github.com/ros2/rcutils/issues/517>)
* Contributors: mergify[bot]
```
