### PR TITLE
ament_package: 0.14.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -446,7 +446,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.14.1-1
+      version: 0.14.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.14.2-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.14.1-1`

## ament_package

```
* fix setuptools deprecations (#156 <https://github.com/ament/ament_package/issues/156>) (#160 <https://github.com/ament/ament_package/issues/160>)
* Contributors: mergify[bot]
```
