### PR TITLE
behaviortree_cpp_v4: 4.8.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1261,7 +1261,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.7.1-1
+      version: 4.8.3-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.8.3-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.7.1-1`

## behaviortree_cpp

```
* minor change
* remove nolint
* Entry should be non copyable
* miscellaneus
* fix
* run clang tidy in CI
* fix remaining warnings
* apply the rulke of 5
* fix compilation in c++17
* add clang tidy and fix warnings
* update copyright year
* add unit test
* fix multiple issues with SimpleString
* Merge pull request #1043 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1043> from uilianries/fix/cppzmq-visibility
  [fix] Make cppzmq as public dependency to avoid linkage errors for tools
* Turn cppzmq dependency public
* Restore Star History and add Contributors section
  Reintroduced the Star History section and added Contributors section to the README.
* Update copyright year in README.md
* Contributors: Davide Faconti, Uilian Ries
```
