### PR TITLE
ros2_kortex: 0.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8529,7 +8529,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_kortex-release.git
-      version: 0.2.4-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/Kinovarobotics/ros2_kortex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_kortex` to `0.2.6-1`:

- upstream repository: https://github.com/Kinovarobotics/ros2_kortex.git
- release repository: https://github.com/ros2-gbp/ros2_kortex-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.4-1`

## kinova_gen3_6dof_robotiq_2f_85_moveit_config

```
* Package version updates
* Contributors: Abed Al Rahman Al Mrad
```

## kinova_gen3_7dof_robotiq_2f_85_moveit_config

```
* Package version updates
* Contributors: Abed Al Rahman Al Mrad
```

## kinova_gen3_lite_moveit_config

```
* Package version updates
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_api

```
* Changed Kortex API fetching from online URL to local path
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_bringup

```
* Package version updates
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_description

```
* Package version updates
* Contributors: Abed Al Rahman Al Mrad
```

## kortex_driver

```
* Package version updates
* Contributors: Abed Al Rahman Al Mrad
```
