### PR TITLE
Add libsoup-3.0-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6799,8 +6799,8 @@ libsoup-3.0-dev:
       packages: [libsoup]
   rhel:
     '*': [libsoup3]
-    '9': null
     '8': null
+    '9': null
   slackware: [libsoup3]
   ubuntu:
     '*': [libsoup-3.0-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6783,6 +6783,27 @@ libsoundio-dev:
   macports: [libsoundio]
   nixos: [libsoundio]
   ubuntu: [libsoundio-dev]
+libsoup-3.0-dev:
+  alpine: [libsoup3-dev]
+  arch: [libsoup3]
+  debian: [libsoup-3.0-dev]
+  fedora: [libsoup3-devel]
+  gentoo: ['net-libs/libsoup:3.0']
+  nixos: [libsoup_3]
+  openembedded: [libsoup@openembedded-core]
+  opensuse:
+    '*': [libsoup-3.0-dev]
+    '15.2': null
+  osx:
+    homebrew:
+      packages: [libsoup]
+  rhel:
+    '*': [libsoup3-devel]
+    '8': null
+  slackware: [libsoup3]
+  ubuntu:
+    '*': [libsoup-3.0-dev]
+    'focal': null
 libsoup2-dev:
   alpine: [libsoup-dev]
   arch: [libsoup]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6798,7 +6798,8 @@ libsoup-3.0-dev:
     homebrew:
       packages: [libsoup]
   rhel:
-    '*': [libsoup3-devel]
+    '*': [libsoup3]
+    '9': null
     '8': null
   slackware: [libsoup3]
   ubuntu:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

libsoup-3.0-dev

## Purpose of using this:

Used in C++ for websockets. Version 2 is already indexed but outdated.

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libsoup-3.0-dev
- Ubuntu: https://packages.ubuntu.com/noble/libsoup-3.0-dev
- Fedora: https://packages.fedoraproject.org/pkgs/libsoup3/libsoup3-devel/
- Arch: https://archlinux.org/packages/extra/x86_64/libsoup3/
- Gentoo: https://packages.gentoo.org/packages/net-libs/libsoup
- macOS: https://formulae.brew.sh/formula/libsoup
- Alpine: https://pkgs.alpinelinux.org/packages?name=libsoup3-dev
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=unstable&query=libsoup_3
- openSUSE: https://software.opensuse.org/package/libsoup-3.0-dev
- rhel: https://packages.fedoraproject.org/pkgs/libsoup3/libsoup3-devel/