### PR TITLE
rcutils: 7.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6626,7 +6626,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.0.5-1
+      version: 7.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.0.6-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.0.5-1`

## rcutils

```
* Add {short_file_name} as log format option (#541 <https://github.com/ros2/rcutils/issues/541>)
* Add base64 encoding and decoding functions with tests (#533 <https://github.com/ros2/rcutils/issues/533>)
* remove default: so that compiler can detect the missing case. (#534 <https://github.com/ros2/rcutils/issues/534>)
* Contributors: Barry Xu, Tomoya Fujita, Tony Najjar
```
