### PR TITLE
compass: 3.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1613,6 +1613,17 @@ repositories:
       type: git
       url: https://github.com/ctu-vras/compass.git
       version: ros2
+    release:
+      packages:
+      - compass_conversions
+      - compass_interfaces
+      - magnetic_model
+      - magnetometer_compass
+      - magnetometer_pipeline
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/compass-release.git
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1623,7 +1623,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `3.0.2-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## compass_conversions

```
* Fixed deprecations on Rolling
* ROS 2 port.
* Contributors: Adam Herold, Martin Pecka
```

## compass_interfaces

```
* ROS 2 port.
* Contributors: Adam Herold, Martin Pecka
```

## magnetic_model

```
* Added IGRF-14 and GAZEBO magnetic models.
* ROS 2 port.
* Contributors: Adam Herold, Martin Pecka
```

## magnetometer_compass

```
* Fixed detection of IMU support in tf2_sensor_msgs
* Use upstream tf2_sensor_msgs if it can already transform IMU messages.
* Added support for out_frame_id to allow overwriting frame_id of transformed messages.
* Added possibility to use wall time for declination computations.
  This can be useful in simulations which start in time 0 and you're not really that much interested into correct declination values.
* ROS 2 port.
* Contributors: Adam Herold, Martin Pecka
```

## magnetometer_pipeline

```
* ROS 2 port.
* Contributors: Adam Herold, Martin Pecka
```
