### PR TITLE
Add potential_fields to rosdistro

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6920,8 +6920,8 @@ repositories:
     release:
       packages:
       - potential_fields
-      - potential_fields_interfaces
       - potential_fields_demos
+      - potential_fields_interfaces
       - potential_fields_library
       tags:
         release: release/jazzy/{package}/{version}

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6751,6 +6751,26 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
       version: master
     status: maintained
+  potential_fields:
+    doc:
+      type: git
+      url: https://github.com/argallab/potential_fields.git
+      version: main
+    release:
+      packages:
+        - potential_fields
+        - potential_fields_interfaces
+        - potential_fields_demos
+        - potential_fields_library
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/potential_fields-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/argallab/potential_fields.git
+      version: main
+    status: developed
   proto2ros:
     doc:
       type: git
@@ -11998,26 +12018,6 @@ repositories:
     source:
       type: git
       url: https://github.com/tier4/zmqpp_vendor.git
-      version: main
-    status: developed
-  potential_fields:
-    doc:
-      type: git
-      url: https://github.com/argallab/potential_fields.git
-      version: main
-    release:
-      packages:
-        - potential_fields
-        - potential_fields_interfaces
-        - potential_fields_demos
-        - potential_fields_library
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/potential_fields-release.git
-      version: 1.0.1-1
-    source:
-      type: git
-      url: https://github.com/argallab/potential_fields.git
       version: main
     status: developed
 type: distribution

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6919,10 +6919,10 @@ repositories:
       version: main
     release:
       packages:
-        - potential_fields
-        - potential_fields_interfaces
-        - potential_fields_demos
-        - potential_fields_library
+      - potential_fields
+      - potential_fields_interfaces
+      - potential_fields_demos
+      - potential_fields_library
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/potential_fields-release.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12000,5 +12000,25 @@ repositories:
       url: https://github.com/tier4/zmqpp_vendor.git
       version: main
     status: developed
+  potential_fields:
+    doc:
+      type: git
+      url: https://github.com/argallab/potential_fields.git
+      version: main
+    release:
+      packages:
+        - potential_fields
+        - potential_fields_interfaces
+        - potential_fields_demos
+        - potential_fields_library
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/potential_fields-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/argallab/potential_fields.git
+      version: main
+    status: developed
 type: distribution
 version: 2

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7158,16 +7158,6 @@ repositories:
       type: git
       url: https://github.com/argallab/potential_fields.git
       version: main
-    release:
-      packages:
-      - potential_fields
-      - potential_fields_demos
-      - potential_fields_interfaces
-      - potential_fields_library
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/potential_fields-release.git
-      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/argallab/potential_fields.git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Package Names:

```
potential_fields
potential_fields_library
potential_fields_interfaces
potential_fields_demos
```

This repository contains 4 packages I would like to index into rosdistro. `potential_fields_library` is a pure C++ library that can be built with colcon and has `ament_cmake` as the build type along with rest of the ROS packages. The project is for a motion planning library for robot arms utilizing artificial potential fields to perform obstacle avoidance. Read more about it here: https://www.sharwinpatil.info/posts/pfields/

# The source is here:

https://github.com/argallab/potential_fields

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
