### PR TITLE
rclcpp: 29.5.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6521,7 +6521,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.5.5-1
+      version: 29.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.5.6-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `29.5.5-1`

## rclcpp

```
* Unified Node Interfaces: Add const version of get_node_x_interface() (#3006 <https://github.com/ros2/rclcpp/issues/3006>) (#3008 <https://github.com/ros2/rclcpp/issues/3008>)
* remove I/O from signal handler. (#3000 <https://github.com/ros2/rclcpp/issues/3000>)
* correct test function descriptions (#2970 <https://github.com/ros2/rclcpp/issues/2970>) (#2992 <https://github.com/ros2/rclcpp/issues/2992>)
* Contributors: Tomoya Fujita, mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
