### PR TITLE
mp2p_icp: 2.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5972,7 +5972,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.6.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-1`

## mp2p_icp

```
* Merge pull request #42 <https://github.com/MOLAorg/mp2p_icp/issues/42> from MOLAorg/feat/filter-remove-several-point-fields
  FilterRemovePointCloudField now accepts multiple fields
* FilterRemovePointCloudField now accepts multiple fields
* Merge pull request #41 <https://github.com/MOLAorg/mp2p_icp/issues/41> from MOLAorg/feat/functor-save-log-file
  Add functor_should_generate_debug_file to override the decision of whether to write .icplog files
* Add functor_should_generate_debug_file to override the decision of whether to write .icplog files
* Merge pull request #40 <https://github.com/MOLAorg/mp2p_icp/issues/40> from MOLAorg/feat/new-clear-remove-field-filters
  Add new filters: FilterClear and FilterRemovePointCloudField
* Add new filters: FilterClear and FilterRemovePointCloudField
* docs: refer to the online pipeline editor
* docs: add missing docs for FilterRenameLayer
* Contributors: Jose Luis Blanco-Claraco
```
