### PR TITLE
mola_imu_preintegration: 1.15.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5303,7 +5303,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.14.1-1
+      version: 1.15.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.15.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.14.1-1`

## mola_imu_preintegration

```
* Merge pull request #1 <https://github.com/MOLAorg/mola_imu_preintegration/issues/1> from MOLAorg/feat/transform-without-w
  ImuTransformer: work on acceleration even without omega
* BUG FIX: Wrong copy-paste sign error in centripetal acceleration
* ImuTransformer: work on acceleration even without omega
* Contributors: Jose Luis Blanco-Claraco
```
