### PR TITLE
mola_lidar_odometry: 1.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4385,7 +4385,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `1.3.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.3.0-1`

## mola_lidar_odometry

```
* Merge pull request #36 from MOLAorg/feat/use-generic-map-fields
  Use CGenericPointsMap to propagate all sensor per-point fields thru mapping pipelines
* Support to visualize clouds in MOLA Viz recolorized by any cloud point field
* Use CGenericPointsMap to propagate all sensor per-point fields thru mapping pipelines
* Contributors: Jose Luis Blanco-Claraco
```
