### PR TITLE
feetech_ros2_driver: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2006,7 +2006,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
-      version: 0.1.0-2
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/JafarAbdi/feetech_ros2_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `feetech_ros2_driver` to `0.2.1-1`:

- upstream repository: https://github.com/JafarAbdi/feetech_ros2_driver.git
- release repository: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-2`

## feetech_ros2_driver

```
* Fix unused result warning (#24 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/24>)
* 🛠️ Bump actions/cache from 4 to 5 (#23 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/23>)
  Bumps [actions/cache](https://github.com/actions/cache) from 4 to 5.
  - [Release notes](https://github.com/actions/cache/releases)
  - [Changelog](https://github.com/actions/cache/blob/main/RELEASES.md)
  - [Commits](https://github.com/actions/cache/compare/v4...v5)
  ---
  updated-dependencies:
  - dependency-name: actions/cache
  dependency-version: '5'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Fixes errors about missing braces (#21 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/21>)
* Fix deprecated hardware_interface API (#18 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/18>)
  * Fix deprecated hardware_interface API
  * Support both humble and jazzy
  ---------
  Co-authored-by: JafarAbdi <mailto:jafar.uruc@gmail.com>
* 🛠️ Bump actions/setup-python from 5 to 6 (#17 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/17>)
  Bumps [actions/setup-python](https://github.com/actions/setup-python) from 5 to 6.
  - [Release notes](https://github.com/actions/setup-python/releases)
  - [Commits](https://github.com/actions/setup-python/compare/v5...v6)
  ---
  updated-dependencies:
  - dependency-name: actions/setup-python
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
  Co-authored-by: Jafar Uruç <jafar.uruc@gmail.com>
* 🛠️ Bump actions/checkout from 5 to 6 (#20 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/20>)
  Bumps [actions/checkout](https://github.com/actions/checkout) from 5 to 6.
  - [Release notes](https://github.com/actions/checkout/releases)
  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/actions/checkout/compare/v5...v6)
  ---
  updated-dependencies:
  - dependency-name: actions/checkout
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Contributors: Christoph Fröhlich, Louis LE LAY, Sebastian Castro, dependabot[bot]
```
