### PR TITLE
rviz: 15.1.17-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8757,7 +8757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.16-1
+      version: 15.1.17-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.17-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.16-1`

## rviz2

- No changes

## rviz_common

```
* Fix setHidden regression in PropertyTreeWidget (#1667 <https://github.com/ros2/rviz/issues/1667>)
* Add topic name filtering when adding new visualizations (#1662 <https://github.com/ros2/rviz/issues/1662>)
* use QPointer in QTimer::singleShot to prevent use-after-free (#1657 <https://github.com/ros2/rviz/issues/1657>)
* Contributors: Mateusz Żak, Matteo Princisgh, t0k0shi
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
