### PR TITLE
lvr2: 25.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4889,6 +4889,15 @@ repositories:
       version: ros2
     status: maintained
   lvr2:
+    doc:
+      type: git
+      url: https://github.com/uos/lvr2.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/lvr2-release.git
+      version: 25.2.1-1
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `25.2.1-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/ros2-gbp/lvr2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
