### PR TITLE
ros2_controllers: 5.13.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7429,7 +7429,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.12.0-1
+      version: 5.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `5.12.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Check robot description validity in AdmittanceController (backport #2009 <https://github.com/ros-controls/ros2_controllers/issues/2009>) (#2114 <https://github.com/ros-controls/ros2_controllers/issues/2114>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* docs: diff_drive_controller - complete wheel_separation_multiplier description and fix then→than typo (backport #2108 <https://github.com/ros-controls/ros2_controllers/issues/2108>) (#2121 <https://github.com/ros-controls/ros2_controllers/issues/2121>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Revert behavior change of JSB regarding skipping boolean interfaces (#2132 <https://github.com/ros-controls/ros2_controllers/issues/2132>) (#2135 <https://github.com/ros-controls/ros2_controllers/issues/2135>)
* Add test to check JSB is not throwing when there is a boolean interface (backport #2115 <https://github.com/ros-controls/ros2_controllers/issues/2115>) (#2132 <https://github.com/ros-controls/ros2_controllers/issues/2132>)
* Contributors: Christoph Fröhlich, mergify[bot]
```

## joint_trajectory_controller

- No changes

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

```
* Populate pose covariance correctly in steering controllers (backport #2109 <https://github.com/ros-controls/ros2_controllers/issues/2109>) (#2138 <https://github.com/ros-controls/ros2_controllers/issues/2138>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
