### PR TITLE
yasmin: 4.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13322,7 +13322,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 4.1.0-1
+      version: 4.2.1-2
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `4.2.1-2`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.0-1`

## yasmin

```
* minor fix in C++ header guards
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

- No changes

## yasmin_editor

- No changes

## yasmin_factory

```
* minor fix in C++ header guards
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* minor fix in C++ header guards
* Adapting tests for Foxy and Galactic
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

```
* minor fix in C++ header guards
* Contributors: Miguel Ángel González Santamarta
```
