### PR TITLE
ros_gz: 2.1.15-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7786,7 +7786,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.14-1
+      version: 2.1.15-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.15-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.14-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Added WorldStatistics message support for the ros_gz_bridge (#841 <https://github.com/gazebosim/ros_gz/issues/841>) (#845 <https://github.com/gazebosim/ros_gz/issues/845>)
* Use GID filtering to prevent loops (#834 <https://github.com/gazebosim/ros_gz/issues/834>) (#842 <https://github.com/gazebosim/ros_gz/issues/842>)
* Contributors: mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

```
* Added WorldStatistics message support for the ros_gz_bridge (#841 <https://github.com/gazebosim/ros_gz/issues/841>) (#845 <https://github.com/gazebosim/ros_gz/issues/845>)
* Contributors: mergify[bot]
```

## ros_gz_sim

```
* Added descriptions to gz_server and ros_gz_sim launch files (#838 <https://github.com/gazebosim/ros_gz/issues/838>) (#839 <https://github.com/gazebosim/ros_gz/issues/839>)
* Added verbosity_level parameter. (#833 <https://github.com/gazebosim/ros_gz/issues/833>) (#835 <https://github.com/gazebosim/ros_gz/issues/835>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

- No changes
