### PR TITLE
robot_calibration: 0.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7185,7 +7185,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_calibration-release.git
-      version: 0.10.0-1
+      version: 0.10.1-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_calibration` to `0.10.1-1`:

- upstream repository: https://github.com/mikeferguson/robot_calibration.git
- release repository: https://github.com/ros2-gbp/robot_calibration-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.10.0-1`

## robot_calibration

```
* remove ament_target_dependencies (#197 <https://github.com/mikeferguson/robot_calibration/issues/197>)
* Fix initial magnetic field strength unit (#194 <https://github.com/mikeferguson/robot_calibration/issues/194>)
* Contributors: Michael Ferguson, Tatsuro Sakaguchi
```

## robot_calibration_msgs

- No changes
