### PR TITLE
elite_common_interface: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2573,6 +2573,19 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  elite_common_interface:
+    release:
+      packages:
+      - eli_common_interface
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/747309172a-cpu/elite_common_interface-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/747309172a-cpu/Elite_Robots_CS_ROS2_Driver.git
+      version: eli_common_interface_only
+    status: maintained
   ess_imu_driver2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_common_interface` to `0.0.1-1`:

- upstream repository: https://github.com/747309172a-cpu/Elite_Robots_CS_ROS2_Driver.git
- release repository: https://github.com/747309172a-cpu/elite_common_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
