### PR TITLE
clearpath_simulator: 2.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1427,7 +1427,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_simulator-release.git
-      version: 2.7.1-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_simulator` to `2.9.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_simulator.git
- release repository: https://github.com/clearpath-gbp/clearpath_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.1-1`

## clearpath_generator_gz

```
* Update cmake version to 3.20 (#100 <https://github.com/clearpathrobotics/clearpath_simulator/issues/100>)
* Add SeyondLidar support in sensors.py (param generator) (#98 <https://github.com/clearpathrobotics/clearpath_simulator/issues/98>)
  * Add SeyondLidar support in sensors.py (param generator)
  * Reorganize imports for 3D lidars in sensors.py
  Fix imports out-of-alphabetical-order and line too long
* Contributors: Andrei Costinescu, luis-camero
```

## clearpath_gz

```
* Update cmake version to 3.20 (#100 <https://github.com/clearpathrobotics/clearpath_simulator/issues/100>)
* Rename node from 'generate_launch' to 'generate_param' (#97 <https://github.com/clearpathrobotics/clearpath_simulator/issues/97>)
  Fix copy-paste issue when naming the generate_param node
* Contributors: Andrei Costinescu, luis-camero
```

## clearpath_simulator

```
* Update cmake version to 3.20 (#100 <https://github.com/clearpathrobotics/clearpath_simulator/issues/100>)
* Contributors: luis-camero
```
