### PR TITLE
image_common: 6.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3114,7 +3114,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.3-1
+      version: 6.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.4-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.4.3-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

```
* Updated deprecated ament_index_cpp API (#388 <https://github.com/ros-perception/image_common/issues/388>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* properly shut down rclcpp after all tests complete. (#384 <https://github.com/ros-perception/image_common/issues/384>)
* Contributors: Tomoya Fujita
```

## image_transport_py

- No changes
