### PR TITLE
[openembedded] pydocstyle: removed the deprecated PYTHON_PN

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -397,7 +397,7 @@ pydocstyle:
   freebsd: [devel/py-pydocstyle]
   gentoo: [dev-python/pydocstyle]
   nixos: [python3Packages.pydocstyle]
-  openembedded: ['${PYTHON_PN}-pydocstyle@meta-ros-common']
+  openembedded: [python3-pydocstyle@meta-ros-common]
   osx:
     pip:
       packages: [pydocstyle]


### PR DESCRIPTION
PYTHON_PN is deprecated in Yocto/OpenEmbedded

@robwoolley Could you review and ack?  And there are still many to go, but I prefer to change the ones I’m working with.