### PR TITLE
rclc: 6.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7813,7 +7813,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclc-release.git
-      version: 6.1.0-3
+      version: 6.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclc` to `6.1.2-1`:

- upstream repository: https://github.com/ros2/rclc.git
- release repository: https://github.com/ros2-gbp/rclc-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.0-3`

## rclc

```
* updated ci.yml
```

## rclc_examples

```
* no changes
```

## rclc_lifecycle

```
* no changes
```

## rclc_parameter

```
* no changes
```
