### PR TITLE
crx_kinematics: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1474,6 +1474,11 @@ repositories:
       type: git
       url: https://github.com/danielcranston/crx_kinematics.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/crx_kinematics-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/danielcranston/crx_kinematics.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crx_kinematics` to `1.0.0-1`:

- upstream repository: https://github.com/danielcranston/crx_kinematics.git
- release repository: https://github.com/ros2-gbp/crx_kinematics-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## crx_kinematics

```
* Implement FK/IK for the Fanuc CRX series cobots, following closely Geometric Approach for Inverse Kinematics of the FANUC CRX Collaborative Robot by Abbes and Poisson (2024) <https://hal.science/hal-04915402v1/file/IFToMM2024-02-20.pdf>.
* Add support for all robots in the CRX series
* Add MoveIt 2 Kinematics plugin
* Add tests for FK/IK and MoveIt Kinematics plugin
* Add CI that builds and tests for Humble, Jazzy, Kilted and Rolling
* Contributors: Daniel Cranston
```
