### PR TITLE
gz_ros2_control: 2.0.14-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2942,7 +2942,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.13-1
+      version: 2.0.14-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.14-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.13-1`

## gz_ros2_control

```
* Removed unused ament_index_cpp (#760 <https://github.com/ros-controls/gz_ros2_control/issues/760>) (#761 <https://github.com/ros-controls/gz_ros2_control/issues/761>)
* Minor code consistency fix (#732 <https://github.com/ros-controls/gz_ros2_control/issues/732>) (#733 <https://github.com/ros-controls/gz_ros2_control/issues/733>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes
