### PR TITLE
Index package nebula

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6360,6 +6360,16 @@ repositories:
       url: https://github.com/koide3/ndt_omp.git
       version: master
     status: developed
+  nebula:
+    doc:
+      type: git
+      url: https://github.com/tier4/nebula.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/tier4/nebula.git
+      version: main
+    status: developed
   neo_nav2_bringup:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

* humble

We are working hard on getting it up-to-date with Rolling, but at the moment we only support Humble.

# The source is here:

https://github.com/tier4/nebula

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro