### PR TITLE
easynav_plugins: 0.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1781,6 +1781,10 @@ repositories:
       version: kilted
     status: developed
   easynav_plugins:
+    doc:
+      type: git
+      url: https://github.com/EasyNavigation/easynav_plugins.git
+      version: kilted
     release:
       packages:
       - easynav_bonxai_maps_manager
@@ -1808,6 +1812,10 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/EasyNavigation/easynav_plugins-release.git
       version: 0.3.1-1
+    source:
+      type: git
+      url: https://github.com/EasyNavigation/easynav_plugins.git
+      version: kilted
     status: developed
   ecal:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1762,6 +1762,35 @@ repositories:
       url: https://github.com/EasyNavigation/EasyNavigation.git
       version: kilted
     status: developed
+  easynav_plugins:
+    release:
+      packages:
+      - easynav_bonxai_maps_manager
+      - easynav_costmap_common
+      - easynav_costmap_localizer
+      - easynav_costmap_maps_manager
+      - easynav_costmap_planner
+      - easynav_fusion_localizer
+      - easynav_gps_localizer
+      - easynav_mpc_controller
+      - easynav_mppi_controller
+      - easynav_navmap_localizer
+      - easynav_navmap_maps_manager
+      - easynav_navmap_planner
+      - easynav_octomap_maps_manager
+      - easynav_routes_maps_manager
+      - easynav_serest_controller
+      - easynav_simple_common
+      - easynav_simple_controller
+      - easynav_simple_localizer
+      - easynav_simple_maps_manager
+      - easynav_simple_planner
+      - easynav_vff_controller
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/EasyNavigation/easynav_plugins-release.git
+      version: 0.3.1-1
+    status: developed
   ecal:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `easynav_plugins` to `0.3.1-1`:

- upstream repository: https://github.com/EasyNavigation/easynav_plugins.git
- release repository: https://github.com/EasyNavigation/easynav_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## easynav_mpc_controller

```
* GPLv3 -> Apache 2.0
* Remove C++20/C++23 features and update to new MethodBase interface
* TFInfo in RTTFBuffer
* Refactor to use TFInfo
* Trim path for MPC
* Stop controllers at IDLE
* Obstacles are detected
* Methods were added to access to private attributes
* Optimizer header file was added
* Dependencies were fixed
* MPC with differential model is working
* MPC Controller minimizes path following
* Visualization Marker was added
* CI updated
* MPC controller is working
* Optimizer was changed
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno, José Miguel Guerrero, Juan S. Cely G., Miguel
```
