### PR TITLE
moveit: 2.14.3 in 'kilted/distribution.yaml' [manual]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4560,7 +4560,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.14.1-1
+      version: 2.14.3-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
My fork of rosdistro was not found in `bloom-release` so I've made this manually.

This is a continuation of https://github.com/ros/rosdistro/pull/49425 but I fixed the entries in the kilted track according to info in https://docs.ros.org/en/jazzy/How-To-Guides/Releasing/Release-Track.html#what-is-a-track to
- `devel_branch: main` to `devel_branch: kilted`
- `release_tag: :{version}` to `release_tag: kilted-:{version}`

---

Increasing version of package(s) in repository moveit to 2.14.3-1:

upstream repository: https://github.com/moveit/moveit2.git
release repository: https://github.com/ros2-gbp/moveit2-release.git
distro file: kilted/distribution.yaml
previous version for package: 2.14.1-1