### PR TITLE
[openembedded] python3-nose: moved from openembedded-core to meta-ros-common

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7828,7 +7828,7 @@ python3-nose:
   fedora: [python3-nose]
   gentoo: [dev-python/nose]
   nixos: [python3Packages.nose]
-  openembedded: [python3-nose@openembedded-core]
+  openembedded: [python3-nose@meta-ros-common]
   opensuse: [python3-nose]
   osx:
     pip:


### PR DESCRIPTION

The python3-nose recipe is removed from openembedded-core [1].

  python3-nose: drop recipe
  The code has not been touched since 2016 and numerous files still have
  Python2 syntax code in them. This causes do_compile errors when
  packaging a wheel (PEP-517 packaging).

  Nothing in oe-core depends on python3-nose.

  [YOCTO #14638]

  Signed-off-by: Tim Orling <tim.orling@konsulko.com>
  Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

There is an older recipe available in meta-ros-common [2]

[1]: https://github.com/openembedded/openembedded-core/commit/19135f8b7cbaabeb2e38572d11e909ce386d60b8
[2]: https://layers.openembedded.org/layerindex/recipe/354023/



@robwoolley Could you verify and ack
It could be we can drop the recipe in meta-ros-common soon too.
