### PR TITLE
tiago_pro_robot: 1.35.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11988,7 +11988,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_robot-release.git
-      version: 1.32.1-1
+      version: 1.35.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_robot` to `1.35.4-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_robot.git
- release repository: https://github.com/ros2-gbp/tiago_pro_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.32.1-1`

## tiago_pro_bringup

```
* adding calibration_tool param
* Contributors: silviamasiello
```

## tiago_pro_controller_configuration

- No changes

## tiago_pro_description

```
* adding calibration_tool param
* Contributors: silviamasiello
```

## tiago_pro_robot

- No changes
