### PR TITLE
imu_tools: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3217,7 +3217,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.2.2-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.1-1`

## imu_complementary_filter

```
* Fixed a static library linking issue with the imu_complementary_filter package on Windows. (#218 <https://github.com/CCNYRoboticsLab/imu_tools/issues/218>)
* Merge pull request #202 <https://github.com/CCNYRoboticsLab/imu_tools/issues/202> from enwaytech:sr/reverse-backport-from-noetic  (#202 <https://github.com/CCNYRoboticsLab/imu_tools/issues/202>)
* Added ability to reset IMU filters when ROS time jumps back (#165 <https://github.com/CCNYRoboticsLab/imu_tools/issues/165>)
* Update deprecated TransformBroadcaster constructor (#223 <https://github.com/CCNYRoboticsLab/imu_tools/issues/223>)
* Update deprecated message filters and tf2 headers (#222 <https://github.com/CCNYRoboticsLab/imu_tools/issues/222>)
* Contributors: Alejandro Hernández Cordero, Martin Günther, Sharmin Ramli, wentywenty
```

## imu_filter_madgwick

```
* Merge pull request #202 <https://github.com/CCNYRoboticsLab/imu_tools/issues/202> from enwaytech:sr/reverse-backport-from-noetic  (#202 <https://github.com/CCNYRoboticsLab/imu_tools/issues/202>)
* Added ability to reset IMU filters when ROS time jumps back (#165 <https://github.com/CCNYRoboticsLab/imu_tools/issues/165>)
* Increase max stddev, add pose visualization (#192 <https://github.com/CCNYRoboticsLab/imu_tools/issues/192>)
* use modern postSetParametersCallback (#220 <https://github.com/CCNYRoboticsLab/imu_tools/issues/220>)
  Use modern postSetParametersCallback. Also solves the bug causing every Double parameters change in the entire system to be printed as a change in this node.
* Update deprecated TransformBroadcaster constructor (#223 <https://github.com/CCNYRoboticsLab/imu_tools/issues/223>)
* Update deprecated message filters and tf2 headers (#222 <https://github.com/CCNYRoboticsLab/imu_tools/issues/222>)
* Contributors: Adi Vardi, Alejandro Hernández Cordero, Martin Günther, Sharmin Ramli
```

## imu_tools

- No changes

## rviz_imu_plugin

```
* Update deprecated message filters and tf2 headers (#222 <https://github.com/CCNYRoboticsLab/imu_tools/issues/222>)
* Add Qt6 support (#221 <https://github.com/CCNYRoboticsLab/imu_tools/issues/221>)
* Contributors: Alejandro Hernández Cordero
```
