### PR TITLE
dbw_ros: 2.3.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1872,7 +1872,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.9-1
+      version: 2.3.10-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.10-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.9-1`

## ds_dbw

- No changes

## ds_dbw_can

```
* Bump firmware versions to match 2025/12/18 release package
* Split GPIO cmd/report messages into gateway/shift/misc
* Add DriverDoor ReasonNotReady
* Add diagnostic for external brake mismatch between redundant inputs
* Add Polaris MRZR Alpha platform
* Add Waev GEM platform
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```

## ds_dbw_joystick_demo

- No changes

## ds_dbw_msgs

```
* Add diagnostic for external brake mismatch between redundant inputs
* Contributors: Kevin Hallenbeck
```
