### PR TITLE
generate_parameter_library: 0.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3507,7 +3507,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.6.0-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.7.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.0-1`

## generate_parameter_library

```
* Use a temporary build directory for Python module output (#303 <https://github.com/PickNikRobotics/generate_parameter_library/issues/303>)
* Move linters to pre-commit (#298 <https://github.com/PickNikRobotics/generate_parameter_library/issues/298>)
* Contributors: Błażej Sowa, Christoph Fröhlich
```

## generate_parameter_library_py

```
* Deprecate parameter_traits package and header file (#297 <https://github.com/PickNikRobotics/generate_parameter_library/issues/297>)
* Move linters to pre-commit (#298 <https://github.com/PickNikRobotics/generate_parameter_library/issues/298>)
* Contributors: Christoph Fröhlich
```

## parameter_traits

```
* Fix pre-commit workflow (#310 <https://github.com/PickNikRobotics/generate_parameter_library/issues/310>)
* Deprecate parameter_traits package and header file (#297 <https://github.com/PickNikRobotics/generate_parameter_library/issues/297>)
* Move linters to pre-commit (#298 <https://github.com/PickNikRobotics/generate_parameter_library/issues/298>)
* Contributors: Christoph Fröhlich
```
