### PR TITLE
rmf_task: 2.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6935,7 +6935,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.7.0-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.9.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.7.0-1`

## rmf_task

```
* Customizable weights for task assignment cost (#129 <https://github.com/open-rmf/rmf_task/issues/129>)
* Contributors: kj
```

## rmf_task_sequence

```
* Fix nullopt dereference in GoToPlace goal selection (#130 <https://github.com/open-rmf/rmf_task/issues/130>)
* Introduce start_at_departure option for go_to_place event (#128 <https://github.com/open-rmf/rmf_task/issues/128>)
* Contributors: kj
```
