### PR TITLE
bob_llm: 1.0.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1329,6 +1329,21 @@ repositories:
       url: https://github.com/bnbhat/bno08x_ros2_driver.git
       version: master
     status: maintained
+  bob_llm:
+    doc:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: y
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: git@github.com:bob-ros2/bob_llm-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: main
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bob_llm` to `1.0.0-3`:

- upstream repository: git@github.com:bob-ros2/bob_llm.git
- release repository: git@github.com:bob-ros2/bob_llm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
