### PR TITLE
Add cxxopts-devel for RHEL in base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3557,6 +3557,7 @@ libcxxopts-dev:
     '*': [cxxopts]
     '15.2': null
   osx: [cxxopts]
+  rhel: [cxxopts-devel]
   ubuntu:
     '*': [libcxxopts-dev]
     focal: null


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

libcxxopts-dev

- rhel: https://rhel.pkgs.org/9/epel-x86_64/cxxopts-devel-3.3.1-1.el9.x86_64.rpm.html