### PR TITLE
mrpt_ros: 2.15.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4703,7 +4703,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.3-1
+      version: 2.15.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.4-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.15.3-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

```
* Bug fixes:  Fix regression in mrpt::obs::recolorize3Dpc()
* mrpt::obs::CObservationPointCloud::getDescriptionAsText() now shows all cloud fields and ignores NaNs.
* mrpt::maps::CGenericPointsMap "uint" methods renamed "uint16" for consistency.
* mrpt::maps::CPointsMap::prepareForInsertPointsFrom() made "non const", since it implies changes.
* loadFromKittiVelodyneFile() moved from deprecated CPointsMapXYZI into mrpt::maps::CGenericPointsMap
* Updated embedded nanoflann to v1.9.0
```

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
