### PR TITLE
geometry2: 0.41.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2511,7 +2511,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.41.5-1
+      version: 0.41.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.41.6-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.41.5-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* static function to crate quaternions directly from rotation added (#881 <https://github.com/ros2/geometry2/issues/881>) (#882 <https://github.com/ros2/geometry2/issues/882>)
* Move author tags to file brief (#870 <https://github.com/ros2/geometry2/issues/870>) (#875 <https://github.com/ros2/geometry2/issues/875>)
* Contributors: R Kent James, mergify[bot]
```

## tf2_bullet

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Move author tags to file brief (#870 <https://github.com/ros2/geometry2/issues/870>) (#875 <https://github.com/ros2/geometry2/issues/875>)
* Contributors: R Kent James, mergify[bot]
```

## tf2_eigen

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Move author tags to file brief (#870 <https://github.com/ros2/geometry2/issues/870>) (#875 <https://github.com/ros2/geometry2/issues/875>)
* Contributors: R Kent James, mergify[bot]
```

## tf2_eigen_kdl

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Contributors: R Kent James
```

## tf2_geometry_msgs

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Move author tags to file brief (#870 <https://github.com/ros2/geometry2/issues/870>) (#875 <https://github.com/ros2/geometry2/issues/875>)
* Contributors: R Kent James, mergify[bot]
```

## tf2_kdl

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Move author tags to file brief (#870 <https://github.com/ros2/geometry2/issues/870>) (#875 <https://github.com/ros2/geometry2/issues/875>)
* Contributors: R Kent James, mergify[bot]
```

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Move author tags to file brief (#870 <https://github.com/ros2/geometry2/issues/870>) (#875 <https://github.com/ros2/geometry2/issues/875>)
* Contributors: R Kent James, mergify[bot]
```

## tf2_ros_py

```
* Disable TAGFILES in rosdoc2 to separate namespace tf2 documentation into packages (manual kilted backport of #856 <https://github.com/ros2/geometry2/issues/856>) (#885 <https://github.com/ros2/geometry2/issues/885>)
* Contributors: R Kent James
```

## tf2_sensor_msgs

```
* Add imu & mag support in tf2_sensor_msgs (#800 <https://github.com/ros2/geometry2/issues/800>) (#813 <https://github.com/ros2/geometry2/issues/813>) (#867 <https://github.com/ros2/geometry2/issues/867>)
* Contributors: mergify[bot]
```

## tf2_tools

- No changes
