### PR TITLE
gz_cmake_vendor: 0.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2720,7 +2720,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.4.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## gz_cmake_vendor

```
* Bump version to 5.0.1 (#20 <https://github.com/gazebo-release/gz_cmake_vendor/issues/20>)
* Contributors: Addisu Z. Taddese
```
