### PR TITLE
rmw_dds_common: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7018,7 +7018,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_dds_common-release.git
-      version: 4.0.2-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_dds_common` to `6.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_dds_common.git
- release repository: https://github.com/ros2-gbp/rmw_dds_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.2-1`

## rmw_dds_common

- No changes
