### PR TITLE
mrpt_ros_bridge: 3.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4787,7 +4787,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.4.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.3.0-1`

## mrpt_libros_bridge

```
* Merge pull request #3 <https://github.com/MRPT/mrpt_ros_bridge/issues/3> from MRPT/feat/refactor-rosbag2
  Refactor to reuse common code in mola bridge and rosbag input
* fix reversed tf look up
* Gracefully handle optional rosbag2_cpp
* Fix bug: in stereo_msg conversion
* Refactor to reuse common code in mola bridge and rosbag input
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

```
* Merge pull request #3 <https://github.com/MRPT/mrpt_ros_bridge/issues/3> from MRPT/feat/refactor-rosbag2
  Refactor to reuse common code in mola bridge and rosbag input
* rosbag2rawlog: Use Zstd for output rawlog
* "image_topic" as backwards compatible yaml entry
* Refactor to reuse common code in mola bridge and rosbag input
* Contributors: Jose Luis Blanco-Claraco
```
