### PR TITLE
open_manipulator: 4.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6231,7 +6231,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/open_manipulator-release.git
-      version: 4.1.0-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/open_manipulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `open_manipulator` to `4.1.2-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/open_manipulator.git
- release repository: https://github.com/ros2-gbp/open_manipulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.0-1`

## om_gravity_compensation_controller

```
* None
```

## om_joint_trajectory_command_broadcaster

```
* None
```

## om_spring_actuator_controller

```
* None
```

## open_manipulator

```
* Add urdf for every model
* Contributors: Woojin Wie
```

## open_manipulator_bringup

```
* None
```

## open_manipulator_collision

```
* None
```

## open_manipulator_description

```
* Add urdf for every model
* Contributors: Woojin Wie
```

## open_manipulator_gui

```
* None
```

## open_manipulator_moveit_config

```
* None
```

## open_manipulator_playground

```
* None
```

## open_manipulator_teleop

```
* None
```
