### PR TITLE
off_highway_sensor_drivers: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5227,6 +5227,8 @@ repositories:
       - off_highway_can
       - off_highway_general_purpose_radar
       - off_highway_general_purpose_radar_msgs
+      - off_highway_mm7p10
+      - off_highway_mm7p10_msgs
       - off_highway_premium_radar
       - off_highway_premium_radar_msgs
       - off_highway_premium_radar_sample
@@ -5240,7 +5242,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
-      version: 1.1.0-2
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/bosch-engineering/off_highway_sensor_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `off_highway_sensor_drivers` to `1.2.0-1`:

- upstream repository: https://github.com/bosch-engineering/off_highway_sensor_drivers.git
- release repository: https://github.com/ros2-gbp/off_highway_sensor_drivers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.0-2`

## off_highway_can

```
* Adapt unit tests to reflect the CPU high load fix
* Add force diagnostic update on timeout state transition
* Fix very high CPU usage since it publishes diagnostics on EACH CAN message (#26)
* Contributors: Ferry Schoenmakers, Gabriela Adriana Lapuste
```

## off_highway_general_purpose_radar

```
* Revert "Depend on ros_environment where needed (Jazzy version)" (#31)
  Revert "Depend on ros_environment where needed (Jazzy version) (#28)"
  This reverts commit 843890591d6db93ea883a83c0cecac298c5dba7f.
* Fix pcl_conversions linking error in ROS buildfarm (#30)
* Depend on ros_environment where needed (#24)
* Contributors: Marco A. Gutierrez, Michal Sojka
```

## off_highway_general_purpose_radar_msgs

- No changes

## off_highway_mm7p10

```
* Add ROS2 Bosch MM7P10 inertial measurement unit sensor driver
* Contributors: Gabriela Adriana Lapuste
```

## off_highway_mm7p10_msgs

```
* Add ROS2 Bosch MM7P10 inertial measurement unit sensor driver
* Contributors: Gabriela Adriana Lapuste
```

## off_highway_premium_radar

- No changes

## off_highway_premium_radar_msgs

- No changes

## off_highway_premium_radar_sample

```
* Revert "Depend on ros_environment where needed (Jazzy version)" (#31)
  Revert "Depend on ros_environment where needed (Jazzy version) (#28)"
  This reverts commit 843890591d6db93ea883a83c0cecac298c5dba7f.
* Fix pcl_conversions linking error in ROS buildfarm (#30)
* Depend on ros_environment where needed (#24)
* Contributors: Marco A. Gutierrez, Michal Sojka
```

## off_highway_premium_radar_sample_msgs

- No changes

## off_highway_radar

```
* Revert "Depend on ros_environment where needed (Jazzy version)" (#31)
  Revert "Depend on ros_environment where needed (Jazzy version) (#28)"
  This reverts commit 843890591d6db93ea883a83c0cecac298c5dba7f.
* Fix pcl_conversions linking error in ROS buildfarm (#30)
* Depend on ros_environment where needed (#24)
* Contributors: Marco A. Gutierrez, Michal Sojka
```

## off_highway_radar_msgs

- No changes

## off_highway_sensor_drivers

- No changes

## off_highway_sensor_drivers_examples

- No changes

## off_highway_uss

```
* Revert "Depend on ros_environment where needed (Jazzy version)" (#31)
  Revert "Depend on ros_environment where needed (Jazzy version) (#28)"
  This reverts commit 843890591d6db93ea883a83c0cecac298c5dba7f.
* Fix pcl_conversions linking error in ROS buildfarm (#30)
* Depend on ros_environment where needed (#24)
* Contributors: Marco A. Gutierrez, Michal Sojka
```

## off_highway_uss_msgs

- No changes
