### PR TITLE
leo_common: 3.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3680,7 +3680,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_common-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_common-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_common` to `3.2.0-1`:

- upstream repository: https://github.com/LeoRover/leo_common-ros2.git
- release repository: https://github.com/ros2-gbp/leo_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.0-1`

## leo

- No changes

## leo_description

- No changes

## leo_msgs

```
* feat: Add ChargingMonitorData message type (#27 <https://github.com/LeoRover/leo_common-ros2/issues/27>)
* chore: Remove SetImuCalibration service type (#23 <https://github.com/LeoRover/leo_common-ros2/issues/23>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## leo_teleop

- No changes
