### PR TITLE
pal_pro_gripper: 1.11.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7243,7 +7243,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_pro_gripper-release.git
-      version: 1.8.0-1
+      version: 1.11.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_pro_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_pro_gripper` to `1.11.3-1`:

- upstream repository: https://github.com/pal-robotics/pal_pro_gripper.git
- release repository: https://github.com/ros2-gbp/pal_pro_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.8.0-1`

## pal_pro_gripper

- No changes

## pal_pro_gripper_bringup

- No changes

## pal_pro_gripper_controller_configuration

- No changes

## pal_pro_gripper_description

```
* adding description
* Fix a typo
* adding calibration_tool
* Contributors: silviamasiello
```

## pal_pro_gripper_wrapper

- No changes
