### PR TITLE
rclcpp: 28.1.15-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7558,7 +7558,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.14-1
+      version: 28.1.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.15-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `28.1.14-1`

## rclcpp

```
* Unified Node Interfaces: Add const version of get_node_x_interface() (#3006 <https://github.com/ros2/rclcpp/issues/3006>) (#3009 <https://github.com/ros2/rclcpp/issues/3009>)
* remove I/O from signal handler. (#3000 <https://github.com/ros2/rclcpp/issues/3000>) (#3004 <https://github.com/ros2/rclcpp/issues/3004>)
* correct test function descriptions (#2970 <https://github.com/ros2/rclcpp/issues/2970>) (#2993 <https://github.com/ros2/rclcpp/issues/2993>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
