### PR TITLE
sdformat_vendor: 0.3.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8762,7 +8762,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_vendor-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_vendor` to `0.3.3-1`:

- upstream repository: https://github.com/gazebo-release/sdformat_vendor.git
- release repository: https://github.com/ros2-gbp/sdformat_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.2-1`

## sdformat_vendor

```
* Bump version to 16.0.1 (#22 <https://github.com/gazebo-release/sdformat_vendor/issues/22>)
* Contributors: Arjo Chakravarty
```
