### PR TITLE
event_image_reconstruction_fibar: 3.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2538,6 +2538,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
       version: release
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_image_reconstruction_fibar` to `3.0.1-1`:

- upstream repository: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
- release repository: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## event_image_reconstruction_fibar

```
* added output_bag option to launch script
* Contributors: Bernd Pfrommer
```
