### PR TITLE
control_msgs: 6.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1374,7 +1374,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 6.7.0-1
+      version: 6.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `6.8.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.7.0-1`

## control_msgs

```
* set odometry interface for the new service (#287 <https://github.com/ros-controls/control_msgs/issues/287>)
* Contributors: Ege Kural
```
