### PR TITLE
fadecandy_ros: 1.0.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2600,6 +2600,19 @@ repositories:
       url: https://github.com/ros2/examples.git
       version: jazzy
     status: maintained
+  fadecandy_ros:
+    doc:
+      type: git
+      url: https://github.com/eurogroep/fadecandy_ros.git
+      version: ros2
+    release:
+      packages:
+      - fadecandy_driver
+      - fadecandy_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/eurogroep/fadecandy_ros-release.git
+      version: 1.0.2-2
   fastcdr:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `fadecandy_ros` to `1.0.2-2`:

- upstream repository: https://github.com/eurogroep/fadecandy_ros.git
- release repository: https://github.com/eurogroep/fadecandy_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## fadecandy_driver

```
* fix(drivers): missing build depend on pkg-config
* Contributors: Rein Appeldoorn
```

## fadecandy_msgs

- No changes
