### PR TITLE
mp2p_icp: 2.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4567,7 +4567,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.4.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## mp2p_icp

```
* Merge pull request #27 <https://github.com/MOLAorg/mp2p_icp/issues/27> from MOLAorg/feat/new-filter-voxel-sor
* Add new unit test for class factory
* Add new FilterVoxelSOR filter
* Merge pull request #26 <https://github.com/MOLAorg/mp2p_icp/issues/26> from MOLAorg/feat/mm2las
* Add mm2las CLI tool
* Contributors: Jose Luis Blanco-Claraco
```
