### PR TITLE
twist_mux: 4.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9903,7 +9903,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/twist_mux-release.git
-      version: 4.4.0-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/ros-teleop/twist_mux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twist_mux` to `4.5.0-1`:

- upstream repository: https://github.com/ros-teleop/twist_mux.git
- release repository: https://github.com/ros2-gbp/twist_mux-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.4.0-1`

## twist_mux

```
* Fix regression: do not automatically declare "use_stamped" as it can cause an exception to be raised. (#61 <https://github.com/ros-teleop/twist_mux/issues/61>)
* Add priority validation warnings in TopicHandle (#64 <https://github.com/ros-teleop/twist_mux/issues/64>)
* Set twist_marker/use_stamped to default true, to match twist_mux (#55 <https://github.com/ros-teleop/twist_mux/issues/55>)
* Contributors: Alexander Entinger, Martin Pecka, Tom Wallis
```
