### PR TITLE
octomap_mapping: 2.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5233,7 +5233,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_mapping-release.git
-      version: 2.3.0-2
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_mapping` to `2.3.1-1`:

- upstream repository: https://github.com/OctoMap/octomap_mapping.git
- release repository: https://github.com/ros2-gbp/octomap_mapping-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-2`

## octomap_mapping

- No changes

## octomap_server

```
* chore: update headers for message filters and tf2 ros (#138 <https://github.com/OctoMap/octomap_mapping/issues/138>)
* Contributors: Daisuke Nishimatsu
```
