### PR TITLE
synapticon_ros2_control: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10595,7 +10595,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: main
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -10604,7 +10604,7 @@ repositories:
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: main
+      version: jazzy
     status: maintained
   sync_tooling_msgs:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10600,7 +10600,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/synapticon/synapticon_ros2_control-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `synapticon_ros2_control` to `0.2.0-1`:

- upstream repository: https://github.com/synapticon/synapticon_ros2_control.git
- release repository: https://github.com/synapticon/synapticon_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.2-1`
