### PR TITLE
replay_testing: 0.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8756,7 +8756,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/replay_testing-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/polymathrobotics/replay_testing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `replay_testing` to `0.0.4-1`:

- upstream repository: https://github.com/polymathrobotics/replay_testing.git
- release repository: https://github.com/ros2-gbp/replay_testing-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.3-1`

## replay_testing

```
* Nexus caching (#37 <https://github.com/polymathrobotics/replay_testing/issues/37>)
* Remove mcap binary dependency (#35 <https://github.com/polymathrobotics/replay_testing/issues/35>)
* Add extra nexus header options (#36 <https://github.com/polymathrobotics/replay_testing/issues/36>)
* Add option to prevent auto-termination after MCAP playback (#31 <https://github.com/polymathrobotics/replay_testing/issues/31>)
* Add kilted to CI (#25 <https://github.com/polymathrobotics/replay_testing/issues/25>)
* Contributors: Emerson Knapp, Troy Gibb, ぐるぐる
```
