### PR TITLE
[openembedded] drop python2 from meta-qt5

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -492,7 +492,6 @@ pyqt5-dev-tools:
   fedora: [python-qt5-devel]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   rhel: [python3-qt5-devel]
   ubuntu: [pyqt5-dev-tools]
 pyqt6-dev-tools:
@@ -3487,7 +3486,6 @@ python-qt5-bindings:
   freebsd: [py27-qt5]
   gentoo: ['dev-python/PyQt5[gui,widgets]']
   nixos: [pythonPackages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5-devel, python2-sip-devel]
   slackware: [PyQt5]
   ubuntu:
@@ -3501,14 +3499,12 @@ python-qt5-bindings-gl:
   freebsd: [py27-qt5-opengl]
   gentoo: ['dev-python/PyQt5[opengl]']
   nixos: [pythonPackages.pyqt5]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5]
   slackware: [PyQt5]
   ubuntu:
     bionic: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-quick:
   debian: [python-pyqt5.qtquick]
@@ -3522,7 +3518,6 @@ python-qt5-bindings-webkit:
   freebsd: [py27-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
   nixos: [pythonPackages.pyqt5_with_qtwebkit]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
   opensuse: [python2-qt5]
   ubuntu:
     bionic: [python-pyqt5.qtwebkit]
@@ -9011,7 +9006,7 @@ python3-pyqt5.qtwebengine:
   fedora: [python3-qt5-webengine, pyqtwebengine-devel]
   gentoo: [dev-python/PyQtWebEngine]
   nixos: [python3Packages.pyqtwebengine]
-  openembedded: ['${PYTHON_PN}-pyqt5@meta-qt5']
+  openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qtwebengine-qt5]
   rhel:
     '*': [python3-qt5-webengine, pyqtwebengine-devel]


### PR DESCRIPTION
There are no python2 recipes anymore in meta-qt5.

One step in clean-up the PYTHON_PN variable.  A variable that is deprecated in Yocto/Openembedded.
https://docs.yoctoproject.org/singleindex.html#removed-variables

@robwoolley Could you verify?