### PR TITLE
rqt_topic: 1.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10680,7 +10680,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `1.5.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.0-1`

## rqt_topic

```
* fix setuptools deprecations (backport #57 <https://github.com/ros-visualization/rqt_topic/issues/57>) (#61 <https://github.com/ros-visualization/rqt_topic/issues/61>)
* Contributors: mergify[bot]
```
