### PR TITLE
libfranka: 0.20.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4995,7 +4995,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/frankaemika/libfranka-release.git
-      version: 0.15.0-1
+      version: 0.20.3-1
     source:
       type: git
       url: https://github.com/frankaemika/libfranka.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka` to `0.20.3-1`:

- upstream repository: https://github.com/frankaemika/libfranka.git
- release repository: https://github.com/frankaemika/libfranka-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.15.0-1`
