### PR TITLE
Support libgsl on debian bookworm

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4316,10 +4316,7 @@ libgrpc:
   ubuntu: [libgrpc++-dev]
 libgsl:
   arch: [gsl]
-  debian:
-    buster: [libgsl-dev]
-    stretch: [libgsl-dev]
-    wheezy: [libgsl0-dev]
+  debian: [libgsl-dev]
   fedora: [gsl-devel]
   gentoo: [sci-libs/gsl]
   macports: [gsl]


### PR DESCRIPTION
I thought it was easiest to deprecate wheezy since it's EOL.

Required to fix buildfarm errors with the `mp_units_vendor` package.