### PR TITLE
rqt_publisher: 1.7.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9604,7 +9604,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.7.2-2
+      version: 1.7.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.7.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.2-2`

## rqt_publisher

```
* fix setuptools deprecations (backport #52 <https://github.com/ros-visualization/rqt_publisher/issues/52>) (#54 <https://github.com/ros-visualization/rqt_publisher/issues/54>)
  fix setuptools deprecations (#52 <https://github.com/ros-visualization/rqt_publisher/issues/52>)
  (cherry picked from commit b64a99c25a351645284e2880999cab3f32ea5512)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS (backport #47 <https://github.com/ros-visualization/rqt_publisher/issues/47>) (#48 <https://github.com/ros-visualization/rqt_publisher/issues/48>)
  Remove CODEOWNERS (#47 <https://github.com/ros-visualization/rqt_publisher/issues/47>)
  (cherry picked from commit ee9cb5d8fce08c87c52e63e695fc5aecca7b8192)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
