### PR TITLE
mrpt_ros_bridge: 3.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5581,7 +5581,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.1.1-1
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.2.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.1.1-1`

## mrpt_libros_bridge

```
* Merge pull request #1 <https://github.com/MRPT/mrpt_ros_bridge/issues/1> from MRPT/feat/export-pointcloud-color
  Fix: export RGB color clouds in the expected format by RViz/PCL
* Fix: export RGB color clouds in the expected format by RViz/PCL
* Support LaserScan.scan_time for mrpt 2.15.6
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

- No changes
