### PR TITLE
ament_index: 1.13.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -284,7 +284,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.12.1-1
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.13.0-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.12.1-1`

## ament_index_cpp

```
* Extend API to use std::filesystem (#104 <https://github.com/ament/ament_index/issues/104>)
* Fix CMake deprecation (#102 <https://github.com/ament/ament_index/issues/102>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## ament_index_python

- No changes
