### PR TITLE
tiago_pro_moveit_config: 1.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11948,7 +11948,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_moveit_config-release.git
-      version: 1.3.2-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_moveit_config` to `1.4.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_moveit_config.git
- release repository: https://github.com/ros2-gbp/tiago_pro_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.2-1`

## tiago_pro_moveit_config

```
* delete teleop end effector
* Contributors: ileniaperrella
```
