### PR TITLE
synapticon_ros2_control: 0.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11500,7 +11500,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/synapticon/synapticon_ros2_control-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11495,7 +11495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -11504,7 +11504,7 @@ repositories:
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: main
+      version: humble
     status: maintained
   sync_parameter_server:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `synapticon_ros2_control` to `0.1.3-1`:

- upstream repository: https://github.com/synapticon/synapticon_ros2_control.git
- release repository: https://github.com/synapticon/synapticon_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.2-1`
