### PR TITLE
dynamixel_sdk: 4.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1639,7 +1639,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_sdk-release.git
-      version: 3.8.4-1
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_sdk` to `4.0.3-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
- release repository: https://github.com/ros2-gbp/dynamixel_sdk-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.4-1`

## dynamixel_sdk

```
* Dynamixel Easy SDK supports Linux SBC environments, Linux 32-bit platforms, and ROS 2 based build and deployment workflows
* Contributors: Hyungyu Kim
```

## dynamixel_sdk_custom_interfaces

```
* None
```

## dynamixel_sdk_examples

```
* None
```
