### PR TITLE
vector_pursuit_controller: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11700,6 +11700,21 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: jazzy
     status: maintained
+  vector_pursuit_controller:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/vector_pursuit_controller-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
+      version: jazzy
+    status: maintained
   velodyne:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `vector_pursuit_controller` to `2.0.0-1`:

- upstream repository: https://github.com/blackcoffeerobotics/vector_pursuit_controller.git
- release repository: https://github.com/ros2-gbp/vector_pursuit_controller-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## vector_pursuit_controller

```
* Prevent overshoot for final rotation
* Contributors: Tatsuro Sakaguchi
```
