### PR TITLE
ros_gz: 3.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7688,7 +7688,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.5-1
+      version: 3.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.6-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.5-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Add support for configurable frame_id in Gazebo subscriber (#825 <https://github.com/gazebosim/ros_gz/issues/825>)
* Add override_frame_id parameter (#826 <https://github.com/gazebosim/ros_gz/issues/826>)
* Fix missing timestamp in Pose_V -> PoseArray bridge (#812 <https://github.com/gazebosim/ros_gz/issues/812>)
* get rid of deprecated rclcpp::spin_some() (#813 <https://github.com/gazebosim/ros_gz/issues/813>)
* Contributors: Alejandro Hernández Cordero, Ian Chen, Shahazad Abdulla
```

## ros_gz_image

```
* Remove image_transport deprecation (#814 <https://github.com/gazebosim/ros_gz/issues/814>)
* Contributors: Alejandro Hernández Cordero
```

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Add dependency to ros2pkg (#816 <https://github.com/gazebosim/ros_gz/issues/816>)
* Contributors: Felix Exner
```

## ros_gz_sim_demos

- No changes
