### PR TITLE
mapviz: 2.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5192,7 +5192,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.6.0-1
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.6.1-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.0-1`

## mapviz

- No changes

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Added image rotation option for image_plugin (#865 <https://github.com/swri-robotics/mapviz/issues/865>)
* Contributors: Alex Youngs
```

## multires_image

- No changes

## tile_map

- No changes
