### PR TITLE
move_base_flex: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5379,6 +5379,25 @@ repositories:
       version: ros2
     status: developed
   move_base_flex:
+    doc:
+      type: git
+      url: https://github.com/naturerobots/move_base_flex.git
+      version: ros2
+    release:
+      packages:
+      - mbf_abstract_core
+      - mbf_abstract_nav
+      - mbf_msgs
+      - mbf_simple_core
+      - mbf_simple_nav
+      - mbf_test_utility
+      - mbf_utility
+      - move_base_flex
+      - rviz_mbf_plugins
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/move_base_flex-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `1.0.1-1`:

- upstream repository: https://github.com/naturerobots/move_base_flex.git
- release repository: https://github.com/ros2-gbp/move_base_flex-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## mbf_abstract_core

```
* Fixes tests, see #362
```

## mbf_abstract_nav

```
* Fixes tests, see #362
```

## mbf_msgs

```
* Fixes tests, see #362
```

## mbf_simple_core

```
* Fixes tests, see #362
```

## mbf_simple_nav

```
* Fixes tests, see #362
```

## mbf_test_utility

```
* Fixes tests, see #362
```

## mbf_utility

```
* Fixes tests, see #362
```

## move_base_flex

```
* Fixes tests, see #362
```

## rviz_mbf_plugins

```
* Fixes tests, see #362
```
