### PR TITLE
mp_units_vendor: 2.5.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5359,7 +5359,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mp_units_vendor-release.git
-      version: 2.5.0-1
+      version: 2.5.0-2
     source:
       type: git
       url: https://github.com/nobleo/mp_units_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp_units_vendor` to `2.5.0-2`:

- upstream repository: https://github.com/nobleo/mp_units_vendor.git
- release repository: https://github.com/ros2-gbp/mp_units_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.0-1`
