### PR TITLE
sros2: 0.15.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9242,7 +9242,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.15.3-1
+      version: 0.15.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.15.4-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.3-1`

## sros2

```
* kilted backports of rmw_test_fixture (#376 <https://github.com/ros2/sros2/issues/376>)
* Contributors: Tomoya Fujita
```

## sros2_cmake

- No changes
