### PR TITLE
ros2cli: 0.38.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7548,7 +7548,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.38.1-1
+      version: 0.38.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.38.2-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.38.1-1`

## ros2action

```
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2cli

```
* fix: Also catch a TimeoutError (#1092 <https://github.com/ros2/ros2cli/issues/1092>) (#1157 <https://github.com/ros2/ros2cli/issues/1157>)
* Remove importlib packages (backport #1117 <https://github.com/ros2/ros2cli/issues/1117>) (#1119 <https://github.com/ros2/ros2cli/issues/1119>)
* skip history and depth check for rmw_connextdds. (#1064 <https://github.com/ros2/ros2cli/issues/1064>) (#1127 <https://github.com/ros2/ros2cli/issues/1127>)
* Fix handling of empty ROS_DOMAIN_ID in ros2cli (#1112 <https://github.com/ros2/ros2cli/issues/1112>) (#1113 <https://github.com/ros2/ros2cli/issues/1113>)
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

```
* Remove importlib packages (backport #1117 <https://github.com/ros2/ros2cli/issues/1117>) (#1119 <https://github.com/ros2/ros2cli/issues/1119>)
* Harden ros2doctor system calls. (#1118 <https://github.com/ros2/ros2cli/issues/1118>) (#1138 <https://github.com/ros2/ros2cli/issues/1138>)
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2interface

- No changes

## ros2lifecycle

```
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

```
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2param

```
* skip test_verb_load_wildcard for rmw_connextdds. (#1150 <https://github.com/ros2/ros2cli/issues/1150>) (#1152 <https://github.com/ros2/ros2cli/issues/1152>)
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2pkg

```
* Add Native ROS2 Rust Package Create Capability (#1107 <https://github.com/ros2/ros2cli/issues/1107>) (#1135 <https://github.com/ros2/ros2cli/issues/1135>)
* Remove importlib packages (backport #1117 <https://github.com/ros2/ros2cli/issues/1117>) (#1119 <https://github.com/ros2/ros2cli/issues/1119>)
* add mypy (#1109 <https://github.com/ros2/ros2cli/issues/1109>) (#1110 <https://github.com/ros2/ros2cli/issues/1110>)
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

```
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: mergify[bot]
```

## ros2topic

```
* add "--all/-a" option to "ros2 topic hz" with screen refresh. (backport #1122 <https://github.com/ros2/ros2cli/issues/1122>) (#1144 <https://github.com/ros2/ros2cli/issues/1144>)
* return explicitly from internal functions. (backport #1128 <https://github.com/ros2/ros2cli/issues/1128>) (#1134 <https://github.com/ros2/ros2cli/issues/1134>)
* Use rmw_test_fixture to isolate ros2cli tests (backport #1062 <https://github.com/ros2/ros2cli/issues/1062>) (#1106 <https://github.com/ros2/ros2cli/issues/1106>)
* Contributors: Tomoya Fujita, mergify[bot]
```
