### PR TITLE
ament_lint: 0.17.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -344,7 +344,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.17.3-1
+      version: 0.17.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.17.4-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.17.3-1`

## ament_clang_format

- No changes

## ament_clang_tidy

```
* ament_clang_tidy - Fix Reporting when WarningsAsErrors is specified in config (#397 <https://github.com/ament/ament_lint/issues/397>) (#490 <https://github.com/ament/ament_lint/issues/490>)
  (cherry picked from commit f985e675d872f39327484633e2a7fdce0213ce28)
  Co-authored-by: Matt Condino <mailto:36555625+mwcondino@users.noreply.github.com>
* Contributors: mergify[bot]
```

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

- No changes

## ament_cmake_cppcheck

- No changes

## ament_cmake_cpplint

- No changes

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

- No changes

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

- No changes

## ament_cmake_xmllint

- No changes

## ament_copyright

- No changes

## ament_cppcheck

- No changes

## ament_cpplint

- No changes

## ament_flake8

- No changes

## ament_lint

- No changes

## ament_lint_auto

- No changes

## ament_lint_cmake

- No changes

## ament_lint_common

- No changes

## ament_mypy

- No changes

## ament_pclint

```
* fix setuptools deprecation (backport #551 <https://github.com/ament/ament_lint/issues/551>) (#559 <https://github.com/ament/ament_lint/issues/559>)
  * fix setuptools deprecation (#551 <https://github.com/ament/ament_lint/issues/551>)
  (cherry picked from commit 6c532cfefefcb1af20bdb84d5d4d246571713830)
  * clean setup.py (#552 <https://github.com/ament/ament_lint/issues/552>)
  ---------
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```

## ament_pep257

- No changes

## ament_pycodestyle

- No changes

## ament_pyflakes

- No changes

## ament_uncrustify

- No changes

## ament_xmllint

- No changes
