### PR TITLE
zed-ros2-description: 0.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12255,7 +12255,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-description-release.git
-      version: 0.1.1-2
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-description` to `0.1.2-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-description.git
- release repository: https://github.com/ros2-gbp/zed-ros2-description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.1-2`

## zed_description

```
* Merge pull request #1 <https://github.com/stereolabs/zed-ros2-description/issues/1> from pucciland95/main
  URDF xacro and mesh path fix
* Fix file path in CMakeLists.txt for extra files target
* Fix: update include paths in zed_macro.urdf.xacro to use zed_description instead of zed_wrapper
* Fix: changed include path for zed_macro.urdf.xacro from zed_wrapper -> zed_description
* Contributors: Pucciland95, Walter Lucetti
```
