### PR TITLE
ai_worker: 1.1.16-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -153,6 +153,7 @@ repositories:
       - ffw_joint_trajectory_command_broadcaster
       - ffw_joystick_controller
       - ffw_moveit_config
+      - ffw_navigation
       - ffw_robot_manager
       - ffw_spring_actuator_controller
       - ffw_swerve_drive_controller
@@ -160,7 +161,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ai_worker-release.git
-      version: 1.1.14-1
+      version: 1.1.16-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ai_worker` to `1.1.16-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ai_worker.git
- release repository: https://github.com/ros2-gbp/ai_worker-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.14-1`

## ffw

```
* Added dual_laser_merger for SG2
* Configured ros_gz_bridge via YAML
* Updated Gazebo world and spawn parameters
* Added Lidar support (URDF & Gazebo config)
* Corrected inertial parameters for stability
* Optimized wheel collision geometry
* Initial release of ffw_navigation
* Added Nav2, SLAM Toolbox, and AMCL config
* Added default map and RViz setup
* Contributors: Sungho Woo, HyunKyu Kim, Yongjun Kwon
```

## ffw_bringup

```
* Added dual_laser_merger for SG2
* Configured ros_gz_bridge via YAML
* Updated Gazebo world and spawn parameters
* Contributors: Yongjun Kwon
```

## ffw_description

```
* Added Lidar support (URDF & Gazebo config)
* Corrected inertial parameters for stability
* Optimized wheel collision geometry
* Contributors: Yongjun Kwon
```

## ffw_joint_trajectory_command_broadcaster

```
* None
```

## ffw_joystick_controller

```
* None
```

## ffw_moveit_config

```
* None
```

## ffw_navigation

```
* Initial release of ffw_navigation
* Added Nav2, SLAM Toolbox, and AMCL config
* Added default map and RViz setup
* Contributors: Yongjun Kwon, HyunKyu Kim, Sungho Woo
```

## ffw_robot_manager

```
* None
```

## ffw_spring_actuator_controller

```
* None
```

## ffw_swerve_drive_controller

```
* None
```

## ffw_teleop

```
* Added mobile_teleop node for keyboard control
* Contributors: Sungho Woo
```
