### PR TITLE
visp: 3.7.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13261,7 +13261,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/visp-release.git
-      version: 3.5.0-2
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/lagadic/visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.7.0-1`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/ros2-gbp/visp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.0-2`
