### PR TITLE
mp_units_vendor: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5350,6 +5350,21 @@ repositories:
       url: https://github.com/MOLAorg/mp2p_icp.git
       version: develop
     status: developed
+  mp_units_vendor:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mp_units_vendor.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/mp_units_vendor-release.git
+      version: 2.5.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/mp_units_vendor.git
+      version: main
+    status: developed
   mqtt_client:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4606,7 +4606,7 @@ repositories:
       type: git
       url: https://github.com/nobleo/mp_units_vendor.git
       version: main
-    status: maintained
+    status: developed
   mqtt_client:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4567,7 +4567,7 @@ repositories:
       type: git
       url: https://github.com/nobleo/mp_units_vendor.git
       version: main
-    status: maintained
+    status: developed
   mqtt_client:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp_units_vendor` to `2.5.0-1`:

- upstream repository: https://github.com/nobleo/mp_units_vendor.git
- release repository: https://github.com/ros2-gbp/mp_units_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
