### PR TITLE
google_benchmark_vendor: 0.5.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3205,7 +3205,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.5.0-2
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.5.1-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.0-2`

## google_benchmark_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-main workflow. (#31 <https://github.com/ament/google_benchmark_vendor/issues/31>) (#32 <https://github.com/ament/google_benchmark_vendor/issues/32>)
  They are both outdated and both no longer serving their
  intended purpose.
  (cherry picked from commit 0de27c29e3fa10c13b579f4b31fe6e03e4352ce2)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
