### PR TITLE
zed-ros2-description: 0.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13366,7 +13366,7 @@ repositories:
       - zed_description
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/stereolabs/zed-ros2-description.git
+      url: https://github.com/stereolabs/zed-ros2-description-release.git
       version: 0.1.0-1
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13360,13 +13360,13 @@ repositories:
     doc:
       type: git
       url: https://github.com/stereolabs/zed-ros2-description.git
-      version: 0.1.0
+      version: humble
     release:
       packages:
       - zed_description
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/stereolabs/zed-ros2-description-release.git
+      url: https://github.com/ros2-gbp/zed-ros2-description-release.git
       version: 0.1.0-1
     source:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13356,6 +13356,23 @@ repositories:
       url: https://github.com/ros-drivers/zbar_ros.git
       version: humble
     status: maintained
+  zed-ros2-description:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: 0.1.0
+    release:
+      packages:
+      - zed_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: 0.1.0
+    status: developed
   zed-ros2-interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-description` to `0.1.0-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-description
- release repository: https://github.com/stereolabs/zed-ros2-description.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## zed_description

```
* Initial commit
* Contributors: Walter Lucetti
```
