### PR TITLE
Add gstreamer1.0-nice

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1817,6 +1817,16 @@ gstreamer1.0-libav:
   openembedded: [gstreamer1.0-libav@openembedded-core]
   opensuse: [gstreamer-plugins-libav]
   ubuntu: [gstreamer1.0-libav]
+gstreamer1.0-nice:
+  arch: [libnice]
+  debian: [gstreamer1.0-nice]
+  fedora: [libnice-gstreamer1]
+  gentoo: ['net-libs/libnice']
+  nixos: [gst_all_1.gst-plugins-bad]
+  openembedded: [gstreamer1.0-plugins-bad@openembedded-core]
+  opensuse: [gstreamer1.0-nice]
+  rhel: [libnice-gstreamer1]
+  ubuntu: [gstreamer1.0-nice]
 gstreamer1.0-plugins-bad:
   arch: [gst-plugins-bad]
   debian: [gstreamer1.0-plugins-bad]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1824,7 +1824,7 @@ gstreamer1.0-nice:
   gentoo: ['net-libs/libnice']
   nixos: [gst_all_1.gst-plugins-bad]
   openembedded: [gstreamer1.0-plugins-bad@openembedded-core]
-  opensuse: [gstreamer1.0-nice]
+  opensuse: [gstreamer-libnice]
   rhel: [libnice-gstreamer1]
   ubuntu: [gstreamer1.0-nice]
 gstreamer1.0-plugins-bad:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1821,7 +1821,7 @@ gstreamer1.0-nice:
   arch: [libnice]
   debian: [gstreamer1.0-nice]
   fedora: [libnice-gstreamer1]
-  gentoo: ['net-libs/libnice']
+  gentoo: ['media-plugins/gst-plugins-libnice:1.0']
   nixos: [gst_all_1.gst-plugins-bad]
   openembedded: [gstreamer1.0-plugins-bad@openembedded-core]
   opensuse: [gstreamer-libnice]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

gstreamer1.0-nice

## Purpose of using this:

Used by the webrtcbin for example.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/gstreamer1.0-nice
- Ubuntu: https://packages.ubuntu.com/noble/gstreamer1.0-nice
- Fedora: https://packages.fedoraproject.org/pkgs/libnice/libnice-gstreamer1/
- Arch: https://archlinux.org/packages/extra/x86_64/libnice/
- Gentoo: https://packages.gentoo.org/packages/net-libs/libnice
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=unstable&query=gst-plugins-bad
- openSUSE: https://software.opensuse.org/package/gstreamer1.0-nice
- rhel: https://rhel.pkgs.org/9/epel-x86_64/libnice-gstreamer1-0.1.19-2.el9.x86_64.rpm.html
