### PR TITLE
orbbec_camera_v2: 2.7.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6487,8 +6487,8 @@ repositories:
       - orbbec_description
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros2-gbp/orbbec_camera_v2-release.git
-      version: 2.6.3-5
+      url: https://github.com/orbbec/orbbec_camera_v2-release.git
+      version: 2.7.6-1
     source:
       type: git
       url: https://github.com/orbbec/OrbbecSDK_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `orbbec_camera_v2` to `2.7.6-1`:

- upstream repository: https://github.com/orbbec/OrbbecSDK_ROS2.git
- release repository: https://github.com/orbbec/orbbec_camera_v2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.3-5`
