### PR TITLE
mrpt_ros: 2.15.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5544,7 +5544,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.5-1
+      version: 2.15.6-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.6-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.15.5-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

```
* nanogui: Updated to new version (DockablePanel)
```

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

```
* All point cloud classes: now gets per-point timestamps from 2D LiDAR range scans.
```

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
