### PR TITLE
easynav: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2185,7 +2185,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/EasyNavigation/EasyNavigation-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/EasyNavigation/EasyNavigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav` to `0.2.2-1`:

- upstream repository: https://github.com/EasyNavigation/EasyNavigation.git
- release repository: https://github.com/EasyNavigation/EasyNavigation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`

## easynav

- No changes

## easynav_common

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_controller

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_core

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_interfaces

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_localizer

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_maps_manager

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_planner

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_sensors

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_support_py

- No changes

## easynav_system

```
* Hotfix: Remove remaining C++20/23 features
* Contributors: Francisco Miguel Moreno
```

## easynav_tools

- No changes
