### PR TITLE
web_video_server: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10428,7 +10428,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/web_video_server-release.git
-      version: 2.1.1-1
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `web_video_server` to `3.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/web_video_server.git
- release repository: https://github.com/ros2-gbp/web_video_server-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.1-1`

## web_video_server

```
* refactor: Add clang-tidy checks (#195)
* feat: Use pluginlib to load streamer plugins at runtime, general refactor (#192)
* Contributors: Błażej Sowa
```
