### PR TITLE
Make joint_state_publisher use Humble patch

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4351,7 +4351,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/joint_state_publisher.git
-      version: ros2
+      version: humble
     release:
       packages:
       - joint_state_publisher
@@ -4364,7 +4364,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/joint_state_publisher.git
-      version: ros2
+      version: humble
     status: maintained
   joy_tester:
     doc:


### PR DESCRIPTION
Context: https://github.com/ros/joint_state_publisher/pull/120