### PR TITLE
nobleo_socketcan_bridge: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5054,7 +5054,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/nobleo/nobleo_socketcan_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nobleo_socketcan_bridge` to `1.0.4-1`:

- upstream repository: https://github.com/nobleo/nobleo_socketcan_bridge.git
- release repository: https://github.com/ros2-gbp/nobleo_socketcan_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.3-1`

## nobleo_socketcan_bridge

```
* Add extensive CAN diagnostics (#26 <https://github.com/nobleo/nobleo_socketcan_bridge/issues/26>)
  Instead of only okay/warn/error level, we can now also show more detailed diagnostics, error counters and reasons for errors.
* Fix #include <linux/can.h> and fmt::join
* Bump supported distros
* Contributors: Ferry Schoenmakers, Tim Clephas
```
