### PR TITLE
[openembedded] Add cbor2 ujson

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5389,6 +5389,7 @@ python3-cbor2:
   fedora: [python3-cbor2]
   gentoo: [dev-python/cbor2]
   nixos: [python3Packages.cbor2]
+  openembedded: [python3-cbor2@meta-python]
   opensuse: [python-cbor2]
   osx:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4459,6 +4459,7 @@ python-ujson:
   fedora: [python-ujson]
   gentoo: [dev-python/ujson]
   nixos: [pythonPackages.ujson]
+  openembedded: [python3-ujson@meta-python]
   osx:
     pip:
       packages: [ujson]


### PR DESCRIPTION
Add python3-cbor2 and python3-ujson for openembedded platform.