### PR TITLE
rviz: 15.0.12-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8832,7 +8832,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.11-1
+      version: 15.0.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.12-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.0.11-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix setHidden regression in PropertyTreeWidget (#1667 <https://github.com/ros2/rviz/issues/1667>) (#1668 <https://github.com/ros2/rviz/issues/1668>)
* Add topic name filtering when adding new visualizations (#1662 <https://github.com/ros2/rviz/issues/1662>) (#1663 <https://github.com/ros2/rviz/issues/1663>)
* use QPointer in QTimer::singleShot to prevent use-after-free (#1657 <https://github.com/ros2/rviz/issues/1657>) (#1658 <https://github.com/ros2/rviz/issues/1658>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
