### PR TITLE
rqt_graph: 1.5.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9509,7 +9509,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.5.5-1
+      version: 1.5.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.5.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.5-1`

## rqt_graph

```
* fix setuptools deprecations (backport #107 <https://github.com/ros-visualization/rqt_graph/issues/107>) (#112 <https://github.com/ros-visualization/rqt_graph/issues/112>)
  fix setuptools deprecations (#107 <https://github.com/ros-visualization/rqt_graph/issues/107>)
  (cherry picked from commit e72fdcb4a2c26781cc25415549f73ecd5f1c7419)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```
