### PR TITLE
resource_retriever: 3.7.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6701,7 +6701,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.7.0-1
+      version: 3.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.7.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.7.0-1`

## libcurl_vendor

```
* Update Curl (#114 <https://github.com/ros/resource_retriever/issues/114>) (#115 <https://github.com/ros/resource_retriever/issues/115>)
* Contributors: mergify[bot]
```

## resource_retriever

- No changes
