### PR TITLE
ur_robot_driver: 4.5.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10015,7 +10015,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.5.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.4.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Ensure latched qos is reliable (#1594 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1594>)
* Contributors: Rahat Dhande
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Fix flange-to-TCP wrench transformation (#1615 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1615>)
* Exposes rw_rate in xacro macro for hardware interface (#1631 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1631>)
* Initialize force mode interfaces to NaN on init (#1625 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1625>)
* [DashboardClient] Add a parameter callback (#1598 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1598>)
* Replace dashboard client on PolyScope X warning (#1599 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1599>)
* Add ros2run as a test_depend (#1597 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1597>)
* Docs: Update tool comm setup for PolyScope X (#1588 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1588>)
* Contributors: Felix Exner, Li Yunwen, Maximilian Schik
```
