### PR TITLE
Update lz4 keys of base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7749,16 +7749,16 @@ lua5.2-dev:
 lz4:
   alpine: [lz4-dev]
   arch: [lz4]
-  debian: [liblz4-dev]
-  fedora: [lz4-devel]
+  debian: [liblz4-dev, lz4]
+  fedora: [lz4-devel, lz4]
   freebsd: [liblz4]
   gentoo: [app-arch/lz4]
   nixos: [lz4]
   openembedded: [lz4@openembedded-core]
-  opensuse: [liblz4-devel]
-  rhel: [lz4-devel]
+  opensuse: [liblz4-devel, lz4]
+  rhel: [lz4-devel, lz4]
   slackware: [lz4]
-  ubuntu: [liblz4-dev]
+  ubuntu: [liblz4-dev, lz4]
 m2r:
   alpine:
     pip:


### PR DESCRIPTION
## Package name:

lz4

## Purpose of using this:

I want to add `lz4` command dependency to my package. But current `lz4` key in ubuntu is resolved as `liblz4-dev`, which is actually a library package.
https://github.com/ros/rosdistro/pull/3938

It seems that this keys are already used as dependency to dev package. ( e.g. https://github.com/ros/rosdistro/pull/16915 looks like fixing dependency of lz4 in ros_comm in melodic )

So I will just add command package to the key in addition to existing keys.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/lz4
- Ubuntu: https://packages.ubuntu.com/
  - https://launchpad.net/ubuntu/+source/lz4
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/lz4/lz4/
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/lz4
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/lz4