### PR TITLE
event_image_reconstruction_fibar: 3.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1993,6 +1993,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
       version: release
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_image_reconstruction_fibar` to `3.0.3-1`:

- upstream repository: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
- release repository: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## event_image_reconstruction_fibar

```
* added dependency on ament_cmake_clang_format
* Contributors: Bernd Pfrommer
```
