### PR TITLE
Add lightning_rrt and lightning_rrt_interfaces packages

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4649,22 +4649,12 @@ repositories:
       version: jazzy
     status: maintained
   lightning_rrt:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/david-dorf/lightning_rrt-release.git
-      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/david-dorf/lightning_rrt.git
       version: jazzy
     status: maintained
   lightning_rrt_interfaces:
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/david-dorf/lightning_rrt_interfaces-release.git
-      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/david-dorf/lightning_rrt_interfaces.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4633,6 +4633,28 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: jazzy
     status: maintained
+  lightning_rrt:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/david-dorf/lightning_rrt-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/david-dorf/lightning_rrt.git
+      version: jazzy
+    status: maintained
+  lightning_rrt_interfaces:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/david-dorf/lightning_rrt_interfaces-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/david-dorf/lightning_rrt_interfaces.git
+      version: jazzy
+    status: maintained
   linux_isolate_process:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:
lightning_rrt
lightning_rrt_interfaces

## Package Upstream Source:
https://github.com/david-dorf/lightning_rrt.git
https://github.com/david-dorf/lightning_rrt_interfaces.git

## Purpose of using this:
It's a fast and simple RRT path generator for navigation, which doesn't currently have an equivalent package in rosdep

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://github.com/david-dorf/lightning_rrt.git
  - https://github.com/david-dorf/lightning_rrt_interfaces.git
- Ubuntu: https://packages.ubuntu.com/
  - https://github.com/david-dorf/lightning_rrt.git
  - https://github.com/david-dorf/lightning_rrt_interfaces.git
- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Jazzy

# The source is here:

https://github.com/david-dorf/lightning_rrt.git
https://github.com/david-dorf/lightning_rrt_interfaces.git

# Checks
 - [ X] All packages have a declared license in the package.xml
 - [ X] This repository has a LICENSE file
 - [ X] This package is expected to build on the submitted rosdistro
