### PR TITLE
mola_state_estimation: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5290,7 +5290,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.0.0-1`

## mola_georeferencing

```
* simplemap_georeference(): returns std::optional to reflect lack of GNSS data enough
* Merge pull request #12 <https://github.com/MOLAorg/mola_state_estimation/issues/12> from MOLAorg/feat/mm-geodetic
  Feat/mm-geodetic
* Add mola-mm-add-geodetic-cli app
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Merge pull request #13 <https://github.com/MOLAorg/mola_state_estimation/issues/13> from MOLAorg/feat/publish-georef-on-converge
  Publish geo-ref on convergence
* Include the RDC API in the tests
* Refactor publish georef and sensor label regex
  fix filtering observations by sensor label regex
  refactor to publish georef on converged automatically
  fix build against older mola_kernel
  Fix wrong logic in GNSS fuse
* remove old mola version guards
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Merge pull request #13 <https://github.com/MOLAorg/mola_state_estimation/issues/13> from MOLAorg/feat/publish-georef-on-converge
  Publish geo-ref on convergence
* get onObservation() and has_converged_localization() method tested too
* Refactor publish georef and sensor label regex
  fix filtering observations by sensor label regex
  refactor to publish georef on converged automatically
  fix build against older mola_kernel
  Fix wrong logic in GNSS fuse
* remove old mola version guards
* unit test: relax threshold to avoid spurious failures
* Publish geo-ref on convergence
  add new params to yaml file
* Contributors: Jose Luis Blanco-Claraco
```
