### PR TITLE
rviz: 15.1.14-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8597,7 +8597,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.13-1
+      version: 15.1.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.14-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.13-1`

## rviz2

```
* Use qt6 as the default dependency from rosdep (#1635 <https://github.com/ros2/rviz/issues/1635>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_common

```
* Fix crash with no tools (#1639 <https://github.com/ros2/rviz/issues/1639>)
* Use qt6 as the default dependency from rosdep (#1635 <https://github.com/ros2/rviz/issues/1635>)
* Pointcloud2 display set QoS to best effort (#1621 <https://github.com/ros2/rviz/issues/1621>)
* Contributors: Alejandro Hernández Cordero, David V. Lu!!
```

## rviz_default_plugins

```
* Add CameraInfo topic property to DepthCloudDisplay (#1643 <https://github.com/ros2/rviz/issues/1643>)
* Use qt6 as the default dependency from rosdep (#1635 <https://github.com/ros2/rviz/issues/1635>)
* Pointcloud2 display set QoS to best effort (#1621 <https://github.com/ros2/rviz/issues/1621>)
* Contributors: Alejandro Hernández Cordero, Alexis Tsogias
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Use qt6 as the default dependency from rosdep (#1635 <https://github.com/ros2/rviz/issues/1635>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

```
* Use qt6 as the default dependency from rosdep (#1635 <https://github.com/ros2/rviz/issues/1635>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

```
* Use qt6 as the default dependency from rosdep (#1635 <https://github.com/ros2/rviz/issues/1635>)
* Contributors: Alejandro Hernández Cordero
```
