### PR TITLE
rosdep: add libjson-c-dev & nanobind-dev on NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4637,6 +4637,7 @@ libjson-c-dev:
   debian: [libjson-c-dev]
   fedora: [json-c-devel]
   gentoo: ['dev-libs/json-c:0']
+  nixos: [json-c]
   openembedded: [jsoncpp@meta-oe]
   opensuse: [libjson-c-devel]
   rhel: [json-c-devel]
@@ -7987,6 +7988,7 @@ nanobind-dev:
       pip:
         packages: [nanobind]
   freebsd: [nanobind]
+  nixos: [python3Packages.nanobind]
   ubuntu:
     '*': [nanobind-dev]
     focal:


### PR DESCRIPTION
Hi,

This add some rosdep keys for nixos:

- libjson-c-dev: https://search.nixos.org/packages?channel=unstable&show=json-c
- nanobind-dev: https://search.nixos.org/packages?channel=unstable&show=python313Packages.nanobind

ref. https://github.com/lopsided98/nix-ros-overlay/pull/770