### PR TITLE
rqt: 1.6.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9400,7 +9400,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.6.2-2
+      version: 1.6.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.6.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.2-2`

## rqt

```
* fix setuptools deprecations (#334 <https://github.com/ros-visualization/rqt/issues/334>) (#336 <https://github.com/ros-visualization/rqt/issues/336>)
  (cherry picked from commit dc64942338ef429c288f394f8c623494a0fcd302)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rqt_gui

- No changes

## rqt_gui_cpp

- No changes

## rqt_gui_py

- No changes

## rqt_py_common

- No changes
