### PR TITLE
autoware_core: 1.7.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -953,6 +953,7 @@ repositories:
       packages:
       - autoware_adapi_adaptors
       - autoware_adapi_specs
+      - autoware_awsim_sensor_kit_description
       - autoware_behavior_velocity_planner
       - autoware_behavior_velocity_planner_common
       - autoware_behavior_velocity_stop_line_module
@@ -1003,8 +1004,11 @@ repositories:
       - autoware_point_types
       - autoware_pose_initializer
       - autoware_pyplot
+      - autoware_qos_utils
       - autoware_qp_interface
       - autoware_route_handler
+      - autoware_sample_sensor_kit_description
+      - autoware_sample_vehicle_description
       - autoware_signal_processing
       - autoware_simple_pure_pursuit
       - autoware_stop_filter
@@ -1019,7 +1023,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_core-release.git
-      version: 1.4.0-1
+      version: 1.7.0-2
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_core` to `1.7.0-2`:

- upstream repository: https://github.com/autowarefoundation/autoware_core.git
- release repository: https://github.com/ros2-gbp/autoware_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`

## autoware_adapi_adaptors

- No changes

## autoware_adapi_specs

- No changes

## autoware_awsim_sensor_kit_description

```
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* fix: fix dependency to archived package sample_sensor_kit_launch (#823 <https://github.com/autowarefoundation/autoware_core/issues/823>)
  * fix::fix dependency to archived package sample_sensor_kit_launch
  * fix:using autoware_awsim_sensor_kit_description's imu and camera marxo file instead of using archived packages
  ---------
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu, 心刚
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* fix: fix dependency to archived package sample_sensor_kit_launch (#823 <https://github.com/autowarefoundation/autoware_core/issues/823>)
  * fix::fix dependency to archived package sample_sensor_kit_launch
  * fix:using autoware_awsim_sensor_kit_description's imu and camera marxo file instead of using archived packages
  ---------
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu, 心刚
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* fix: fix dependency to archived package sample_sensor_kit_launch (#823 <https://github.com/autowarefoundation/autoware_core/issues/823>)
  * fix::fix dependency to archived package sample_sensor_kit_launch
  * fix:using autoware_awsim_sensor_kit_description's imu and camera marxo file instead of using archived packages
  ---------
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu, 心刚
```

## autoware_behavior_velocity_planner

- No changes

## autoware_behavior_velocity_planner_common

```
* Merge remote-tracking branch 'origin/main' into humble
* refactor(planning, common): replace lanelet2_extension function (#796 <https://github.com/autowarefoundation/autoware_core/issues/796>)
* Contributors: Mamoru Sobue, Ryohsuke Mitsudome
```

## autoware_behavior_velocity_stop_line_module

- No changes

## autoware_component_interface_specs

- No changes

## autoware_core

- No changes

## autoware_core_api

- No changes

## autoware_core_control

- No changes

## autoware_core_localization

- No changes

## autoware_core_map

- No changes

## autoware_core_perception

- No changes

## autoware_core_planning

- No changes

## autoware_core_sensing

- No changes

## autoware_core_vehicle

- No changes

## autoware_crop_box_filter

- No changes

## autoware_default_adapi

- No changes

## autoware_downsample_filters

- No changes

