### PR TITLE
foxglove-sdk: 3.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3207,7 +3207,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.2.2-1
+      version: 3.2.3-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.2.3-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.2-1`

## foxglove_bridge

```
* Fix build errors in ROS Rolling (#805 <https://github.com/foxglove/foxglove-sdk/pull/805>)
* Fix message format error when using cache (#769 <https://github.com/foxglove/foxglove-sdk/pull/769>)
* Contributors: Eric Lujan, chencaidy
```

## foxglove_msgs

```
* Fixes to documentation and schema descriptions
* Contributors: Jacob Bandes-Storch, jesse-foxglove
```
