### PR TITLE
tf_tree_terminal: 2.0.0-2 in 'humble/distribution.yaml', 2.0.0-1 in  'jazzy/distribution.yaml' and 'rolling/distribution.yaml'

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11719,6 +11719,21 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  tf_tree_terminal:
+      doc:
+        type: git
+        url: https://github.com/Tanneguydv/tf_tree_terminal.git
+        version: master
+      release:
+        tags:
+          release: release/humble/{package}/{version}
+        url: https://github.com/Tanneguydv/tf_tree_terminal-release.git
+        version: 2.0.0-2
+      source:
+        type: git
+        url: https://github.com/Tanneguydv/tf_tree_terminal.git
+        version: master
+      status: developed
   the_navigation_gauntlet:
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11720,20 +11720,20 @@ repositories:
       version: main
     status: maintained
   tf_tree_terminal:
-      doc:
-        type: git
-        url: https://github.com/Tanneguydv/tf_tree_terminal.git
-        version: master
-      release:
-        tags:
-          release: release/humble/{package}/{version}
-        url: https://github.com/Tanneguydv/tf_tree_terminal-release.git
-        version: 2.0.0-2
-      source:
-        type: git
-        url: https://github.com/Tanneguydv/tf_tree_terminal.git
-        version: master
-      status: developed
+    doc:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/Tanneguydv/tf_tree_terminal-release.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: master
+    status: developed
   the_navigation_gauntlet:
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11723,7 +11723,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Tanneguydv/tf_tree_terminal.git
-      version: master
+      version: 2.0.0
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -11732,7 +11732,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Tanneguydv/tf_tree_terminal.git
-      version: master
+      version: 2.0.0
     status: developed
   the_navigation_gauntlet:
     source:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10751,7 +10751,7 @@ repositories:
        type: git
        url: https://github.com/Tanneguydv/tf_tree_terminal.git
        version: master
-      status: developed
+    status: developed
   tinyspline_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10737,6 +10737,21 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  tf_tree_terminal:
+    doc:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/Tanneguydv/tf_tree_terminal-release.git
+      version: 2.0.0-1
+    source:
+       type: git
+       url: https://github.com/Tanneguydv/tf_tree_terminal.git
+       version: master
+      status: developed
   tinyspline_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10741,7 +10741,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Tanneguydv/tf_tree_terminal.git
-      version: master
+      version: 2.0.0
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -10750,7 +10750,7 @@ repositories:
     source:
        type: git
        url: https://github.com/Tanneguydv/tf_tree_terminal.git
-       version: master
+       version: 2.0.0
     status: developed
   tinyspline_vendor:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9365,7 +9365,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Tanneguydv/tf_tree_terminal.git
-      version: master
+      version: 2.0.0
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -9374,7 +9374,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Tanneguydv/tf_tree_terminal.git
-      version: master
+      version: 2.0.0
     status: developed
   tinyspline_vendor:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9361,6 +9361,21 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  tf_tree_terminal:
+    doc:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/Tanneguydv/tf_tree_terminal-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: master
+    status: developed
   tinyspline_vendor:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

HUMBLE, JAZZY, ROLLING

# The source is here:

https://github.com/Tanneguydv/tf_tree_terminal-release

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
