### PR TITLE
rqt_service_caller: 1.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9710,7 +9710,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.2.1-3
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `1.2.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.1-3`

## rqt_service_caller

```
* fix setuptools deprecations (backport #33 <https://github.com/ros-visualization/rqt_service_caller/issues/33>) (#35 <https://github.com/ros-visualization/rqt_service_caller/issues/35>)
  fix setuptools deprecations (#33 <https://github.com/ros-visualization/rqt_service_caller/issues/33>)
  (cherry picked from commit 4f02b443f773c75ed2e29e4249b028c870e655e0)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS (backport #29 <https://github.com/ros-visualization/rqt_service_caller/issues/29>) (#30 <https://github.com/ros-visualization/rqt_service_caller/issues/30>)
  <hr>This is an automatic backport of pull request #29 <https://github.com/ros-visualization/rqt_service_caller/issues/29> done by
  [Mergify](https://mergify.com).
* Contributors: mergify[bot]
```
