### PR TITLE
rosidlcpp: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8061,7 +8061,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidlcpp-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.5.0-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-1`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

- No changes

## rosidlcpp_generator_core

- No changes

## rosidlcpp_generator_cpp

```
* Backport #16 <https://github.com/TonyWelte/rosidlcpp/issues/16> (#19 <https://github.com/TonyWelte/rosidlcpp/issues/19>)
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_py

```
* Port rosidl_python`#232 <https://github.com/TonyWelte/rosidlcpp/issues/232>`_ (#20 <https://github.com/TonyWelte/rosidlcpp/issues/20>)
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_type_description

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_parser

- No changes

## rosidlcpp_typesupport_c

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_cpp

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_c

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_fastrtps_cpp

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_c

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```

## rosidlcpp_typesupport_introspection_cpp

```
* Fix build with cmake version before 3.27 (#18 <https://github.com/TonyWelte/rosidlcpp/issues/18>)
* Remove implicit dependencies blocking the start of the generators (#17 <https://github.com/TonyWelte/rosidlcpp/issues/17>)
* Contributors: Anthony Welte
```
