### PR TITLE
network_bridge: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4992,7 +4992,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/network_bridge-release.git
-      version: 2.0.0-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/brow1633/network_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `network_bridge` to `3.0.0-1`:

- upstream repository: https://github.com/brow1633/network_bridge.git
- release repository: https://github.com/ros2-gbp/network_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## network_bridge

```
* Add a specific management of TF topics
* Fixed several bugs
* Fix formatting in CMakeLists.txt for target_link_libraries
* Update README with installation instructions
  Added installation instructions for apt and building from source.
* Contributors: Cedric Pradalier, Ethan Brown
```
