### PR TITLE
[openembedded] clang: moved from meta-clang to openembedded-core

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -590,7 +590,7 @@ clang:
   fedora: [clang]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  openembedded: [clang@meta-clang]
+  openembedded: [clang@openembedded-core]
   rhel:
     '*': [clang]
     '7': null
@@ -603,7 +603,7 @@ clang-format:
   freebsd: [llvm]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  openembedded: [clang@meta-clang]
+  openembedded: [clang@openembedded-core]
   opensuse: [clang]
   osx:
     homebrew:
@@ -620,7 +620,7 @@ clang-tidy:
   freebsd: [llvm]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  openembedded: [clang@meta-clang]
+  openembedded: [clang@openembedded-core]
   opensuse: [clang]
   rhel:
     '*': [clang-tools-extra]
@@ -634,6 +634,7 @@ clangd:
   fedora: [clang-tools-extra]
   gentoo: [sys-devel/clang]
   nixos: [clang]
+  openembedded: [clang@openembedded-core]
   opensuse: [clang]
   rhel: [clang-tools-extra]
   ubuntu: [clangd]
@@ -3444,7 +3445,7 @@ libclang-dev:
   fedora: [clang-devel]
   gentoo: [sys-devel/clang]
   nixos: [clang]
-  openembedded: [clang@meta-clang]
+  openembedded: [clang@openembedded-core]
   rhel: [clang-devel]
   ubuntu: [libclang-dev]
 libcoin60-dev:


### PR DESCRIPTION
clang moved a while ago from meta-clang [1] to openembedded-core [2]

* clang-format is a package of the clang recipe [3]
* same for clang-tidy
* same for libclang
* clangd is a default enable packageconfig of clang [4]

1. https://layers.openembedded.org/layerindex/branch/master/layer/meta-clang/
2. https://layers.openembedded.org/layerindex/recipe/448649/
3. https://git.openembedded.org/openembedded-core/tree/meta/recipes-devtools/clang/clang_git.bb?h=master#n116
4. https://git.openembedded.org/openembedded-core/tree/meta/recipes-devtools/clang/clang_git.bb?h=master#n29

@robwoolley Could you verify please?
  * `libclang-dev` and `clangd` seems to be not used in meta-ros.  Should I remove the entry in this rosdistro?
  * It could solve this in meta-ros@rolling:

    ```
    conf/ros-distro/include/rolling/ros-distro.inc:ROS_UNRESOLVED_DEP-clang-format = "clang"
    conf/ros-distro/include/rolling/ros-distro.inc:ROS_UNRESOLVED_DEP-clang-format-native = "clang-native"
    conf/ros-distro/include/rolling/ros-distro.inc:ROS_UNRESOLVED_DEP-clang-tidy = "clang"
    conf/ros-distro/include/rolling/ros-distro.inc:ROS_UNRESOLVED_DEP-clang-tidy-native = "clang-native"
   ```
