### PR TITLE
rmf_ros2: 2.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6898,7 +6898,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.11.1-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_ros2` to `2.12.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_ros2.git
- release repository: https://github.com/ros2-gbp/rmf_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.11.1-1`

## rmf_charging_schedule

- No changes

## rmf_fleet_adapter

```
* Fix dispatch command acknowledgment message publishing (#508 <https://github.com/open-rmf/rmf_ros2/issues/508>)
* Publish WaitForCharge phase completed (#502 <https://github.com/open-rmf/rmf_ros2/issues/502>)
* Choose nearest parking spot for "park" idle behavior (#495 <https://github.com/open-rmf/rmf_ros2/issues/495>)
* enable path replanning during emergency pull over (#500 <https://github.com/open-rmf/rmf_ros2/issues/500>)
* Fix parking spot selection for one-way lanes (#499 <https://github.com/open-rmf/rmf_ros2/issues/499>)
* Customizable weights for task assignment cost (#466 <https://github.com/open-rmf/rmf_ros2/issues/466>)
* Accurate GoToPlace task update and reservation fixes (#498 <https://github.com/open-rmf/rmf_ros2/issues/498>)
* Attempt to fix the spam generated by false completion of a task during detours in GoToPlace (#491 <https://github.com/open-rmf/rmf_ros2/issues/491>)
* Fix double coordinate transformation of robot position during action execution (#494 <https://github.com/open-rmf/rmf_ros2/issues/494>)
* Removed /task_summaries publishers from rmf_fleet_adapter (#487 <https://github.com/open-rmf/rmf_ros2/issues/487>)
* Makes sure that the reservation system always assigns nearest goal during Emergency Pullover (#484 <https://github.com/open-rmf/rmf_ros2/issues/484>)
* Remove cancel method from ReservationManager (#483 <https://github.com/open-rmf/rmf_ros2/issues/483>)
* Fix race condition crash in estimate_path_traveling (#486 <https://github.com/open-rmf/rmf_ros2/issues/486>)
* add return (#480 <https://github.com/open-rmf/rmf_ros2/issues/480>)
* Implement rule of five for on_error_notification (#476 <https://github.com/open-rmf/rmf_ros2/issues/476>)
* Fix tool_power_drain bug (#474 <https://github.com/open-rmf/rmf_ros2/issues/474>)
* feature/Add start_at_departure flag for GoToPlace (#467 <https://github.com/open-rmf/rmf_ros2/issues/467>)
* handling of task_api_requests on active task during emergency pullover (#465 <https://github.com/open-rmf/rmf_ros2/issues/465>)
* Retreat to charger if there will not be enough charge for the next task (#423 <https://github.com/open-rmf/rmf_ros2/issues/423>)
* Fix mutex group erasure bug in _retain_mutex_groups (#473 <https://github.com/open-rmf/rmf_ros2/issues/473>)
* Fix interrupter for compliant path planning (#470 <https://github.com/open-rmf/rmf_ros2/issues/470>)
* Remove potential data races (#464 <https://github.com/open-rmf/rmf_ros2/issues/464>)
* Fix recharge state of charge validation in set_task_planner_params (#469 <https://github.com/open-rmf/rmf_ros2/issues/469>)
* Added RCL logging for BroadcastServer (#458 <https://github.com/open-rmf/rmf_ros2/issues/458>)
* Clear planner inner cache planner cache size check timer (#454 <https://github.com/open-rmf/rmf_ros2/issues/454>)
* Contributors: Adharsh Venkatachalam, Arjo Chakravarty, Cheng-Wei Chen, Grey, Leong Teck, Saurabh Kamat, Xiyu, cheriehu, cwrx777, kj, yadunund, yutaroha
```

## rmf_fleet_adapter_python

```
* Removed /task_summaries publishers from rmf_fleet_adapter (#487 <https://github.com/open-rmf/rmf_ros2/issues/487>)
* Contributors: cheriehu
```

## rmf_reservation_node

```
* Accurate GoToPlace task update and reservation fixes (#498 <https://github.com/open-rmf/rmf_ros2/issues/498>)
* Makes sure that the reservation system always assigns nearest goal during Emergency Pullover (#484 <https://github.com/open-rmf/rmf_ros2/issues/484>)
* Contributors: Arjo Chakravarty, Xiyu
```

## rmf_task_ros2

```
* Removed /task_summaries publishers from rmf_fleet_adapter (#487 <https://github.com/open-rmf/rmf_ros2/issues/487>)
* Fix indefinite growth of active_dispatch_states (#468 <https://github.com/open-rmf/rmf_ros2/issues/468>)
* Contributors: cheriehu, kj
```

## rmf_traffic_ros2

```
* Correct early cull of negotiations (#478 <https://github.com/open-rmf/rmf_ros2/issues/478>)
* Contributors: kj
```

## rmf_websocket

```
* Added RCL logging for BroadcastServer (#458 <https://github.com/open-rmf/rmf_ros2/issues/458>)
* Fix BroadcastServer shutdown errors (#457 <https://github.com/open-rmf/rmf_ros2/issues/457>)
* Contributors: Saurabh Kamat
```
