### PR TITLE
cras_msgs: 2.0.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1335,6 +1335,11 @@ repositories:
       type: git
       url: https://github.com/ctu-vras/cras_msgs.git
       version: master
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/cras_msgs-release.git
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/cras_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_msgs` to `2.0.1-1`:

- upstream repository: https://github.com/ctu-vras/cras_msgs.git
- release repository: https://github.com/ros2-gbp/cras_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## cras_msgs

```
* CI: Fixed name of license lint action
* Fixed package website link
* Contributors: Martin Pecka
```
