### PR TITLE
mola_state_estimation: 2.0.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5702,13 +5702,15 @@ repositories:
       version: develop
     release:
       packages:
+      - mola_georeferencing
+      - mola_gtsam_factors
       - mola_state_estimation
       - mola_state_estimation_simple
       - mola_state_estimation_smoother
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 1.11.1-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.0.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.11.1-1`

## mola_georeferencing

```
* Merge pull request #7 <https://github.com/MOLAorg/mola_state_estimation/issues/7> from MOLAorg/feature/tricycle-kinematic
  Add tricycle kinematics
* lint clean ups
* Copyright year bump
* Merge pull request #10 <https://github.com/MOLAorg/mola_state_estimation/issues/10> from MOLAorg/feature/add-georef-tests
  Add georeference unit tests
* Add georef unit test
* Merge pull request #5 <https://github.com/MOLAorg/mola_state_estimation/issues/5> from MOLAorg/feature/fuse-gnss-imu-odom
  Refactor: new packages mola_georeferencing, mola_gtsam_factors, functional smoother state estimator
* Make mola_gtsam_factors non headers-only and rename GNSS2ENU as GnssEnu for consistency
* process CObservationRobotPose
* integrate code coverage in cmake
* package.xml: add FILE to license tags
* Refactor to expose all gtsam factors into a new library 'mola_gtsam_factors'
* new package mola_georeferencing, imported and refactored from mola_sm_loop_closure
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

```
* Merge pull request #7 <https://github.com/MOLAorg/mola_state_estimation/issues/7> from MOLAorg/feature/tricycle-kinematic
  Add tricycle kinematics
* fix jacobians
* remove now unused ctor param
* Fix build for gtsam>=4.3
* Copyright year bump
* Add FactorTricycleKinematic
* Merge pull request #9 <https://github.com/MOLAorg/mola_state_estimation/issues/9> from MOLAorg/fix/build-deps
  Fix wrong dep name
* Fix wrong dep name
* Merge pull request #5 <https://github.com/MOLAorg/mola_state_estimation/issues/5> from MOLAorg/feature/fuse-gnss-imu-odom
  Refactor: new packages mola_georeferencing, mola_gtsam_factors, functional smoother state estimator
* fixed imu acc gravity alignment
* add IMU+GPS  based azimuth estimation
* Refactor: symbolic factor classes moved as internal smoother classes
* Make mola_gtsam_factors non headers-only and rename GNSS2ENU as GnssEnu for consistency
* implement correct auto geo-referenciation
* refactor to use Pose3 instead of P+R
* One further fix for cmake
* integrate code coverage in cmake
* package.xml: add FILE to license tags
* Fix build with gtsam>2.3
* Refactor to expose all gtsam factors into a new library 'mola_gtsam_factors'
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation

```
* Merge pull request #5 <https://github.com/MOLAorg/mola_state_estimation/issues/5> from MOLAorg/feature/fuse-gnss-imu-odom
  Refactor: new packages mola_georeferencing, mola_gtsam_factors, functional smoother state estimator
* Refactor to expose all gtsam factors into a new library 'mola_gtsam_factors'
* Contributors: Jose Luis Blanco-Claraco
* Merge pull request #5 <https://github.com/MOLAorg/mola_state_estimation/issues/5> from MOLAorg/feature/fuse-gnss-imu-odom
  Refactor: new packages mola_georeferencing, mola_gtsam_factors, functional smoother state estimator
* Refactor to expose all gtsam factors into a new library 'mola_gtsam_factors'
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_simple

```
* Merge pull request #7 <https://github.com/MOLAorg/mola_state_estimation/issues/7> from MOLAorg/feature/tricycle-kinematic
  Add tricycle kinematics
* lint clean ups
* Copyright year bump
* Merge pull request #8 <https://github.com/MOLAorg/mola_state_estimation/issues/8> from MOLAorg/fix/add-simple-estimator-unit-tests
  Add tests for simple estimator
* Add tests for simple estimator
* Merge pull request #5 <https://github.com/MOLAorg/mola_state_estimation/issues/5> from MOLAorg/feature/fuse-gnss-imu-odom
  Refactor: new packages mola_georeferencing, mola_gtsam_factors, functional smoother state estimator
* One further fix for cmake
* integrate code coverage in cmake
* Refactor to expose all gtsam factors into a new library 'mola_gtsam_factors'
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Merge pull request #7 <https://github.com/MOLAorg/mola_state_estimation/issues/7> from MOLAorg/feature/tricycle-kinematic
  Add tricycle kinematics
* Use bad initial pose for unit test
* unit test: same conditions for different kinematic models
* Copyright year bump
* Add FactorTricycleKinematic
* Implement twist fusion
* Add twist unit test
* Unit test: include tricycle tests too
* Enable connection to MolaViz for console messages
* converted into ament_cmake; update template yaml params file
* Add templates to launch the estimator as a standalone ROS 2 node
* Merge pull request #5 <https://github.com/MOLAorg/mola_state_estimation/issues/5> from MOLAorg/feature/fuse-gnss-imu-odom
  Refactor: new packages mola_georeferencing, mola_gtsam_factors, functional smoother state estimator
* More realistic drift case: IMU helps LO
* fix test: correct IMU acc simulation
* Default params: more common case of starting near static
* fixed imu acc gravity alignment
* Add two-odometry unit test
* fix error, and add support for azimuth offset
* add IMU+GPS  based azimuth estimation
* Refactor: symbolic factor classes moved as internal smoother classes
* Make mola_gtsam_factors non headers-only and rename GNSS2ENU as GnssEnu for consistency
* fixed missing extrapolation steps
* implement basic pose extrapolation
* honor initial twist
* Fixed odom+gnss fusion
* implement correct auto geo-referenciation
* Support fusing poses wrt map frame too
* marginals for uncertainty
* refactor to use Pose3 instead of P+R
* initialize georef gtsam variables
* Make important parameters mandatory in yaml config files
* New unit test for fusing GPS+odometry
* process CObservationRobotPose
* One further fix for cmake
* integrate code coverage in cmake
* Update .h docs to match the new design
* Enable code coverage
* Update parameters to hold new geo-ref fields
* Refactor to expose all gtsam factors into a new library 'mola_gtsam_factors'
* Contributors: Jose Luis Blanco-Claraco
```
