### PR TITLE
sros2: 0.13.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10499,7 +10499,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.13.4-1
+      version: 0.13.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.13.5-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.13.4-1`

## sros2

```
* fix setuptools deprecations (#357 <https://github.com/ros2/sros2/issues/357>) (#364 <https://github.com/ros2/sros2/issues/364>)
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
