### PR TITLE
zed-ros2-interfaces: 5.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13598,7 +13598,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
-      version: 5.1.1-1
+      version: 5.2.1-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-interfaces` to `5.2.1-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-interfaces.git
- release repository: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.1-1`

## zed_msgs

```
* Remove unused URDF files and associated references from CMakeLists and README
  * Mesh files are now in the zed_description package available via APT
* Improve formatting and clarity in CONTRIBUTING.md
* Fix CONTRIBUTING
* Fix README
* Contributors: Walter Lucetti
```
