### PR TITLE
mvsim: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4865,7 +4865,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 0.16.0-1
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `1.0.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.16.0-1`

## mvsim

```
* Merge pull request #89 <https://github.com/MRPT/mvsim/issues/89> from MRPT/fix/elevation-2-wheels
  Fix elevation maps for 2-wheels vehicles
* Merge pull request #88 <https://github.com/MRPT/mvsim/issues/88> from MRPT/feat/human-actors
  Add: human actors
* Merge pull request #86 <https://github.com/MRPT/mvsim/issues/86> from MRPT/feat/publish-log-to-ros
  Optional publish to ROS2 all CsvLogger entries
* Merge pull request #85 <https://github.com/MRPT/mvsim/issues/85> from MRPT/feat/per-block-scale
  Feat/per-block-scale
* Implement per block scale (Fixes #38 <https://github.com/MRPT/mvsim/issues/38>)
* Merge pull request #84 <https://github.com/MRPT/mvsim/issues/84> from MRPT/fix/box2d-bugs
  Fix/box2d-bugs
* docs: add ROS2 topics
* fix bug in setTwist()
* Fix wrong collision detection (Fixes #42 <https://github.com/MRPT/mvsim/issues/42>)
* Fix linear acceleration
* Merge pull request #83 <https://github.com/MRPT/mvsim/issues/83> from MRPT/feat/new-joints
  Implement joints between archors
* Demo worlds: update to add RGBD camera in greenhouse
* ROS node: fix missing publication of RGBD CameraInfo for RGB channel
* Merge pull request #82 <https://github.com/MRPT/mvsim/issues/82> from MRPT/feat/rgbd-publish-new-types
  RGBD cameras: implement publishing depth and RGB clouds
* RGBD cameras: implement publishing depth and RGB clouds
* Merge pull request #81 <https://github.com/MRPT/mvsim/issues/81> from MRPT/fix/py-bytes
  Fix: use py-bytes
* Fix trying to decode strings as utf-8 (Closes #62 <https://github.com/MRPT/mvsim/issues/62>)
* Merge pull request #80 <https://github.com/MRPT/mvsim/issues/80> from MRPT/feat/imu-noise
  IMU: add random walk and fix bug in acceleration
* Fix g sign
* Bump copyright year
* BUG FIX: Fix wrong linear acceleration in IMU readings
* Implement IMU noise model with random walk biases
* Rename ROS1 launch files so they don't interfere with autocomplete for ROS2
* indoor_outdoor demo: add IMU to robot
* Contributors: Jose Luis Blanco-Claraco
```
