### PR TITLE
rclpy: 10.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6451,7 +6451,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.2-1
+      version: 10.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.4-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.0.2-1`

## rclpy

```
* Fix performance bug in MultiThreadedExecutor (hopefully) (#1547 <https://github.com/ros2/rclpy/issues/1547>)
* Expose action graph functions as Node class methods. (#1574 <https://github.com/ros2/rclpy/issues/1574>)
* Improve wildcard parsing and optimize the logic for parsing YAML para… (#1571 <https://github.com/ros2/rclpy/issues/1571>)
* Improve the compatibility of processing YAML parameter files (#1548 <https://github.com/ros2/rclpy/issues/1548>)
* Fix parameter parsing for unspecified target nodes (#1552 <https://github.com/ros2/rclpy/issues/1552>)
* Remove default from switch with enum, so that compiler warns. (#1566 <https://github.com/ros2/rclpy/issues/1566>)
* Use unconditional wait when possible. (#1563 <https://github.com/ros2/rclpy/issues/1563>)
* Increase clock accuracy (#1564 <https://github.com/ros2/rclpy/issues/1564>)
* Contributors: Barry Xu, Florian Vahl, Michael Tandy, Tomoya Fujita
```
