### PR TITLE
control_msgs: 6.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1281,7 +1281,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 6.6.0-1
+      version: 6.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `6.7.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.6.0-1`

## control_msgs

```
* add BatteryStates msg (#250 <https://github.com/ros-controls/control_msgs/issues/250>)
* Add vda5050 safety state msg (#266 <https://github.com/ros-controls/control_msgs/issues/266>)
* Contributors: Yara Shahin
```
