### PR TITLE
mola_imu_preintegration: 1.14.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4370,7 +4370,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.14.0-1
+      version: 1.14.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.14.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.14.0-1`

## mola_imu_preintegration

```
* Add option 'use_imu_orientation' to disable using IMU orientation for initialization
* CI: Use standard checkout action
* Contributors: Jose Luis Blanco-Claraco
```
