### PR TITLE
launch_ros: 0.26.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4403,7 +4403,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.10-1
+      version: 0.26.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.26.11-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.10-1`

## launch_ros

- No changes

## launch_testing_ros

```
* WaitForTopics: let the user inject a callaback to be executed after starting the subscribers (backport #356 <https://github.com/ros2/launch_ros/issues/356>) (#504 <https://github.com/ros2/launch_ros/issues/504>)
* Contributors: mergify[bot]
```

## ros2launch

- No changes
