### PR TITLE
behaviortree_cpp_v4: 4.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1029,7 +1029,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.8.3-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.9.0-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.8.3-1`

## behaviortree_cpp

```
* Fix Blackboard thread-safety: 6 data races fixed, use shared_mutex for storage
* Fix XML parser null pointer dereference in loadSubtreeModel on missing SubTree ID
* Add TryCatch control node for try/catch recovery patterns
* Fix #1111 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1111>: EntryUpdatedDecorator::halt() not halting its child (#1112 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1112>)
* Add polymorphic shared_ptr port support (#943 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/943>) (#1107 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1107>)
* Fix std::from_chars compilation on older g++ versions (#1110 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1110>)
* Fix clang-tidy warnings across tests, examples, and samples (#1109 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1109>)
* Add exception tracking with node backtrace (#990 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/990>) (#1106 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1106>)
* Fix #861 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/861>
* Fix #917 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/917>: add comments about preconditions
* Fix missing read_parameter_from_ports initialization in DelayNode (#1103 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1103>)
* Fix #880 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/880>: createTreeFromText now finds previously registered subtrees (#1105 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1105>)
* Remove lexy dependency, replace with hand-written tokenizer and Pratt parser (#1099 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1099>)
* Fix #953 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/953>: getInput() now uses stored converter for plugin custom types (#1104 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1104>)
* Improve test suite quality and coverage (#1102 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1102>)
* Fix Groot2Publisher destructor infinite loop (#1057 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1057>) (#1100 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1100>)
* Fix misleading static_assert when extra args have wrong type (#837 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/837>) (#1098 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1098>)
* Fix DelayNode ignoring delay_msec when created from XML (#1097 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1097>)
* Fix Windows build issues (#762 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/762>, #869 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/869>, #836 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/836>) (#1089 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1089>)
* Fix #989 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/989>: JsonExporter use-after-move in vector converter registration (#1090 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1090>)
* Fix #672 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/672>: reject deeply-nested/recursive XML to prevent stack overflow (#1091 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1091>)
* Fix #930 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/930>: mock substitution hangs when TestNodeConfigs is absent (#1086 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1086>)
* Detect recursive subtree cycles at parse time (#979 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/979>) (#1085 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1085>)
* Fix #1046 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1046>: use-after-free when factory destroyed before tree (#1081 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1081>)
* Fix #934 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/934>: segfault when substituting a SubTree node (#1083 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1083>)
* Fix #937 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/937>: enable returning BehaviorTreeFactory by value (#1082 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1082>)
* Add vcpkg installation instructions (#421 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/421>)
* Fix #942 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/942>: getLockedPortContent creates entry for default-remapped ports (#1078 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1078>)
* Add code coverage CI with Codecov, Coveralls, Codacy, and SonarCloud (#1068 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1068>)
* Fix Groot2Publisher destructor infinite loop (#1058 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1058>)
* Remove deprecated std::aligned_storage (#1061 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1061>)
* Add regression test for #1065 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1065>: subtree string literal to LoopDouble (#1072 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1072>)
* Add regression test for #858 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/858>: getInput with default port value (#1076 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1076>)
* Add regression test for #832 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/832>: script compare with negative number (#1071 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1071>)
* Add regression test for #923 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/923>: ValidateScript OOB read with large scripts (#1070 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1070>)
* Fix #948 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/948>: parseString supports enums with convertFromString specializations (#1075 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1075>)
* Fix #982 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/982>: handle json: prefix in vector convertFromString specializations (#1073 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1073>)
* Fix #408 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/408>: debugMessage shows type info for remapped subtree entries (#1079 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1079>)
* Fix #969 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/969>: LoopNode accepts std::vector<T> in addition to SharedQueue<T> (#1074 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1074>)
* Fix #1029 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1029>: correct left-associativity for arithmetic operators in script parser (#1069 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1069>)
* Generate .clangd in PROJECT_SOURCE_DIR for submodule/FetchContent support (#1059 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1059>)
* Contributors: Christoph Hertzberg, Copilot, Davide Faconti, Frank, Vincent PALANCHER, alvintps, dependabot[bot]
```
