### PR TITLE
gscam: 2.0.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2728,7 +2728,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gscam-release.git
-      version: 2.0.2-4
+      version: 2.0.3-2
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `2.0.3-2`:

- upstream repository: https://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros2-gbp/gscam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-4`

## gscam

```
* Replace ament_target_dependencies with target_link_libraries (#102 <https://github.com/ros-drivers/gscam/issues/102>)
* Shutdown node when pipeline thread finishes (#86 <https://github.com/ros-drivers/gscam/issues/86>)
* Contributors: Alejandro Hernández Cordero, Jeremy Roy
```
