### PR TITLE
ros_gz: 2.1.13-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7698,7 +7698,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.12-1
+      version: 2.1.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.13-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.12-1`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Add dependency to ros2pkg (#816 <https://github.com/gazebosim/ros_gz/issues/816>) (#817 <https://github.com/gazebosim/ros_gz/issues/817>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

- No changes
