### PR TITLE
Add 'qt6-tools-dev' to rosdep/base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9171,6 +9171,25 @@ qt6-svg-dev:
     '*': [qt6-svg-dev]
     'focal': null
     'jammy': null
+qt6-tools-dev:
+  alpine: [qt6-qttools-dev]
+  arch: [qt6-tools]
+  debian:
+    '*': [qt6-tools-dev]
+    bullseye: null
+  fedora: [qt6-qttools-devel]
+  freebsd: [qt6-tools]
+  gentoo: ['dev-qt/qttools:6']
+  openembedded: [qttools@meta-qt6]
+  osx:
+    homebrew:
+      packages: [qttools]
+  rhel:
+    '*': [qt6-qttools-devel]
+    '8': null
+  ubuntu:
+    '*': [qt6-tools-dev]
+    focal: null
 qtbase5-dev:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

`qt6-tools-dev`

## Package Upstream Source:

https://github.com/qt/qttools

## Purpose of using this:

Porting an existing package which depended on `qt5tools-dev` noticed this one was missing from rosdep database. Not quite sure what's in it in detail, to be fair...

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=qt6-tools-dev&searchon=names&suite=all&section=all
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=qt6-tools-dev&searchon=names&suite=all&section=all
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qttools/qt6-qttools-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=qt6-tools&maintainer=&flagged=
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qttools
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/qttools#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qttools-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - Tried to find it but failed. Failed to find `qt6.qtsvg` which is listed right above as well, so I may be doing something wrong. Not sure if any of [these](https://search.nixos.org/packages?channel=25.11&query=qttools) apply?
- openSUSE: https://software.opensuse.org/package/
  - Not sure if available. Search page returns 503 error
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/qt6-qttools-devel-6.6.2-4.el9.x86_64.rpm.html
- FreeBSD
  - https://www.freshports.org/devel/qt6-tools/
- openembedded
  - https://layers.openembedded.org/layerindex/recipe/348219/
