### PR TITLE
ros2_control: 6.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7339,7 +7339,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.3.2-1
+      version: 6.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.3.2-1`

## controller_interface

- No changes

## controller_manager

```
* Add a log entry if enforce_command_limits is false (#2998 <https://github.com/ros-controls/ros2_control/issues/2998>)
* Replace std::for_each with idiomatic container operations (#2986 <https://github.com/ros-controls/ros2_control/issues/2986>)
* Improve warning if spawner cannot acquire filelock (#2970 <https://github.com/ros-controls/ros2_control/issues/2970>)
* [Simulation] Catch exceptions of sleep_until context (#2963 <https://github.com/ros-controls/ros2_control/issues/2963>)
* Fix typo in TODO comments: MutliThreadedExecutor -> MultiThreadedExecutor (#2958 <https://github.com/ros-controls/ros2_control/issues/2958>)
* Contributors: Bence Magyar, Christoph Fröhlich, Sai Kishor Kothakota, Vignesh Vembar
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the node name overlapping in the Hardware Components (#3006 <https://github.com/ros-controls/ros2_control/issues/3006>)
* Resort members of InterfaceInfo to avoid ABI break (#3001 <https://github.com/ros-controls/ros2_control/issues/3001>)
* Fix disabling joint limits via URDF (#2992 <https://github.com/ros-controls/ros2_control/issues/2992>)
* Add documentation about enabling limiters (#2993 <https://github.com/ros-controls/ros2_control/issues/2993>)
* Don't throw on position joint limits in case of velocity command (#2978 <https://github.com/ros-controls/ros2_control/issues/2978>)
* Strip leading and trailing whitespaces while parsing components (#2974 <https://github.com/ros-controls/ros2_control/issues/2974>)
* Add helper method to strip whitespaces (#2934 <https://github.com/ros-controls/ros2_control/issues/2934>)
* Contributors: Christoph Fröhlich, Dr. Denis, Sai Kishor Kothakota
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix disabling joint limits via URDF (#2992 <https://github.com/ros-controls/ros2_control/issues/2992>)
* Don't throw on position joint limits in case of velocity command (#2978 <https://github.com/ros-controls/ros2_control/issues/2978>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Fix disabling joint limits via URDF (#2992 <https://github.com/ros-controls/ros2_control/issues/2992>)
* Strip leading and trailing whitespaces while parsing components (#2974 <https://github.com/ros-controls/ros2_control/issues/2974>)
* Contributors: Sai Kishor Kothakota
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
