### PR TITLE
cpp_polyfills: 1.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1655,6 +1655,10 @@ repositories:
       version: jazzy
     status: maintained
   cpp_polyfills:
+    doc:
+      type: git
+      url: https://github.com/PickNikRobotics/cpp_polyfills.git
+      version: main
     release:
       packages:
       - tcb_span
@@ -1662,7 +1666,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
-      version: 1.0.2-5
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/cpp_polyfills.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpp_polyfills` to `1.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/cpp_polyfills.git
- release repository: https://github.com/ros2-gbp/cpp_polyfills-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-5`

## tcb_span

```
* Add some new maintainers for ROS releases
* fixing license tag in package.xml to conform to SPDX
* Contributors: Matthias Schoepfer, Nathan Brooks
```

## tl_expected

```
* Add simple pre-commit job and dependabot config (#7 <https://github.com/PickNikRobotics/cpp_polyfills/issues/7>)
* Add some new maintainers for ROS releases
* Update header to version 1.2.0
* fixing license tag in package.xml to conform to SPDX
* Contributors: Christoph Fröhlich, Ezra Brooks, Matthias Schoepfer, Nathan Brooks, Sebastian Castro
```
