### PR TITLE
mapviz: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4730,7 +4730,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.5.10-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.6.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.10-1`

## mapviz

```
* HiDPI Scaling (#863 <https://github.com/swri-robotics/mapviz/issues/863>)
  Fixes issues related with HiDPI scaling.
* Contributors: Logan Elliott
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

```
* Added additional tilemap sources (#864 <https://github.com/swri-robotics/mapviz/issues/864>)
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Contributors: Logan Elliott
```
