### PR TITLE
Add Fedora rule for libqt6widgets6t64

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6487,6 +6487,7 @@ libqt6svg6:
 libqt6widgets6t64:
   arch: [qt6-base]
   debian: [libqt6widgets6]
+  fedora: [qt6-qtbase-gui]
   rhel:
     '*': [qt6-qtbase]
     '8': null


### PR DESCRIPTION
Fedora package: https://packages.fedoraproject.org/pkgs/qt6-qtbase/qt6-qtbase-gui/fedora-rawhide.html#files
Corresponding Ubuntu package: https://packages.ubuntu.com/noble/amd64/libqt6widgets6t64/filelist