### PR TITLE
octomap_mapping: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5113,7 +5113,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.3.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## octomap_mapping

- No changes

## octomap_server

```
* chore: update headers for message filters and tf2 ros (#138 <https://github.com/OctoMap/octomap_mapping/issues/138>)
* Contributors: Daisuke Nishimatsu
```
