### PR TITLE
gz_cmake_vendor: 0.0.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3457,7 +3457,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
-      version: 0.0.10-1
+      version: 0.0.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_cmake_vendor` to `0.0.11-1`:

- upstream repository: https://github.com/gazebo-release/gz_cmake_vendor.git
- release repository: https://github.com/ros2-gbp/gz_cmake_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.10-1`

## gz_cmake_vendor

```
* Bump version to 3.5.6 (#22 <https://github.com/gazebo-release/gz_cmake_vendor/issues/22>)
* Contributors: Addisu Z. Taddese
```
