### PR TITLE
ros2_control: 5.12.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7369,7 +7369,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.11.3-1
+      version: 5.12.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.12.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.11.3-1`

## controller_interface

- No changes

## controller_manager

```
* Add a log entry if enforce_command_limits is false (#2998 <https://github.com/ros-controls/ros2_control/issues/2998>) (#3000 <https://github.com/ros-controls/ros2_control/issues/3000>)
* Replace std::for_each with idiomatic container operations (#2986 <https://github.com/ros-controls/ros2_control/issues/2986>) (#2991 <https://github.com/ros-controls/ros2_control/issues/2991>)
* Improve warning if spawner cannot acquire filelock (#2970 <https://github.com/ros-controls/ros2_control/issues/2970>) (#2973 <https://github.com/ros-controls/ros2_control/issues/2973>)
* [Simulation] Catch exceptions of sleep_until context (#2963 <https://github.com/ros-controls/ros2_control/issues/2963>) (#2965 <https://github.com/ros-controls/ros2_control/issues/2965>)
* Fix typo in TODO comments: MutliThreadedExecutor -> MultiThreadedExecutor (#2958 <https://github.com/ros-controls/ros2_control/issues/2958>) (#2960 <https://github.com/ros-controls/ros2_control/issues/2960>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the node name overlapping in the Hardware Components (#3006 <https://github.com/ros-controls/ros2_control/issues/3006>) (#3015 <https://github.com/ros-controls/ros2_control/issues/3015>)
* Resort members of InterfaceInfo to avoid ABI break (#3001 <https://github.com/ros-controls/ros2_control/issues/3001>) (#3003 <https://github.com/ros-controls/ros2_control/issues/3003>)
* Fix disabling joint limits via URDF (#2992 <https://github.com/ros-controls/ros2_control/issues/2992>) (#2997 <https://github.com/ros-controls/ros2_control/issues/2997>)
* Add documentation about enabling limiters (#2993 <https://github.com/ros-controls/ros2_control/issues/2993>) (#2995 <https://github.com/ros-controls/ros2_control/issues/2995>)
* Don't throw on position joint limits in case of velocity command (#2978 <https://github.com/ros-controls/ros2_control/issues/2978>) (#2980 <https://github.com/ros-controls/ros2_control/issues/2980>)
* Strip leading and trailing whitespaces while parsing components (#2974 <https://github.com/ros-controls/ros2_control/issues/2974>) (#2977 <https://github.com/ros-controls/ros2_control/issues/2977>)
* Add helper method to strip whitespaces (#2934 <https://github.com/ros-controls/ros2_control/issues/2934>) (#2962 <https://github.com/ros-controls/ros2_control/issues/2962>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix disabling joint limits via URDF (#2992 <https://github.com/ros-controls/ros2_control/issues/2992>) (#2997 <https://github.com/ros-controls/ros2_control/issues/2997>)
* Don't throw on position joint limits in case of velocity command (#2978 <https://github.com/ros-controls/ros2_control/issues/2978>) (#2980 <https://github.com/ros-controls/ros2_control/issues/2980>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Fix disabling joint limits via URDF (#2992 <https://github.com/ros-controls/ros2_control/issues/2992>) (#2997 <https://github.com/ros-controls/ros2_control/issues/2997>)
* Strip leading and trailing whitespaces while parsing components (#2974 <https://github.com/ros-controls/ros2_control/issues/2974>) (#2977 <https://github.com/ros-controls/ros2_control/issues/2977>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
