### PR TITLE
Add language-pack- rules for Debian and RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2607,12 +2607,12 @@ konsole:
   ubuntu: [konsole]
 language-pack-de:
   debian: null
-  fedora: [filesystem]
-  rhel: [glibc-langpack-de]
+  fedora: [glibc-langpack-de]
+  rhel: null
   ubuntu: [language-pack-de]
 language-pack-en:
   debian: []
-  fedora: [filesystem]
+  fedora: [filesystem, glibc-langpack-en]
   rhel: [glibc-langpack-en]
   ubuntu: [language-pack-en]
 lcov:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2608,7 +2608,7 @@ konsole:
 language-pack-de:
   debian: null
   fedora: [glibc-langpack-de]
-  rhel: null
+  rhel: [glibc-langpack-de]
   ubuntu: [language-pack-de]
 language-pack-en:
   debian: []

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2612,7 +2612,7 @@ language-pack-de:
   ubuntu: [language-pack-de]
 language-pack-en:
   debian: []
-  fedora: [filesystem, glibc-langpack-en]
+  fedora: [glibc-langpack-en]
   rhel: [glibc-langpack-en]
   ubuntu: [language-pack-en]
 lcov:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2606,10 +2606,14 @@ konsole:
   nixos: [plasma5Packages.konsole]
   ubuntu: [konsole]
 language-pack-de:
+  debian: null
   fedora: [filesystem]
+  rhel: [glibc-langpack-de]
   ubuntu: [language-pack-de]
 language-pack-en:
+  debian: []
   fedora: [filesystem]
+  rhel: [glibc-langpack-en]
   ubuntu: [language-pack-en]
 lcov:
   arch: [lcov]


### PR DESCRIPTION
Please update the following dependencies in the rosdep database.

## Package name:

language-pack-de
language-pack-en

- Debian: https://packages.debian.org/
  - the locales do not have any package, they need to be manually configured; however, Bookworm has by default a C.UTF-8 locale which is quite close to en_US, so I decided to mark -en locale package as satisfied by default. However, a precise solution would be to put `null` even to the english version.
- Fedora:
  - https://fedora.pkgs.org/42/fedora-x86_64/glibc-langpack-de-2.41-1.fc42.x86_64.rpm.html
  - https://fedora.pkgs.org/42/fedora-x86_64/glibc-langpack-en-2.41-1.fc42.x86_64.rpm.html
- rhel:
  - https://rhel.pkgs.org/9/red-hat-ubi-baseos-aarch64/glibc-langpack-en-2.34-231.el9_7.2.aarch64.rpm.html
  - de locale is not supported in RHEL according to pkgs.org
