### PR TITLE
rosidl_rust: 0.4.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9340,7 +9340,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_rust-release.git
-      version: 0.4.10-1
+      version: 0.4.11-1
     source:
       type: git
       url: https://github.com/ros2-rust/rosidl_rust.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_rust` to `0.4.11-1`:

- upstream repository: https://github.com/ros2-rust/rosidl_rust.git
- release repository: https://github.com/ros2-gbp/rosidl_rust-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.10-1`

## rosidl_generator_rs

```
* fix: do not monkey-patch _removesuffix into str (#18 <https://github.com/ros2-rust/rosidl_rust/issues/18>)
* fix: add str.removesuffix() backport for Python < 3.9 (RHEL 8) (#17 <https://github.com/ros2-rust/rosidl_rust/issues/17>)
* feat: relative Module Path Resolution (#12 <https://github.com/ros2-rust/rosidl_rust/issues/12>)
  * Changed all generated code to use relative symbols instead of crate:: ones.
  Reworked the rosidl_generator_rs slightly to be a bit simpler.
  Separate actual templates from the files that reuse them.
  * WIP For adding documentation to all structs, members, and constants generated from idl's.
  * Clean up all the surfaced warnings from generated code.
* Contributors: Esteve Fernandez, Sam Privett
```
