### PR TITLE
rviz: 11.2.26-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10859,7 +10859,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.25-1
+      version: 11.2.26-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.26-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `11.2.25-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix setHidden regression in PropertyTreeWidget  (backport #1667 <https://github.com/ros2/rviz/issues/1667>) (#1670 <https://github.com/ros2/rviz/issues/1670>)
* use QPointer in QTimer::singleShot to prevent use-after-free (backport #1657 <https://github.com/ros2/rviz/issues/1657>) (#1660 <https://github.com/ros2/rviz/issues/1660>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
