### PR TITLE
rosbag2: 0.15.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9936,7 +9936,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.15.15-1
+      version: 0.15.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.15.16-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.15-1`

## mcap_vendor

- No changes

## ros2bag

```
* add rosbag2_storage_default_plugins to exec_depend of ros2bag. (#2227 <https://github.com/ros2/rosbag2/issues/2227>) (#2232 <https://github.com/ros2/rosbag2/issues/2232>)
* Fix missing blanks in help text (#2112 <https://github.com/ros2/rosbag2/issues/2112>)
* Contributors: Eric Su, mergify[bot]
```

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

```
* [humble] Enable rosbag2_performance_benchmarking package to be built by default (backport #2093 <https://github.com/ros2/rosbag2/issues/2093>) (#2098 <https://github.com/ros2/rosbag2/issues/2098>)
* [humble] Bugfix: prosbag2_performance_benchmarking outputs incorrect results for topics with frequency more than 1 kHz (backport #2077 <https://github.com/ros2/rosbag2/issues/2077>) (#2086 <https://github.com/ros2/rosbag2/issues/2086>)
* Contributors: mergify[bot]
```

## rosbag2_py

- No changes

## rosbag2_storage

```
* fix memory leak on make_empty_serialized_message(). (#2253 <https://github.com/ros2/rosbag2/issues/2253>) (#2261 <https://github.com/ros2/rosbag2/issues/2261>)
* Contributors: mergify[bot]
```

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

```
* [humble] Bugfix for incorrect MCAPStorage::seek(timestamp) when timestamp is current (backport #2157 <https://github.com/ros2/rosbag2/issues/2157>) (#2161 <https://github.com/ros2/rosbag2/issues/2161>)
* Contributors: mergify[bot]
```

## rosbag2_storage_mcap_testdata

- No changes

## rosbag2_test_common

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [humble] Bugfix for incorrect MCAPStorage::seek(timestamp) when timestamp is current (backport #2157 <https://github.com/ros2/rosbag2/issues/2157>) (#2161 <https://github.com/ros2/rosbag2/issues/2161>)
* [humble] rosbag2_transport: parametrize test_rewrite (backport #1206 <https://github.com/ros2/rosbag2/issues/1206>) (#2162 <https://github.com/ros2/rosbag2/issues/2162>)
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
