### PR TITLE
parameter_expression: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6425,6 +6425,11 @@ repositories:
       version: master
     status: maintained
   parameter_expression:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/parameter_expression-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ForteFibre/parameter_expression.git


### PR DESCRIPTION
Increasing version of package(s) in repository `parameter_expression` to `0.0.2-1`:

* upstream repository: https://github.com/ForteFibre/parameter_expression.git
* release repository: https://github.com/ros2-gbp/parameter_expression-release.git
* distro file: `jazzy/distribution.yaml`
* bloom version: `0.0.2`
* previous version for package: `null`

## parameter_expression
```
* Merge pull request `#1 <https://github.com/ForteFibre/parameter_expression/issues/1>`_ from ForteFibre/fix/pkg-config
  Add pkg-config as build dependencies
* Add pkg-config as build dependencies
* Apply formatter
* Change to Apache License 2.0
* Add README
* Move from our internal library
* initial commit
* Contributors: f0reachARR, ぐるぐる
```
