### PR TITLE
cloudini: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1209,7 +1209,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/facontidavide/cloudini-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/facontidavide/cloudini.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `1.0.1-1`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`

## cloudini_lib

```
* fix(ci): use correct rosdep key libpcl-all-dev for PCL
  libpcl-dev is not a valid rosdep key (KeyError on buildfarm).
  The correct key is libpcl-all-dev which resolves to apt package
  libpcl-dev. This also fixes the original Humble buildfarm issue:
  the old libpcl-common/libpcl-io keys only installed runtime libs
  (libpcl-common1.12), never the dev headers/PCLConfig.cmake needed
  by find_package(PCL).
  Co-Authored-By: Claude Opus 4.6 <mailto:noreply@anthropic.com>
* fix(ci): use system packages in ROS builds to fix buildfarm compilation (#72 <https://github.com/facontidavide/cloudini/issues/72>)
  * fix(ci): use system packages in ROS builds to fix buildfarm compilation
  Two buildfarm failures fixed:
  1. Jazzy Noble ARM64 (cloudini_lib): buildfarm sets
  FETCHCONTENT_FULLY_DISCONNECTED=ON, but CLOUDINI_FORCE_VENDORED_DEPS
  was forced ON in ament builds, skipping find_package() and trying to
  CPM-download zstd/lz4. With no network, file(GLOB) returned empty
  sources and add_library() failed. Fix: force FORCE_VENDORED=OFF when
  ament is found so system packages (declared in package.xml) are used.
  2. Humble Jammy ARM64 (cloudini_ros): libpcl-common + libpcl-io rosdep
  keys only install component libs without PCLConfig.cmake, so
  find_package(PCL QUIET) silently failed and pcl_conversion.cpp was
  excluded from libcloudini_lib.so. PCLPointCloudDecode was then
  missing at link time when building cloudini_ros. Fix: use libpcl-dev
  which ships the full CMake config.
  Also fix find_package() calls to use CONFIG mode with lowercase package
  names (zstd/lz4) matching the actual CMake config files provided by
  Ubuntu's libzstd-dev and liblz4-dev packages, with fallback to module
  mode for compatibility.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
  * fix(ci): use Docker containers for Humble and Jazzy workflows
  Bare runners fail because:
  - Humble: setup-ros installs minimal ROS without typesupport
  implementations, causing "No rosidl_typesupport_c found"
  - Jazzy: Ubuntu 24.04 PEP 668 Python isolation conflicts with
  setup-ros pip-installed tools, causing "No module ament_package"
  Switch to rostooling/setup-ros-docker containers with ros-base
  pre-installed, which have the correct ROS + Python environment.
  Co-Authored-By: Claude Opus 4.6 <mailto:noreply@anthropic.com>
  ---------
  Co-authored-by: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* Contributors: Davide Faconti
```

## cloudini_ros

- No changes
