### PR TITLE
elite_cs_series_sdk: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2573,6 +2573,21 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  elite_cs_series_sdk:
+    doc:
+      type: git
+      url: https://github.com/747309172a-cpu/Elite_Robots_CS_SDK.git
+      version: featrun/sdk_2_ros
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/747309172a-cpu/elite_cs_series_sdk-release.git
+      version: 1.3.0-1
+    source:
+      type: git
+      url: https://github.com/747309172a-cpu/Elite_Robots_CS_SDK.git
+      version: featrun/sdk_2_ros
+    status: maintained
   ess_imu_driver2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `elite_cs_series_sdk` to `1.3.0-1`:

- upstream repository: https://github.com/747309172a-cpu/Elite_Robots_CS_SDK.git
- release repository: https://github.com/747309172a-cpu/elite_cs_series_sdk-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
