### PR TITLE
mujoco_ros2_control: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4836,6 +4836,15 @@ repositories:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git
       version: main
+    release:
+      packages:
+      - mujoco_ros2_control
+      - mujoco_ros2_control_demos
+      - mujoco_ros2_control_msgs
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_ros2_control` to `0.0.1-1`:

- upstream repository: https://github.com/ros-controls/mujoco_ros2_control.git
- release repository: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## mujoco_ros2_control

```
* Update documentation of URDF <-> MJCF tool (#117 <https://github.com/ros-controls/mujoco_ros2_control/issues/117>)
* Add proper logging for the mimic joints (#118 <https://github.com/ros-controls/mujoco_ros2_control/issues/118>)
* Fix mardown link checker CI + fix local references (#114 <https://github.com/ros-controls/mujoco_ros2_control/issues/114>)
* Updates docs and comments (#113 <https://github.com/ros-controls/mujoco_ros2_control/issues/113>)
* Cleanup of Docs and Dev Guides (#111 <https://github.com/ros-controls/mujoco_ros2_control/issues/111>)
* Update other ROS Controls maintainers (#112 <https://github.com/ros-controls/mujoco_ros2_control/issues/112>)
* Update README.md across repository (#110 <https://github.com/ros-controls/mujoco_ros2_control/issues/110>)
* Conditioning visual fixes on if there are images or not for daes (#109 <https://github.com/ros-controls/mujoco_ros2_control/issues/109>)
* Cleanup the non-vendor mujoco install (#105 <https://github.com/ros-controls/mujoco_ros2_control/issues/105>)
* Feature: Add --no-fuse arg to preserve body hierarchy (#93 <https://github.com/ros-controls/mujoco_ros2_control/issues/93>)
* Add mujoco_vendor integration (#6 <https://github.com/ros-controls/mujoco_ros2_control/issues/6>)
* Containerize pixi in CI (#99 <https://github.com/ros-controls/mujoco_ros2_control/issues/99>)
* Add ResetWorld service to reset to a specific defined keyframe (#95 <https://github.com/ros-controls/mujoco_ros2_control/issues/95>)
* Separate tests to mujoco_ros2_control_tests package (#90 <https://github.com/ros-controls/mujoco_ros2_control/issues/90>)
* Support for starting from a specific declared keyframe  (#89 <https://github.com/ros-controls/mujoco_ros2_control/issues/89>)
* Add reset_world service functionality (#88 <https://github.com/ros-controls/mujoco_ros2_control/issues/88>)
* Fix the issue with the PIDs applying to wrong variable (#87 <https://github.com/ros-controls/mujoco_ros2_control/issues/87>)
* Move the main contents of mujoco_ros2_control to subfolder (#76 <https://github.com/ros-controls/mujoco_ros2_control/issues/76>)
* Contributors: Erik Holum, Louis LE LAY, Nathan Dunkelberger, Sai Kishor Kothakota, Sergi de las Muelas
```

## mujoco_ros2_control_demos

```
* Updates docs and comments (#113 <https://github.com/ros-controls/mujoco_ros2_control/issues/113>)
* Cleanup of Docs and Dev Guides (#111 <https://github.com/ros-controls/mujoco_ros2_control/issues/111>)
* Add mujoco_ros2_control_demos package and retarget tests (#100 <https://github.com/ros-controls/mujoco_ros2_control/issues/100>)
* Contributors: Erik Holum, Louis LE LAY, Sai Kishor Kothakota
```

## mujoco_ros2_control_msgs

```
* Add ResetWorld service to reset to a specific defined keyframe (#95 <https://github.com/ros-controls/mujoco_ros2_control/issues/95>)
* Contributors: Sai Kishor Kothakota
```
