### PR TITLE
sros2: 0.15.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9215,7 +9215,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.15.2-1
+      version: 0.15.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.15.3-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.2-1`

## sros2

```
* Remove importlib (#368 <https://github.com/ros2/sros2/issues/368>) (#369 <https://github.com/ros2/sros2/issues/369>)
* fix setuptools deprecations (#357 <https://github.com/ros2/sros2/issues/357>) (#363 <https://github.com/ros2/sros2/issues/363>)
* update utilities to pass instance not class of ec.SECP256R1 (#352 <https://github.com/ros2/sros2/issues/352>) (#353 <https://github.com/ros2/sros2/issues/353>)
* suppress multi-threaded warnings. (#346 <https://github.com/ros2/sros2/issues/346>) (#349 <https://github.com/ros2/sros2/issues/349>)
* Contributors: mergify[bot]
```

## sros2_cmake

```
* Update CMakeLists.txt (#344 <https://github.com/ros2/sros2/issues/344>) (#345 <https://github.com/ros2/sros2/issues/345>)
* Contributors: mergify[bot]
```
