### PR TITLE
rqt_action: 2.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9416,7 +9416,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_action-release.git
-      version: 2.2.0-3
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_action` to `2.2.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_action.git
- release repository: https://github.com/ros2-gbp/rqt_action-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-3`

## rqt_action

```
* fix setuptools deprecations (backport #19 <https://github.com/ros-visualization/rqt_action/issues/19>) (#21 <https://github.com/ros-visualization/rqt_action/issues/21>)
  fix setuptools deprecations (#19 <https://github.com/ros-visualization/rqt_action/issues/19>)
  (cherry picked from commit d4063e0ce3393e15c517d82c40802cb29719462b)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS and mirror-rolling-to-main workflow (backport #16 <https://github.com/ros-visualization/rqt_action/issues/16>) (#17 <https://github.com/ros-visualization/rqt_action/issues/17>)
  Remove CODEOWNERS and mirror-rolling-to-main workflow (#16 <https://github.com/ros-visualization/rqt_action/issues/16>)
  (cherry picked from commit a0427dbaed8c5b2390d583bbb0905b9b5f59d60f)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
