### PR TITLE
agnocast: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -213,10 +213,23 @@ repositories:
       url: https://github.com/PickNikRobotics/affordance_primitives.git
       version: main
   agnocast:
+    release:
+      packages:
+      - agnocast_e2e_test
+      - agnocast_ioctl_wrapper
+      - agnocast_sample_application
+      - agnocast_sample_interfaces
+      - agnocastlib
+      - ros2agnocast
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/agnocast-release.git
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/tier4/agnocast.git
       version: main
+    status: developed
   ai_prompt_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `agnocast` to `2.1.2-1`:

- upstream repository: https://github.com/tier4/agnocast.git
- release repository: https://github.com/ros2-gbp/agnocast-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## agnocast_e2e_test

- No changes

## agnocast_ioctl_wrapper

- No changes

## agnocast_sample_application

```
* feat(agnocastlib): cie spin (#669 <https://github.com/tier4/agnocast/issues/669>)
* fix(agnocastlib): stop possessing shared pointer to nodes in agnocast executor (#664 <https://github.com/tier4/agnocast/issues/664>)
```

## agnocast_sample_interfaces

- No changes

## agnocastlib

```
* fix: remove unnecessary TRACETOOLS_LTTNG_ENABLED (#678 <https://github.com/tier4/agnocast/issues/678>)
* test(integration): Add integration test investigate malloc region differences after fork (#675 <https://github.com/tier4/agnocast/issues/675>)
* feat(agnocastlib): template the callback type for greater flexibility (#665 <https://github.com/tier4/agnocast/issues/665>)
* build: set C++ standard explicitly to support Clang builds (#677 <https://github.com/tier4/agnocast/issues/677>)
* test(integration): Add integration test for malloc allocator switching based on publisher_num (#661 <https://github.com/tier4/agnocast/issues/661>)
* feat(agnocastlib): impl get_all_callback_groups method in cie (#674 <https://github.com/tier4/agnocast/issues/674>)
* feat(agnocastlib): cie spin (#669 <https://github.com/tier4/agnocast/issues/669>)
* feat(agnocastlib): add/remove node in cie (#668 <https://github.com/tier4/agnocast/issues/668>)
* feat(agnocastlib): add/remove callback group in cie (#667 <https://github.com/tier4/agnocast/issues/667>)
* feat(agnocastlib): add cie skelton (#666 <https://github.com/tier4/agnocast/issues/666>)
* fix(agnocastlib): stop possessing shared pointer to nodes in agnocast executor (#664 <https://github.com/tier4/agnocast/issues/664>)
* feat(agnocastlib) change epoll updates behavior for cie (#663 <https://github.com/tier4/agnocast/issues/663>)
* feat(agnocastlib): single threaded executor for cie (#660 <https://github.com/tier4/agnocast/issues/660>)
* fix(agnocastlib): use override keyword (#662 <https://github.com/tier4/agnocast/issues/662>)
* feat: tracepoint definition for CARET (#659 <https://github.com/tier4/agnocast/issues/659>)
* refactor(agnocastlib): lower the log level when mq_open fails (#650 <https://github.com/tier4/agnocast/issues/650>)
* style: add a trailing underscore to the data member of Subscriber (#645 <https://github.com/tier4/agnocast/issues/645>)
```

## ros2agnocast

- No changes
