### PR TITLE
pal_gripper: 3.6.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7169,7 +7169,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.6.0-1
+      version: 3.6.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.6.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/pal-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.6.0-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

- No changes

## pal_gripper_description

```
* addition of property for gazebo_version
* gazebo version arg missing
* Contributors: Michela Cavuoto
```

## pal_gripper_simulation

```
* formatting problem solved
* addition of property for gazebo_version
* gazebo version arg missing
* Contributors: Michela Cavuoto
```
