### PR TITLE
rosbridge_suite: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7936,7 +7936,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 3.0.2-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `4.0.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.2-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Use new interface base classes for type checking, drop Kilted support (#1164 <https://github.com/RobotWebTools/rosbridge_suite/issues/1164>)
* fix: numpy.ndarray not handled in CBOR serialization (#1161 <https://github.com/RobotWebTools/rosbridge_suite/issues/1161>)
* fix: Handle action rejection and server timeout (#1139 <https://github.com/RobotWebTools/rosbridge_suite/issues/1139>)
* fix: Failing service and subscription tests (#1147 <https://github.com/RobotWebTools/rosbridge_suite/issues/1147>)
* Contributors: Błażej Sowa, Spir0u, atofetti-botbot
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* feat: Add an option to use EventsExecutor (#1157 <https://github.com/RobotWebTools/rosbridge_suite/issues/1157>)
* fix: Reduce idle CPU consumption of websocket server (#1040 <https://github.com/RobotWebTools/rosbridge_suite/issues/1040>)
* Contributors: Błażej Sowa
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
