### PR TITLE
depthai: 2.31.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1982,7 +1982,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-core-release.git
-      version: 2.31.0-1
+      version: 2.31.1-1
     source:
       type: git
       url: https://github.com/luxonis/depthai-core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai` to `2.31.1-1`:

- upstream repository: https://github.com/luxonis/depthai-core.git
- release repository: https://github.com/luxonis/depthai-core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.31.0-1`

## depthai

```
* Minor bugfixes
```