## autoware_ekf_localizer

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(ekf_localizer): queue pop on ekf localizer (#679 <https://github.com/autowarefoundation/autoware_core/issues/679>)
  * feat: separate max_age and max_queue_size in AgedObjectQueue
  When multiple pose sources (e.g., GNSS + NDT) are active, the queue
  can legitimately grow beyond max_age. Separating these concerns allows:
  1. max_age controls how many times each element is reused
  2. max_queue_size monitors overall queue health without enforcing hard limits
  * fix: warn and pop if queue is exceeded
  * refactor: make less if statement
  * chore: fix unclear comments
  * doc: update schema.json
  * doc: modify comments
  ---------
* Contributors: Motz, Ryohsuke Mitsudome
```

## autoware_euclidean_cluster_object_detector

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: use local default config files instead of autoware_launch (for core) (#832 <https://github.com/autowarefoundation/autoware_core/issues/832>)
  use local default config files instead of autoware_launch
* Contributors: Ryohsuke Mitsudome, Taeseung Sohn
```

## autoware_geography_utils

- No changes

## autoware_global_parameter_loader

- No changes

## autoware_gnss_poser

- No changes

## autoware_ground_filter

- No changes

## autoware_gyro_odometer

- No changes

## autoware_interpolation

```
* Merge remote-tracking branch 'origin/main' into humble
* chore(autoware_motion_utils, autoware_trajectory, autoware_interpolation): add maintainers for packages (#821 <https://github.com/autowarefoundation/autoware_core/issues/821>)
  * add maintainers for autoware_interpolation
  * add maintainers for autoware_motion_utils
  * add maintainers for autoware_trajectory
  ---------
  Co-authored-by: Satoshi OTA <mailto:44889564+satoshi-ota@users.noreply.github.com>
* chore(autoware_interpolation): add a maintainer (#818 <https://github.com/autowarefoundation/autoware_core/issues/818>)
* feat(autoware_interpolation): exposing access to coefficients (#671 <https://github.com/autowarefoundation/autoware_core/issues/671>)
  * Changes to spline_interpolation code to expose access to spline coefficients
  * fixes
  * style(pre-commit): autofix
  * removed unnecessary comments
  * Added includes
  * add includes
  * added comment
  * style(pre-commit): autofix
  * unit-testing for new public functions
  * style(pre-commit): autofix
  * extra unit tests
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Taiki Yamada <mailto:129915538+TaikiYamada4@users.noreply.github.com>
* perf(interpolation): optimize calc_closest_segment_indices (#797 <https://github.com/autowarefoundation/autoware_core/issues/797>)
* Contributors: Arjun Jagdish Ram, Junya Sasaki, Maxime CLEMENT, Ryohsuke Mitsudome, mkquda
```

## autoware_kalman_filter

- No changes

## autoware_lanelet2_map_visualizer

- No changes

## autoware_lanelet2_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(lanelet2_utils): add empty input handler for get_arc_coordinates (#831 <https://github.com/autowarefoundation/autoware_core/issues/831>)
  * add empty input lanelets handler for get_arc_coordinates
  * add test ensure default ArcCoordinates
  ---------
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* docs(lanelet2_utils): add succeeding/preceding lanelet sequence illustration (#830 <https://github.com/autowarefoundation/autoware_core/issues/830>)
  added succeeding/preceding lanelet sequences illustration
* feat(lanelet2_extension): port some lanelet2_extension query functions (2) (#809 <https://github.com/autowarefoundation/autoware_core/issues/809>)
* feat(lanelet2_extension): port remaining lanelet2_extension utilities functions (#760 <https://github.com/autowarefoundation/autoware_core/issues/760>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* feat(lanelet2_extension): port some lanelet2_extension query functions  (#790 <https://github.com/autowarefoundation/autoware_core/issues/790>)
  * port left/right/all_neighbor_lanelets and their tests
  * replace getAllNeighbors* with ported functions
  * add neighbors order description and verify in test
  * add ported functions to API table
  * add example code snippet
  * Remove optional from return value
  Assume one lanelet is always in return value (itself)
  * change usage of left/right_lanelets (always check access)
  * fix README for example code snippet
  * fix cppcheck-differential
  * fix README description
  ---------
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
  Co-authored-by: Mamoru Sobue <mailto:hilo.soblin@gmail.com>
* revert: feat(path_generator): use route_manager to handle route data #725 <https://github.com/autowarefoundation/autoware_core/issues/725> (#801 <https://github.com/autowarefoundation/autoware_core/issues/801>)
  This reverts commit 2403cb5952d33db8e4a403d6cc7b368521d47f5e.
* feat(path_generator): use route_manager to handle route data (#725 <https://github.com/autowarefoundation/autoware_core/issues/725>)
* Contributors: Mitsuhiro Sakamoto, Ryohsuke Mitsudome, Sarun MUKDAPITAK
```

## autoware_localization_util

- No changes

## autoware_map_height_fitter

- No changes

## autoware_map_loader

- No changes

## autoware_map_projection_loader

- No changes

## autoware_marker_utils

- No changes

## autoware_mission_planner

```
* Merge remote-tracking branch 'origin/main' into humble
* refactor(planning): deprecate lanelet_extension geometry conversion function (#834 <https://github.com/autowarefoundation/autoware_core/issues/834>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* refactor(planning, common): replace lanelet2_extension function (#796 <https://github.com/autowarefoundation/autoware_core/issues/796>)
* Contributors: Mamoru Sobue, Ryohsuke Mitsudome
```

## autoware_motion_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(autoware_motion_utils): stop point detection while resampling trajectory (#808 <https://github.com/autowarefoundation/autoware_core/issues/808>)
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Shumpei Wakabayashi <mailto:42209144+shmpwk@users.noreply.github.com>
* chore(autoware_motion_utils, autoware_trajectory, autoware_interpolation): add maintainers for packages (#821 <https://github.com/autowarefoundation/autoware_core/issues/821>)
  * add maintainers for autoware_interpolation
  * add maintainers for autoware_motion_utils
  * add maintainers for autoware_trajectory
  ---------
  Co-authored-by: Satoshi OTA <mailto:44889564+satoshi-ota@users.noreply.github.com>
* chore(autoware_motion_utils): add a maintainer (#820 <https://github.com/autowarefoundation/autoware_core/issues/820>)
* chore(autoware_motion_utils): remove boost (#646 <https://github.com/autowarefoundation/autoware_core/issues/646>)
  remove boost from cmake and package.xml
* Contributors: Felix F Xu, Junya Sasaki, Mehmet Emin BAŞOĞLU, Ryohsuke Mitsudome, mkquda
```

## autoware_motion_velocity_obstacle_stop_module

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(obstacle_stop): add height and size filter (#822 <https://github.com/autowarefoundation/autoware_core/issues/822>)
* feat(motion_velocity_planner): publish debug trajectory for each module (#761 <https://github.com/autowarefoundation/autoware_core/issues/761>)
* docs(obstacle_stop): revise documentation (#793 <https://github.com/autowarefoundation/autoware_core/issues/793>)
* Contributors: Maxime CLEMENT, Ryohsuke Mitsudome, Yuki TAKAGI, Zulfaqar Azmi
```

## autoware_motion_velocity_planner

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: reflect the move of the description packages (#811 <https://github.com/autowarefoundation/autoware_core/issues/811>)
* feat(motion_velocity_planner): publish debug trajectory for each module (#761 <https://github.com/autowarefoundation/autoware_core/issues/761>)
* Contributors: Maxime CLEMENT, Ryohsuke Mitsudome, Takagi, Isamu
```

## autoware_motion_velocity_planner_common

```
* Merge remote-tracking branch 'origin/main' into humble
* feat(motion_velocity_planner): publish debug trajectory for each module (#761 <https://github.com/autowarefoundation/autoware_core/issues/761>)
* Contributors: Maxime CLEMENT, Ryohsuke Mitsudome
```

## autoware_ndt_scan_matcher

- No changes

## autoware_node

- No changes

## autoware_object_recognition_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(object_recognition_utils): init empty tf2::Transform and use the transform (#802 <https://github.com/autowarefoundation/autoware_core/issues/802>)
* feat(object_recognition_utils): add test for public api compile check (#804 <https://github.com/autowarefoundation/autoware_core/issues/804>)
* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome
```

## autoware_objects_of_interest_marker_interface

- No changes

## autoware_osqp_interface

- No changes

## autoware_path_generator

```
* Merge remote-tracking branch 'origin/main' into humble
* refactor(planning): deprecate lanelet_extension geometry conversion function (#834 <https://github.com/autowarefoundation/autoware_core/issues/834>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* chore: reflect the move of the description packages (#811 <https://github.com/autowarefoundation/autoware_core/issues/811>)
* refactor(planning, common): replace lanelet2_extension function (#796 <https://github.com/autowarefoundation/autoware_core/issues/796>)
* revert: feat(path_generator): use route_manager to handle route data #725 <https://github.com/autowarefoundation/autoware_core/issues/725> (#801 <https://github.com/autowarefoundation/autoware_core/issues/801>)
  This reverts commit 2403cb5952d33db8e4a403d6cc7b368521d47f5e.
* feat(path_generator): use route_manager to handle route data (#725 <https://github.com/autowarefoundation/autoware_core/issues/725>)
* Contributors: Mamoru Sobue, Mitsuhiro Sakamoto, Ryohsuke Mitsudome, Takagi, Isamu
```

## autoware_perception_objects_converter

- No changes

## autoware_planning_factor_interface

- No changes

## autoware_planning_test_manager

- No changes

## autoware_planning_topic_converter

- No changes

## autoware_point_types

- No changes

## autoware_pose_initializer

- No changes

## autoware_pyplot

- No changes

## autoware_qos_utils

- No changes

## autoware_qp_interface

- No changes

## autoware_route_handler

```
* Merge remote-tracking branch 'origin/main' into humble
* refactor(planning): deprecate lanelet_extension geometry conversion function (#834 <https://github.com/autowarefoundation/autoware_core/issues/834>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* feat(lanelet2_extension): port some lanelet2_extension query functions (2) (#809 <https://github.com/autowarefoundation/autoware_core/issues/809>)
* feat(lanelet2_extension): port some lanelet2_extension query functions  (#790 <https://github.com/autowarefoundation/autoware_core/issues/790>)
  * port left/right/all_neighbor_lanelets and their tests
  * replace getAllNeighbors* with ported functions
  * add neighbors order description and verify in test
  * add ported functions to API table
  * add example code snippet
  * Remove optional from return value
  Assume one lanelet is always in return value (itself)
  * change usage of left/right_lanelets (always check access)
  * fix README for example code snippet
  * fix cppcheck-differential
  * fix README description
  ---------
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
  Co-authored-by: Mamoru Sobue <mailto:hilo.soblin@gmail.com>
* refactor(planning, common): replace lanelet2_extension function (#796 <https://github.com/autowarefoundation/autoware_core/issues/796>)
* Contributors: Mamoru Sobue, Ryohsuke Mitsudome, Sarun MUKDAPITAK
```

## autoware_sample_sensor_kit_description

```
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu
```

## autoware_sample_vehicle_description

```
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu
* chore: match all package versions and remove old CHANGELOG.rst
* Merge remote-tracking branch 'origin/main' into humble
* feat: move sample description packages (#799 <https://github.com/autowarefoundation/autoware_core/issues/799>)
* Contributors: Ryohsuke Mitsudome, Takagi, Isamu
```

## autoware_signal_processing

- No changes

## autoware_simple_pure_pursuit

- No changes

## autoware_stop_filter

- No changes

## autoware_test_node

- No changes

## autoware_test_utils

```
* Merge remote-tracking branch 'origin/main' into humble
* chore: reflect the move of the description packages (#811 <https://github.com/autowarefoundation/autoware_core/issues/811>)
* revert: feat(path_generator): use route_manager to handle route data #725 <https://github.com/autowarefoundation/autoware_core/issues/725> (#801 <https://github.com/autowarefoundation/autoware_core/issues/801>)
  This reverts commit 2403cb5952d33db8e4a403d6cc7b368521d47f5e.
* feat(path_generator): use route_manager to handle route data (#725 <https://github.com/autowarefoundation/autoware_core/issues/725>)
* Contributors: Mitsuhiro Sakamoto, Ryohsuke Mitsudome, Takagi, Isamu
```

## autoware_testing

- No changes

## autoware_trajectory

```
* Merge remote-tracking branch 'origin/main' into humble
* refactor(planning): deprecate lanelet_extension geometry conversion function (#834 <https://github.com/autowarefoundation/autoware_core/issues/834>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* chore(autoware_motion_utils, autoware_trajectory, autoware_interpolation): add maintainers for packages (#821 <https://github.com/autowarefoundation/autoware_core/issues/821>)
  * add maintainers for autoware_interpolation
  * add maintainers for autoware_motion_utils
  * add maintainers for autoware_trajectory
  ---------
  Co-authored-by: Satoshi OTA <mailto:44889564+satoshi-ota@users.noreply.github.com>
* chore(autoware_trajectory): add a maintainer (#819 <https://github.com/autowarefoundation/autoware_core/issues/819>)
* docs(autoware_trajectory): fix anker link for pre-commit (#816 <https://github.com/autowarefoundation/autoware_core/issues/816>)
* fix(trajectory): fix potential undefined behavior in closest() (#815 <https://github.com/autowarefoundation/autoware_core/issues/815>)
  Remove premature dereference of std::optional before checking if it
  has a value. The original code dereferenced the result of
  closest_with_constraint() before assigning to s, which could cause
  undefined behavior if the function returns std::nullopt.
  Detected by Facebook Infer static analyzer (OPTIONAL_EMPTY_ACCESS).
  Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>
* fix(trajectory): add at least one prev/next lanelet for generating reference_path (#810 <https://github.com/autowarefoundation/autoware_core/issues/810>)
* feat(trajectory): add function to clamp InterpolatedArray to maximum value (#791 <https://github.com/autowarefoundation/autoware_core/issues/791>)
* Contributors: Junya Sasaki, Mamoru Sobue, Mitsuhiro Sakamoto, Ryohsuke Mitsudome, Ryuta Kambe, Takagi, Isamu, mkquda
```

## autoware_twist2accel

- No changes

## autoware_vehicle_info_utils

- No changes

## autoware_vehicle_velocity_converter

- No changes

## autoware_velocity_smoother

```
* Merge remote-tracking branch 'origin/main' into humble
* fix(velocity_smoother): remove dead store in jerk_filtered_smoother (#814 <https://github.com/autowarefoundation/autoware_core/issues/814>)
  Remove unnecessary increment of constr_idx after the last constraint
  setup. The variable is never read after this point, making it a dead store.
  Detected by Facebook Infer static analyzer (DEAD_STORE).
  Co-authored-by: Claude Opus 4.5 <mailto:noreply@anthropic.com>
* Contributors: Ryohsuke Mitsudome, Ryuta Kambe
```
