### PR TITLE
plotjuggler: 3.14.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6599,7 +6599,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.14.2-1
+      version: 3.14.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.14.4-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.14.2-1`

## plotjuggler

```
* change ID
* Install plugins into lib tree (#1228 <https://github.com/facontidavide/PlotJuggler/issues/1228>)
  Fixes #1153 <https://github.com/facontidavide/PlotJuggler/issues/1153>
* 🛠️ Bump actions/download-artifact from 6 to 7 (#1229 <https://github.com/facontidavide/PlotJuggler/issues/1229>)
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* 🛠️ Bump actions/upload-artifact from 5 to 6 (#1230 <https://github.com/facontidavide/PlotJuggler/issues/1230>)
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* fix issue #1226 <https://github.com/facontidavide/PlotJuggler/issues/1226>
* 🛠️ Bump actions/cache from 4 to 5 (#1225 <https://github.com/facontidavide/PlotJuggler/issues/1225>)
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Contributors: Davide Faconti, SammysHP, dependabot[bot]
```
