### PR TITLE
pinocchio: 3.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5662,7 +5662,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git
-      version: master
+      version: devel
     release:
       tags:
         release: release/rolling/{package}/{version}

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5667,7 +5667,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pinocchio-release.git
-      version: 3.8.0-1
+      version: 3.9.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pinocchio` to `3.9.0-1`:

- upstream repository: https://github.com/stack-of-tasks/pinocchio.git
- release repository: https://github.com/ros2-gbp/pinocchio-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.8.0-1`
