### PR TITLE
rmf_demos: 2.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.8.1-2
+      version: 2.8.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `2.8.2-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.8.1-2`

## rmf_demos

```
* Add task_assignment_strategy to fleet config (#332 <https://github.com/open-rmf/rmf_demos/issues/332>)
* Contributors: kj
```

## rmf_demos_assets

- No changes

## rmf_demos_bridges

- No changes

## rmf_demos_fleet_adapter

- No changes

## rmf_demos_gz

- No changes

## rmf_demos_maps

- No changes

## rmf_demos_tasks

- No changes
