### PR TITLE
automatika_ros_sugar: 0.4.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -681,7 +681,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.4.3-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.2-1`

## automatika_ros_sugar

```
* (refactor) Organizes UI custom javascript into three functional scripts
* (docs) Improves the core concepts documentation
* (fix) Fixes check for None max_retries value in fallback
* (fix) Fixes logging colors in multi-process execution
* (feature) Adds parameter for lifecycle transition timeout
* (fix) Add error catching during all fallbacks action execution
* (fix) Fixes fallback init and exposes on_giveup fallback
* (fix) Adds fallbacks serialization to support multi-process execution
* (fix) Removes optional fallback in execute method
* (fix) Updates health status after executing the fallback in component
* (fix) Adds fallback to component lifecycle transition errors
* (feature) Adds method to add event/action pairs from inside child components
* (docs) Adds generation of llms.txt to docs
* (feature) Adds Task UI element to track action requests
* (feature) Adds option to hide the settings panel in the UI
* (feature) Adds property to get a UI input for a component's main action server
* (feature) Adds action clients to UI inputs
* (feature) Improves ActionClient with methods to cancel requests and monitor feedback
* (feature) Adds parsing ROS messages from/to dictionary
* (docs) Fixes installation instructions in readme
* (fix) Fixes external processor argument passing in the launcher
* (refactor) Adds utility function for running external processors
* (feature) Adds service clients to UINode inputs in order to send service calls directly from the UI
* (feature) Adds method to send a service request using data from a dictionary
  This method is useful to send requests without initializing the request class. Used in the UI node to send requests from an input form data
* Contributors: ahr, mkabtoul
```
