### PR TITLE
sync_tooling_msgs: 0.2.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11526,6 +11526,11 @@ repositories:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git
       version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_tooling_msgs` to `0.2.6-1`:

- upstream repository: https://github.com/tier4/sync_tooling_msgs.git
- release repository: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## sync_tooling_msgs

```
* chore: more readme tuning
* chore: adhere to SYNC.TOOLING branding in readme
* chore: add license headers everywhere
* chore: update readme
* chore: use SPDX identifier in package.xml
* chore: more style fixes
* chore: fix import spacing
* chore: fix docstring spacing
* docs: add module docstring
* Contributors: Max SCHMELLER
```
