### PR TITLE
ros2_controllers: 2.52.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9430,7 +9430,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.51.0-1
+      version: 2.52.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.52.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.51.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Remove export of wrench_transformer_node (backport #2069 <https://github.com/ros-controls/ros2_controllers/issues/2069>) (#2070 <https://github.com/ros-controls/ros2_controllers/issues/2070>)
* Add support for positional target frame arguments for transform wrench node (backport #2040 <https://github.com/ros-controls/ros2_controllers/issues/2040>) (#2045 <https://github.com/ros-controls/ros2_controllers/issues/2045>)
* Contributors: mergify[bot]
```

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Add parameter for deactivating dynamic_joint_states (backport #2064 <https://github.com/ros-controls/ros2_controllers/issues/2064>) (#2065 <https://github.com/ros-controls/ros2_controllers/issues/2065>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Fill point_before_trajectory with same information as trajectory (backport #2043 <https://github.com/ros-controls/ros2_controllers/issues/2043>) (#2049 <https://github.com/ros-controls/ros2_controllers/issues/2049>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
