### PR TITLE
rmf_demos: 2.8.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6738,7 +6738,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.8.0-1
+      version: 2.8.1-2
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Note that `rmf_demos` is not broken in the buildfarm sense that it doesn't build and it is marked as a regression but the package is effectively non functional as noted in https://github.com/open-rmf/rmf_visualization/pull/88#issuecomment-3742285992 so it might be worth it to make it into the sync

Increasing version of package(s) in repository `rmf_demos` to `2.8.1-2`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.0-1`

## rmf_demos

```
* Add use_site_map param (#338 <https://github.com/open-rmf/rmf_demos/issues/338>)
* Contributors: Xiyu
```

## rmf_demos_assets

- No changes

## rmf_demos_bridges

- No changes

## rmf_demos_fleet_adapter

- No changes

## rmf_demos_gz

```
* Switch to using ros_gz_sim to run Gazebo (#344 <https://github.com/open-rmf/rmf_demos/issues/344>)
* Contributors: Luca Della Vedova
```

## rmf_demos_maps

- No changes

## rmf_demos_tasks

```
* Add a --start-at-departure option for dispatch_go_to_place (#331 <https://github.com/open-rmf/rmf_demos/issues/331>)
* Fix cancel task stuck indefinitely (#320 <https://github.com/open-rmf/rmf_demos/issues/320>)
* Contributors: Aaron Chong, Grey
```
