### PR TITLE
yasmin: 4.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11978,7 +11978,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 4.1.0-1
+      version: 4.2.1-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `4.2.1-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.0-1`

## yasmin

```
* adding python-dev in deps and removing unused test deps for python
* setting signing handle as false by default
* adding SIGINT handler for YASMIN state machines in core package
* adding abort to fibonacci demo server
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

```
* adding python-dev in deps and removing unused test deps for python
* setting signing handle as false by default
* updating nav demo in docs
* adding SIGINT handler for YASMIN state machines in core package
* adding Reentrant as default callback group in ActionState
* adding abort to fibonacci demo server
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_editor

- No changes

## yasmin_factory

```
* adding python-dev in deps and removing unused test deps for python
* setting signing handle as false by default
* adding SIGINT handler for YASMIN state machines in core package
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* removing duplicated comments and setting generateUUID as inline
* adding python-dev in deps and removing unused test deps for python
* adding SIGINT handler for YASMIN state machines in core package
* creating lock and cs_status before while in monitor state
* adding abort to fibonacci demo server
* adding cancel checks in action state
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

```
* removing duplicated comments and setting generateUUID as inline
* adding python-dev in deps and removing unused test deps for python
* Contributors: Miguel Ángel González Santamarta
```
