### PR TITLE
point_cloud_transport_plugins: 5.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5877,7 +5877,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 5.0.3-1
+      version: 5.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `5.0.4-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.3-1`

## draco_point_cloud_transport

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>) (#74 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/74>)
* Contributors: mergify[bot]
```

## point_cloud_interfaces

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>) (#74 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/74>)
* Contributors: mergify[bot]
```

## point_cloud_transport_plugins

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>) (#74 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/74>)
* Contributors: mergify[bot]
```

## zlib_point_cloud_transport

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>) (#74 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/74>)
* Contributors: mergify[bot]
```

## zstd_point_cloud_transport

```
* Fix cmake deprecation (#73 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/73>) (#74 <https://github.com/ros-perception/point_cloud_transport_plugins//issues/74>)
* Contributors: mergify[bot]
```
