### PR TITLE
sync_tooling_msgs: 0.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10611,6 +10611,11 @@ repositories:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git
       version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_tooling_msgs` to `0.2.6-1`:

- upstream repository: https://github.com/tier4/sync_tooling_msgs.git
- release repository: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## sync_tooling_msgs

```
* chore: more readme tuning
* chore: adhere to SYNC.TOOLING branding in readme
* chore: add license headers everywhere
* chore: update readme
* chore: use SPDX identifier in package.xml
* chore: more style fixes
* chore: fix import spacing
* chore: fix docstring spacing
* docs: add module docstring
* Contributors: Max SCHMELLER
```
