### PR TITLE
talos_robot: 2.10.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11680,7 +11680,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/talos_robot-release.git
-      version: 2.9.1-1
+      version: 2.10.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/talos_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `talos_robot` to `2.10.3-1`:

- upstream repository: https://github.com/pal-robotics/talos_robot.git
- release repository: https://github.com/pal-gbp/talos_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.1-1`

## talos_bringup

- No changes

## talos_controller_configuration

- No changes

## talos_description

```
* Expose safety interface for robot_control
* Contributors: Noel Jimenez
```

## talos_description_calibration

- No changes

## talos_description_inertial

- No changes

## talos_robot

- No changes
