### PR TITLE
kompass: 0.4.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4328,7 +4328,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.4.1-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-1`

## kompass

```
* (fix) Fixes TwistStamped callback
* (fix) Updates turtlebot3 recipe
* (chore) Adds missing config imports from kompass core
* (fix) Adds wait time for fetching inputs on acion execution
* (chore) Adds prompt for llms.txt context ingestion
* (chore) Adds minimum version check for sugarcoat to init
* (refactor) Fixes imports from sugarcoat
* (refactor) Removes events module and updates imports from sugarcoat
* Contributors: ahr, mkabtoul
```

## kompass_interfaces

- No changes
