### PR TITLE
talos_moveit_config: 2.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11662,7 +11662,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_moveit_config-release.git
-      version: 2.0.2-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/talos_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_moveit_config` to `2.0.4-1`:

- upstream repository: https://github.com/pal-robotics/talos_moveit_config.git
- release repository: https://github.com/pal-gbp/talos_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-1`

## talos_moveit_config

```
* Add move_group module
* Contributors: Noel Jimenez
```
