### PR TITLE
rviz: 15.1.15-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8638,7 +8638,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.14-1
+      version: 15.1.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.15-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.14-1`

## rviz2

- No changes

## rviz_common

```
* Updated deprecated ament_index_cpp API (#1647 <https://github.com/ros2/rviz/issues/1647>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Updated deprecated ament_index_cpp API (#1647 <https://github.com/ros2/rviz/issues/1647>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

```
* Remove vendoring freetype and zlib on Windows (#1636 <https://github.com/ros2/rviz/issues/1636>)
* Contributors: Michael Carroll
```

## rviz_rendering

```
* Updated deprecated ament_index_cpp API (#1647 <https://github.com/ros2/rviz/issues/1647>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_rendering_tests

```
* Updated deprecated ament_index_cpp API (#1647 <https://github.com/ros2/rviz/issues/1647>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
