### PR TITLE
mujoco_vendor: 0.0.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4898,7 +4898,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_vendor-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.0.7-1`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.6-1`

## mujoco_vendor

```
* Update readme (#6 <https://github.com/pal-robotics/mujoco_vendor/issues/6>)
* Add symlinks to be able to find executables (#5 <https://github.com/pal-robotics/mujoco_vendor/issues/5>)
* Package prebuilt mujoco binaries (#4 <https://github.com/pal-robotics/mujoco_vendor/issues/4>)
* Contributors: Sai Kishor Kothakota, Erik Holum
```
