### PR TITLE
cloudini: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1496,6 +1496,25 @@ repositories:
       url: https://github.com/carologistics/clips_vendor.git
       version: main
     status: maintained
+  cloudini:
+    doc:
+      type: git
+      url: https://github.com/facontidavide/cloudini.git
+      version: main
+    release:
+      packages:
+      - cloudini_lib
+      - cloudini_ros
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/facontidavide/cloudini-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/facontidavide/cloudini.git
+      version: main
+    status: maintained
   cm_executors:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `1.0.0-1`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## cloudini_lib

```
* minor changes
* feat: add bag directory support and metadata.yaml generation to rosbag converter
  The converter now accepts ROS2 bag directories as input (in addition to
  bare .mcap files), auto-detects sibling metadata.yaml, and generates a
  transformed metadata.yaml alongside the output with updated topic types
  and file references. Output defaults to a new sibling directory to
  prevent accidental overwrites of the original bag.
  Co-Authored-By: Claude Opus 4.6 <mailto:noreply@anthropic.com>
* feat: add single-threaded compression mode to PointcloudEncoder
  Add use_threads field to EncodingInfo (defaults to true). When false,
  LZ4/ZSTD compression runs inline in the calling thread instead of
  spawning a worker thread. Useful for simpler deployments, debugging,
  and environments where threading overhead isn't worth the pipelining
  benefit.
  No wire format changes — the field is runtime-only and not serialized.
* Fixed cmake issues and added some improvements (#55 <https://github.com/facontidavide/cloudini/issues/55>)
* fix: harden encoder/decoder against UB, data races, and corrupted input (#57 <https://github.com/facontidavide/cloudini/issues/57>)
  * fix: harden encoder/decoder against UB, data races, and corrupted input
  Address issues found during code review:
  - Fix decodeVarint shift UB: check overflow before shift operation
  - Fix decodeVarint underflow: guard against uval==0 on corrupted data
  - Fix worker thread deadlock: detect dead worker on subsequent encode()
  - Fix WASM encode: avoid extra allocation by encoding directly when buffer fits
  - Clean up waitForCompressionComplete: only set worker_failed_ in error path
  - Optimize encode(BufferView&): use header_.size() instead of YAML reserialization
  - Improve readability and error messages in DecodeHeader/MaxSerializedFieldSize
  - Add explicit <cstring> include in encoding_utils.hpp
  - Fix pre-existing FloatLossy test bug: use float instead of double for kResolution
  - Re-enable previously commented-out tests
  * fix: additional hardening for decoder bounds checks and encoder thread safety
  - Add per-point bounds check in decodeChunk to replace per-field checks in
  fixed-size decoders (FieldDecoderCopy, FieldDecoderFloat_XOR), eliminating
  12-14% decode overhead while maintaining safety
  - Keep per-field checks for variable-size decoders (Float_Lossy, FloatN_Lossy)
  where overhead is negligible relative to varint decoding
  - Fix encoder deadlock on re-use after worker thread failure by joining dead
  thread and re-spawning; protect shared state resets with mutex
  - Tighten decodeVarint overflow check from shift>=64 to shift>=63
  - Derive point count from actual data size in ROS conversion instead of
  trusting metadata width*height to prevent over-allocation DoS
  * fix: remove non-existent apt package from Jazzy CI workflow
  python3-ament-package does not exist on Ubuntu 24.04. The setup-ros
  action and action-ros-ci already handle installing colcon and ament
  dependencies, matching the working Humble CI workflow.
  * fix: install ros-humble-ament-cmake-test for test runner
  * revert some changes
  ---------
  Co-authored-by: Claude Opus 4.6 <mailto:noreply@anthropic.com>
* Need to add these constructors for emscripten build to work on ubuntu 24 (#54 <https://github.com/facontidavide/cloudini/issues/54>)
  * Need to add these constructors for emscripten build to work
  * add default ctors and default values
  ---------
* Contributors: Alireza Moayyedi, Davide Faconti, tomdeblauwe
```

## cloudini_ros

```
* feat: make topic_converter composable for component container usage
  Build topic_converter as a shared component library with
  rclcpp_components, while keeping the standalone executable via
  EXECUTABLE directive. Intra-process comms moved into constructor
  so it works in both standalone and component container modes.
* feat: add convenience API for compressing PointCloud2 directly (#58 <https://github.com/facontidavide/cloudini/issues/58>)
  Add SerializeCompressedPointCloud2() and ConvertToRosPointCloud2() to allow
  users to compress sensor_msgs::msg::PointCloud2 without the topic_converter
  node. Includes test_direct_publisher example node and CLAUDE.md documentation.
  Also removes redundant PCL_INCLUDE_DIRS from test_cloudini_subscriber target.
* Fixed cmake issues and added some improvements (#55 <https://github.com/facontidavide/cloudini/issues/55>)
* fix resolution profile not applied in ros_topic_converter (#49 <https://github.com/facontidavide/cloudini/issues/49>)
* Contributors: Alireza Moayyedi, Davide Faconti, ペンギンの何か
```
