### PR TITLE
ros2cli: 0.32.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8764,7 +8764,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.7-1
+      version: 0.32.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.8-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.32.7-1`

## ros2action

- No changes

## ros2cli

- No changes

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

```
* ros2interface output the contents for each node. (#1163 <https://github.com/ros2/ros2cli/issues/1163>) (#1167 <https://github.com/ros2/ros2cli/issues/1167>)
  (cherry picked from commit 6e3c7ac2cbdf571819af6d647ef3e7bf8e5fedf3)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* Fix ParameterNameCompleter. (#1172 <https://github.com/ros2/ros2cli/issues/1172>) (#1176 <https://github.com/ros2/ros2cli/issues/1176>)
  (cherry picked from commit 752e0606195cfac31673e3571943d4fa233c4098)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Output node parameters upon each receipt (#1162 <https://github.com/ros2/ros2cli/issues/1162>) (#1166 <https://github.com/ros2/ros2cli/issues/1166>)
  (cherry picked from commit 50547de9f993242b5af77924c4b5ad9aaf0a41ef)
  Co-authored-by: Barry Xu <mailto:barry.xu@sony.com>
* Contributors: mergify[bot]
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
