### PR TITLE
gscam: 2.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2728,7 +2728,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gscam-release.git
-      version: 2.0.2-4
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/ros-drivers/gscam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gscam` to `2.0.4-1`:

- upstream repository: https://github.com/ros-drivers/gscam.git
- release repository: https://github.com/ros2-gbp/gscam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-4`

## gscam

```
* fix: update wrong target (#105 <https://github.com/ros-drivers/gscam/issues/105>)
* fix: rolling build (#107 <https://github.com/ros-drivers/gscam/issues/107>)
* chore(deps): add gstreamer1.0-plugins-good (#100 <https://github.com/ros-drivers/gscam/issues/100>)
* chore: remove cv_bridge in package-xml, as it is not used. (#93 <https://github.com/ros-drivers/gscam/issues/93>)
* ci: update ros distros (#106 <https://github.com/ros-drivers/gscam/issues/106>)
* Contributors: Bastian Jäger, Daisuke Nishimatsu, Séverin Lemaignan
```
