### PR TITLE
tf_tree_terminal: 2.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9476,6 +9476,21 @@ repositories:
       url: https://github.com/DLu/tf_transformations.git
       version: main
     status: maintained
+  tf_tree_terminal:
+    doc:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: 2.0.0
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/Tanneguydv/tf_tree_terminal-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: 2.0.0
+    status: developed
   tinyspline_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_tree_terminal` to `2.0.0-1`:

- upstream repository: https://github.com/Tanneguydv/tf_tree_terminal.git
- release repository: https://github.com/Tanneguydv/tf_tree_terminal-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
