### PR TITLE
gz_ros2_control: 1.2.17-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3558,7 +3558,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.16-1
+      version: 1.2.17-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.17-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.16-1`

## gz_ros2_control

```
* Removed unused ament_index_cpp (backport #760 <https://github.com/ros-controls/gz_ros2_control/issues/760>) (#762 <https://github.com/ros-controls/gz_ros2_control/issues/762>)
* Minor code consistency fix (#732 <https://github.com/ros-controls/gz_ros2_control/issues/732>) (#734 <https://github.com/ros-controls/gz_ros2_control/issues/734>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

- No changes
