### PR TITLE
rosbridge_suite: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9266,7 +9266,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.4.2-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.5.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.2-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: numpy.ndarray not handled in CBOR serialization (backport #1161 <https://github.com/RobotWebTools/rosbridge_suite/issues/1161>) (#1162 <https://github.com/RobotWebTools/rosbridge_suite/issues/1162>)
* fix: Handle action rejection and server timeout (backport #1139 <https://github.com/RobotWebTools/rosbridge_suite/issues/1139>) (#1154 <https://github.com/RobotWebTools/rosbridge_suite/issues/1154>)
* fix: Failing service and subscription tests (backport #1147 <https://github.com/RobotWebTools/rosbridge_suite/issues/1147>) (#1151 <https://github.com/RobotWebTools/rosbridge_suite/issues/1151>)
* Contributors: Błażej Sowa, Spir0u, atofetti-botbot
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Reduce idle CPU consumption of websocket server (backport #1040 <https://github.com/RobotWebTools/rosbridge_suite/issues/1040>) (#1153 <https://github.com/RobotWebTools/rosbridge_suite/issues/1153>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
