### PR TITLE
ros2_controllers: 5.12.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7365,6 +7365,7 @@ repositories:
       - ros2_controllers
       - ros2_controllers_test_nodes
       - rqt_joint_trajectory_controller
+      - state_interfaces_broadcaster
       - steering_controllers_library
       - tricycle_controller
       - tricycle_steering_controller
@@ -7372,7 +7373,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.11.0-1
+      version: 5.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.11.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Remove export of wrench_transformer_node (backport #2069 <https://github.com/ros-controls/ros2_controllers/issues/2069>) (#2072 <https://github.com/ros-controls/ros2_controllers/issues/2072>)
* Contributors: mergify[bot]
```

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Add parameter for deactivating dynamic_joint_states (backport #2064 <https://github.com/ros-controls/ros2_controllers/issues/2064>) (#2067 <https://github.com/ros-controls/ros2_controllers/issues/2067>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

- No changes

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Add state_interfaces_broadcaster (backport #2006 <https://github.com/ros-controls/ros2_controllers/issues/2006>) (#2077 <https://github.com/ros-controls/ros2_controllers/issues/2077>)
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## state_interfaces_broadcaster

```
* Add state_interfaces_broadcaster (backport #2006 <https://github.com/ros-controls/ros2_controllers/issues/2006>) (#2077 <https://github.com/ros-controls/ros2_controllers/issues/2077>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Fix open_loop odometry of steering controllers (backport #2087 <https://github.com/ros-controls/ros2_controllers/issues/2087>) (#2089 <https://github.com/ros-controls/ros2_controllers/issues/2089>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
