### PR TITLE
urdf: 2.13.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10004,7 +10004,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.13.0-2
+      version: 2.13.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.13.1-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.13.0-2`

## urdf

```
* Fix CMAKE deprecation (#48 <https://github.com/ros2/urdf/issues/48>)
* Removed tinyxml2_vendor dependency (#47 <https://github.com/ros2/urdf/issues/47>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## urdf_parser_plugin

```
* Fix CMAKE deprecation (#48 <https://github.com/ros2/urdf/issues/48>)
  cmake version < then 3.10 is deprecated
* Contributors: mosfet80
```
