### PR TITLE
automatika_embodied_agents: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -662,7 +662,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.5.0-1
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_embodied_agents` to `0.5.1-1`:

- upstream repository: https://github.com/automatika-robotics/ros-agents.git
- release repository: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.0-1`

## automatika_embodied_agents

```
* (feature) Adds a record_video action to the Vision component
* Takes specific input topic name and duration to record video
* (feature) Adds a take_picture action to the vision component
* (feature) Adds arbitrary action execution to router
* (feature) Adds handling of topic and action lists in semantic router
* (refactor) Makes action methods in Vision component use extra_callback to avoid starvation
* (refactor) Increases default max new tokens param for llm/vlm configs
* (refactor) Makes changes for new api of events/actions in sugar
* (fix) Fixes semantic router handling of action routes based on new api
* (fix) Fixes warmup for model components
* (chore) Adds think option for ollama models
* (chore) Adds proper docstrings to exposed methods and classes
* (docs) Updates model definitions in examples
* (docs) Adds new prompt for llms.txt and new tutorial intros
* (docs) Fix incorrect import in docs
* (docs) Updates installation instructions
* Contributors: ahr, mkabtoul
```
