### PR TITLE
mp2p_icp: 2.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5880,7 +5880,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.1.2-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.2-1`

## mp2p_icp

```
* docs: explain FilterSOR
* Merge pull request #19 <https://github.com/MOLAorg/mp2p_icp/issues/19> from MOLAorg/feat/mm2ply
  Add mm2ply CLI tool
* Merge pull request #18 <https://github.com/MOLAorg/mp2p_icp/issues/18> from MOLAorg/feat/new-sor-filter
  Add FilterSOR: Statistical Outlier Rejection
* More unit tests: cover MLS
* Merge pull request #17 <https://github.com/MOLAorg/mp2p_icp/issues/17> from MOLAorg/feat/filter-by-expr
  Add new filter: FilterByExpression
* More code coverage; fix protected-level initialize methods
* Add new filter: FilterByExpression
* FIX: missing uint8 fields in Deskew
* sanityCheck: also check all double/uint8 fields
* ui: fix case without geo-ref
* mm-viewer: show lat/lon coordinates for mouse selected points
* mm-viewer: GUI now shows the ENU & map miniviews for orientation hints
* mm-viewer: handle special coloring channel groups 'rgb' and 'rgbf'
* clean non used code in deskew test
* map viz: use new mrpt 2.15.3 coloring modes
* sm2mm: auto-guess lazy-load externals directory for .simplemap files
* mm-viewer: implement colorize clouds by any field
* MLS filter: add 'output_layer_class' parameter
* mm2txt: export all fields of CGenericPointsMap layers
* Merge pull request #16 <https://github.com/MOLAorg/mp2p_icp/issues/16> from MOLAorg/fix/generic-cloud-deskew-fields
  Add test for missing fields in generic cloud deskew
* FIX: correctly register arbitrary pointcloud fields into output clouds
* Add test for missing fields in generic cloud deskew
* sm2mm: FIx console message on "FinalFilters" did not obey verbosity level
* Fix clang-tidy warnings
* Contributors: Jose Luis Blanco-Claraco
```
