### PR TITLE
Add husarion_controllers & husarion_gz_worlds to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3916,6 +3916,18 @@ repositories:
       url: https://github.com/husarion/husarion_components_description.git
       version: ros2
     status: developed
+  husarion_controllers:
+    source:
+      type: git
+      url: https://github.com/husarion/husarion_controllers.git
+      version: jazzy
+    status: developed
+  husarion_gz_worlds:
+    source:
+      type: git
+      url: https://github.com/husarion/husarion_gz_worlds.git
+      version: jazzy
+    status: developed
   husarion_ugv_ros:
     release:
       packages:


### PR DESCRIPTION
## Please Add These Packages to be indexed in the rosdistro.

### Packages names

- husarion_controllers
- husarion_gz_worlds

### The sources are here:

https://github.com/husarion/husarion_controllers/tree/jazzy
https://github.com/husarion/husarion_gz_worlds/tree/jazzy

### Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
