### PR TITLE
point_cloud_transport_tutorial: 0.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5802,7 +5802,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
-      version: 0.0.6-1
+      version: 0.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_tutorial` to `0.0.8-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_tutorial
- release repository: https://github.com/ros2-gbp/point_cloud_transport_tutorial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.6-1`

## point_cloud_transport_tutorial

```
* Fixed warning (#20 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/20>)
* Cleanup bsd 3 clause license usage (#19 <https://github.com/ros-perception/point_cloud_transport_tutorial/issues/19>)
* Contributors: Alejandro Hernández Cordero
```
