### PR TITLE
visp: 3.7.0-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10411,7 +10411,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/visp-release.git
-      version: 3.5.0-4
+      version: 3.7.0-2
     source:
       type: git
       url: https://github.com/lagadic/visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.7.0-2`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/ros2-gbp/visp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.0-4`
