### PR TITLE
bond_core: 4.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -988,7 +988,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.2-1
+      version: 4.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.1.3-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.2-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* memory safe subscription callback (#108 <https://github.com/ros/bond_core//issues/108>)
* Check the availability of mutex before locking it. (#111 <https://github.com/ros/bond_core//issues/111>)
* Contributors: ChenYing Kuo (CY), ewak
```

## bondpy

- No changes

## smclib

- No changes
