### PR TITLE
sros2: 0.13.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10637,7 +10637,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.13.5-1
+      version: 0.13.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.13.6-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.13.5-1`

## sros2

```
* python3-pytest-timeout is missing for test dependency. (#377 <https://github.com/ros2/sros2/issues/377>) (#379 <https://github.com/ros2/sros2/issues/379>)
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
