### PR TITLE
ament_cmake: 2.7.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -209,7 +209,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.7.3-2
+      version: 2.7.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.7.4-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.3-2`

## ament_cmake

- No changes

## ament_cmake_auto

```
* Do not error on USE_SCOPED_HEADER_INSTALL_DIR (#596 <https://github.com/ament/ament_cmake/issues/596>) (#610 <https://github.com/ament/ament_cmake/issues/610>)
* Contributors: mergify[bot]
```

## ament_cmake_core

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>) (#606 <https://github.com/ament/ament_cmake/issues/606>)
* Contributors: mergify[bot]
```

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_interfaces

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>) (#606 <https://github.com/ament/ament_cmake/issues/606>)
* Contributors: mergify[bot]
```

## ament_cmake_gen_version_h

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>) (#606 <https://github.com/ament/ament_cmake/issues/606>)
* Update CMake requirement (#589 <https://github.com/ament/ament_cmake/issues/589>) (#590 <https://github.com/ament/ament_cmake/issues/590>)
* Contributors: mergify[bot]
```

## ament_cmake_gmock

- No changes

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

- No changes

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

```
* Address ament_lint_cmake regressions (#604 <https://github.com/ament/ament_cmake/issues/604>) (#606 <https://github.com/ament/ament_cmake/issues/606>)
* Contributors: mergify[bot]
```

## ament_cmake_pytest

- No changes

## ament_cmake_python

- No changes

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

- No changes

## ament_cmake_version

- No changes
