### PR TITLE
azure_iot_sdk_c: 1.14.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -857,7 +857,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
-      version: 1.14.0-1
+      version: 1.14.0-2
     source:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git


### PR DESCRIPTION
Increasing version of package(s) in repository `azure_iot_sdk_c` to `1.14.0-2`:

- upstream repository: https://github.com/Azure/azure-iot-sdk-c.git
- release repository: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.14.0-1`
