### PR TITLE
move_base_flex: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5882,7 +5882,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/move_base_flex-release.git
-      version: 1.0.1-2
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `1.0.2-1`:

- upstream repository: git@github.com:naturerobots/move_base_flex.git
- release repository: https://github.com/ros2-gbp/move_base_flex-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.1-2`

## mbf_abstract_core

```
* Removed unused dependencies, see #368
```

## mbf_abstract_nav

```
* Removed unused dependencies, see #368
```

## mbf_msgs

```
* Removed unused dependencies, see #368
```

## mbf_simple_core

```
* Removed unused dependencies, see #368
```

## mbf_simple_nav

```
* Removed unused dependencies, see #368
```

## mbf_test_utility

```
* Removed unused dependencies, see #368
```

## mbf_utility

```
* Removed unused dependencies, see #368
```

## move_base_flex

```
* Removed unused dependencies, see #368
```

## rviz_mbf_plugins

```
* Removed unused dependencies, see #368
```
