### PR TITLE
simple_grasping: 0.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9003,7 +9003,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simple_grasping-release.git
-      version: 0.5.0-2
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/mikeferguson/simple_grasping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_grasping` to `0.6.0-1`:

- upstream repository: https://github.com/mikeferguson/simple_grasping.git
- release repository: https://github.com/ros2-gbp/simple_grasping-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.5.0-2`

## simple_grasping

```
* replace ament_target_dependencies (#18 <https://github.com/mikeferguson/simple_grasping/issues/18>)
* update CI to run on kilted/rolling (#19 <https://github.com/mikeferguson/simple_grasping/issues/19>)
* Contributors: Michael Ferguson
```
