### PR TITLE
compass: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1299,7 +1299,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `3.0.2-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## compass_conversions

```
* Fixed build with GCC 11
* Contributors: Martin Pecka
```

## compass_interfaces

```
* Fixed build with GCC 11
* Contributors: Martin Pecka
```

## magnetic_model

```
* Fixed build with GCC 11
* Contributors: Martin Pecka
```

## magnetometer_compass

```
* Fixed build with GCC 11
* Contributors: Martin Pecka
```

## magnetometer_pipeline

- No changes
