### PR TITLE
sros2: 0.16.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9218,7 +9218,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.16.3-1
+      version: 0.16.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.16.4-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.16.3-1`

## sros2

```
* python3-pytest-timeout is missing for test dependency. (#377 <https://github.com/ros2/sros2/issues/377>)
* Contributors: Tomoya Fujita
```

## sros2_cmake

- No changes
