### PR TITLE
mvsim: 0.15.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5546,7 +5546,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.14.2-1
+      version: 0.15.0-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.15.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.14.2-1`

## mvsim

```
* Fix build against upcoming mrpt 2.15.4
* Implement missing visualization of 3D LiDAR FOV 'frustrum'
* Merge pull request #69 <https://github.com/MRPT/mvsim/issues/69> from MRPT/feat/imu-with-heading
  IMU sensor: add support for optional global heading sensor
* Implement IMU sensor orientation mode
* Fix clang-tidy style warnings
* Fix misused get parameter API usage for use_sim_time
* cmake now builds embedded box2d using --parallel
* Contributors: Jose Luis Blanco-Claraco
```
