### PR TITLE
warehouse_ros_sqlite: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10468,7 +10468,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.6-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.5-1`

## warehouse_ros_sqlite

```
* Remove deprecated sqlite3_vendor (#57 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/57>)
* Replace deprecated ament_target_dependencies (#55 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/55>)
* Contributors: Robert Haschke, mosfet80
```
