### PR TITLE
rqt_srv: 1.2.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9740,7 +9740,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_srv-release.git
-      version: 1.2.2-3
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_srv` to `1.2.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_srv.git
- release repository: https://github.com/ros2-gbp/rqt_srv-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.2-3`

## rqt_srv

```
* fix setuptools deprecations (backport #16 <https://github.com/ros-visualization/rqt_srv/issues/16>) (#18 <https://github.com/ros-visualization/rqt_srv/issues/18>)
  fix setuptools deprecations (#16 <https://github.com/ros-visualization/rqt_srv/issues/16>)
  (cherry picked from commit 3b7e0672e5c710689995102ec08c2a2921fcedbc)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Remove CODEOWNERS (backport #13 <https://github.com/ros-visualization/rqt_srv/issues/13>) (#14 <https://github.com/ros-visualization/rqt_srv/issues/14>)
  <hr>This is an automatic backport of pull request #13 <https://github.com/ros-visualization/rqt_srv/issues/13> done by
  [Mergify](https://mergify.com).
* Contributors: mergify[bot]
```
