### PR TITLE
launch_ros: 0.29.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3731,7 +3731,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.5-1
+      version: 0.29.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.29.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.29.5-1`

## launch_ros

```
* Compatiblity with 'Populate Transitions' ros2/rcl#1269 <https://github.com/ros2/rcl/issues/1269> (#495 <https://github.com/ros2/launch_ros/issues/495>)
* Contributors: Jasper van Brakel
```

## launch_testing_ros

- No changes

## ros2launch

- No changes
