### PR TITLE
clearpath_config: 2.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1339,7 +1339,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.8.2-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.9.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.2-1`

## clearpath_config

```
* CI in container (#213 <https://github.com/clearpathrobotics/clearpath_config/issues/213>)
* Feature: Proton Samples (#212 <https://github.com/clearpathrobotics/clearpath_config/issues/212>)
* Feature: Other Middleware  (#210 <https://github.com/clearpathrobotics/clearpath_config/issues/210>)
* Feature: Proton (#206 <https://github.com/clearpathrobotics/clearpath_config/issues/206>)
* Added mergify and auto-label. (#207 <https://github.com/clearpathrobotics/clearpath_config/issues/207>)
* Contributors: Tony Baltovski, Luis Camero
```
