### PR TITLE
tf_tree_terminal: 2.0.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10888,6 +10888,15 @@ repositories:
       version: main
     status: maintained
   tf_tree_terminal:
+    doc:
+      type: git
+      url: https://github.com/Tanneguydv/tf_tree_terminal.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/tf_tree_terminal-release.git
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/Tanneguydv/tf_tree_terminal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_tree_terminal` to `2.0.0-3`:

- upstream repository: https://github.com/Tanneguydv/tf_tree_terminal.git
- release repository: https://github.com/ros2-gbp/tf_tree_terminal-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## tf_tree_terminal

```
* update humble ubuntu version
* rename CI workflows
* fix typo []
* add distinct workflows
* update badges
* update ros2 ci
* updat ros tooling
* ros2 ci workflow
* Fix description for ROS2 TF Tree CLI Helper
* Add geometry_msgs dependency to package.xml
* add test for tree node
* Strip ANSI codes from content before saving
  Added ANSI escape code stripping to save_to_file method.
* Add --no-color option to command line arguments
* Add color support for terminal output
* Implement TF rate summary in tree_node.py
  Added functionality to track and summarize TF rates.
* Add frequency label to light tree node output
* Add --clear option to command line arguments
* Add clear_screen option to TFTreeCLI initialization
* Update TF snapshot formatting and compliance status symbols
* Update symbols for better clarity in output messages
* add helper comment
* update version
* update readme
* add light arg
* Hz, tf and joit_states status, helper with options
* linter changes
* add my name to package.xml
* Contributors: tanneguy, tanneguydv
```
