### PR TITLE
jazzy: index depthai_v3 and depthai-ros-v3 repositories

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2086,6 +2086,28 @@ repositories:
       url: https://github.com/luxonis/depthai-ros.git
       version: jazzy
     status: developed
+  depthai-ros-v3:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3-jazzy
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3-jazzy
+    status: developed
+  depthai_v3:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: v3-jazzy
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: v3-jazzy
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Add minimal `source`/`doc` entries for `depthai-ros-v3` and `depthai_v3` in `jazzy/distribution.yaml`.

Reference:
https://docs.ros.org/en/jazzy/How-To-Guides/Releasing/Index-Your-Packages.html

### Why this change

`depthai`/`depthai-ros` v2 are already released on Jazzy and are used by existing users.  
We are introducing v3 on Jazzy under new package names (`*_v3`) to avoid breaking existing v2 users and to allow coexistence/migration.

This PR only performs indexing (minimal repository entries) so the new repositories are discoverable in rosdistro. Release metadata will be handled by bloom in follow-up release PR(s).

# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

- https://github.com/luxonis/depthai-core.git (branch: `v3-jazzy`)
- https://github.com/luxonis/depthai-ros.git (branch: `v3-jazzy`)

# Checks
- [x] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [x] This package is expected to build on the submitted rosdistro

