### PR TITLE
swri_console: 2.1.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10651,7 +10651,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.0.8-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.1.2-2`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.8-1`

## swri_console

```
* Include <limits> for std::numeric_limits (#75 <https://github.com/swri-robotics/swri_console/issues/75>)
  * Include <limits> for std::numeric_limits
* Contributors: Tim Clephas
```
