### PR TITLE
rosbridge_suite: 2.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10126,7 +10126,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.0.4-1
+      version: 2.0.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.0.5-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.4-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: numpy.ndarray not handled in CBOR serialization (backport #1161 <https://github.com/RobotWebTools/rosbridge_suite/issues/1161>) (#1163 <https://github.com/RobotWebTools/rosbridge_suite/issues/1163>)
* fix: Handle action rejection and server timeout (backport #1139 <https://github.com/RobotWebTools/rosbridge_suite/issues/1139>) (#1156 <https://github.com/RobotWebTools/rosbridge_suite/issues/1156>)
* fix: Failing service and subscription tests (backport #1147 <https://github.com/RobotWebTools/rosbridge_suite/issues/1147>) (#1155 <https://github.com/RobotWebTools/rosbridge_suite/issues/1155>)
* Contributors: Błażej Sowa, Spir0u, atofetti-botbot
```

## rosbridge_msgs

- No changes

## rosbridge_server

- No changes

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
