### PR TITLE
tiago_pro_head_robot: 1.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11915,7 +11915,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_head_robot-release.git
-      version: 1.7.0-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_head_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_head_robot` to `1.9.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_head_robot.git
- release repository: https://github.com/ros2-gbp/tiago_pro_head_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.0-1`

## tiago_pro_head_bringup

- No changes

## tiago_pro_head_controller_configuration

- No changes

## tiago_pro_head_description

```
* Unifying frames
* adding depth frame for calibration
* Contributors: silviamasiello
```

## tiago_pro_head_robot

- No changes
