### PR TITLE
motion_capture_tracking: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4503,7 +4503,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
-      version: 1.0.3-2
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motion_capture_tracking` to `1.0.6-1`:

- upstream repository: https://github.com/IMRCLab/motion_capture_tracking.git
- release repository: https://github.com/ros2-gbp/motion_capture_tracking-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.3-2`

## motion_capture_tracking

```
* disable optitrack_closed_source by default
* update librigidbodytracker (hybrid tracking)
* update libmotioncapture to 1.0a4
* add support for custom frame_id's
* Replace ament_target_dependencies with target_link_libraries
* Fix poses message not having a timestamp
* Contributors: Alejandro Hernandez Cordero, John TGZ, Wolfgang Hönig
```

## motion_capture_tracking_interfaces

- No changes
