### PR TITLE
bob_llm: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1333,8 +1333,8 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: git@github.com:bob-ros2/bob_llm-release.git
-      version: 1.0.1-1
+      url: https://github.com/bob-ros2/bob_llm-release.git
+      version: 1.0.1-3
   bond_core:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1329,6 +1329,12 @@ repositories:
       url: https://github.com/bnbhat/bno08x_ros2_driver.git
       version: master
     status: maintained
+  bob_llm:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: git@github.com:bob-ros2/bob_llm-release.git
+      version: 1.0.1-1
   bond_core:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1343,11 +1343,15 @@ repositories:
       version: master
     status: maintained
   bob_llm:
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/bob-ros2/bob_llm-release.git
-      version: 1.0.1-3
+    doc:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: main
+    status: maintained
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bob_llm` to `1.0.1-1`:

- upstream repository: git@github.com:bob-ros2/bob_llm.git
- release repository: git@github.com:bob-ros2/bob_llm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## bob_llm

```
* Fix 270+ linter and style issues for ROS2 compliance
* Fix package.xml schema validation
* Standardize docstrings and copyright headers
* Contributors: Bob Ros
```
