### PR TITLE
add autoware_rviz_plugins package to humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1079,6 +1079,12 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_msgs.git
       version: main
     status: developed
+  autoware_rviz_plugins:
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_rviz_plugins.git
+      version: main
+    status: developed
   autoware_utils:
     release:
       packages:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Humble

# The source is here:

https://github.com/autowarefoundation/autoware_rviz_plugins

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
