### PR TITLE
gz_ros2_control: 3.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2860,7 +2860,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 3.0.5-1
+      version: 3.0.6-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `3.0.6-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.5-1`

## gz_ros2_control

```
* Removed unused ament_index_cpp (#760 <https://github.com/ros-controls/gz_ros2_control/issues/760>)
* fix failing pre-commit (#741 <https://github.com/ros-controls/gz_ros2_control/issues/741>)
* Fix platform-independent logging in gz_ros2_control plugin (#740 <https://github.com/ros-controls/gz_ros2_control/issues/740>)
* Minor code consistency fix (#732 <https://github.com/ros-controls/gz_ros2_control/issues/732>)
* Contributors: Alejandro Hernández Cordero, Dhruv Patel, Patrick Roncagliolo, Sai Kishor Kothakota
```

## gz_ros2_control_demos

- No changes
