### PR TITLE
Add gtsam2mrpt_serial to index in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3774,6 +3774,16 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: developed
+  gtsam2mrpt_serial:
+    doc:
+      type: git
+      url: https://github.com/MRPT/gtsam2mrpt_serial.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MRPT/gtsam2mrpt_serial.git
+      version: develop
+    status: developed
   hash_library_vendor:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/MRPT/gtsam2mrpt_serial.git

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
