### PR TITLE
bob_llm: 1.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -950,6 +950,11 @@ repositories:
       type: git
       url: https://github.com/bob-ros2/bob_llm.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/bob-ros2/bob_llm-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/bob-ros2/bob_llm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bob_llm` to `1.0.2-1`:

- upstream repository: https://github.com/bob-ros2/bob_llm.git
- release repository: https://github.com/bob-ros2/bob_llm-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## bob_llm

```
* Full ROS 2 Rolling and Humble compliance (fixed linter issues)
* Standardized import ordering and quote usage
```
