### PR TITLE
cras_msgs: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1379,6 +1379,11 @@ repositories:
       type: git
       url: https://github.com/ctu-vras/cras_msgs.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/cras_msgs-release.git
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/cras_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_msgs
- release repository: https://github.com/ros2-gbp/cras_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## cras_msgs

```
* CI: Fixed name of license lint action
* Fixed package website link
* Contributors: Martin Pecka
```
