### PR TITLE
zmqpp_vendor: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12064,7 +12064,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/zmqpp_vendor-release.git
-      version: 0.0.2-4
+      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/zmqpp_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zmqpp_vendor` to `0.1.0-1`:

- upstream repository: https://github.com/tier4/zmqpp_vendor.git
- release repository: https://github.com/ros2-gbp/zmqpp_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.2-4`

## zmqpp_vendor

```
* ci: update bloom release info (#11 <https://github.com/autowarefoundation/zmqpp_vendor/issues/11>)
* feat: use ament_vendor for setting up zmqpp (#9 <https://github.com/autowarefoundation/zmqpp_vendor/issues/9>)
  * Use ament_vendor and CMake export features
  * Use more specific version (formerly master)
* ci: update humble, kilted, jazzy, rolling and rm EoL distros (#10 <https://github.com/autowarefoundation/zmqpp_vendor/issues/10>)
* Merge pull request #8 <https://github.com/autowarefoundation/zmqpp_vendor/issues/8> from tier4/feature/bloom_release_action
  add BloomRelease Action
* add BloomRelease Action
* Contributors: Masaya Kataoka, MasayaKataoka, Mete Fatih Cırıt, ぐるぐる
```
