### PR TITLE
rclcpp: 29.5.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6581,7 +6581,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 29.5.6-1
+      version: 29.5.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `29.5.7-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `29.5.6-1`

## rclcpp

```
* include the 1st spin that might throw the exception. (#3042 <https://github.com/ros2/rclcpp/issues/3042>) (#3044 <https://github.com/ros2/rclcpp/issues/3044>)
* print warning message on owner node if the parameter operation fails. (#3037 <https://github.com/ros2/rclcpp/issues/3037>) (#3038 <https://github.com/ros2/rclcpp/issues/3038>)
* remove test_static_executor_entities_collector.cpp (#3041 <https://github.com/ros2/rclcpp/issues/3041>) (#3045 <https://github.com/ros2/rclcpp/issues/3045>)
* fix context in wait for message wait set (#3030 <https://github.com/ros2/rclcpp/issues/3030>) (#3031 <https://github.com/ros2/rclcpp/issues/3031>)
* Improve the robustness of the TopicEndpointInfo constructor (#3013 <https://github.com/ros2/rclcpp/issues/3013>) (#3014 <https://github.com/ros2/rclcpp/issues/3014>)
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Update exception documentation for goal cancellation in ServerGoalHandle (#3019 <https://github.com/ros2/rclcpp/issues/3019>) (#3022 <https://github.com/ros2/rclcpp/issues/3022>)
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
