### PR TITLE
lvr2: 25.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5248,6 +5248,15 @@ repositories:
       version: ros2
     status: developed
   lvr2:
+    doc:
+      type: git
+      url: https://github.com/uos/lvr2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/lvr2-release.git
+      version: 25.2.1-1
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `25.2.1-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/ros2-gbp/lvr2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
