### PR TITLE
mola: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5624,7 +5624,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.4.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Prepare for not using deprecated mrpt_maps types starting for mrpt >=3.0.0
* FIX: Potential segfault if observations come before ROS2 /tf broadcasters are initialized
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

- No changes

## mola_input_euroc_dataset

```
* simplify destructors declarations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Use newer mrpt map classes
* fix clang-tidy warnings
* simplify destructors declarations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* fix clang-tidy warnings
* simplify destructors declarations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

```
* fix clang-tidy warnings
* Prepare for deprecated mrpt::maps classes towards mrpt 3.0.0
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* Use newer mrpt map classes
* fix clang-tidy warnings
* simplify destructors declarations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Fix build against upcoming mrpt 2.15.4
* fix clang-tidy warnings
* simplify destructors declarations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* Fix build against upcoming mrpt 2.15.4
* prepare for mrpt 2.15.4
* simplify destructors declarations
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

- No changes

## mola_kernel

- No changes

## mola_launcher

- No changes

## mola_metric_maps

```
* KeyframePointCloudMap: viz now reuses mrpt function for better generalized per-field coloring and avoid code duplication
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* Fix build against upcoming mrpt 2.15.4
* Prepare for deprecated mrpt::maps classes towards mrpt 3.0.0
* viz pointclouds preview: fix missing uint8_t fields
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

- No changes
