### PR TITLE
autoware_internal_msgs: 1.12.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -734,7 +734,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
-      version: 1.12.0-1
+      version: 1.12.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_internal_msgs` to `1.12.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_internal_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_internal_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.12.0-1`

## autoware_internal_debug_msgs

```
* docs: add documentation to remaining msg/srv fields (#82 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/82>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - VelocityLimit.msg: max_velocity unit [m/s], sender constants
  - VelocityLimitClearCommand.msg: sender field description
  - ControlPoint.msg: velocity [m/s], shift_length [m], distance [m]
  - SafetyFactor.msg: ttc_begin/ttc_end units [s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * fix sender
  * docs: add unit and range documentation to message definitions
  * style(pre-commit): autofix
  * remove node_modules
  * Update autoware_internal_debug_msgs/msg/ProcessingTimeNode.msg
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* Contributors: Yutaka Kondo
```

## autoware_internal_localization_msgs

- No changes

## autoware_internal_metric_msgs

- No changes

## autoware_internal_msgs

- No changes

## autoware_internal_perception_msgs

- No changes

## autoware_internal_planning_msgs

```
* docs: add documentation to remaining msg/srv fields (#82 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/82>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - VelocityLimit.msg: max_velocity unit [m/s], sender constants
  - VelocityLimitClearCommand.msg: sender field description
  - ControlPoint.msg: velocity [m/s], shift_length [m], distance [m]
  - SafetyFactor.msg: ttc_begin/ttc_end units [s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * fix sender
  * docs: add unit and range documentation to message definitions
  * style(pre-commit): autofix
  * remove node_modules
  * Update autoware_internal_debug_msgs/msg/ProcessingTimeNode.msg
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* docs: add unit and range documentation to message fields (#81 <https://github.com/autowarefoundation/autoware_internal_msgs/issues/81>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - VelocityLimit.msg: max_velocity unit [m/s], sender constants
  - VelocityLimitClearCommand.msg: sender field description
  - ControlPoint.msg: velocity [m/s], shift_length [m], distance [m]
  - SafetyFactor.msg: ttc_begin/ttc_end units [s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * fix sender
  ---------
* Contributors: Yutaka Kondo
```
