### PR TITLE
mp2p_icp: 2.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5885,7 +5885,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.3.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## mp2p_icp

```
* Merge pull request #25 <https://github.com/MOLAorg/mp2p_icp/issues/25> from MOLAorg/feat/naive-decimate
  Add trivial FilterDecimate for fast downsampling without spatial awareness
* lint fixes
* Add trivial FilterDecimate for fast downsampling without spatial awareness
* Parameterizable: add virtual base dtor
* Remove the NormalizeIntensity stage in the demo pipelines; visualization does that already
* docs: fill missing manpages
* docs: add sm2mm pipelines page
* Clarify map layers and simple maps descriptions
  Updated references to CMetricMap and CGenericPointsMap in the documentation for clarity and accuracy.
* Contributors: Jose Luis Blanco-Claraco
```
