### PR TITLE
Add NixOS key for python3-smbus2

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10316,6 +10316,7 @@ python3-smbus:
   ubuntu: [python3-smbus]
 python3-smbus2:
   debian: [python3-smbus2]
+  nixos: [python3Packages.smbus2]
   ubuntu:
     '*': [python3-smbus2]
     focal: null


### PR DESCRIPTION
See https://search.nixos.org/packages?channel=unstable&query=smbus2

