### PR TITLE
gz_common_vendor: 0.0.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3473,7 +3473,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.0.8-1
+      version: 0.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.0.9-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.8-1`

## gz_common_vendor

```
* Bump version to 5.8.0 (#24 <https://github.com/gazebo-release/gz_common_vendor/issues/24>)
* Contributors: Addisu Z. Taddese
```
