### PR TITLE
Add Qt6 Websockets.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6490,6 +6490,24 @@ libqt6-quick:
   ubuntu:
     '*': [libqt6quick6]
     'focal': null
+libqt6-websockets:
+  alpine: [qt6-qtwebsockets]
+  arch: [qt6-websockets]
+  debian: [libqt6websockets6]
+  fedora: [qt6-qtwebsockets]
+  gentoo: ['dev-qt/qtwebsockets:6']
+  nixos: [qt6.qtwebsockets]
+  openembedded: [qtwebsockets@meta-qt6]
+  opensuse:
+    '*': [libQt6WebSockets6]
+    '15.2': null
+  rhel:
+    '*': [qt6-qtwebsockets]
+    '8': null
+  slackware: [qt6]
+  ubuntu:
+    '*': [libqt6websockets6]
+    'focal': null
 libqt6bluetooth6:
   alpine: [qt6-qtconnectivity]
   arch: [qt6-connectivity]
@@ -9237,6 +9255,24 @@ qt6-tools-dev:
   ubuntu:
     '*': [qt6-tools-dev]
     focal: null
+qt6-websockets-dev:
+  alpine: [qt6-qtwebsockets-dev]
+  arch: [qt6-websockets]
+  debian: [qt6-websockets-dev]
+  fedora: [qt6-qtwebsockets-devel]
+  gentoo: ['dev-qt/qtwebsockets:6']
+  nixos: [qt6.qtwebsockets]
+  openembedded: [qtwebsockets@meta-qt6]
+  opensuse:
+    '*': [qt6-websockets-devel]
+    '15.2': null
+  rhel:
+    '*': [qt6-qtwebsockets-devel]
+    '8': null
+  slackware: [qt6]
+  ubuntu:
+    '*': [qt6-websockets-dev]
+    'focal': null
 qtbase5-dev:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9272,6 +9272,7 @@ qt6-websockets-dev:
   slackware: [qt6]
   ubuntu:
     '*': [qt6-websockets-dev]
+    'jammy': null
     'focal': null
 qtbase5-dev:
   alpine: [qt5-qtbase-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9272,8 +9272,8 @@ qt6-websockets-dev:
   slackware: [qt6]
   ubuntu:
     '*': [qt6-websockets-dev]
-    'jammy': null
     'focal': null
+    'jammy': null
 qtbase5-dev:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6501,6 +6501,9 @@ libqt6-websockets:
   opensuse:
     '*': [libQt6WebSockets6]
     '15.2': null
+  osx:
+    homebrew:
+      packages: [qtwebsockets]
   rhel:
     '*': [qt6-qtwebsockets]
     '8': null
@@ -9266,6 +9269,9 @@ qt6-websockets-dev:
   opensuse:
     '*': [qt6-websockets-devel]
     '15.2': null
+  osx:
+    homebrew:
+      packages: [qtwebsockets]
   rhel:
     '*': [qt6-qtwebsockets-devel]
     '8': null


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

Qt6 Websockets (+ dev package)

## Purpose of using this:

Needed for websockets in Qt6. I will use it for a package that connects webrtc video with ROS.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian:
  - https://packages.debian.org/sid/qt6-websockets-dev
  - https://packages.debian.org/sid/libqt6websockets6
- Ubuntu:
  - https://packages.ubuntu.com/noble/qt6-websockets-dev
  - https://packages.ubuntu.com/noble/libqt6websockets6
- Fedora:
  - https://packages.fedoraproject.org/pkgs/qt6-qtwebsockets/qt6-qtwebsockets-devel/
  - https://packages.fedoraproject.org/pkgs/qt6-qtwebsockets/qt6-qtwebsockets/
- Arch: https://archlinux.org/packages/extra/x86_64/qt6-websockets/
- Gentoo: https://packages.gentoo.org/packages/dev-qt/qtwebsockets
- macOS: https://formulae.brew.sh/formula/qtwebsockets
- Alpine:
  - https://pkgs.alpinelinux.org/packages?name=qt6-qtwebsockets-dev
  - https://pkgs.alpinelinux.org/packages?name=qt6-qtwebsockets
- NixOS/nixpkgs: Not found in the search
- openSUSE:
  - https://software.opensuse.org/package/qt6-websockets
  - https://software.opensuse.org/package/libQt6WebSockets6
- rhel:
  - https://packages.fedoraproject.org/pkgs/qt6-qtwebsockets/qt6-qtwebsockets-devel/
  - https://packages.fedoraproject.org/pkgs/qt6-qtwebsockets/qt6-qtwebsockets/
