### PR TITLE
bob_llm: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -945,6 +945,21 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
+  bob_llm:
+    doc:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: y
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: git@github.com:bob-ros2/bob_llm-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: main
+    status: developed
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bob_llm` to `1.0.0-1`:

- upstream repository: git@github.com:bob-ros2/bob_llm.git
- release repository: git@github.com:bob-ros2/bob_llm-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
