### PR TITLE
pal_sea_arm: 1.23.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7282,7 +7282,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_sea_arm-release.git
-      version: 1.21.0-1
+      version: 1.23.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm` to `1.23.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm.git
- release repository: https://github.com/ros2-gbp/pal_sea_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.21.0-1`

## pal_sea_arm

- No changes

## pal_sea_arm_bringup

- No changes

## pal_sea_arm_controller_configuration

- No changes

## pal_sea_arm_description

```
* adding calibration_tool param
* Contributors: silviamasiello
```
