### PR TITLE
warehouse_ros: 2.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10453,7 +10453,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros` to `2.0.6-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros.git
- release repository: https://github.com/ros2-gbp/warehouse_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.5-1`

## warehouse_ros

```
* Fix deprecation of tf2_ros/buffer.h (#104 <https://github.com/ros-planning/warehouse_ros/issues/104>)
* Replace ament_target_dependencies with target_link_libraries (#99 <https://github.com/ros-planning/warehouse_ros/issues/99>)
* Contributors: Alejandro Hernández Cordero, Robert Haschke, mosfet80
```
