### PR TITLE
mola_gnss_to_markers: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4306,7 +4306,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_gnss_to_markers-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_gnss_to_markers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_gnss_to_markers` to `0.1.2-1`:

- upstream repository: https://github.com/MOLAorg/mola_gnss_to_markers.git
- release repository: https://github.com/ros2-gbp/mola_gnss_to_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.1.1-1`

## mola_gnss_to_markers

```
* Relax unit tests (don't use ament clang-format)
* Update broken link to ROS Index
* Contributors: Jose Luis Blanco-Claraco
```
