### PR TITLE
ament_package: 0.16.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -371,7 +371,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.16.4-1
+      version: 0.16.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.16.5-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.16.4-1`

## ament_package

```
* fix setuptools deprecations (#156 <https://github.com/ament/ament_package/issues/156>) (#159 <https://github.com/ament/ament_package/issues/159>)
  (cherry picked from commit 7b5dea841784a511e275ac0d12a8a4036d943838)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
