### PR TITLE
dbw_ros: 2.3.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1961,7 +1961,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_ros-release.git
-      version: 2.3.10-1
+      version: 2.3.11-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dbw_ros` to `2.3.11-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dbw_ros.git
- release repository: https://github.com/DataspeedInc-release/dbw_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.10-1`

## ds_dbw

```
* Use curl instead of bash to download and run scripts
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```

## ds_dbw_can

```
* Bump firmware versions to match 2026/02/19 release package
* Respawn CAN node on crash
* Add internal steering offset enumeration
* Add gear manual number control
* Add door lock statuses to MiscReport
* Add door/trunk open/close control to MiscCmd
* Add support for hazard light control
* Add 2nd and 3rd row seat-belt statuses
* Add Ford P708 (2023+ F-250 to F-600)
* Add BrakeReport BrakeAvailablePartialInf signal
* Add gear ready to calibrate status
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```

## ds_dbw_joystick_demo

```
* Add support for larger positive ACC brake acceleration commands
* Contributors: Kevin Hallenbeck
```

## ds_dbw_msgs

```
* Add internal steering offset enumeration
* Add gear manual number control
* Add door lock statuses to MiscReport
* Add door/trunk open/close control to MiscCmd
* Add support for larger positive ACC brake acceleration commands
* Add 2nd and 3rd row seat-belt statuses
* Add BrakeReport BrakeAvailablePartialInf signal
* Add gear ready to calibrate status
* Contributors: Gabriel Oetjens, Kevin Hallenbeck
```
