### PR TITLE
perception_pcl: 2.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5622,7 +5622,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.7.3-1
+      version: 2.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.8.0-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.3-1`

## pcl_conversions

```
* Fix BSD-3-Cause license name in package.xml files (#516 <https://github.com/ros-perception/perception_pcl/issues/516>)
* Contributors: Garrett Brown
```

## pcl_ros

```
* chore: tf2_ros to hpp headers (#506 <https://github.com/ros-perception/perception_pcl/issues/506>)
* Add ament_cmake_ros to build libraries by default as SHARED
  Previously there were some inconsistencies in the libraries, some where
  shared, others where static. By adding ament_cmake_ros everything is
  shared by default.
* Add keep organized parameter (#518 <https://github.com/ros-perception/perception_pcl/issues/518>)
* Fix BSD-3-Cause license name in package.xml files (#516 <https://github.com/ros-perception/perception_pcl/issues/516>)
* Contributors: Garrett Brown, Ramon Wijnands, Tatsuro Sakaguchi, Tim Clephas
```

## perception_pcl

```
* Fix BSD-3-Cause license name in package.xml files (#516 <https://github.com/ros-perception/perception_pcl/issues/516>)
* Contributors: Garrett Brown
```
