### PR TITLE
rqt_msg: 1.5.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9574,7 +9574,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.5.1-3
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `1.5.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.1-3`

## rqt_msg

```
* fix setuptools deprecations (backport #23 <https://github.com/ros-visualization/rqt_msg/issues/23>) (#25 <https://github.com/ros-visualization/rqt_msg/issues/25>)
  fix setuptools deprecations (#23 <https://github.com/ros-visualization/rqt_msg/issues/23>)
  (cherry picked from commit b5c456ee25b953b6a7f80d91223e8829c569ce23)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS (backport #20 <https://github.com/ros-visualization/rqt_msg/issues/20>) (#21 <https://github.com/ros-visualization/rqt_msg/issues/21>)
  Remove CODEOWNERS (#20 <https://github.com/ros-visualization/rqt_msg/issues/20>)
  (cherry picked from commit d76adcec529ee7018d92c42045dce297d2a5bcfc)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
