### PR TITLE
kobuki_velocity_smoother: 0.15.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3561,7 +3561,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
-      version: 0.15.0-3
+      version: 0.15.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kobuki_velocity_smoother` to `0.15.1-1`:

- upstream repository: https://github.com/kobuki-base/kobuki_velocity_smoother.git
- release repository: https://github.com/ros2-gbp/kobuki_velocity_smoother-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.0-3`

## kobuki_velocity_smoother

```
* [kilted] Update deprecated call to ament_target_dependencies (#21 <https://github.com/kobuki-base/kobuki_velocity_smoother/issues/21>)
* Contributors: David V. Lu!!
```
