### PR TITLE
iridescence: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4030,6 +4030,20 @@ repositories:
       url: https://github.com/unisa-acg/inverse-dynamics-solver.git
       version: jazzy
     status: developed
+  iridescence:
+    doc:
+      type: git
+      url: https://github.com/koide3/iridescence.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/koide3/iridescence-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/koide3/iridescence.git
+      version: master
   irobot_create_msgs:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `iridescence` to `1.0.1-1`:

- upstream repository: https://github.com/koide3/iridescence.git
- release repository: https://github.com/koide3/iridescence-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
