### PR TITLE
sros2: 0.16.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9104,7 +9104,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.16.2-1
+      version: 0.16.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.16.3-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.16.2-1`

## sros2

```
* Clean up isolated ros2 daemon process for tests. (#375 <https://github.com/ros2/sros2/issues/375>)
* Remove importlib (#368 <https://github.com/ros2/sros2/issues/368>)
* Contributors: Michael Carlstrom, Tomoya Fujita
```

## sros2_cmake

- No changes
