### PR TITLE
bcr_arm: 0.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -934,6 +934,21 @@ repositories:
       version: main
     status: maintained
   bcr_arm:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_arm.git
+      version: ros2
+    release:
+      packages:
+      - bcr_arm
+      - bcr_arm_description
+      - bcr_arm_gazebo
+      - bcr_arm_moveit_config
+      - bcr_arm_ros2
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/bcr_arm-release.git
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/blackcoffeerobotics/bcr_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bcr_arm` to `0.1.2-1`:

- upstream repository: https://github.com/blackcoffeerobotics/bcr_arm.git
- release repository: https://github.com/ros2-gbp/bcr_arm-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## bcr_arm

```
* Synchronize package version
* Contributors: Mathew Hans
```

## bcr_arm_description

```
* fixed usd for isaac sim
* Contributors: Mathew Hans
```

## bcr_arm_gazebo

```
* removed redundent plugins
* Contributors: mathew4star
```

## bcr_arm_moveit_config

```
* removed redundent plugins
* Contributors: mathew4star
```

## bcr_arm_ros2

```
* Synchronize package version
* Contributors: Mathew Hans
```
