### PR TITLE
autoapms: 1.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -600,7 +600,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoapms-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/AutoAPMS/auto-apms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoapms` to `1.4.1-1`:

- upstream repository: https://github.com/AutoAPMS/auto-apms.git
- release repository: https://github.com/ros2-gbp/autoapms-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`

## auto_apms_behavior_tree

- No changes

## auto_apms_behavior_tree_core

```
* fix: complete type for SubTree when including tree_document.hpp
* Fix issue that leads to segfaults when loading behavior tree node plugins from libraries that have been built using link-time optimization (LTO) as in the ROS 2 build farm
* Contributors: Robin Müller
* Fix issue that leads to segfaults when loading behavior tree node plugins from libraries that have been built using link-time optimization (LTO) as in the ROS 2 build farm
* Contributors: Robin Müller
```

## auto_apms_examples

- No changes

## auto_apms_interfaces

- No changes

## auto_apms_mission

- No changes

## auto_apms_ros2behavior

- No changes

## auto_apms_util

- No changes
