### PR TITLE
zed-ros2-description: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12108,7 +12108,7 @@ repositories:
       - zed_description
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/stereolabs/zed-ros2-description.git
+      url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
       version: 0.1.0-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12102,7 +12102,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stereolabs/zed-ros2-description.git
-      version: 0.1.0
+      version: humble
     release:
       packages:
       - zed_description

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12108,7 +12108,7 @@ repositories:
       - zed_description
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
+      url: https://github.com/ros2-gbp/zed-ros2-description-release.git
       version: 0.1.0-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12098,6 +12098,23 @@ repositories:
       url: https://github.com/ros-drivers/zbar_ros.git
       version: jazzy
     status: maintained
+  zed-ros2-description:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: 0.1.0
+    release:
+      packages:
+      - zed_description
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: 0.1.0
+    status: developed
   zed-ros2-interfaces:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-description` to `0.1.0-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-description
- release repository: https://github.com/stereolabs/zed-ros2-description.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## zed_description

```
* Initial commit
* Contributors: Walter Lucetti
```
