### PR TITLE
ros2cli: 0.40.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7467,7 +7467,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.40.3-1
+      version: 0.40.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.40.4-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.40.3-1`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* skip test_verb_load_wildcard for rmw_connextdds. (#1150 <https://github.com/ros2/ros2cli/issues/1150>)
* Contributors: Tomoya Fujita
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

```
* add "--all/-a" option to "ros2 topic bw" with screen refresh. (#1130 <https://github.com/ros2/ros2cli/issues/1130>)
* Contributors: nomumu
```
