### PR TITLE
Fix libjson-c-dev entry for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4660,7 +4660,7 @@ libjson-c-dev:
   debian: [libjson-c-dev]
   fedora: [json-c-devel]
   gentoo: ['dev-libs/json-c:0']
-  nixos: [json-c]
+  nixos: [json_c]
   openembedded: [jsoncpp@meta-oe]
   opensuse: [libjson-c-devel]
   rhel: [json-c-devel]


### PR DESCRIPTION
The attribute name uses underscore instead of hyphen. See https://search.nixos.org/packages?channel=unstable&query=json_c&show=json_c.
