### PR TITLE
joint_state_publisher: 2.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3386,7 +3386,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.4.0-3
+      version: 2.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.4.1-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-3`

## joint_state_publisher

```
* Cleanup bsd 3 clause license usage (#120 <https://github.com/ros/joint_state_publisher/issues/120>)
* Correct topic type in source_list parameter description (#119 <https://github.com/ros/joint_state_publisher/issues/119>)
* upgrade log level of 'got description ...' from DEBUG to INFO (#114 <https://github.com/ros/joint_state_publisher/issues/114>)
* Flake8 cleanup. (#107 <https://github.com/ros/joint_state_publisher/issues/107>)
* Cleanup COLLADA support (#96 <https://github.com/ros/joint_state_publisher/issues/96>)
* Add in linters (#98 <https://github.com/ros/joint_state_publisher/issues/98>)
* Add in parsing tests. (#97 <https://github.com/ros/joint_state_publisher/issues/97>)
* Contributors: Alejandro Hernández Cordero, Atticus Russell, Chris Lalancette, Patrick Roncagliolo
```

## joint_state_publisher_gui

```
* Cleanup bsd 3 clause license usage (#120 <https://github.com/ros/joint_state_publisher/issues/120>)
* Contributors: Alejandro Hernández Cordero
```
