### PR TITLE
rosbot_ros: 0.18.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9224,6 +9224,26 @@ repositories:
       version: ros2
     status: maintained
   rosbot_ros:
+    doc:
+      type: git
+      url: https://raw.githubusercontent.com/husarion/rosbot_ros/refs/heads/jazzy/README.md
+      version: jazzy
+    release:
+      packages:
+      - rosbot
+      - rosbot_bringup
+      - rosbot_controller
+      - rosbot_description
+      - rosbot_gazebo
+      - rosbot_hardware_interfaces
+      - rosbot_joy
+      - rosbot_localization
+      - rosbot_moveit
+      - rosbot_utils
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbot_ros-release.git
+      version: 0.18.6-1
     source:
       type: git
       url: https://github.com/husarion/rosbot_ros.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9226,7 +9226,7 @@ repositories:
   rosbot_ros:
     doc:
       type: git
-      url: https://raw.githubusercontent.com/husarion/rosbot_ros/refs/heads/jazzy/README.md
+      url: https://github.com/husarion/rosbot_ros.git
       version: jazzy
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbot_ros` to `0.18.6-1`:

- upstream repository: https://github.com/husarion/rosbot_ros.git
- release repository: https://github.com/ros2-gbp/rosbot_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rosbot

- No changes

## rosbot_bringup

- No changes

## rosbot_controller

- No changes

## rosbot_description

- No changes

## rosbot_gazebo

- No changes

## rosbot_hardware_interfaces

- No changes

## rosbot_joy

- No changes

## rosbot_localization

- No changes

## rosbot_moveit

- No changes

## rosbot_utils

- No changes
