### PR TITLE
rosbag2: 0.26.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9007,7 +9007,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.9-1
+      version: 0.26.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.10-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.9-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

```
* add rosbag2_storage_default_plugins to exec_depend of ros2bag. (#2227 <https://github.com/ros2/rosbag2/issues/2227>) (#2231 <https://github.com/ros2/rosbag2/issues/2231>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

```
* [jazzy] Make topics persistent between writer's close() and open() API calls. (backport #2229 <https://github.com/ros2/rosbag2/issues/2229>) (#2243 <https://github.com/ros2/rosbag2/issues/2243>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Address flakiness in the recorder tests with small cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>) (#2207 <https://github.com/ros2/rosbag2/issues/2207>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Workaround for flaky bagsize_split_is_at_least_specified_size test (#2311 <https://github.com/ros2/rosbag2/issues/2311>) (#2315 <https://github.com/ros2/rosbag2/issues/2315>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [kilted] Upstream minor fixes from Apex.AI (backport #2240 <https://github.com/ros2/rosbag2/issues/2240>) (#2294 <https://github.com/ros2/rosbag2/issues/2294>) (#2301 <https://github.com/ros2/rosbag2/issues/2301>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [kilted] Check for nullptrs when pushing new messages to the message cache (backport #2219 <https://github.com/ros2/rosbag2/issues/2219>) (#2222 <https://github.com/ros2/rosbag2/issues/2222>) (#2246 <https://github.com/ros2/rosbag2/issues/2246>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: José Faria <mailto:jncfa@pm.me>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Make topics persistent between writer's close() and open() API calls. (backport #2229 <https://github.com/ros2/rosbag2/issues/2229>) (#2243 <https://github.com/ros2/rosbag2/issues/2243>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Address flakiness in the recorder tests with small cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>) (#2207 <https://github.com/ros2/rosbag2/issues/2207>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Log reasoning for not found message definition only in debug log (backport #2183 <https://github.com/ros2/rosbag2/issues/2183>) (#2186 <https://github.com/ros2/rosbag2/issues/2186>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* minor error checks for rosbag2_cpp (#2127 <https://github.com/ros2/rosbag2/issues/2127>) (#2146 <https://github.com/ros2/rosbag2/issues/2146>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Fix: Add null pointer check for reader_imp in the Reader constructor (#2135 <https://github.com/ros2/rosbag2/issues/2135>) (#2140 <https://github.com/ros2/rosbag2/issues/2140>)
  Co-authored-by: YuJin Hong <mailto:150586358+dbwls99706@users.noreply.github.com>
  Co-authored-by: yujinhong <mailto:yujin@nbyus.com>
* [jazzy] Use rclcpp type support helpers in rosbag2_cpp (backport #2017 <https://github.com/ros2/rosbag2/issues/2017>) (#2130 <https://github.com/ros2/rosbag2/issues/2130>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

```
* [jazzy] Add Record, Stop, StartDiscovery, StopDiscovery and IsDiscoveryRunning services for Recorder (backport #2248 <https://github.com/ros2/rosbag2/issues/2248>) (#2309 <https://github.com/ros2/rosbag2/issues/2309>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

```
* [kilted] Upstream minor fixes from Apex.AI (backport #2240 <https://github.com/ros2/rosbag2/issues/2240>) (#2294 <https://github.com/ros2/rosbag2/issues/2294>) (#2301 <https://github.com/ros2/rosbag2/issues/2301>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Make sure test topic is discovered by recorder in rosbag2_py test (#2132 <https://github.com/ros2/rosbag2/issues/2132>) (#2138 <https://github.com/ros2/rosbag2/issues/2138>)
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_storage

```
* Fix decoder and encode mismatch fails YAML deserialization. (#2277 <https://github.com/ros2/rosbag2/issues/2277>) (#2298 <https://github.com/ros2/rosbag2/issues/2298>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Throw YAML::Exception during conversion if the data type mismatches. (#2262 <https://github.com/ros2/rosbag2/issues/2262>) (#2304 <https://github.com/ros2/rosbag2/issues/2304>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* [kilted] Upstream minor fixes from Apex.AI (backport #2240 <https://github.com/ros2/rosbag2/issues/2240>) (#2294 <https://github.com/ros2/rosbag2/issues/2294>) (#2301 <https://github.com/ros2/rosbag2/issues/2301>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* fix memory leak on make_empty_serialized_message(). (#2253 <https://github.com/ros2/rosbag2/issues/2253>) (#2260 <https://github.com/ros2/rosbag2/issues/2260>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* Bugfix for MCAPStorage::seek(time) advance in time is current (#2157 <https://github.com/ros2/rosbag2/issues/2157>) (#2160 <https://github.com/ros2/rosbag2/issues/2160>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_storage_sqlite3

```
* vulnerable string concatenation with parameterized queries. (#2290 <https://github.com/ros2/rosbag2/issues/2290>) (#2297 <https://github.com/ros2/rosbag2/issues/2297>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* Contributors: mergify[bot]
```

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

```
* Workaround for flaky bagsize_split_is_at_least_specified_size test (#2311 <https://github.com/ros2/rosbag2/issues/2311>) (#2315 <https://github.com/ros2/rosbag2/issues/2315>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Address flakiness in the recorder tests with small cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>) (#2207 <https://github.com/ros2/rosbag2/issues/2207>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Use rclcpp type support helpers in rosbag2_cpp (backport #2017 <https://github.com/ros2/rosbag2/issues/2017>) (#2130 <https://github.com/ros2/rosbag2/issues/2130>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## rosbag2_transport

```
* [jazzy] Add Record, Stop, StartDiscovery, StopDiscovery and IsDiscoveryRunning services for Recorder (backport #2248 <https://github.com/ros2/rosbag2/issues/2248>) (#2309 <https://github.com/ros2/rosbag2/issues/2309>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [kilted] Use QoS override settings for inner Rosbag2 publishing topics (backport #2286 <https://github.com/ros2/rosbag2/issues/2286>) (#2302 <https://github.com/ros2/rosbag2/issues/2302>) (#2307 <https://github.com/ros2/rosbag2/issues/2307>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
* Fix decoder and encode mismatch fails YAML deserialization. (#2277 <https://github.com/ros2/rosbag2/issues/2277>) (#2298 <https://github.com/ros2/rosbag2/issues/2298>)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
* [kilted] Upstream minor fixes from Apex.AI (backport #2240 <https://github.com/ros2/rosbag2/issues/2240>) (#2294 <https://github.com/ros2/rosbag2/issues/2294>) (#2301 <https://github.com/ros2/rosbag2/issues/2301>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Address flakiness in the recorder tests with small cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>) (#2207 <https://github.com/ros2/rosbag2/issues/2207>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Reduce CPU overhead in the Rosbag2 recorder discovery (#2201 <https://github.com/ros2/rosbag2/issues/2201>) (#2205 <https://github.com/ros2/rosbag2/issues/2205>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* [jazzy] Fix for data races in tests with MockSequentialWriter (backport #2192 <https://github.com/ros2/rosbag2/issues/2192>) (#2196 <https://github.com/ros2/rosbag2/issues/2196>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Make the player respect the original messages' order with the same timestamp (backport #2172 <https://github.com/ros2/rosbag2/issues/2172>) (#2188 <https://github.com/ros2/rosbag2/issues/2188>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Follow-up on "Fix for multibag replay stagnation (#2158 <https://github.com/ros2/rosbag2/issues/2158>)" (backport #2182 <https://github.com/ros2/rosbag2/issues/2182>) (#2189 <https://github.com/ros2/rosbag2/issues/2189>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Bugfix: Player can't play with read_ahead_queue_size equal 1 (backport #2174 <https://github.com/ros2/rosbag2/issues/2174>) (#2180 <https://github.com/ros2/rosbag2/issues/2180>)
  Co-Authored by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Fixes for multiple race conditions in player (backport #2171 <https://github.com/ros2/rosbag2/issues/2171>) (#2177 <https://github.com/ros2/rosbag2/issues/2177>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Fix for multibag replay stagnation (backport #2158 <https://github.com/ros2/rosbag2/issues/2158>) (#2170 <https://github.com/ros2/rosbag2/issues/2170>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Bugfix for MCAPStorage::seek(time) advance in time is current (#2157 <https://github.com/ros2/rosbag2/issues/2157>) (#2160 <https://github.com/ros2/rosbag2/issues/2160>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Add RecorderEventNotifier class (backport #2144 <https://github.com/ros2/rosbag2/issues/2144>) (backport #2149 <https://github.com/ros2/rosbag2/issues/2149>) (#2151 <https://github.com/ros2/rosbag2/issues/2151>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
* [jazzy] Bugfix for deadlock in multibag replay (backport #2143 <https://github.com/ros2/rosbag2/issues/2143>) (#2148 <https://github.com/ros2/rosbag2/issues/2148>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [jazzy] Use rclcpp type support helpers in rosbag2_cpp (backport #2017 <https://github.com/ros2/rosbag2/issues/2017>) (#2130 <https://github.com/ros2/rosbag2/issues/2130>)
  Co-authored-by: Michael Orlov <mailto:michael.orlov@apex.ai>
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
