### PR TITLE
control_msgs: 5.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1683,7 +1683,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 5.7.0-1
+      version: 5.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `5.8.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.7.0-1`

## control_msgs

```
* set odometry interface for the new service (#287 <https://github.com/ros-controls/control_msgs/issues/287>) (#288 <https://github.com/ros-controls/control_msgs/issues/288>)
* Contributors: mergify[bot]
```
