### PR TITLE
off_highway_sensor_drivers: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6092,7 +6092,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `1.1.0-1`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.0-1`

## off_highway_can

```
* Fix formatting for linter
* off_highway_can: split license element into two
  Having two license strings into one element does give issues when generating
  the Yocto/OpenEmbedde bitbake recipes for meta-ros.
  see: https://github.com/ros/meta-ros/commit/72dfb21b8f297d23e8c029edc04baadb17b1d24f
  see:
  <license> (multiple, but at least one)
  Name of license for this package, e.g. BSD, GPL, LGPL.
  In order to assist machine readability, only include the license name in this tag.
  For multiple licenses multiple separate tags must be used.
  A package will have multiple licenses if different source files have different licenses.
  Every license occurring in the source files should have a corresponding <license> tag.
  For any explanatory text about licensing caveats, please use the <description> tag.
  -- https://ros.org/reps/rep-0149.html#license-multiple-but-at-least-one
* Add unit tests for timeout
* Fix incorrect timeout toggling
* Draw conclusion in the watchdog, not in the diagnostics callback
* Fix issue 20, don't publish sensor data when there is a sensor timeout
* ament_target_dependencies is deprecated for Kilted and Rolling
  This syntax should work as of ROS 2 Foxy already
* Contributors: Calin-Vasile Sopterean, Ferry Schoenmakers, Jan Vermaete, Tim Clephas
```

## off_highway_general_purpose_radar

```
* Update dependency declarations for target_link_libraries
* Fix issue 20, don't publish sensor data when there is a sensor timeout
* Remove ament deprecation warning from remaining packages
* ament_target_dependencies is deprecated for Kilted and Rolling
  This syntax should work as of ROS 2 Foxy already
* Add pcl_point_xxx.hpp deprecation warning
* Contributors: Calin-Vasile Sopterean, Ferry Schoenmakers, Tim Clephas
```

## off_highway_general_purpose_radar_msgs

- No changes

## off_highway_premium_radar

```
* Remove PCL libraries from ohw_premium_radar
* Add PCL deprecation warning for pcl_radar_point_type.hpp
* Remove ament deprecation warning from remaining packages
* Update README
* Add unit tests for Measurement Program PDU
* Add unit tests for Ego Vehicle Input PDU
* Add unit tests for Location Atrributes PDU
* Add unit test for Location Data PDU
* Contributors: Calin-Vasile Sopterean, Gabriela Adriana Lapuste
```

## off_highway_premium_radar_msgs

```
* Add unit tests for Location Atrributes PDU
* Add unit test for Location Data PDU
* Contributors: Calin-Vasile Sopterean
```

## off_highway_premium_radar_sample

```
* Update dependency declarations for target_link_libraries
* Remove ament deprecation warning from remaining packages
* ament_target_dependencies is deprecated for Kilted and Rolling
  This syntax should work as of ROS 2 Foxy already
* Add unit test for Location Data PDU
* Add unit test for Sensor State Information PDU
* Contributors: Calin-Vasile Sopterean, Sarah Huber, Tim Clephas
```

## off_highway_premium_radar_sample_msgs

```
* Add unit test for Location Data PDU
* Contributors: Calin-Vasile Sopterean
```

## off_highway_radar

```
* Update dependency declarations for target_link_libraries
* Fix issue 20, don't publish sensor data when there is a sensor timeout
* ament_target_dependencies is deprecated for Kilted and Rolling
  This syntax should work as of ROS 2 Foxy already
* Add pcl_point_xxx.hpp deprecation warning
* Contributors: Calin-Vasile Sopterean, Ferry Schoenmakers, Tim Clephas
```

## off_highway_radar_msgs

- No changes

## off_highway_sensor_drivers

- No changes

## off_highway_sensor_drivers_examples

```
* Remove ament deprecation warning from remaining packages
* Contributors: Calin-Vasile Sopterean
```

## off_highway_uss

```
* Add timeout functionality for uss direct_echos
* Update dependency declarations for target_link_libraries
* Fix issue 20, don't publish sensor data when there is a sensor timeout
* ament_target_dependencies is deprecated for Kilted and Rolling
  This syntax should work as of ROS 2 Foxy already
* Add pcl_point_xxx.hpp deprecation warning
* Contributors: Calin-Vasile Sopterean, Ferry Schoenmakers, Tim Clephas
```

## off_highway_uss_msgs

- No changes
