### PR TITLE
gz_sensors_vendor: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2905,7 +2905,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sensors_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_sensors_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sensors_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`

## gz_sensors_vendor

```
* Bump version to 10.0.1 (#12 <https://github.com/gazebo-release/gz_sensors_vendor/issues/12>)
* Contributors: Ian Chen
```
