### PR TITLE
ros2_tracing: 4.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9678,7 +9678,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 4.1.1-1
+      version: 4.1.2-1
     source:
       type: git
       url: https://github.com/ros2/ros2_tracing.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `4.1.2-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.1-1`

## ros2trace

```
* fix setuptools deprecation (backport #189 <https://github.com/ros2/ros2_tracing/issues/189>) (#204 <https://github.com/ros2/ros2_tracing/issues/204>)
* Contributors: mergify[bot]
```

## tracetools

- No changes

## tracetools_launch

```
* fix setuptools deprecation (backport #189 <https://github.com/ros2/ros2_tracing/issues/189>) (#204 <https://github.com/ros2/ros2_tracing/issues/204>)
* Contributors: mergify[bot]
```

## tracetools_read

```
* fix setuptools deprecation (backport #189 <https://github.com/ros2/ros2_tracing/issues/189>) (#204 <https://github.com/ros2/ros2_tracing/issues/204>)
* Contributors: mergify[bot]
```

## tracetools_test

```
* fix setuptools deprecation (backport #189 <https://github.com/ros2/ros2_tracing/issues/189>) (#204 <https://github.com/ros2/ros2_tracing/issues/204>)
* Contributors: mergify[bot]
```

## tracetools_trace

```
* fix setuptools deprecation (backport #189 <https://github.com/ros2/ros2_tracing/issues/189>) (#204 <https://github.com/ros2/ros2_tracing/issues/204>)
* Contributors: mergify[bot]
```
