### PR TITLE
bob_llm: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -949,8 +949,8 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: git@github.com:bob-ros2/bob_llm-release.git
-      version: 1.0.1-1
+      url: https://github.com/bob-ros2/bob_llm-release.git
+      version: 1.0.1-3
   bond_core:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -946,11 +946,15 @@ repositories:
       version: main
     status: maintained
   bob_llm:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/bob-ros2/bob_llm-release.git
-      version: 1.0.1-3
+    doc:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/bob-ros2/bob_llm.git
+      version: main
+    status: maintained
   bond_core:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -945,6 +945,12 @@ repositories:
       url: https://github.com/flynneva/bno055.git
       version: main
     status: maintained
+  bob_llm:
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: git@github.com:bob-ros2/bob_llm-release.git
+      version: 1.0.1-1
   bond_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bob_llm` to `1.0.1-1`:

- upstream repository: git@github.com:bob-ros2/bob_llm.git
- release repository: git@github.com:bob-ros2/bob_llm-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## bob_llm

```
* Fix 270+ linter and style issues for ROS2 compliance
* Fix package.xml schema validation
* Standardize docstrings and copyright headers
* Contributors: Bob Ros
```
