### PR TITLE
rcl_logging_syslog: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6503,6 +6503,15 @@ repositories:
       version: master
     status: maintained
   rcl_logging_syslog:
+    doc:
+      type: git
+      url: https://github.com/fujitatomoya/rcl_logging_syslog.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rcl_logging_syslog-release.git
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/fujitatomoya/rcl_logging_syslog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging_syslog` to `0.1.2-1`:

- upstream repository: https://github.com/fujitatomoya/rcl_logging_syslog.git
- release repository: https://github.com/ros2-gbp/rcl_logging_syslog-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rcl_logging_syslog

```
* update doc with rcl_logging_implementation support. (#138 <https://github.com/fujitatomoya/rcl_logging_syslog/issues/138>)
  * update doc with rcl_logging_implementation support.
  * typo fixes and address review comments.
  ---------
* Upgrade github action/run-gemini-cli workflows. (#136 <https://github.com/fujitatomoya/rcl_logging_syslog/issues/136>)
* enable actions/stale to close issues and PRs. (#131 <https://github.com/fujitatomoya/rcl_logging_syslog/issues/131>)
  * enable actions/stale to close issues and PRs.
  * address Copilot review comments.
  ---------
* ROSCon 2025 Singapore Slide Deck. (#125 <https://github.com/fujitatomoya/rcl_logging_syslog/issues/125>)
* add gemini-cli github actions. (#118 <https://github.com/fujitatomoya/rcl_logging_syslog/issues/118>)
* Contributors: Tomoya Fujita
```
