### PR TITLE
Revert "off_highway_sensor_drivers: 0.10.0-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6742,7 +6742,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 0.10.0-1
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Reverts ros/rosdistro#49095, which seemed to have created a regression on the build farm.

https://github.com/bosch-engineering/off_highway_sensor_drivers/issues/25

FYI @Gabriela-AdrianaLapuste