### PR TITLE
mujoco_vendor: 0.0.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4780,7 +4780,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_vendor-release.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.0.6-1`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.5-1`

## mujoco_vendor

```
* Merge branch 'bump/mujoco_vendor/3.4.0' into 'master'
  Bump mujoco_vendor to 3.4.0
  See merge request third-party/mujoco_vendor!5
* set the -flto flag to auto
* switch to wayland-dev rosdep
* add wayland dependency as exec depend
* Add libwayland-dev libxkbcommon-dev dependencies
* add libx11-dev dependency
* add pkg-config as build depend
* Update description
* Bump mujoco_vendor to 3.4.0
* Contributors: Sai Kishor Kothakota
```
