### PR TITLE
resource_retriever: 3.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6623,7 +6623,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.9.0-1
+      version: 3.9.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.9.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.0-1`

## resource_retriever

```
* Updated deprecated ament_index_cpp API (#118 <https://github.com/ros/resource_retriever/issues/118>)
* Contributors: Alejandro Hernández Cordero
```
