### PR TITLE
ros2_control: 6.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7241,7 +7241,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.2.0-1
+      version: 6.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.3.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.2.0-1`

## controller_interface

```
* Add new interface_configuration_types and reusable methods (#2902 <https://github.com/ros-controls/ros2_control/issues/2902>)
* Use Pimpl approach for controller and hardware component interfaces (#2898 <https://github.com/ros-controls/ros2_control/issues/2898>)
* Contributors: Sai Kishor Kothakota
```

## controller_manager

```
* Add new interface_configuration_types and reusable methods (#2902 <https://github.com/ros-controls/ros2_control/issues/2902>)
* Add cleanup_controller lifecycle transition (#2414 <https://github.com/ros-controls/ros2_control/issues/2414>)
* Contributors: Sai Kishor Kothakota, Soham Patil
```

## controller_manager_msgs

```
* Add cleanup_controller lifecycle transition (#2414 <https://github.com/ros-controls/ros2_control/issues/2414>)
* Contributors: Soham Patil
```

## hardware_interface

```
* Use Pimpl approach for controller and hardware component interfaces (#2898 <https://github.com/ros-controls/ros2_control/issues/2898>)
* Fix missing copy and move operations of data_type_ variable (#2903 <https://github.com/ros-controls/ros2_control/issues/2903>)
* Contributors: Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add unconfigure state to set_controller_state verb (#2913 <https://github.com/ros-controls/ros2_control/issues/2913>)
* Add cleanup_controller lifecycle transition (#2414 <https://github.com/ros-controls/ros2_control/issues/2414>)
* Contributors: Soham Patil
```

## rqt_controller_manager

```
* Use proper cleanup transition (#2917 <https://github.com/ros-controls/ros2_control/issues/2917>)
* Contributors: Soham Patil
```

## transmission_interface

- No changes
