### PR TITLE
Add python3-ftdi to rosdep python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6480,9 +6480,12 @@ python3-ftdi:
   debian: [python3-ftdi]
   fedora: [python3-pyftdi]
   nixos: [python3Packages.pyftdi]
-  opensuse: [python3-pyftdi]
-  rhel: [python3-pyftdi]
-  ubuntu: [python3-ftdi]
+  rhel:
+    '*': [python3-pyftdi]
+    '9': null
+  ubuntu:
+    '*': [python3-ftdi]
+    focal: null
 python3-ftdi1:
   arch: [libftdi]
   debian: [python3-ftdi1]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6476,6 +6476,13 @@ python3-freezegun:
   opensuse: [python3-freezegun]
   rhel: [python3-freezegun]
   ubuntu: [python3-freezegun]
+python3-ftdi:
+  debian: [python3-ftdi]
+  fedora: [python3-pyftdi]
+  nixos: [python3Packages.pyftdi]
+  opensuse: [python3-pyftdi]
+  rhel: [python3-pyftdi]
+  ubuntu: [python3-ftdi]
 python3-ftdi1:
   arch: [libftdi]
   debian: [python3-ftdi1]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pyftdi

## Package Upstream Source:

https://pypi.org/project/pyftdi/

## Purpose of using this:

UART, SPI, I2C communifaction, GPIO control.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/python3-ftdi
- Ubuntu: https://packages.ubuntu.com/
  - https://ubuntu.pkgs.org/24.04/ubuntu-universe-arm64/python3-ftdi_0.54.0-1_arm64.deb.html
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-pyftdi/python3-pyftdi/
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.11&query=python+future
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/python3-pyftdi
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=pyftdi
  
  Related with: #49002 
