### PR TITLE
sros2: 0.15.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9291,7 +9291,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.15.4-1
+      version: 0.15.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.15.5-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.4-1`

## sros2

```
* python3-pytest-timeout is missing for test dependency. (#377 <https://github.com/ros2/sros2/issues/377>) (#378 <https://github.com/ros2/sros2/issues/378>)
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
