### PR TITLE
gtsam2mrpt_serial: 0.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2749,6 +2749,21 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: developed
+  gtsam2mrpt_serial:
+    doc:
+      type: git
+      url: https://github.com/MRPT/gtsam2mrpt_serial.git
+      version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/gtsam2mrpt_serial-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/MRPT/gtsam2mrpt_serial.git
+      version: develop
+    status: developed
   gz_cmake_vendor:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gtsam2mrpt_serial` to `0.2.0-1`:

- upstream repository: https://github.com/MRPT/gtsam2mrpt_serial.git
- release repository: https://github.com/ros2-gbp/gtsam2mrpt_serial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## gtsam2mrpt_serial

```
* Modernize and fix style
* fix build in new gtsam
* Add devcontainer for Rolling
* Add build farm badges
* Update README.md
* clarify license
* build depend: fix missing ones
* reorganize files for proper finding headers downstream
* Update as a colcon package
* fix newer gtsam version API
* Add .so version numbers
* tighter tests
* more correct cmake export
* Update README.md
* doc images
* more tests and profiling
* refactor unit tests
* First working version (requires mod gtsam)
* Progress with noise models
* Update README.md
* Delete azure-pipelines.yml
* Update README.md
* Serialization of basic values
* Update cmake.yml
* Create cmake.yml
* depends
* initial commit with basic structure
* Initial commit
* Contributors: Jose Luis Blanco-Claraco
```
