### PR TITLE
rcutils: 5.1.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8592,7 +8592,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 5.1.7-1
+      version: 5.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `5.1.8-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.7-1`

## rcutils

```
* Check SIZE_MAX for array initialization. (backport #527 <https://github.com/ros2/rcutils/issues/527>) (#531 <https://github.com/ros2/rcutils/issues/531>)
* Export -latomic even if BUILD_TESTING is disabled. (backport #516 <https://github.com/ros2/rcutils/issues/516>) (#519 <https://github.com/ros2/rcutils/issues/519>)
* Contributors: mergify[bot]
```
