### PR TITLE
clearpath_common: 2.8.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1311,7 +1311,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 2.8.4-1
+      version: 2.8.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_common` to `2.8.5-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_common.git
- release repository: https://github.com/clearpath-gbp/clearpath_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.4-1`

## clearpath_bt_joy

- No changes

## clearpath_common

- No changes

## clearpath_control

- No changes

## clearpath_customization

- No changes

## clearpath_description

- No changes

## clearpath_diagnostics

- No changes

## clearpath_generator_common

- No changes

## clearpath_manipulators

- No changes

## clearpath_manipulators_description

```
* Update Kinova 2F lite gripper joint limits (#298 <https://github.com/clearpathrobotics/clearpath_common/issues/298>)
* Update Ignition nomenclature to new Gazebo gz names (#293 <https://github.com/clearpathrobotics/clearpath_common/issues/293>)
  * Rename ignition_frame_id to gz_frame_id in kinova_gen3_6dof.urdf.xacro
  * Rename ignition_frame_id to gz_frame_id in kinove_gen3_7dof.urdf.xacro
  * Change gripper plugin from Ignition to Gazebo in franka_gripper.urdf.xacro
  * Change Gazebo plugin from Ignition to GazeboSim in franka.urdf.xacro
  * Change ignition_frame_id to gz_frame_id in ouster_os1.urdf.xacro
* Fix: Universal Robot Simulation Control (#290 <https://github.com/clearpathrobotics/clearpath_common/issues/290>)
  Add simulation control tag
* Contributors: Andrei Costinescu, luis-camero
```

## clearpath_mounts_description

- No changes

## clearpath_platform_description

- No changes

## clearpath_sensors_description

```
* Update Ignition nomenclature to new Gazebo gz names (#293 <https://github.com/clearpathrobotics/clearpath_common/issues/293>)
  * Rename ignition_frame_id to gz_frame_id in kinova_gen3_6dof.urdf.xacro
  * Rename ignition_frame_id to gz_frame_id in kinove_gen3_7dof.urdf.xacro
  * Change gripper plugin from Ignition to Gazebo in franka_gripper.urdf.xacro
  * Change Gazebo plugin from Ignition to GazeboSim in franka.urdf.xacro
  * Change ignition_frame_id to gz_frame_id in ouster_os1.urdf.xacro
* Contributors: Andrei Costinescu
```
