### PR TITLE
gz_sim_vendor: 0.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2984,7 +2984,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
-      version: 0.4.3-1
+      version: 0.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sim_vendor` to `0.4.4-1`:

- upstream repository: https://github.com/gazebo-release/gz_sim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sim_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.3-1`

## gz_sim_vendor

```
* Bump version to 10.1.1 (#23 <https://github.com/gazebo-release/gz_sim_vendor/issues/23>)
* Contributors: Ian Chen
```
