### PR TITLE
easynav: 0.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1669,7 +1669,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/EasyNavigation/EasyNavigation-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/EasyNavigation/EasyNavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav` to `0.3.2-1`:

- upstream repository: https://github.com/EasyNavigation/EasyNavigation.git
- release repository: https://github.com/EasyNavigation/EasyNavigation-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## easynav

- No changes

## easynav_common

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_controller

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_core

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_interfaces

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_localizer

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_maps_manager

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_planner

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_sensors

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_support_py

- No changes

## easynav_system

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_tools

- No changes
