### PR TITLE
rcl: 10.2.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6349,7 +6349,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.2.6-1
+      version: 10.2.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.2.7-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.2.6-1`

## rcl

```
* Remove default from switch with enum, so that compiler warns. (#1278 <https://github.com/ros2/rcl/issues/1278>)
* Contributors: Tomoya Fujita
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Validate name input in add_name_to_ns function (#1281 <https://github.com/ros2/rcl/issues/1281>)
* parse_key() should use yaml_map_lvl_t instead of uint_32. (#1279 <https://github.com/ros2/rcl/issues/1279>)
* Remove default from switch with enum, so that compiler warns. (#1278 <https://github.com/ros2/rcl/issues/1278>)
* Add yaml tags support (#1275 <https://github.com/ros2/rcl/issues/1275>)
  Co-authored-by: Lei Liu <mailto:Lei.Liu.AP@sony.com>
* Contributors: Barry Xu, Tomoya Fujita
```
