### PR TITLE
qml6_ros2_plugin: 1.26.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7131,7 +7131,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 1.25.121-1
+      version: 1.26.10-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `1.26.10-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.25.121-1`

## qml6_ros2_plugin

```
* Fixed segfault if Service or ActionClient are no longer associated with qjsEngine when callback is invoked.
* Improved image conversion to also deal with infinite values in depth images.
* Fixed crash when ServiceClient is processing request while client is destroyed.
  Use QPointer for callbacks to prevent crashes due to the object being destroyed while an asynchronous operation is still in progress.
* Contributors: Stefan Fabian
```
