### PR TITLE
tiago_robot: 4.24.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12026,7 +12026,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.22.0-1
+      version: 4.24.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_robot` to `4.24.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_robot
- release repository: https://github.com/pal-gbp/tiago_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.22.0-1`

## tiago_bringup

- No changes

## tiago_controller_configuration

- No changes

## tiago_description

```
* Use package instead of find for meshes lookup
  This change avoids errors when visualizing the robot in rviz2 from a
  remote host instead of directly inside the robot
* Contributors: Noel Jimenez
```

## tiago_robot

- No changes
