### PR TITLE
perception_pcl: 2.7.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5472,7 +5472,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.7.3-1
+      version: 2.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.7.4-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.3-1`

## pcl_conversions

- No changes

## pcl_ros

```
* Update PCLNode to use TransformListener Node constructor so that it does not create a new node under the hood
* Correct Statistical Outlier Removal param description
* Add support for Windows
* Contributors: AntoBrandi, Silvio Traversaro, Xavier Ruiz
```

## perception_pcl

- No changes
