### PR TITLE
ros_tutorials: 1.10.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7757,7 +7757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.10.5-1
+      version: 1.10.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.10.6-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.10.5-1`

## turtlesim

```
* Use get_package_share_path (#193 <https://github.com/ros/ros_tutorials/issues/193>)
* Contributors: Alejandro Hernández Cordero
```

## turtlesim_msgs

- No changes
