### PR TITLE
orbbec_camera_v2: 2.6.3-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6370,7 +6370,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/orbbec/orbbec_camera_v2-release.git
-      version: 2.6.3-1
+      version: 2.6.3-2
     source:
       type: git
       url: https://github.com/orbbec/OrbbecSDK_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orbbec_camera_v2` to `2.6.3-2`:

- upstream repository: https://github.com/orbbec/OrbbecSDK_ROS2.git
- release repository: https://github.com/orbbec/orbbec_camera_v2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.3-1`
