### PR TITLE
add python3-colorlog key for ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5491,16 +5491,11 @@ python3-colorcet:
       pip:
         packages: [colorcet]
 python3-colorlog:
-  debian:
-    '*': [python3-colorlog]
-  fedora:
-    '*': [python3-colorlog]
-  opensuse:
-    '*': [python3-colorlog]
-  rhel:
-    '*': [python3-colorlog]
-  ubuntu:
-    '*': [python3-colorlog]
+  debian: [python3-colorlog]
+  fedora: [python3-colorlog]
+  opensuse: [python3-colorlog]
+  rhel: [python3-colorlog]
+  ubuntu: [python3-colorlog]
 python3-conan-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5490,6 +5490,17 @@ python3-colorcet:
     focal:
       pip:
         packages: [colorcet]
+python3-colorlog:
+  debian:
+    '*': [python3-colorlog]
+  fedora:
+    '*': [python3-colorlog]
+  opensuse:
+    '*': [python3-colorlog]
+  rhel:
+    '*': [python3-colorlog]
+  ubuntu:
+    '*': [python3-colorlog]
 python3-conan-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-colorlog

## Package Upstream Source:

https://github.com/borntyping/python-colorlog

## Purpose of using this:

This dependency is being used to enable color logging support for ros2 launch.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.ubuntu.com/questing/python3-colorlog
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/questing/python3-colorlog
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE
