### PR TITLE
demos: 0.36.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1415,7 +1415,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.36.3-1
+      version: 0.36.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.36.4-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.36.3-1`

## action_tutorials_cpp

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

- No changes

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

- No changes

## intra_process_demo

```
* fixup image_pipeline_demo (#755 <https://github.com/ros2/demos/issues/755>) (#756 <https://github.com/ros2/demos/issues/756>)
* Contributors: mergify[bot]
```

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

- No changes

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

- No changes

## topic_statistics_demo

- No changes
