### PR TITLE
rclpy: 10.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6549,7 +6549,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.4-1
+      version: 10.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.5-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.0.4-1`

## rclpy

```
* Prevents the Future result from being set twice. (#1599 <https://github.com/ros2/rclpy/issues/1599>)
* Wrap up ActionClient construction before spining (#1591 <https://github.com/ros2/rclpy/issues/1591>)
* Compatiblity with 'Populate Transitions' ros2/rcl#1269 <https://github.com/ros2/rcl/issues/1269> (#1528 <https://github.com/ros2/rclpy/issues/1528>)
* Drop invalid waitables from wait set (#1590 <https://github.com/ros2/rclpy/issues/1590>)
* give some time for the discovery for test_on_new_message_callback. (#1585 <https://github.com/ros2/rclpy/issues/1585>)
* print warning message on owner node if the parameter operation fails. (#1584 <https://github.com/ros2/rclpy/issues/1584>)
* Update release version to 10.0.4 (#1583 <https://github.com/ros2/rclpy/issues/1583>)
* Update type_support.py to use new message abstract base classes  (#1509 <https://github.com/ros2/rclpy/issues/1509>)
* Contributors: Jasper van Brakel, Michael Carlstrom, Tomoya Fujita, mhidalgo-rai
```
