### PR TITLE
mp2p_icp: 2.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5344,7 +5344,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.2.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## mp2p_icp

```
* Merge pull request #21 <https://github.com/MOLAorg/mp2p_icp/issues/21> from MOLAorg/feat/abs-stamp-filter
  Added new filter: FilterAbsoluteTimestamp
* Fix the logic of the FilterEdgePlane filter parameters
* Added new filter: FilterAbsoluteTimestamp
* mm2txt: also export uint8 fields (missing in last release)
* Merge pull request #20 <https://github.com/MOLAorg/mp2p_icp/issues/20> from MOLAorg/feat/more-unit-tests
  More unit tests
* Add generators unit tests
* More unit tests
* Contributors: Jose Luis Blanco-Claraco
```
