### PR TITLE
ros2_medkit: add source entry for jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8659,6 +8659,12 @@ repositories:
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
     status: developed
+  ros2_medkit:
+    source:
+      type: git
+      url: https://github.com/selfpatch/ros2_medkit.git
+      version: main
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Jazzy Jalisco

# The source is here:

https://github.com/selfpatch/ros2_medkit.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro