### PR TITLE
add ros2_snapshot package  to rosdistro

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7632,6 +7632,16 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
+  ros2_snapshot:
+    doc:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: kilted
+    source:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: kilted
+    status: developed
   ros_babel_fish:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7497,6 +7497,16 @@ repositories:
       url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
       version: main
     status: maintained
+  ros2_snapshot:
+    doc:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: kilted
+    source:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: kilted
+    status: developed
   ros2_socketcan:
     doc:
       type: git
@@ -7632,16 +7642,6 @@ repositories:
       url: https://github.com/osrf/ros2launch_security.git
       version: main
     status: maintained
-  ros2_snapshot:
-    doc:
-      type: git
-      url: https://github.com/cnurobotics/ros2_snapshot.git
-      version: kilted
-    source:
-      type: git
-      url: https://github.com/cnurobotics/ros2_snapshot.git
-      version: kilted
-    status: developed
   ros_babel_fish:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

name: ros2_snapshot

# The source is here:
https://github.com/CNURobotics/ros2_snapshot

# Description 

Within this repository are Python-based ROS 2 tools that can be used to capture a software model of a ROS 2 Workspace and running ROS deployment.

The captured model can be loaded, manipulated, and exported for documentation or use in so-called Model Integrated Computing (MIC) or Model Driven Engineering (MDE).

This repository includes the following modules:

   - core - ROS Entity metamodel classes and tools for marshalling/unmarshalling instances of these metamodels (model)
  - workspace_modeler - a tool to capture specification model of existing ROS workspace
  -  snapshot - a tool to capture models from currently running ROS deployments

The system is useful for Interface Control Documentation (ICD) of deployed systems.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
