### PR TITLE
kompass: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4220,7 +4220,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.3.3-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.4.0-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.3-1`

## kompass

```
* (chore) Adds version check for kompass-core
* (fix) Uses new PointFieldType for emergency stop checking with point cloud data
* (fix) Removes assertion from pointcloud callback and gives a warning
* (fix) Adds pure pursuit config class to control module
* (fix) Adds warning message for unsupported configuration in drive manager
* (feature) Adds global map server to turtlebot3 recipe
* (fix) Adds missing header frame to global path publisher
* (feature) Enables using pure pursuit controller from kompass-core
* (fix) Fixes TwistStamped converter
* (fix) Updates drive manager to enable using point cloud data directly in critical zone check
* Contributors: ahr, aleph-ra, mkabtoul
```

## kompass_interfaces

```
* (fix) Adds number of point to path recording/saving service response
* Contributors: ahr, mkabtoul
```
