### PR TITLE
popf: 1.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5985,7 +5985,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/popf-release.git
-      version: 0.0.18-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/fmrico/popf.git


### PR DESCRIPTION
Increasing version of package(s) in repository `popf` to `1.0.0-1`:

- upstream repository: https://github.com/fmrico/popf.git
- release repository: https://github.com/ros2-gbp/popf-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.18-1`

## popf

```
* Fix link problem
* Contributors: Francisco Martín Rico
```
