### PR TITLE
Add Move Base Flex to humble and jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5747,6 +5747,12 @@ repositories:
       url: https://github.com/IMRCLab/motion_capture_tracking.git
       version: ros2
     status: developed
+  move_base_flex:
+    source:
+      type: git
+      url: https://github.com/naturerobots/move_base_flex.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5216,6 +5216,12 @@ repositories:
       url: https://github.com/IMRCLab/motion_capture_tracking.git
       version: ros2
     status: developed
+  move_base_flex:
+    source:
+      type: git
+      url: https://github.com/naturerobots/move_base_flex.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

* humble
* jazzy

# The source is here:

https://github.com/naturerobots/move_base_flex

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
