### PR TITLE
Add mola_mapper_2d to index in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5729,6 +5729,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_lidar_odometry.git
       version: develop
     status: developed
+  mola_mapper_2d:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_mapper_2d.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_mapper_2d.git
+      version: develop
+    status: developed
   mola_sm_loop_closure:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/MOLAorg/mola_mapper_2d

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
