### PR TITLE
yasmin: 4.2.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10530,7 +10530,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 4.2.1-2
+      version: 4.2.2-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `4.2.2-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.1-2`

## yasmin

```
* minor fix in C++ header guards
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

- No changes

## yasmin_editor

```
* Improving editor C++ plugins filter using the base_class_type to avoid no-yasmin plugins
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_factory

```
* Adding enable_viewer_pub to factory nodes
* minor fix in C++ header guards
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* minor fix in C++ header guards
* Adapting tests for Foxy and Galactic
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

```
* minor fix in C++ header guards
* Contributors: Miguel Ángel González Santamarta
```
