### PR TITLE
mp2p_icp: 2.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4586,7 +4586,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.2.1-1`

## mp2p_icp

```
* Merge pull request #24 <https://github.com/MOLAorg/mp2p_icp/issues/24> from MOLAorg/feat/mm2txt-select-fields
  mm2txt and mm2ply now have a --export-fields flag
* mm2txt and mm2ply now have a --export-fields flag
* Merge pull request #23 <https://github.com/MOLAorg/mp2p_icp/issues/23> from MOLAorg/fix/some-deprecations
  Fix usage of deprecated cloud types
* Provide shortcut names for common cloud field names
* More deprecated cloud usage
* FIX bug: FilterDecimateVoxel, if using flatten, did not propagate all input cloud fields
* Fix usage of some deprecated cloud types
* FilterSOR: create output layers even if input is empty
* FilterDeskew: propagate input fields even if the cloud is empty
* FilterByExpression: show debug-level stats
* FilterNormalizeIntensity: do not throw on empty clouds
* Merge pull request #22 <https://github.com/MOLAorg/mp2p_icp/issues/22> from MOLAorg/feat/new-filters
  Add new filter FilterRenameLayer
* Added filter FilterRenameLayer
* mm2txt: prepare for deprecated classes in 3.0.0
* FilterAdjustTimestamps: new method 'None' to bypass filter
* Fix: sm2mm did not attach to ParameterSource the final_filter elements
* sm2mm: did not observe the optional profiler parameter for the final_filter stage
* Fix: FilterMLS did not properly copy all point fields when using upsampling
* Fix: FilterAbsoluteTimestamp now also works for accumulated points in one layer
* Contributors: Jose Luis Blanco-Claraco
```
