### PR TITLE
urdfdom: 5.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10168,7 +10168,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 5.0.3-1
+      version: 5.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `5.1.0-1`:

- upstream repository: https://github.com/ros/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.0.3-1`

## urdfdom

```
* Support for URDF Specification 1.1
  
  Add support for capsule geometry type (#238)
  * Add documentation about versioning
  * Require version 2.1.0 of urdfdom_headers
  Co-authored-by: Steve Peters <scpeters@openrobotics.org>
  
  Support quaternions in URDF 1.1 (#235)
  Co-authored-by: Guillaume Doisy <doisyg@users.noreply.github.com>
* Fix multiple format-string vulnerabilities in URDF parser logging (#243 <https://github.com/ros/urdfdom/issues/243>)
  User-controlled URDF content was passed directly to CONSOLE_BRIDGE_logError()
  at multiple call sites, allowing printf-style format string interpretation.
  All affected logging paths now use explicit "%s" format specifiers to ensure
  input is treated as data and to prevent information disclosure or undefined
  behavior.
* More logging format string fixes (#244 <https://github.com/ros/urdfdom/issues/244>)
  * Add explicit "%s" format strings when logging
  * Use %s format string instead of string addition
* Read cmake version from package.xml (#236 <https://github.com/ros/urdfdom/issues/236>)
  * Use regex to match version string.
  Based on suggestion from Chris Lalancette.
  * Require cmake minimum version 3.10
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: Florencia, Sai Kishor Kothakota, Steve Peters
```
