### PR TITLE
Include RTI Connext 7.7.0 in the base.yaml file

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9404,6 +9404,15 @@ rti-connext-dds-7.3.0:
     '*': [rti-connext-dds-7.3.0-ros]
     focal: null
     jammy: null
+rti-connext-dds-7.7.0:
+  debian:
+    '*': [rti-connext-dds-7.7.0-ros]
+    bullseye: null
+  nixos: []
+  ubuntu:
+    '*': [rti-connext-dds-7.7.0-ros]
+    focal: null
+    jammy: null
 rtklib:
   debian: [rtklib]
   fedora: [rtklib]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9405,14 +9405,12 @@ rti-connext-dds-7.3.0:
     focal: null
     jammy: null
 rti-connext-dds-7.7.0:
-  debian:
-    '*': [rti-connext-dds-7.7.0-ros]
-    bullseye: null
   nixos: []
   ubuntu:
     '*': [rti-connext-dds-7.7.0-ros]
     focal: null
     jammy: null
+    noble: null
 rtklib:
   debian: [rtklib]
   fedora: [rtklib]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

rti-connext-dds-7.7.0

## Package Upstream Source:

TODO link to source repository

## Purpose of using this:

This new package includes the last LTS release of RTI Connext, version 7.7.0.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here:

http://sourcecode_url

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
