### PR TITLE
mrpt_ros: 2.15.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6039,7 +6039,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.7-1
+      version: 2.15.8-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.8-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.15.7-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

- No changes

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

- No changes

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

```
* New class mrpt::opengl::CAnimatedAssimpModel for 3D models with animations.
```

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
