### PR TITLE
cras_ros_utils: 3.0.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1734,7 +1734,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/cras_ros_utils-release.git
-      version: 3.0.0-1
+      version: 3.0.0-2
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1725,6 +1725,16 @@ repositories:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git
       version: ros2
+    release:
+      packages:
+      - cras_bag_tools
+      - cras_cpp_common
+      - cras_lint
+      - cras_topic_tools
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/cras_ros_utils-release.git
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `3.0.0-2`:

- upstream repository: https://github.com/ctu-vras/ros-utils.git
- release repository: https://github.com/ros2-gbp/cras_ros_utils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## cras_bag_tools

```
* Better ROS 2 format.
* docs: Updated readmes.
* Improved and fixed extract_images.
* Initial port of extract_images.
* Initial ROS 2 port.
* Contributors: Martin Pecka
```

## cras_cpp_common

```
* Improved build files, added convenience CMake target cras_cpp_common::cras_cpp_common .
* Fix build on Rolling.
* docs: Updated readmes.
* log_utils: Ported to ROS 2.
* expected: Now provided as a CMake target and automatically installed the library.
* string_utils: Returned cras::format and renamed to cras::snprintf.
* time_utils: Added SimpleClockInterface and float_secs().
* Ported tf2_utils to ROS 2.
* Added test_utils.
* ROS 2 port of the rest of string_utils.
* ROS 2 port of rate_limiter.
* ROS 2 port of time_utils.
* Removed std::bind_front() shim.
* Switched to C++20 and removed shims for older compilers.
* Removed invalid rosdoc config.
* Fixed wrong QoS initialization.
* Initial ROS 2 port.
* Fixed handling of char and signed char parameters on platforms where char is unsigned (e.g. arm64).
* Contributors: Martin Pecka
```

## cras_lint

```
* docs: Updated readmes.
* A few style fixes.
* Also xmllint launch files.
* Added package and applied linting to other packages.
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* Temporarily disabled cras_msgs for release.
  The dependency will be put back once cras_msgs is released.
* Improved build files.
* docs: Updated readmes.
* Fixed linter.
* count_messages: Fixed launching in component container.
* change_header: Added --report CLI option.
* count_messages: Default to BEST_AVAILABLE QoS.
* Initial ROS 2 port.
* Contributors: Martin Pecka
```
