### PR TITLE
lightning_rrt_interfaces: 0.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4763,6 +4763,11 @@ repositories:
       version: jazzy
     status: maintained
   lightning_rrt_interfaces:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/david-dorf/lightning_rrt_interfaces.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/david-dorf/lightning_rrt_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lightning_rrt_interfaces` to `0.0.2-1`:

- upstream repository: https://github.com/david-dorf/lightning_rrt_interfaces.git
- release repository: https://github.com/david-dorf/lightning_rrt_interfaces.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
