### PR TITLE
rclcpp: 16.0.18-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8603,7 +8603,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.17-1
+      version: 16.0.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.18-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `16.0.17-1`

## rclcpp

```
* print warning message on owner node if the parameter operation fails. (backport #3037 <https://github.com/ros2/rclcpp/issues/3037>) (#3040 <https://github.com/ros2/rclcpp/issues/3040>)
* fix context in wait for message wait set (#3030 <https://github.com/ros2/rclcpp/issues/3030>) (#3033 <https://github.com/ros2/rclcpp/issues/3033>)
* Improve the robustness of the TopicEndpointInfo constructor (backport #3013 <https://github.com/ros2/rclcpp/issues/3013>) (#3016 <https://github.com/ros2/rclcpp/issues/3016>)
* Contributors: mergify[bot]
```

## rclcpp_action

```
* Update exception documentation for goal cancellation in ServerGoalHandle (#3019 <https://github.com/ros2/rclcpp/issues/3019>) (#3024 <https://github.com/ros2/rclcpp/issues/3024>)
* Contributors: mergify[bot]
```

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
