### PR TITLE
ros2_controllers: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7293,6 +7293,7 @@ repositories:
       - ros2_controllers
       - ros2_controllers_test_nodes
       - rqt_joint_trajectory_controller
+      - state_interfaces_broadcaster
       - steering_controllers_library
       - tricycle_controller
       - tricycle_steering_controller
@@ -7300,7 +7301,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.1.0-1
+      version: 6.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.2.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Use TF prefix helper for diff drive controller (#1997 <https://github.com/ros-controls/ros2_controllers/issues/1997>)
* Contributors: Ege Kural
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Remove export of wrench_transformer_node (#2069 <https://github.com/ros-controls/ros2_controllers/issues/2069>)
* Add support for positional target frame arguments for transform wrench node (#2040 <https://github.com/ros-controls/ros2_controllers/issues/2040>)
* Contributors: Sai Kishor Kothakota, Vedh
```

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Add parameter for deactivating dynamic_joint_states (#2064 <https://github.com/ros-controls/ros2_controllers/issues/2064>)
* Contributors: Christoph Fröhlich
```

## joint_trajectory_controller

```
* Fix BSD license (#2054 <https://github.com/ros-controls/ros2_controllers/issues/2054>)
* Use get_lifecycle_id instead of get_lifecycle_state (#2053 <https://github.com/ros-controls/ros2_controllers/issues/2053>)
* Fill point_before_trajectory with same information as trajectory (#2043 <https://github.com/ros-controls/ros2_controllers/issues/2043>)
* Contributors: Christoph Fröhlich, Felix Exner (fexner), Sai Kishor Kothakota
```

## mecanum_drive_controller

```
* Tf prefix helper for mecanum drive controller (#2063 <https://github.com/ros-controls/ros2_controllers/issues/2063>)
* Contributors: Ege Kural
```

## motion_primitives_controllers

```
* Use get_lifecycle_id instead of get_lifecycle_state (#2053 <https://github.com/ros-controls/ros2_controllers/issues/2053>)
* Contributors: Sai Kishor Kothakota
```

## omni_wheel_drive_controller

```
* Tf prefix helper for omniwheel drive (#2073 <https://github.com/ros-controls/ros2_controllers/issues/2073>)
* Contributors: Ege Kural
```

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Add state_interfaces_broadcaster (#2006 <https://github.com/ros-controls/ros2_controllers/issues/2006>)
* Contributors: Sai Kishor Kothakota
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## state_interfaces_broadcaster

```
* Add state_interfaces_broadcaster (#2006 <https://github.com/ros-controls/ros2_controllers/issues/2006>)
* Contributors: Sai Kishor Kothakota
```

## steering_controllers_library

```
* Fix open_loop odometry of steering controllers (#2087 <https://github.com/ros-controls/ros2_controllers/issues/2087>)
* tf prefix helper used in steering controllers library (#2080 <https://github.com/ros-controls/ros2_controllers/issues/2080>)
* Contributors: Christoph Fröhlich, Ege Kural
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
