### PR TITLE
synapticon_ros2_control: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9202,7 +9202,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -9211,7 +9211,7 @@ repositories:
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
-      version: main
+      version: rolling
     status: maintained
   sync_tooling_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9206,8 +9206,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/synapticon_ros2_control-release.git
-      version: 0.1.2-1
+      url: https://github.com/synapticon/synapticon_ros2_control-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `synapticon_ros2_control` to `0.3.0-1`:

- upstream repository: https://github.com/synapticon/synapticon_ros2_control.git
- release repository: https://github.com/synapticon/synapticon_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.2-1`
