### PR TITLE
crocoddyl: 3.2.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1463,7 +1463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/crocoddyl-release.git
-      version: 3.2.0-2
+      version: 3.2.0-3
     source:
       type: git
       url: https://github.com/loco-3d/crocoddyl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crocoddyl` to `3.2.0-3`:

- upstream repository: https://github.com/loco-3d/crocoddyl.git
- release repository: https://github.com/ros2-gbp/crocoddyl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.0-2`
