### PR TITLE
rqt_bag: 1.5.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9434,7 +9434,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 1.5.5-1
+      version: 1.5.6-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `1.5.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.5-1`

## rqt_bag

```
* fix setuptools deprecations (backport #185 <https://github.com/ros-visualization/rqt_bag/issues/185>) (#203 <https://github.com/ros-visualization/rqt_bag/issues/203>)
  fix setuptools deprecations (#185 <https://github.com/ros-visualization/rqt_bag/issues/185>)
  (cherry picked from commit 34e39bcb6455d18d0073a05797e6e1f04bbcbf7c)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rqt_bag_plugins

```
* fix setuptools deprecations (backport #185 <https://github.com/ros-visualization/rqt_bag/issues/185>) (#203 <https://github.com/ros-visualization/rqt_bag/issues/203>)
  fix setuptools deprecations (#185 <https://github.com/ros-visualization/rqt_bag/issues/185>)
  (cherry picked from commit 34e39bcb6455d18d0073a05797e6e1f04bbcbf7c)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```
