### PR TITLE
image_common: 6.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3211,7 +3211,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.4-1
+      version: 6.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.5-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.4.4-1`

## camera_calibration_parsers

```
* Update BSD licenses to SPDX identifier (#389 <https://github.com/ros-perception/image_common/issues/389>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Garrett Brown
```

## camera_info_manager

```
* Use get_package_share_path (#391 <https://github.com/ros-perception/image_common/issues/391>)
* Update BSD licenses to SPDX identifier (#389 <https://github.com/ros-perception/image_common/issues/389>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Alejandro Hernández Cordero, Garrett Brown
```

## camera_info_manager_py

```
* Update BSD licenses to SPDX identifier (#389 <https://github.com/ros-perception/image_common/issues/389>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Garrett Brown
```

## image_common

```
* Update BSD licenses to SPDX identifier (#389 <https://github.com/ros-perception/image_common/issues/389>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Garrett Brown
```

## image_transport

```
* Update BSD licenses to SPDX identifier (#389 <https://github.com/ros-perception/image_common/issues/389>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Garrett Brown
```

## image_transport_py

```
* Update BSD licenses to SPDX identifier (#389 <https://github.com/ros-perception/image_common/issues/389>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Garrett Brown
```
