### PR TITLE
rqt_plot: 1.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9589,7 +9589,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.4.4-1
+      version: 1.4.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.4.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.4-1`

## rqt_plot

```
* fix setuptools deprecations (backport #123 <https://github.com/ros-visualization/rqt_plot/issues/123>) (#125 <https://github.com/ros-visualization/rqt_plot/issues/125>)
  fix setuptools deprecations (#123 <https://github.com/ros-visualization/rqt_plot/issues/123>)
  (cherry picked from commit 839ff5b7434f7a8342a085d2bf7182a00d38f040)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```
