### PR TITLE
Add python3-zeroconf key to rosdep database

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11400,6 +11400,14 @@ python3-yourdfpy-pip:
   '*':
     pip:
       packages: [yourdfpy]
+python3-zeroconf:
+  arch: [python-zeroconf]
+  debian: [python3-zeroconf]
+  fedora: [python3-zeroconf]
+  gentoo: [dev-python/zeroconf]
+  nixos: [python3Packages.zeroconf]
+  opensuse: [python3-zeroconf]
+  ubuntu: [python3-zeroconf]
 python3-zmq:
   arch: [python-pyzmq]
   debian: [python3-zmq]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-zeroconf

## Package Upstream Source:

https://github.com/python-zeroconf/python-zeroconf

## Purpose of using this:

Need this for a new package I'm developing which will provide scripts that utilize mDNS name resolution.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/trixie/python3-zeroconf
- Ubuntu: https://packages.ubuntu.com/questing/python3-zeroconf
- Fedora: https://packages.fedoraproject.org/pkgs/python-zeroconf/python3-zeroconf/
- Arch: https://archlinux.org/packages/extra/x86_64/python-zeroconf/
- Gentoo: https://packages.gentoo.org/packages/dev-python/zeroconf
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.11&show=python312Packages.zeroconf
- openSUSE: https://software.opensuse.org/package/python3-zeroconf
- rhel: https://rhel.pkgs.org/
  - NOT AVAILABLE
 