### PR TITLE
Add python3-types-setuptools to python configuration

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10974,6 +10974,18 @@ python3-types-pyyaml:
     focal:
       pip:
         packages: [types-pyyaml]
+python3-types-setuptools:
+  debian: [python3-typeshed]
+  fedora: [python3-types-setuptools]
+  rhel:
+    '*': 
+      pip:
+        packages: [types-setuptools]
+  ubuntu:
+    '*': [python3-typeshed]
+    focal:
+      pip:
+        packages: [types-setuptools]
 python3-typing-extensions:
   arch: [python-typing_extensions]
   debian: [python3-typing-extensions]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10978,9 +10978,8 @@ python3-types-setuptools:
   debian: [python3-typeshed]
   fedora: [python3-types-setuptools]
   rhel:
-    '*': 
-      pip:
-        packages: [types-setuptools]
+    pip:
+      packages: [types-setuptools]
   ubuntu:
     '*': [python3-typeshed]
     focal:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`python3-types-setuptools`

## Package Upstream Source:

https://github.com/python/typeshed

## Purpose of using this:

To static type check setuptools.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/python3-typeshed
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-typeshed
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-types-setuptools/python3-types-setuptools/
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE
