### PR TITLE
autoapms: 1.4.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -600,7 +600,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/autoapms-release.git
-      version: 1.4.1-1
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/AutoAPMS/auto-apms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoapms` to `1.4.2-1`:

- upstream repository: https://github.com/AutoAPMS/auto-apms.git
- release repository: https://github.com/ros2-gbp/autoapms-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.1-1`

## auto_apms_behavior_tree

```
* Remove tinyxml2_vendor in favor of system dependency
* Contributors: Robin Müller
```

## auto_apms_behavior_tree_core

```
* Remove dependency for eigen3_cmake_module
* Remove tinyxml2_vendor in favor of system dependency
* Contributors: Robin Müller
```

## auto_apms_examples

- No changes

## auto_apms_interfaces

- No changes

## auto_apms_mission

- No changes

## auto_apms_ros2behavior

- No changes

## auto_apms_util

- No changes
