### PR TITLE
ur_robot_driver: 2.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12655,7 +12655,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.12.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.11.0-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Ensure latched qos is reliable (backport #1594 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1594>) (#1632 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1632>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Fix flange-to-TCP wrench transformation (backport #1615 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1615>) (#1635 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1635>)
* Initialize force mode interfaces to NaN on init (backport #1625 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1625>) (#1627 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1627>)
* [DashboardClient] Add a parameter callback (backport #1598 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1598>) (#1604 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1604>)
* Replace dashboard client on PolyScope X warning (backport of #1599 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1599>) (#1602 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1602>)
* Add ros2run as a test_depend (backport of #1597 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1597>) (#1600 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1600>)
```