### PR TITLE
slam_toolbox: 2.8.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10302,7 +10302,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/SteveMacenski/slam_toolbox-release.git
-      version: 2.8.3-1
+      version: 2.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `slam_toolbox` to `2.8.4-1`:

- upstream repository: https://github.com/SteveMacenski/slam_toolbox.git
- release repository: https://github.com/SteveMacenski/slam_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.3-1`
