### PR TITLE
mp2p_icp: 2.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5915,7 +5915,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.4.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.4.0-1`

## mp2p_icp

```
* Add more unit tests
* Update README to keep it in sync with the provided apps and libraries
* Merge pull request #29 <https://github.com/MOLAorg/mp2p_icp/issues/29> from MOLAorg/fix/cov
  Fix bugs in covariance estimation for some cases
* fix covariance estimation bugs; add unit tests for cov2cov
* Update commit for mola_common
* Merge pull request #28 <https://github.com/MOLAorg/mp2p_icp/issues/28> from MOLAorg/feat/mm-viewer-3d-layers
  mm-viewer: add CLI flags to load overlaid 3D scenes for visualization
* mm-viewer: add CLI flags to load overlaid 3D scenes for visualization
* Contributors: Jose Luis Blanco-Claraco
```
