### PR TITLE
Add missing Qt6 rosdep entries for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6441,6 +6441,7 @@ libqt6gui6t64:
   arch: [qt6-base]
   debian: [libqt6gui6]
   fedora: [qt6-qtbase-gui]
+  nixos: [qt6.qtbase]
   rhel:
     '*': [qt6-qtbase-gui]
     '8': null
@@ -6488,6 +6489,7 @@ libqt6widgets6t64:
   arch: [qt6-base]
   debian: [libqt6widgets6]
   fedora: [qt6-qtbase-gui]
+  nixos: [qt6.qtbase]
   rhel:
     '*': [qt6-qtbase]
     '8': null


### PR DESCRIPTION
Note that https://search.nixos.org/packages?channel=unstable&query=qtbase only shows `qtbase` under `kdePackages`, which is, however, an alias of `qt6.qtbase`. The other rosdep entries use `qt6.qtbase` too.

The toplevel `qt6` attribute is defined [here](https://github.com/NixOS/nixpkgs/blob/16ca0f1e7efbc38387754d721e70d95e5e11da51/pkgs/top-level/all-packages.nix#L8180).
