### PR TITLE
Index gstreamer_ros_babel_fish

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2734,6 +2734,12 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: ros2
     status: developed
+  gstreamer_ros_babel_fish:
+    source:
+      type: git
+      url: https://github.com/StefanFabian/gstreamer_ros_babel_fish.git
+      version: rolling
+    status: maintained
   gtsam:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2738,7 +2738,7 @@ repositories:
     source:
       type: git
       url: https://github.com/StefanFabian/gstreamer_ros_babel_fish.git
-      version: rolling
+      version: main
     status: maintained
   gtsam:
     doc:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

gstreamer_ros_babel_fish

# The source is here:

https://github.com/StefanFabian/gstreamer_ros_babel_fish.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
