### PR TITLE
zed-ros2-description: 0.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13365,6 +13365,17 @@ repositories:
       version: humble
     status: maintained
   zed-ros2-description:
+    doc:
+      type: git
+      url: https://github.com/stereolabs/zed-ros2-description.git
+      version: main
+    release:
+      packages:
+      - zed_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/zed-ros2-description-release.git
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-description` to `0.1.1-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-description.git
- release repository: https://github.com/ros2-gbp/zed-ros2-description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## zed_description

```
* Fix CONTRIBUTING
* Fix ROS2 occurrences
* Fix README
* Fix copyright
* Fix build issue
* Contributors: Walter Lucetti
```
