### PR TITLE
septentrio_gnss_driver: 1.4.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8837,7 +8837,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.5-1
+      version: 1.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.6-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.5-1`

## septentrio_gnss_driver

```
* Fixes
  
  Reset of settings on shutdown
  
  GBAS status of NavSatFix
  
  Missing conversions of do-not-use values of covariances to adhere ROS convention
* Improvements
  
  Change timestamp handling of NMEA messages.
  
  Adapt firmware check to include mosaic G5.
  
  Add ros_environment as a build dependency.
* Contributors: Khuzema Darugar, Martin Pecka, Thomas Emter, Tibor Dome, septentrio-users
```
