### PR TITLE
ros2_snapshot release to jazzy, kilted, and rolling

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8761,6 +8761,21 @@ repositories:
       url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
       version: main
     status: maintained
+  ros2_snapshot:
+    doc:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_snapshot-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: jazzy
+    status: developed
   ros2_socketcan:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7525,6 +7525,11 @@ repositories:
       type: git
       url: https://github.com/cnurobotics/ros2_snapshot.git
       version: kilted
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_snapshot-release.git
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/cnurobotics/ros2_snapshot.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7481,6 +7481,21 @@ repositories:
       url: https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
       version: main
     status: maintained
+  ros2_snapshot:
+    doc:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_snapshot-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/cnurobotics/ros2_snapshot.git
+      version: main
+    status: developed
   ros2_socketcan:
     doc:
       type: git


### PR DESCRIPTION

# Initial release of package to jazzy, kilted, and rolling

ros2_snapshot

* upstream repository:  https://github.com/cnurobotics/ros2_snapshot.git
* release repository: https://github.com/ros2-gbp/ros2_snapshot-release.git
* distro file:  `jazzy/distribution.yaml`, `kilted/distribution.yaml`, `rolling/distribution.yaml`
* bloom version: 0.13.0
* previous version for package: null


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
