### PR TITLE
rmf_traffic: 3.7.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6845,7 +6845,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.5.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `3.7.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.0-1`

## rmf_traffic

```
* Align start waypoint with lane exit waypoint for consistency (#127 <https://github.com/open-rmf/rmf_traffic/issues/127>)
* Skip in-place rotation after Dock to prevent duplicate events (#126 <https://github.com/open-rmf/rmf_traffic/issues/126>)
* Embed mutex inside Planner::Result (#124 <https://github.com/open-rmf/rmf_traffic/issues/124>)
* Add API to clear planner inner cache (#123 <https://github.com/open-rmf/rmf_traffic/issues/123>)
* Contributors: Grey, cwrx777, kj
```

## rmf_traffic_examples

- No changes
