### PR TITLE
Add python3-can support for Ubuntu Noble

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -893,6 +893,9 @@ python-can:
       packages: [python-can]
   ubuntu:
     bionic: [python-can]
+python3-can:
+  ubuntu:
+    noble: [python3-can]
 python-cantools-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-can

## Package Upstream Source:

[TODO link to source repository](https://packages.ubuntu.com/noble/python3-can)

## Purpose of using this:



Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/python3-can
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-can
  - https://packages.ubuntu.com/jammy/python3-can

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
