### PR TITLE
neo_nav2_bringup: 1.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5038,7 +5038,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
-      version: 1.0.4-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.4.1-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.4-1`
