### PR TITLE
Add RHEL mapping for procps

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8534,6 +8534,7 @@ procps:
   gentoo: [sys-process/procps]
   nixos: [procps]
   openembedded: [procps@openembedded-core]
+  rhel: [procps-ng]
   ubuntu: [procps]
 proj:
   arch: [proj]


### PR DESCRIPTION
<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

procps

## Package Upstream Source:

N/A?

## Purpose of using this:

It's missing for RHEL. Apparently `procps-ng` replaced `procps`.

Distro packaging links: https://pkgs.org/search/?q=procps

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=procps