### PR TITLE
Revert "feetech_ros2_driver: 0.2.1-1 in 'humble/distribution.yaml' [bloom]"

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2869,7 +2869,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
-      version: 0.2.1-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/JafarAbdi/feetech_ros2_driver.git


### PR DESCRIPTION
Reverts ros/rosdistro#49252, which seems to have created a regression on the buildfarm.

https://github.com/JafarAbdi/feetech_ros2_driver/issues/25

FYI @JafarAbdi