### PR TITLE
hebi_cpp_api: 3.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3000,7 +3000,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/hebi_cpp_api-release.git
-      version: 3.15.0-1
+      version: 3.16.0-1
     source:
       type: git
       url: https://github.com/HebiRobotics/hebi_cpp_api_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hebi_cpp_api` to `3.16.0-1`:

- upstream repository: https://github.com/HebiRobotics/hebi_cpp_api_ros.git
- release repository: https://github.com/ros2-gbp/hebi_cpp_api-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.15.0-1`

## hebi_cpp_api

```
* Added function to rescale trajectory duration
* Add function to create a trapezoidal-like trajectory with minimum jerk acceleration and deceleration phases (e.g., "Jerkazoidal")
* Update C API dependency to 2.23.1 to fix various issues and enable trajectory rescaling and jerkazoidal functionality listed above
* Add settable acceleration and velocity limits to hebi::Arm object. By default these are set based on the module types in the HRDF file, defaulting to infinity for basic "joint" types. When setting a new goal, these limits are respected and the trajectory timestamps are rescaled if necessary to prevent exceeding the limits.
* Add several new arm::Goal constructors allowing creation of a goal by defining position and velocity but not accelerations
* Do not limit unicast lookup addresses to current network interface address ranges (from C API update 2.22.1)
* Fixed RX sequence number of receive timestamps on GroupFeedback objects read from log files (from C API update 2.23.0)
* Performance optimization when writing logfiles, and other improved internal error handling (from C API update 2.23.0)
* Contributors: Hariharan Ravichandran, Matthew Tesch
```
