### PR TITLE
rviz: 14.1.20-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10113,7 +10113,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.19-1
+      version: 14.1.20-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.20-2`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `14.1.19-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix setHidden regression in PropertyTreeWidget (#1667 <https://github.com/ros2/rviz/issues/1667>) (#1669 <https://github.com/ros2/rviz/issues/1669>)
* Add topic name filtering when adding new visualizations (#1662 <https://github.com/ros2/rviz/issues/1662>) (#1664 <https://github.com/ros2/rviz/issues/1664>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
