### PR TITLE
rclcpp: 28.1.16-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7667,7 +7667,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.15-1
+      version: 28.1.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.16-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `28.1.15-1`

## rclcpp

```
* Improve the robustness of the TopicEndpointInfo constructor (#3013 <https://github.com/ros2/rclcpp/issues/3013>) (#3015 <https://github.com/ros2/rclcpp/issues/3015>)
  (cherry picked from commit 7f783cbf587a2897572263b48b9583d8021f3958)
  Co-authored-by: Barry Xu <mailto:barry.xu@sony.com>
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Update exception documentation for goal cancellation in ServerGoalHandle (#3019 <https://github.com/ros2/rclcpp/issues/3019>) (#3023 <https://github.com/ros2/rclcpp/issues/3023>)
  * Update exception documentation for goal cancellation
  The documentation for the canceled function is misleading.
  Previously, the description said:
  1. "Only call this if the goal is canceling." and
  2. "throws rclcpp::exceptions::RCLError If the goal is in any state besides executing."
  This is a contradiction.
  Experimentally verified that if the goal is executing and this method is called, an error is thrown. This makes the second statement wrong => correct the statement in the documentation.
  (cherry picked from commit 6397047d4795f594cf65dd360d70f5c9c3618700)
  Co-authored-by: Andrei Costinescu <AndreiCostinescu@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
