### PR TITLE
leo_robot: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3724,7 +3724,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.5.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## leo_bringup

```
* feat: Add charging monitor node (#38 <https://github.com/LeoRover/leo_robot-ros2/issues/38>)
* Contributors: Błażej Sowa
```

## leo_filters

- No changes

## leo_fw

```
* Use sphinx format docstrings (#36 <https://github.com/LeoRover/leo_robot-ros2/issues/36>)
* Add missing dependency on rcl_interfaces
* Contributors: Błażej Sowa
```

## leo_robot

- No changes
