### PR TITLE
sros2: 0.10.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11382,7 +11382,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.10.7-1
+      version: 0.10.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.10.8-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.10.7-1`

## sros2

```
* fix setuptools deprecations (#357 <https://github.com/ros2/sros2/issues/357>) (#365 <https://github.com/ros2/sros2/issues/365>)
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
