### PR TITLE
tiago_pro_simulation: 1.14.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12006,7 +12006,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
-      version: 1.12.2-1
+      version: 1.14.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_simulation` to `1.14.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_simulation.git
- release repository: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.12.2-1`

## tiago_pro_gazebo

```
* uncomment tuck arm
* remove end effectors teleop station - add wrist
* Contributors: ileniaperrella
```

## tiago_pro_simulation

- No changes
