### PR TITLE
rcutils: 6.9.10-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6713,7 +6713,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.9-1
+      version: 6.9.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.10-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.9.9-1`

## rcutils

```
* Add {short_file_name} as log format option (#541 <https://github.com/ros2/rcutils/issues/541>) (#543 <https://github.com/ros2/rcutils/issues/543>)
* Contributors: mergify[bot]
```
