### PR TITLE
ros_gz: 3.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7698,7 +7698,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.6-1
+      version: 3.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.7-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.6-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Use GID filtering to prevent loops (#834 <https://github.com/gazebosim/ros_gz/issues/834>)
* Added WorldStatistics message support for the ros_gz_bridge (#841 <https://github.com/gazebosim/ros_gz/issues/841>)
* Contributors: Andreas Loeffler, Carlos Agüero
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Added WorldStatistics message support for the ros_gz_bridge (#841 <https://github.com/gazebosim/ros_gz/issues/841>)
* Contributors: Andreas Loeffler
```

## ros_gz_sim

```
* Added descriptions to gz_server and ros_gz_sim launch files (#838 <https://github.com/gazebosim/ros_gz/issues/838>)
* Added verbosity_level parameter. (#833 <https://github.com/gazebosim/ros_gz/issues/833>)
* Contributors: Martin Pecka
```

## ros_gz_sim_demos

- No changes
