### PR TITLE
octomap_rviz_plugins: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5211,7 +5211,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap_rviz_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `octomap_rviz_plugins` to `2.2.0-1`:

- upstream repository: https://github.com/OctoMap/octomap_rviz_plugins.git
- release repository: https://github.com/ros2-gbp/octomap_rviz_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.1-1`

## octomap_rviz_plugins

```
* Update package.xml
  Remove maintainer
* Merge pull request #50 <https://github.com/OctoMap/octomap_rviz_plugins/issues/50> from traversaro/patch-1
  [ros2] Actully search for octomap in CMakeLists.txt
* Actully search for octomap in CMakeLists.txt
* Contributors: Armin Hornung, Silvio Traversaro
```

including qt6 support
