### PR TITLE
ament_index: 1.11.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -280,7 +280,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.11.0-1
+      version: 1.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.11.1-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.11.0-1`

## ament_index_cpp

```
* Fix CMake deprecation (#102 <https://github.com/ament/ament_index/issues/102>) (#103 <https://github.com/ament/ament_index/issues/103>)
* Contributors: mergify[bot]
```

## ament_index_python

- No changes
