### PR TITLE
rcpputils: 2.11.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7699,7 +7699,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.11.2-1
+      version: 2.11.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.11.3-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.11.2-1`

## rcpputils

```
* Remove unnecessary dependencies from rcpputils. (#216 <https://github.com/ros2/rcpputils/issues/216>) (#218 <https://github.com/ros2/rcpputils/issues/218>)
  It doesn't need to have dependencies on python tests.
  (cherry picked from commit 0e78962a52e0d09d7b1214e5e055fe23883e7b72)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
