### PR TITLE
neo_nav2_bringup: 1.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5819,7 +5819,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `neo_nav2_bringup` to `1.3.2-1`:

- upstream repository: https://github.com/neobotix/neo_nav2_bringup.git
- release repository: https://github.com/ros2-gbp/neo_nav2_bringup-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.1-1`
