### PR TITLE
rviz: 15.1.18-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8757,7 +8757,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.16-1
+      version: 15.1.18-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.18-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.16-1`

## rviz2

- No changes

## rviz_common

```
* Use get_package_share_path (#1671 <https://github.com/ros2/rviz/issues/1671>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

```
* Use get_package_share_path (#1671 <https://github.com/ros2/rviz/issues/1671>)
* Contributors: Alejandro Hernández Cordero
```
