### PR TITLE
sdformat_urdf: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8840,7 +8840,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 2.0.2-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `2.1.0-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-1`

## sdformat_test_files

- No changes

## sdformat_urdf

```
* chore: remove tinyxml2 vendor (#40 <https://github.com/ros/sdformat_urdf/issues/40>)
* Contributors: Daisuke Nishimatsu
```
