### PR TITLE
Add sync_tooling_msgs to Rolling, Jazzy, Humble index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11473,6 +11473,10 @@ repositories:
       version: main
     status: developed
   sync_tooling_msgs:
+    doc:
+      type: git
+      url: https://github.com/tier4/sync_tooling_msgs.git
+      version: main
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11472,6 +11472,12 @@ repositories:
       url: https://github.com/Tacha-S/sync_parameter_server.git
       version: main
     status: developed
+  sync_tooling_msgs:
+    source:
+      type: git
+      url: https://github.com/tier4/sync_tooling_msgs.git
+      version: main
+    status: developed
   synchros2:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10517,6 +10517,10 @@ repositories:
       version: main
     status: maintained
   sync_tooling_msgs:
+    doc:
+      type: git
+      url: https://github.com/tier4/sync_tooling_msgs.git
+      version: main
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10516,6 +10516,12 @@ repositories:
       url: https://github.com/synapticon/synapticon_ros2_control.git
       version: main
     status: maintained
+  sync_tooling_msgs:
+    source:
+      type: git
+      url: https://github.com/tier4/sync_tooling_msgs.git
+      version: main
+    status: developed
   synchros2:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9171,6 +9171,12 @@ repositories:
       url: https://github.com/synapticon/synapticon_ros2_control.git
       version: main
     status: maintained
+  sync_tooling_msgs:
+    source:
+      type: git
+      url: https://github.com/tier4/sync_tooling_msgs.git
+      version: main
+    status: developed
   system_fingerprint:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9172,6 +9172,10 @@ repositories:
       version: main
     status: maintained
   sync_tooling_msgs:
+    doc:
+      type: git
+      url: https://github.com/tier4/sync_tooling_msgs.git
+      version: main
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Package: `sync_tooling_msgs`

Distros:
* rolling
* jazzy
* humble

# The source is here:

https://github.com/tier4/sync_tooling_msgs.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

Tested build with

```bash
git clone https://github.com/tier4/sync_tooling_msgs.git
cd sync_tooling_msgs
for distro in humble jazzy rolling
do
  docker run -v $PWD:/ws ros:${distro} bash -c 'cd /ws/ && rosdep update && apt update && rosdep install -yq --from-paths . -i && colcon build && colcon test && colcon test-result'
  sudo rm -rf ./build/ ./log/ ./install/
done
```
