### PR TITLE
hitch_estimation_apriltag_array: 0.0.2-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3843,7 +3843,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
-      version: 0.0.1-1
+      version: 0.0.2-3
     source:
       type: git
       url: https://github.com/li9i/hitch-estimation-apriltag-array.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hitch_estimation_apriltag_array` to `0.0.2-3`:

- upstream repository: https://github.com/li9i/hitch-estimation-apriltag-array.git
- release repository: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.1-1`
