### PR TITLE
hitch_estimation_apriltag_array: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3728,6 +3728,21 @@ repositories:
       url: https://github.com/damanikjosh/heightmap_spawner.git
       version: jazzy
     status: developed
+  hitch_estimation_apriltag_array:
+    doc:
+      type: git
+      url: https://github.com/li9i/hitch-estimation-apriltag-array.git
+      version: jazzy-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/li9i/hitch-estimation-apriltag-array.git
+      version: jazzy-devel
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hitch_estimation_apriltag_array` to `0.0.2-1`:

- upstream repository: https://github.com/li9i/hitch-estimation-apriltag-array.git
- release repository: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
