### PR TITLE
autoapms: 1.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -635,6 +635,19 @@ repositories:
       type: git
       url: https://github.com/AutoAPMS/auto-apms.git
       version: master
+    release:
+      packages:
+      - auto_apms_behavior_tree
+      - auto_apms_behavior_tree_core
+      - auto_apms_examples
+      - auto_apms_interfaces
+      - auto_apms_mission
+      - auto_apms_ros2behavior
+      - auto_apms_util
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/autoapms-release.git
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/AutoAPMS/auto-apms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoapms` to `1.4.0-1`:

- upstream repository: https://github.com/AutoAPMS/auto-apms.git
- release repository: https://github.com/ros2-gbp/autoapms-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## auto_apms_behavior_tree

```
* Feat: Enable to use the CLI to define behaviors dynamically (#14 <https://github.com/AutoAPMS/auto-apms/issues/14>)
  * Add build_request, entrypoint and node_manifest keyword args to run and send cli
  * Rename entrypoint to entry_point
  * Use hyphen instead of underscore for entry point in argparse arguments
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Rename forgotten entry point occurences
  * Update auto_apms_ros2behavior/auto_apms_ros2behavior/verb/send.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Update auto_apms_behavior_tree/auto_apms_behavior_tree/scripting.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Fix version number to match last release
* Fix: Avoid silently skipping registering nodes when another one with the same name was previously registered (#12 <https://github.com/AutoAPMS/auto-apms/issues/12>)
  * Remove insufficient check for node equality
  * Update documentation for clarifying the decision of being more strict with duplicate node names
  * Add applyNodeNamespace methods and extend tests for the tree builder API
  * Fix typo
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Add tests for registering nodes using existing plugins
  * fix docs for newTreeFromResource
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Also apply namespace to bt factory registrations
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Add ament_cmake_copyright to all packages
* Change default integer type from int64_t to standard int for better compatibility
* Move auto_apms_simulation to seperate repo and update package manifests for ros index
* Change URLs after move to organization
* Move python scripting tools to auto_apms_behavior_tree package
* fix: Make RosPublisherNode waiting for at least one subscriber on init
* node: add PublishPose node
* [NodeManifest] Allow hiding node ports (#9 <https://github.com/AutoAPMS/auto-apms/issues/9>)
  * Add method to write node model from NodeModelMap
  * Add registration option hidden_ports and TreeDocument implementation to hide port
  * Introduce individual job names in CI for each ROS 2 distro
  NOTE: Rolling build is currently broken since there is an issue with BT.CPP 4.8 and the tinyxml2 version on Ubuntu 24 systems
* Fix linting
* Add std_srvs nodes
* Contributors: Robin Müller
```

## auto_apms_behavior_tree_core

```
* Feat: Enable to use the CLI to define behaviors dynamically (#14 <https://github.com/AutoAPMS/auto-apms/issues/14>)
  * Add build_request, entrypoint and node_manifest keyword args to run and send cli
  * Rename entrypoint to entry_point
  * Use hyphen instead of underscore for entry point in argparse arguments
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Rename forgotten entry point occurences
  * Update auto_apms_ros2behavior/auto_apms_ros2behavior/verb/send.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Update auto_apms_behavior_tree/auto_apms_behavior_tree/scripting.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Fix version number to match last release
* Fix: Avoid silently skipping registering nodes when another one with the same name was previously registered (#12 <https://github.com/AutoAPMS/auto-apms/issues/12>)
  * Remove insufficient check for node equality
  * Update documentation for clarifying the decision of being more strict with duplicate node names
  * Add applyNodeNamespace methods and extend tests for the tree builder API
  * Fix typo
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Add tests for registering nodes using existing plugins
  * fix docs for newTreeFromResource
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Also apply namespace to bt factory registrations
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Add ament_cmake_copyright to all packages
* Add ALIAS_NAMESPACE cmake macro argument to auto_apms_behavior_tree_register_trees to allow customizing the tree namespace and reusing the same xml file under different names and possibly different node manifests
* Change default integer type from int64_t to standard int for better compatibility
* Move auto_apms_simulation to seperate repo and update package manifests for ros index
* feat: support include tag with tree documents (#11 <https://github.com/AutoAPMS/auto-apms/issues/11>)
  * feat: support include tag with tree documents
  * Use filesystem path to make ros_pkg attribute more robust
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Fix typo
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Fix linting
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Fix linting
* Fix typo
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Use filesystem path to make ros_pkg attribute more robust
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* feat: support include tag with tree documents
* Add markdown cli lint exception MD060 for auto generated reference files
* Change URLs after move to organization
* Support calling cmake macro auto_apms_behavior_tree_register_nodes without any node class names (keyword only)
* fix: Make RosPublisherNode waiting for at least one subscriber on init
* Add an error when port aliasing is used when the nodes constructor does not support it
* [NodeManifest] Add port aliasing feature (#10 <https://github.com/AutoAPMS/auto-apms/issues/10>)
  * Add port aliasing feature
  * Update auto_apms_behavior_tree_core/src/node/ros_node_context.cpp
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Fix build error
  * Apply suggestion from @Copilot
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* [NodeManifest] Allow hiding node ports (#9 <https://github.com/AutoAPMS/auto-apms/issues/9>)
  * Add method to write node model from NodeModelMap
  * Add registration option hidden_ports and TreeDocument implementation to hide port
  * Introduce individual job names in CI for each ROS 2 distro
  NOTE: Rolling build is currently broken since there is an issue with BT.CPP 4.8 and the tinyxml2 version on Ubuntu 24 systems
* Contributors: Robin Müller
```

## auto_apms_examples

```
* Fix version number to match last release
* Add ament_cmake_copyright to all packages
* Move auto_apms_simulation to seperate repo and update package manifests for ros index
* Change URLs after move to organization
* Contributors: Robin Müller
```

## auto_apms_interfaces

```
* Change entrypoint field of StartTreeExecutor to entry_point (could be a breaking change)
```

## auto_apms_mission

```
* Feat: Enable to use the CLI to define behaviors dynamically (#14 <https://github.com/AutoAPMS/auto-apms/issues/14>)
  * Add build_request, entrypoint and node_manifest keyword args to run and send cli
  * Rename entrypoint to entry_point
  * Use hyphen instead of underscore for entry point in argparse arguments
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Rename forgotten entry point occurences
  * Update auto_apms_ros2behavior/auto_apms_ros2behavior/verb/send.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Update auto_apms_behavior_tree/auto_apms_behavior_tree/scripting.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Fix version number to match last release
* Add ament_cmake_copyright to all packages
* Move auto_apms_simulation to seperate repo and update package manifests for ros index
* Change URLs after move to organization
* Contributors: Robin Müller
```

## auto_apms_ros2behavior

```
* Feat: Enable to use the CLI to define behaviors dynamically (#14 <https://github.com/AutoAPMS/auto-apms/issues/14>)
  * Add build_request, entrypoint and node_manifest keyword args to run and send cli
  * Rename entrypoint to entry_point
  * Use hyphen instead of underscore for entry point in argparse arguments
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Rename forgotten entry point occurences
  * Update auto_apms_ros2behavior/auto_apms_ros2behavior/verb/send.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  * Update auto_apms_behavior_tree/auto_apms_behavior_tree/scripting.py
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
  ---------
  Co-authored-by: Copilot <mailto:175728472+Copilot@users.noreply.github.com>
* Fix version number to match last release
* Add ament_cmake_copyright to all packages
* Move auto_apms_simulation to seperate repo and update package manifests for ros index
* Improve ros2behavior cli by adding dynamic help messages
* Change URLs after move to organization
* Move python scripting tools to auto_apms_behavior_tree package
* Contributors: Robin Müller
```

## auto_apms_util

```
* Fix version number to match last release
* Add ament_cmake_copyright to all packages
* Stick to SPDX identifier for license tag
* Change URLs after move to organization
* Contributors: Robin Müller
```
