### PR TITLE
crocoddyl: 3.2.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1427,6 +1427,15 @@ repositories:
       version: main
     status: developed
   crocoddyl:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/crocoddyl.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/crocoddyl-release.git
+      version: 3.2.0-2
     source:
       type: git
       url: https://github.com/loco-3d/crocoddyl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crocoddyl` to `3.2.0-2`:

- upstream repository: https://github.com/loco-3d/crocoddyl.git
- release repository: https://github.com/ros2-gbp/crocoddyl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
