### PR TITLE
ament_cmake: 2.8.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -213,7 +213,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.8.4-1
+      version: 2.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.8.5-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.4-1`

## ament_cmake

- No changes

## ament_cmake_auto

```
* Do not error on USE_SCOPED_HEADER_INSTALL_DIR (#596 <https://github.com/ament/ament_cmake/issues/596>)
* Contributors: Tim Clephas
```

## ament_cmake_core

```
* Remove unused AMENT_CMAKE_ENVIRONMENT_GENERATION option (#354 <https://github.com/ament/ament_cmake/issues/354>)
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>)
* Respect find_package(QUIET) in chains from ament_cmake_core (#603 <https://github.com/ament/ament_cmake/issues/603>)
* Contributors: Scott K Logan, Shane Loretz
```

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>)
* Contributors: Scott K Logan
```

## ament_cmake_gen_version_h

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>)
* Contributors: Scott K Logan
```

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>)
* Contributors: Scott K Logan
```

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

```
* Revert "Revert "Removed deprecated function ament_cmake_target_dependencies (…" (#614 <https://github.com/ament/ament_cmake/issues/614>)
* Contributors: Alejandro Hernández Cordero
```

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

```
* ament_vendor: Propagate additional variables to ExternalProject (#593 <https://github.com/ament/ament_cmake/issues/593>)
* Contributors: Silvio Traversaro
```

## ament_cmake_version

- No changes
