### PR TITLE
ur_client_library: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11655,7 +11655,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.6.1-2
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.7.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.1-2`

## ur_client_library

```
* Add more RobotAPI commands to PolyScope X Dashboard Client (#435 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/435>)
* [RTDE client] Test reconnect (#433 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/433>)
* [TCPServer] Close all filedescriptors on shutdown (#432 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/432>)
* [primary interface] More robot messages (#429 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/429>)
* Fix instruction executor idle (#424 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/424>)
* [primary interface] Fix parsing of primary messages (#426 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/426>)
* [primary interface] Add KeyMessage parsing (#428 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/428>)
* Add test for VersionMessage (#427 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/427>)
* Add two new RTDE fields (#420 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/420>)
  Add fields
  - target_gravity
  - target_base_acceleration
* Allow updating robot gravity (#415 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/415>)
* Do not disconnect dashboard_client on read timeout (#414 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/414>)
* Added support for std::vector strings in UrDriver (#408 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/408>)
* Contributors: AdamPettinger, Felix Exner, Pablo David Aranda Rodriguez, dependabot[bot]
```
