### PR TITLE
point_cloud_transport: 5.1.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5855,7 +5855,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.1.5-1
+      version: 5.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.1.6-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.5-1`

## point_cloud_transport

```
* Expose original ROS Publishers and Subscription (#146 <https://github.com/ros-perception/point_cloud_transport/issues/146>) (#147 <https://github.com/ros-perception/point_cloud_transport/issues/147>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

- No changes
