### PR TITLE
orbbec_camera_v2: 2.6.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6954,7 +6954,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/orbbec/orbbec_camera_v2-release.git
-      version: 2.5.5-2
+      version: 2.6.3-1
     source:
       type: git
       url: https://github.com/orbbec/OrbbecSDK_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orbbec_camera_v2` to `2.6.3-1`:

- upstream repository: https://github.com/orbbec/OrbbecSDK_ROS2.git
- release repository: https://github.com/orbbec/orbbec_camera_v2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.5-2`
