### PR TITLE
tango_icons_vendor: 0.3.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10680,7 +10680,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/tango_icons_vendor-release.git
-      version: 0.3.0-3
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tango_icons_vendor` to `0.3.1-1`:

- upstream repository: https://github.com/ros-visualization/tango_icons_vendor.git
- release repository: https://github.com/ros2-gbp/tango_icons_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-3`

## tango_icons_vendor

```
* Remove CODEOWNERS (#11 <https://github.com/ros-visualization/tango_icons_vendor/issues/11>) (#13 <https://github.com/ros-visualization/tango_icons_vendor/issues/13>)
  (cherry picked from commit 04b176b63b4ffaabf7a3d84dfcbe70fd90fd5c58)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Remove the mirror-rolling-to-master workflow. (#12 <https://github.com/ros-visualization/tango_icons_vendor/issues/12>) (#14 <https://github.com/ros-visualization/tango_icons_vendor/issues/14>)
  We no longer need to keep that compatibility, so drop it.
  (cherry picked from commit 94e4d120f14fdc74922152b16d48391958d9c002)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
