### PR TITLE
play_motion2: 1.8.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6750,7 +6750,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/play_motion2-release.git
-      version: 1.8.0-1
+      version: 1.8.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.8.3-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/ros2-gbp/play_motion2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.8.0-1`

## play_motion2

```
* Log motion result error when it's not empty
* Contributors: ileniaperrella
```

## play_motion2_cli

- No changes

## play_motion2_msgs

- No changes
