### PR TITLE
yasmin: 4.2.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13358,7 +13358,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 4.2.3-1
+      version: 4.2.4-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `4.2.4-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.3-1`

## yasmin

```
* Removing cancel check from state machine execute
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_demos

- No changes

## yasmin_editor

- No changes

## yasmin_factory

```
* Creating viewer pub variable for C++ factory node
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_msgs

- No changes

## yasmin_ros

```
* Fixing outcomes of ROS states
* Contributors: Miguel Ángel González Santamarta
```

## yasmin_viewer

- No changes
