### PR TITLE
ros2_control: 5.11.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7313,7 +7313,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.10.0-1
+      version: 5.11.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.11.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.10.0-1`

## controller_interface

```
* Add new interface_configuration_types and reusable methods (#2902 <https://github.com/ros-controls/ros2_control/issues/2902>) (#2936 <https://github.com/ros-controls/ros2_control/issues/2936>)
* Use Pimpl approach for controller and hardware component interfaces (#2898 <https://github.com/ros-controls/ros2_control/issues/2898>) (#2932 <https://github.com/ros-controls/ros2_control/issues/2932>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Add new interface_configuration_types and reusable methods (#2902 <https://github.com/ros-controls/ros2_control/issues/2902>) (#2936 <https://github.com/ros-controls/ros2_control/issues/2936>)
* Add cleanup_controller lifecycle transition (backport #2414 <https://github.com/ros-controls/ros2_control/issues/2414>) (#2915 <https://github.com/ros-controls/ros2_control/issues/2915>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

```
* Add cleanup_controller lifecycle transition (backport #2414 <https://github.com/ros-controls/ros2_control/issues/2414>) (#2915 <https://github.com/ros-controls/ros2_control/issues/2915>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* Use Pimpl approach for controller and hardware component interfaces (#2898 <https://github.com/ros-controls/ros2_control/issues/2898>) (#2932 <https://github.com/ros-controls/ros2_control/issues/2932>)
* Fix missing copy and move operations of data_type_ variable (#2903 <https://github.com/ros-controls/ros2_control/issues/2903>) (#2906 <https://github.com/ros-controls/ros2_control/issues/2906>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add unconfigure state to set_controller_state verb (#2913 <https://github.com/ros-controls/ros2_control/issues/2913>) (#2919 <https://github.com/ros-controls/ros2_control/issues/2919>)
* Add cleanup_controller lifecycle transition (backport #2414 <https://github.com/ros-controls/ros2_control/issues/2414>) (#2915 <https://github.com/ros-controls/ros2_control/issues/2915>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* Use proper cleanup transition (#2917 <https://github.com/ros-controls/ros2_control/issues/2917>) (#2923 <https://github.com/ros-controls/ros2_control/issues/2923>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
