### PR TITLE
boost_sml_vendor: 1.1.13-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -965,7 +965,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/boost_sml_vendor-release.git
-      version: 1.1.11-2
+      version: 1.1.13-1
     source:
       type: git
       url: https://github.com/nobleo/boost_sml_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml_vendor` to `1.1.13-1`:

- upstream repository: https://github.com/nobleo/boost_sml_vendor.git
- release repository: https://github.com/ros2-gbp/boost_sml_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.11-2`
