### PR TITLE
sick_safevisionary_ros2: 1.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9002,7 +9002,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
-      version: 1.0.3-3
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safevisionary_ros2` to `1.0.4-1`:

- upstream repository: https://github.com/SICKAG/sick_safevisionary_ros2.git
- release repository: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `1.0.3-3`

## sick_safevisionary_driver

```
* Removed unneeded boost dependencies
* Updated documentation and package meta data
* Updated pre-commit config
* Contributors: Christian Eichmann, Mikael Arguedas
```

## sick_safevisionary_interfaces

```
* Updated maintainer information
* Contributors: Christian Eichmann
```

## sick_safevisionary_tests

```
* Updated maintainer information
* Contributors: Christian Eichmann
```
