### PR TITLE
rcl: 5.3.12-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8468,7 +8468,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 5.3.11-1
+      version: 5.3.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `5.3.12-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.3.11-1`

## rcl

```
* Fix REP url locations (#1271 <https://github.com/ros2/rcl/issues/1271>) (#1274 <https://github.com/ros2/rcl/issues/1274>)
* Contributors: mergify[bot]
```

## rcl_action

```
* Fix REP url locations (#1271 <https://github.com/ros2/rcl/issues/1271>) (#1274 <https://github.com/ros2/rcl/issues/1274>)
* Contributors: mergify[bot]
```

## rcl_lifecycle

```
* Fix REP url locations (#1271 <https://github.com/ros2/rcl/issues/1271>) (#1274 <https://github.com/ros2/rcl/issues/1274>)
* Contributors: mergify[bot]
```

## rcl_yaml_param_parser

```
* Validate name input in add_name_to_ns function (#1281 <https://github.com/ros2/rcl/issues/1281>) (#1285 <https://github.com/ros2/rcl/issues/1285>)
* Fix REP url locations (#1271 <https://github.com/ros2/rcl/issues/1271>) (#1274 <https://github.com/ros2/rcl/issues/1274>)
* Contributors: mergify[bot]
```
