### PR TITLE
ros2_control: 5.11.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7313,7 +7313,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.11.2-1
+      version: 5.11.3-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.11.3-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.11.2-1`

## controller_interface

- No changes

## controller_manager

```
* Fix the duplicate entries in the controller exported interfaces (#2951 <https://github.com/ros-controls/ros2_control/issues/2951>) (#2955 <https://github.com/ros-controls/ros2_control/issues/2955>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the duplicate entries in the controller exported interfaces (#2951 <https://github.com/ros-controls/ros2_control/issues/2951>) (#2955 <https://github.com/ros-controls/ros2_control/issues/2955>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
