### PR TITLE
ros_gz: 1.0.20-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8946,7 +8946,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.19-1
+      version: 1.0.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.20-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.19-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Add support for configurable frame_id in Gazebo subscriber (backport #825 <https://github.com/gazebosim/ros_gz/issues/825>) (#831 <https://github.com/gazebosim/ros_gz/issues/831>)
* Add override_frame_id parameter (backport #826 <https://github.com/gazebosim/ros_gz/issues/826>) (#828 <https://github.com/gazebosim/ros_gz/issues/828>)
* Fix missing timestamp in Pose_V -> PoseArray bridge (#812 <https://github.com/gazebosim/ros_gz/issues/812>) (#822 <https://github.com/gazebosim/ros_gz/issues/822>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

- No changes
