### PR TITLE
launch_pal: 0.20.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4814,7 +4814,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_pal-release.git
-      version: 0.20.0-1
+      version: 0.20.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.20.1-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/ros2-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.20.0-1`

## launch_pal

```
* Fix linters for jazzy
* Contributors: Noel Jimenez
```
