### PR TITLE
ur_robot_driver: 3.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11539,7 +11539,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.7.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.6.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Ensure latched qos is reliable (backport #1594 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1594>) (#1633 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1633>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Fix flange-to-TCP wrench transformation (backport #1615 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1615>) (#1636 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1636>)
* Expose rw_rate in xacro macro for hardware interface (backport #1631 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1631>) (#1634 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1634>)
* Initialize force mode interfaces to NaN on init (backport #1625 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1625>) (#1628 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1628>)
* [DashboardClient] Add a parameter callback (backport of #1598 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1598>) (#1605 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1605>)
* Replace dashboard client on PolyScope X warning (backport of #1599 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1599>) (#1603 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1603>)
* Add ros2run as a test_depend (backport of #1597 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1597>) (#1601 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1601>)
* [Docs] Update tool comm setup for PolyScope X (backport #1588 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1588>) (#1590 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1590>)
```