### PR TITLE
launch_ros: 0.28.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3693,7 +3693,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.28.4-1
+      version: 0.28.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.28.5-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.28.4-1`

## launch_ros

```
* Remove importlib (backport #508 <https://github.com/ros2/launch_ros/issues/508>) (#509 <https://github.com/ros2/launch_ros/issues/509>)
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* Give the option to inject a quality of service profile (#493 <https://github.com/ros2/launch_ros/issues/493>)
* WaitForTopics: wait for publisher-subscriber connection to be established (#474 <https://github.com/ros2/launch_ros/issues/474>)
* Contributors: Giorgio Pintaudi
```

## ros2launch

- No changes
