### PR TITLE
Fixed upstream branches for twist_mux (Jazzy/Kilted/Rolling)

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11478,7 +11478,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -11487,7 +11487,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   twist_mux_msgs:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9899,7 +9899,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -9908,7 +9908,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   twist_mux_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9882,7 +9882,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
-      version: foxy-devel
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -9891,7 +9891,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git
-      version: foxy-devel
+      version: rolling
     status: maintained
   twist_mux_msgs:
     doc:


### PR DESCRIPTION
Fixing upstream branches of repo twist_mux for Jazzy/Kilted/Rolling.

The branch used by rosdistro before this change was foxy-devel, which [however only has versions up to 4.0.1](https://github.com/ros-teleop/twist_mux/blob/foxy-devel/package.xml). But if you look in binary versions for J/K/R, they are 4.4.0, which is only provided by the rolling branch.

@bmagyar please check this change makes sense.