### PR TITLE
gtsam2mrpt_serial: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3810,6 +3810,11 @@ repositories:
       type: git
       url: https://github.com/MRPT/gtsam2mrpt_serial.git
       version: develop
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/gtsam2mrpt_serial-release.git
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/MRPT/gtsam2mrpt_serial.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam2mrpt_serial` to `0.2.0-1`:

- upstream repository: https://github.com/MRPT/gtsam2mrpt_serial.git
- release repository: https://github.com/ros2-gbp/gtsam2mrpt_serial-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gtsam2mrpt_serial

```
* Modernize and fix style
* fix build in new gtsam
* Add devcontainer for Rolling
* Add build farm badges
* Update README.md
* clarify license
* build depend: fix missing ones
* reorganize files for proper finding headers downstream
* Update as a colcon package
* fix newer gtsam version API
* Add .so version numbers
* tighter tests
* more correct cmake export
* Update README.md
* doc images
* more tests and profiling
* refactor unit tests
* First working version (requires mod gtsam)
* Progress with noise models
* Update README.md
* Delete azure-pipelines.yml
* Update README.md
* Serialization of basic values
* Update cmake.yml
* Create cmake.yml
* depends
* initial commit with basic structure
* Initial commit
* Contributors: Jose Luis Blanco-Claraco
```
