### PR TITLE
urdf: 2.12.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10075,7 +10075,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.12.2-2
+      version: 2.12.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.12.3-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.12.2-2`

## urdf

```
* Fix CMAKE deprecation (#48 <https://github.com/ros2/urdf/issues/48>) (#53 <https://github.com/ros2/urdf/issues/53>)
* Contributors: mergify[bot]
```

## urdf_parser_plugin

```
* Fix CMAKE deprecation (#48 <https://github.com/ros2/urdf/issues/48>) (#53 <https://github.com/ros2/urdf/issues/53>)
* Contributors: mergify[bot]
```
