### PR TITLE
rosidl_rust: 0.4.10-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10088,6 +10088,23 @@ repositories:
       url: https://github.com/ros2/rosidl_runtime_py.git
       version: humble
     status: maintained
+  rosidl_rust:
+    doc:
+      type: git
+      url: https://github.com/ros2-rust/rosidl_rust.git
+      version: main
+    release:
+      packages:
+      - rosidl_generator_rs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_rust-release.git
+      version: 0.4.10-1
+    source:
+      type: git
+      url: https://github.com/ros2-rust/rosidl_rust.git
+      version: main
+    status: developed
   rosidl_typesupport:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_rust` to `0.4.10-1`:

- upstream repository: https://github.com/ros2-rust/rosidl_rust.git
- release repository: https://github.com/ros2-gbp/rosidl_rust-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rosidl_generator_rs

```
* build: update rosidl_runtime_rs dependency version to 0.6 (#14 <https://github.com/ros2-rust/rosidl_rust/issues/14>)
* Contributors: Esteve Fernandez
```
