### PR TITLE
boost_sml_vendor: 1.1.13-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1024,7 +1024,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/boost_sml_vendor-release.git
-      version: 1.1.12-1
+      version: 1.1.13-1
     source:
       type: git
       url: https://github.com/nobleo/boost_sml_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `boost_sml_vendor` to `1.1.13-1`:

- upstream repository: https://github.com/nobleo/boost_sml_vendor.git
- release repository: https://github.com/ros2-gbp/boost_sml_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.12-1`
