### PR TITLE
rclcpp: 30.1.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6533,7 +6533,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 30.1.4-1
+      version: 30.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `30.1.5-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `30.1.4-1`

## rclcpp

```
* remove default: so that compiler can detect the missing case. (#3048 <https://github.com/ros2/rclcpp/issues/3048>)
* use weak_ptr for rcl entities in the memory strategy. (#2988 <https://github.com/ros2/rclcpp/issues/2988>)
* remove test_static_executor_entities_collector.cpp (#3041 <https://github.com/ros2/rclcpp/issues/3041>)
* include the 1st spin that might throw the exception. (#3042 <https://github.com/ros2/rclcpp/issues/3042>)
* print warning message on owner node if the parameter operation fails. (#3037 <https://github.com/ros2/rclcpp/issues/3037>)
* fix context in wait for message wait set (#3030 <https://github.com/ros2/rclcpp/issues/3030>)
* Revert "construct wait set with passed in context (#3021 <https://github.com/ros2/rclcpp/issues/3021>)" (#3028 <https://github.com/ros2/rclcpp/issues/3028>)
* construct wait set with passed in context (#3021 <https://github.com/ros2/rclcpp/issues/3021>)
* Improve the robustness of the TopicEndpointInfo constructor (#3013 <https://github.com/ros2/rclcpp/issues/3013>)
* Deprecate the shared_ptr<MessageT> subscription callback signatures (#2975 <https://github.com/ros2/rclcpp/issues/2975>)
* Contributors: Barry Xu, Maurice Alexander Purnawan, Michael Carroll, Rahat Dhande, Tomoya Fujita
```

## rclcpp_action

```
* remove default: so that compiler can detect the missing case. (#3048 <https://github.com/ros2/rclcpp/issues/3048>)
* Update exception documentation for goal cancellation in ServerGoalHandle (#3019 <https://github.com/ros2/rclcpp/issues/3019>)
* Contributors: Andrei Costinescu, Tomoya Fujita
```

## rclcpp_components

```
* Add library dependency to node executable in rclcpp_components_register_node (#3047 <https://github.com/ros2/rclcpp/issues/3047>)
* Contributors: YuJin Hong
```

## rclcpp_lifecycle

```
* Compatiblity with 'Populate Transitions' ros2/rcl#1269 <https://github.com/ros2/rcl/issues/1269> (#2967 <https://github.com/ros2/rclcpp/issues/2967>)
* Contributors: Jasper van Brakel
```
