### PR TITLE
Add usd-core/pxr

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11065,7 +11065,7 @@ python3-usb:
   nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
   ubuntu: [python3-usb]
-python3-usd-core:
+python3-usd:
   '*':
     pip:
       packages: [usd-core]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11065,6 +11065,11 @@ python3-usb:
   nixos: [python3Packages.pyusb]
   openembedded: [python3-pyusb@meta-python]
   ubuntu: [python3-usb]
+python3-usd-core:
+  '*':
+    pip:
+      packages: [usd-core]
+  fedora: [python3-usd]
 python3-utm:
   debian:
     '*': [python3-utm]


### PR DESCRIPTION

Please add the following dependency to the rosdep database.

## Package name:

pip package name: usd-core

## Package Upstream Source:

https://github.com/PixarAnimationStudios/OpenUSD
https://pypi.org/project/usd-core/

## Purpose of using this:

OpenUSD python bindings. Use-cases for this include creation of simulation environments for Isaac Sim/Lab.
From [pypi](https://pypi.org/project/usd-core/):
> Universal Scene Description (USD) is a system that scalably encodes and interchanges static and time-sampled 3D geometry, shading and lighting data between Digital Content Creation applications. Domain-specific schema modules define the geometry, shading, and lighting encoding atop USD's domain-agnostic core. It provides a low-level data model that supports plugin implementations, and a scenegraph built on top of a multi-threaded "composition engine" for creating complex scenes out of reusable, modular assets.

## Links to Distribution Packages
Primarily via pip https://pypi.org/project/usd-core/
A fedora package is available. Should the rosdep key be named `python3-usd` according to the fedora package name?
I did not find any ubuntu/debian apt packages for this.


- Pip: https://pypi.org/
  - https://pypi.org/project/usd-core/
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/usd/python3-usd/
