### PR TITLE
foxglove-sdk: 3.2.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2963,7 +2963,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.2.3-1
+      version: 3.2.4-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.2.4-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.3-1`

## foxglove_bridge

```
* Add client count topic (#692 <https://github.com/foxglove/foxglove-sdk/pull/692>)
* Fix build warning on newer versions of CMake (#828 <https://github.com/foxglove/foxglove-sdk/pull/828>)
* Update Foxglove SDK version to 0.16.5
* Contributors: Andrew Madden, Chris Lalancette
```

## foxglove_msgs

```
* Clarify direction on FrameTransform
* Contributors: Roman Shtylman
```
