### PR TITLE
mvsim: 0.16.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5642,7 +5642,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.15.0-1
+      version: 0.16.0-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `0.16.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `0.15.0-1`

## mvsim

```
* docs: add new demo worlds
* Remove debian leftover
* Merge pull request #78 <https://github.com/MRPT/mvsim/issues/78> from MRPT/feat/new-indoor-outdoor-world
  Feat/new-indoor-outdoor-world
* fix: ros node didn't publish CGenericPointsMap
* Functional walls with doors and windows with thickness
* Update vertical plane to have doors, windows, and thickness
* fix: lidar3d error with latest mrpt api
* docs: improve vehicles and physics docs
* CircleCI: update to build for u22.04
* Remove #if pragmas for too old mrpt versions
* Implement GNSS honor 'gps_no_coverage' property
* Add new world element: PropertyRegion
* misc clang-tidy fixes
* fix warnings for deprecated mrpt classes
* Merge pull request #70 <https://github.com/MRPT/mvsim/issues/70> from MRPT/feature/noisy-odometry
  Implement noisy odometry
* Implement noisy odometry
* Contributors: Jose Luis Blanco-Claraco
```
