### PR TITLE
Removed ros2_kortex from ROS 2 Kilted distribution

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7378,27 +7378,6 @@ repositories:
       url: https://github.com/nobleo/ros2_fmt_logger.git
       version: main
     status: developed
-  ros2_kortex:
-    doc:
-      type: git
-      url: https://github.com/Kinovarobotics/ros2_kortex.git
-      version: main
-    release:
-      packages:
-      - kinova_gen3_6dof_robotiq_2f_85_moveit_config
-      - kinova_gen3_7dof_robotiq_2f_85_moveit_config
-      - kortex_api
-      - kortex_bringup
-      - kortex_description
-      - kortex_driver
-      tags:
-        release: release/kilted/{package}/{version}
-      url: https://github.com/ros2-gbp/ros2_kortex-release.git
-    source:
-      type: git
-      url: https://github.com/Kinovarobotics/ros2_kortex.git
-      version: main
-    status: developed
   ros2_planning_system:
     doc:
       type: git


### PR DESCRIPTION
This PR removes ros2_kortex from the ROS 2 Kilted distribution.

Reason:
- No plans have been made for Kilted support yet
- Prevents further binary builds on the ROS build farm

No other distributions are affected.