### PR TITLE
mvsim: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6175,7 +6175,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/MRPT/mvsim.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `1.1.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## mvsim

```
* Merge pull request #91 <https://github.com/MRPT/mvsim/issues/91> from MRPT/fix/lidar-3d
  Lidar3D: fix min clip bug; add real intensity color
* Lidar3D: fix min clip bug; add real intensity color
* Contributors: Jose Luis Blanco-Claraco
```
