### PR TITLE
control_msgs: 5.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1633,7 +1633,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.6.0-1
+      version: 5.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.7.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.6.0-1`

## control_msgs

```
* add BatteryStates msg (backport #250 <https://github.com/ros-controls/control_msgs/issues/250>) (#283 <https://github.com/ros-controls/control_msgs/issues/283>)
* Add vda5050 safety state msg (backport #266 <https://github.com/ros-controls/control_msgs/issues/266>) (#282 <https://github.com/ros-controls/control_msgs/issues/282>)
* Contributors: mergify[bot]
```
