### PR TITLE
ros2_tracing: 8.2.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8705,7 +8705,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.2.4-1
+      version: 8.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.5-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.2.4-1`

## lttngpy

```
* [Fix] compile fail (#194 <https://github.com/ros2/ros2_tracing/issues/194>) (#215 <https://github.com/ros2/ros2_tracing/issues/215>)
  (cherry picked from commit e175cde407a2da7fab2a75890cdb9d0e626cc73b)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
* Contributors: mergify[bot]
```

## ros2trace

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>) (#203 <https://github.com/ros2/ros2_tracing/issues/203>)
  (cherry picked from commit 526967c1a0ad3208fe6c28e0cf16f2b045ed5241)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```

## tracetools

- No changes

## tracetools_launch

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>) (#203 <https://github.com/ros2/ros2_tracing/issues/203>)
  (cherry picked from commit 526967c1a0ad3208fe6c28e0cf16f2b045ed5241)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```

## tracetools_read

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>) (#203 <https://github.com/ros2/ros2_tracing/issues/203>)
  (cherry picked from commit 526967c1a0ad3208fe6c28e0cf16f2b045ed5241)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```

## tracetools_test

```
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>) (#203 <https://github.com/ros2/ros2_tracing/issues/203>)
  (cherry picked from commit 526967c1a0ad3208fe6c28e0cf16f2b045ed5241)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```

## tracetools_trace

```
* Add exec_depend on procps to tracetools_trace for ps command (#227 <https://github.com/ros2/ros2_tracing/issues/227>) (#229 <https://github.com/ros2/ros2_tracing/issues/229>)
  (cherry picked from commit 0852cd777d247e7c18fb768968d8b041b673d1a8)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* fix setuptools deprecation (#189 <https://github.com/ros2/ros2_tracing/issues/189>) (#203 <https://github.com/ros2/ros2_tracing/issues/203>)
  (cherry picked from commit 526967c1a0ad3208fe6c28e0cf16f2b045ed5241)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```
