### PR TITLE
Add language-pack-en entry for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2613,6 +2613,7 @@ language-pack-de:
 language-pack-en:
   debian: []
   fedora: [glibc-langpack-en]
+  nixos: []
   rhel: [glibc-langpack-en]
   ubuntu: [language-pack-en]
 lcov:


### PR DESCRIPTION
Similarly to Debian, NixOS doesn't have this package.
