### PR TITLE
rmw_connextdds: 0.11.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9143,7 +9143,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 0.11.5-1
+      version: 0.11.6-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `0.11.6-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.11.5-1`

## rmw_connextdds

```
* fix: remove superflous buildtool_export_depend (backport #206 <https://github.com/ros2/rmw_connextdds/issues/206>) (#209 <https://github.com/ros2/rmw_connextdds/issues/209>)
* Contributors: mergify[bot]
```

## rmw_connextdds_common

```
* fix: remove superflous buildtool_export_depend. (backport #210 <https://github.com/ros2/rmw_connextdds/issues/210>) (#213 <https://github.com/ros2/rmw_connextdds/issues/213>)
* Contributors: mergify[bot]
```

## rti_connext_dds_cmake_module

- No changes
