### PR TITLE
add camera_aravis2 to Kilted

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -971,6 +971,16 @@ repositories:
       url: https://github.com/nobleo/boost_sml_vendor.git
       version: main
     status: maintained
+  camera_aravis2:
+    doc:
+      type: git
+      url: https://github.com/FraunhoferIOSB/camera_aravis2.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/FraunhoferIOSB/camera_aravis2.git
+      version: main
+    status: maintained
   camera_ros:
     doc:
       type: git


### PR DESCRIPTION
Please add the following package to kilted.

## Package name:

camera_aravis2

## Package Upstream Source:

[camera_aravis2](https://github.com/FraunhoferIOSB/camera_aravis2)