### PR TITLE
rcl_logging: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6437,13 +6437,14 @@ repositories:
       version: rolling
     release:
       packages:
+      - rcl_logging_implementation
       - rcl_logging_interface
       - rcl_logging_noop
       - rcl_logging_spdlog
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.3.2-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.4.0-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.2-1`

## rcl_logging_implementation

```
* update rcl_logging_implementation architecture diagram. (#137 <https://github.com/ros2/rcl_logging/issues/137>)
* rcl logging implementation (#135 <https://github.com/ros2/rcl_logging/issues/135>)
  * 1st draft bring-up for rcl_logging_implementation package.
  * add test_logging_implementation to check dynamic loading.
  * address Copilot review comments.
  * fix: correct visibility macro for DLL export in CMakeLists.txt
  * add visibility control with RCL_LOGGING_IMPLEMENTATION_DEFAULT_VISIBILITY.
  * load the all symbols at the initialization.
  * Use goto pattern to eliminate the cleanup duplication.
  * Add basic design doc of rmw_logging_implementation.
  * use RCPPUTILS_SCOPE_EXIT instead of goto statement.
  * logging visibility macro was incorrect.
  * logging symbols stay until the peocess actually exits.
  ---------
  Co-authored-by: Barry Xu <mailto:barry.xu@sony.com>
* Contributors: Tomoya Fujita
```

## rcl_logging_interface

- No changes

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

- No changes
