### PR TITLE
ros2_control: 4.42.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8382,7 +8382,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.40.0-1
+      version: 4.42.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.42.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.40.0-1`

## controller_interface

```
* Add new interface_configuration_types and reusable methods (#2902 <https://github.com/ros-controls/ros2_control/issues/2902>) (#2935 <https://github.com/ros-controls/ros2_control/issues/2935>)
* Use Pimpl approach for controller and hardware component interfaces (backport #2898 <https://github.com/ros-controls/ros2_control/issues/2898>) (#2931 <https://github.com/ros-controls/ros2_control/issues/2931>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Add new interface_configuration_types and reusable methods (#2902 <https://github.com/ros-controls/ros2_control/issues/2902>) (#2935 <https://github.com/ros-controls/ros2_control/issues/2935>)
* Add cleanup_controller lifecycle transition (backport #2414 <https://github.com/ros-controls/ros2_control/issues/2414>) (#2914 <https://github.com/ros-controls/ros2_control/issues/2914>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

```
* Add cleanup_controller lifecycle transition (backport #2414 <https://github.com/ros-controls/ros2_control/issues/2414>) (#2914 <https://github.com/ros-controls/ros2_control/issues/2914>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* Use Pimpl approach for controller and hardware component interfaces (backport #2898 <https://github.com/ros-controls/ros2_control/issues/2898>) (#2931 <https://github.com/ros-controls/ros2_control/issues/2931>)
* Fix missing copy and move operations of data_type_ variable (backport #2903 <https://github.com/ros-controls/ros2_control/issues/2903>) (#2905 <https://github.com/ros-controls/ros2_control/issues/2905>)
* [Handle] Add support to more data types (backport #2879 <https://github.com/ros-controls/ros2_control/issues/2879>) (#2896 <https://github.com/ros-controls/ros2_control/issues/2896>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

```
* Add unconfigure state to set_controller_state verb (#2913 <https://github.com/ros-controls/ros2_control/issues/2913>) (#2918 <https://github.com/ros-controls/ros2_control/issues/2918>)
* Add cleanup_controller lifecycle transition (backport #2414 <https://github.com/ros-controls/ros2_control/issues/2414>) (#2914 <https://github.com/ros-controls/ros2_control/issues/2914>)
* Contributors: mergify[bot]
```

## rqt_controller_manager

```
* Use proper cleanup transition (#2917 <https://github.com/ros-controls/ros2_control/issues/2917>) (#2922 <https://github.com/ros-controls/ros2_control/issues/2922>)
* Contributors: mergify[bot]
```

## transmission_interface

- No changes
