### PR TITLE
common_interfaces: 5.5.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1265,7 +1265,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.5.1-1
+      version: 5.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.5.2-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.5.1-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Update Inertia.msg documentation to clarify inertia is express about the center of mass (#313 <https://github.com/ros2/common_interfaces/issues/313>) (#314 <https://github.com/ros2/common_interfaces/issues/314>)
* Contributors: mergify[bot]
```

## nav_msgs

```
* Adding the Trajectory and trajectoryPoint messages (#296 <https://github.com/ros2/common_interfaces/issues/296>) (#317 <https://github.com/ros2/common_interfaces/issues/317>)
* Contributors: mergify[bot]
```

## sensor_msgs

- No changes

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
