### PR TITLE
ros2_control: 2.53.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9444,7 +9444,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.53.0-1
+      version: 2.53.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `2.53.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.53.0-1`

## controller_interface

```
* Fixed issue with mock_components being linked even when not needed (#2925 <https://github.com/ros-controls/ros2_control/issues/2925>)
* Contributors: Ewoodss
```

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fixed issue with mock_components being linked even when not needed (#2925 <https://github.com/ros-controls/ros2_control/issues/2925>)
* Contributors: Ewoodss
```

## hardware_interface_testing

- No changes

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
