### PR TITLE
point_cloud_transport_plugins: 6.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5786,7 +5786,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 6.0.0-1
+      version: 6.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `6.0.1-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.0-1`

## draco_point_cloud_transport

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>)
* Contributors: Alejandro Hernández Cordero
```

## point_cloud_interfaces

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>)
* Contributors: Alejandro Hernández Cordero
```

## point_cloud_transport_plugins

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>)
* Contributors: Alejandro Hernández Cordero
```

## zlib_point_cloud_transport

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>)
* Contributors: Alejandro Hernández Cordero
```

## zstd_point_cloud_transport

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>)
* Contributors: Alejandro Hernández Cordero
```
