### PR TITLE
remove python2-pydot

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3065,7 +3065,6 @@ python-pydot:
   gentoo: [dev-python/pydot]
   macports: [py27-pydot]
   nixos: [pythonPackages.pydot]
-  openembedded: ['${PYTHON_PN}-pydot@meta-ros-common']
   opensuse: [python2-pydot]
   osx:
     pip:


### PR DESCRIPTION
The python2 packages does not exist anymore at meta-ros-common. And is not used anymore.

@robwoolley Could you verify?  Thanks