### PR TITLE
rviz: 14.1.19-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9825,7 +9825,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.18-1
+      version: 14.1.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.19-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `14.1.18-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix crash with no tools (#1639 <https://github.com/ros2/rviz/issues/1639>) (#1641 <https://github.com/ros2/rviz/issues/1641>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Add CameraInfo topic property to DepthCloudDisplay (#1643 <https://github.com/ros2/rviz/issues/1643>) (#1645 <https://github.com/ros2/rviz/issues/1645>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
