### PR TITLE
vector_pursuit_controller: 1.0.2-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12908,7 +12908,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/vector_pursuit_controller-release.git
-      version: 1.0.1-1
+      version: 1.0.2-2
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `vector_pursuit_controller` to `1.0.2-2`:

- upstream repository: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
- release repository: https://github.com/ros2-gbp/vector_pursuit_controller-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-1`

## vector_pursuit_controller

```
* Fix minor: minor typo
* FIX: typo in turning_radius
* Added unit test for Ackermann constraints (#14 <https://github.com/blackcoffeerobotics/vector_pursuit_controller/issues/14>)
* Fixed angle calculations and out of bounds errors for the main implementation
* Update install binary (#3 <https://github.com/blackcoffeerobotics/vector_pursuit_controller/issues/3>)
* Contributors: Kostubh, Kostubh Khandelwal
```
