### PR TITLE
Revert "rosbag2: 0.26.10-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9007,7 +9007,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.10-1
+      version: 0.26.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#49576 temporarily due to the [upcoming sync](https://discourse.openrobotics.org/t/preparing-for-jazzy-sync-and-patch-release-2026-01-22/51865) as this version seems to break the following downstream packages: 

https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION

cc: @MichaelOrlov 