### PR TITLE
launch: 3.9.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3598,7 +3598,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.5-1
+      version: 3.9.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.6-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.5-1`

## launch

```
* test python substitution with submodules (#688 <https://github.com/ros2/launch/issues/688>)
* Scope launch file dir/path locals to included launch file (#862 <https://github.com/ros2/launch/issues/862>)
* Capture the environment variables in TimerAction (#728 <https://github.com/ros2/launch/issues/728>)
* Remove importlib metadata (#932 <https://github.com/ros2/launch/issues/932>)
* Fix intersphinx_mapping format (#921 <https://github.com/ros2/launch/issues/921>)
* Contributors: Christophe Bedard, Jonas Otto, Michael Carlstrom, Sebastian Javier D'Alessandro Szymanowski, Will
```

## launch_pytest

- No changes

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Capture the environment variables in TimerAction (#728 <https://github.com/ros2/launch/issues/728>)
* Contributors: Sebastian Javier D'Alessandro Szymanowski
```

## launch_yaml

```
* Capture the environment variables in TimerAction (#728 <https://github.com/ros2/launch/issues/728>)
* Contributors: Sebastian Javier D'Alessandro Szymanowski
```
