### PR TITLE
feetech_ros2_driver: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2668,7 +2668,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/JafarAbdi/feetech_ros2_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `feetech_ros2_driver` to `0.2.2-1`:

- upstream repository: https://github.com/JafarAbdi/feetech_ros2_driver.git
- release repository: https://github.com/ros2-gbp/feetech_ros2_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-1`

## feetech_ros2_driver

```
* Fix nodiscard errors by explicitly discarding. (#26 <https://github.com/JafarAbdi/feetech_ros2_driver/issues/26>)
  * Fix nodiscard errors by explicitly discarding.
  * Use std::ignore to ignore returned value
  ---------
  Co-authored-by: JafarAbdi <jafar.uruc@gmail.com>
* Contributors: Marco A. Gutierrez
```
