### PR TITLE
rosidl_defaults: 1.7.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8048,7 +8048,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.7.1-2
+      version: 1.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.7.2-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.7.1-2`

## rosidl_default_generators

```
* fix cmake deprecation (#31 <https://github.com/ros2/rosidl_defaults/issues/31>) (#32 <https://github.com/ros2/rosidl_defaults/issues/32>)
* Contributors: mergify[bot]
```

## rosidl_default_runtime

```
* fix cmake deprecation (#31 <https://github.com/ros2/rosidl_defaults/issues/31>) (#32 <https://github.com/ros2/rosidl_defaults/issues/32>)
* Contributors: mergify[bot]
```
