### PR TITLE
mola_state_estimation: 2.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5710,7 +5710,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.0.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## mola_georeferencing

```
* Fix potential bug in sm_georeferencing
* Merge pull request #11 <https://github.com/MOLAorg/mola_state_estimation/issues/11> from MOLAorg/feat/improve-docs
  Improve docs for mola_gtsam_factors
* Add missing #include for gtsam
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

```
* Fix potential bug in sm_georeferencing
* Merge pull request #11 <https://github.com/MOLAorg/mola_state_estimation/issues/11> from MOLAorg/feat/improve-docs
  Improve docs for mola_gtsam_factors
* Improve docs for mola_gtsam_factors
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation

- No changes

## mola_state_estimation_simple

- No changes

## mola_state_estimation_smoother

```
* test: less strict limits to avoid random failures
* cmake: Remove non-used find_package() for ament_lint_auto
* Merge pull request #11 <https://github.com/MOLAorg/mola_state_estimation/issues/11> from MOLAorg/feat/improve-docs
  Improve docs for mola_gtsam_factors
* Contributors: Jose Luis Blanco-Claraco
```
