### PR TITLE
swri_console: 2.0.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11435,7 +11435,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.7-1
+      version: 2.0.8-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.0.8-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.7-1`

## swri_console

```
* Backport off https://github.com/swri-robotics/swri_console/pull/73 (#74 <https://github.com/swri-robotics/swri_console/issues/74>)
  * Backport off https://github.com/swri-robotics/swri_console/pull/73
* Updating README with information about all distributions.
* Contributors: David Anthony
```
