### PR TITLE
launch: 3.8.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3643,7 +3643,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.6-1
+      version: 3.8.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.8.7-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.6-1`

## launch

```
* Remove importlib metadata (backport #932 <https://github.com/ros2/launch/issues/932>) (#934 <https://github.com/ros2/launch/issues/934>)
* Merge pull request #928 <https://github.com/ros2/launch/issues/928> from ros2/mergify/bp/kilted/pr-873
* Allow Path in substitutions, instead of requiring cast to str (#873 <https://github.com/ros2/launch/issues/873>)
* Fix intersphinx_mapping format (#921 <https://github.com/ros2/launch/issues/921>) (#924 <https://github.com/ros2/launch/issues/924>)
* Contributors: Emerson Knapp, mergify[bot]
```

## launch_pytest

```
* Merge pull request #928 <https://github.com/ros2/launch/issues/928> from ros2/mergify/bp/kilted/pr-873
* Allow Path in substitutions, instead of requiring cast to str (#873 <https://github.com/ros2/launch/issues/873>)
* Contributors: Emerson Knapp
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Merge pull request #928 <https://github.com/ros2/launch/issues/928> from ros2/mergify/bp/kilted/pr-873
* Allow Path in substitutions, instead of requiring cast to str (#873 <https://github.com/ros2/launch/issues/873>)
* Contributors: Emerson Knapp
```

## launch_yaml

- No changes
