### PR TITLE
event_image_reconstruction_fibar: 3.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1921,6 +1921,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
       version: release
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_image_reconstruction_fibar` to `3.0.3-1`:

- upstream repository: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
- release repository: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## event_image_reconstruction_fibar

```
* added dependency on ament_cmake_clang_format
* Contributors: Bernd Pfrommer
```
