### PR TITLE
Add mujoco_ros2_control to the Humble source

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6136,6 +6136,16 @@ repositories:
       url: https://github.com/KIT-MRT/mrt_cmake_modules.git
       version: master
     status: maintained
+  mujoco_ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/mujoco_ros2_control.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/mujoco_ros2_control.git
+      version: main
+    status: developed
   mujoco_vendor:
     doc:
       type: git


### PR DESCRIPTION

## Please Add This Package to be indexed in the rosdistro.

Humble

## The source is here:

https://github.com/ros-controls/mujoco_ros2_control

## Checks

- [x]     All packages have a declared license in the package.xml
- [x]     This repository has a LICENSE file
- [x]     This package is expected to build on the submitted rosdistro
 
