### PR TITLE
rqt_shell: 1.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9725,7 +9725,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.2.2-2
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `1.2.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.2-2`

## rqt_shell

```
* Fix setuptools deprecation (backport #26 <https://github.com/ros-visualization/rqt_shell/issues/26>) (#28 <https://github.com/ros-visualization/rqt_shell/issues/28>)
  Fix setuptools deprecation (#26 <https://github.com/ros-visualization/rqt_shell/issues/26>)
  (cherry picked from commit 23528082dc9fff90587fbfd28ef71737ad97f035)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS (backport #22 <https://github.com/ros-visualization/rqt_shell/issues/22>) (#23 <https://github.com/ros-visualization/rqt_shell/issues/23>)
  Remove CODEOWNERS (#22 <https://github.com/ros-visualization/rqt_shell/issues/22>)
  (cherry picked from commit 9c9550f5a51b2fac713006fa034f2e57cf362c9b)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
