### PR TITLE
Index 'crx_kinematics' for humble, jazzy, kilted and rolling

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2027,6 +2027,16 @@ repositories:
       url: https://github.com/AutonomyLab/create_robot.git
       version: humble
     status: maintained
+  crx_kinematics:
+    doc:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1824,6 +1824,16 @@ repositories:
       url: https://github.com/iRobotEducation/create3_sim.git
       version: jazzy
     status: developed
+  crx_kinematics:
+    doc:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1360,6 +1360,16 @@ repositories:
       url: https://github.com/ctu-vras/ros-utils.git
       version: ros2
     status: developed
+  crx_kinematics:
+    doc:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1406,6 +1406,16 @@ repositories:
       url: https://github.com/loco-3d/crocoddyl.git
       version: devel
     status: maintained
+  crx_kinematics:
+    doc:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/danielcranston/crx_kinematics.git
+      version: master
+    status: developed
   cudnn_cmake_module:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

crx_kinematics

# The source is here:

https://github.com/danielcranston/crx_kinematics

# Checks

 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
  - tests are in place for each distro


# Sidenote

I only really intend to release `crx_kinematics` (not `crx_kinematics_py`). I see that it's possible to specify "[packages:](https://github.com/ros/rosdistro/blob/0334f5a19365dccae5ed3db16f52a34da7f94736/rolling/distribution.yaml#L19)" to the `release` entry (which I'll make once a release team has been made).

Just wanted to check that it's possible to _index_ a repo containing multiple ROS packages, but _release_ only a subset of them.