### PR TITLE
Fix kilted version branches for Gazebo vendor packages

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2841,7 +2841,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/gz_gui_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   gz_launch_vendor:
     doc:
@@ -8837,7 +8837,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
-      version: rolling
+      version: kilted
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -8847,7 +8847,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebo-release/sdformat_vendor.git
-      version: rolling
+      version: kilted
     status: maintained
   septentrio_gnss_driver:
     doc:


### PR DESCRIPTION
These were missed from #46669 