### PR TITLE
launch: 3.4.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4353,7 +4353,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.4.9-1
+      version: 3.4.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.4.10-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.9-1`

## launch

```
* [jazzy] Allow Path in substitutions, instead of requiring cast to str (backport #873 <https://github.com/ros2/launch/issues/873>) (#927 <https://github.com/ros2/launch/issues/927>)
* Fix intersphinx_mapping format (#921 <https://github.com/ros2/launch/issues/921>) (#923 <https://github.com/ros2/launch/issues/923>)
* Contributors: mergify[bot]
```

## launch_pytest

```
* [jazzy] Allow Path in substitutions, instead of requiring cast to str (backport #873 <https://github.com/ros2/launch/issues/873>) (#927 <https://github.com/ros2/launch/issues/927>)
* Contributors: mergify[bot]
```

## launch_testing

- No changes

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* [jazzy] Allow Path in substitutions, instead of requiring cast to str (backport #873 <https://github.com/ros2/launch/issues/873>) (#927 <https://github.com/ros2/launch/issues/927>)
* Contributors: mergify[bot]
```

## launch_yaml

- No changes
