### PR TITLE
rqt_reconfigure: 1.1.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10544,7 +10544,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.1.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.2-1`

## rqt_reconfigure

```
* fix setuptools deprecation (backport #153 <https://github.com/ros-visualization/rqt_reconfigure/issues/153>) (#156 <https://github.com/ros-visualization/rqt_reconfigure/issues/156>)
* add arraytypes into humble (#145 <https://github.com/ros-visualization/rqt_reconfigure/issues/145>)
* Contributors: Gordon Stevenson, mergify[bot]
```
