### PR TITLE
[openembedded] pyflakes: remove the deprecating PYTHON_PN

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -426,7 +426,7 @@ pyflakes3:
   freebsd: [devel/py-pyflakes]
   gentoo: [dev-python/pyflakes]
   nixos: [python3Packages.pyflakes]
-  openembedded: ['${PYTHON_PN}-pyflakes@meta-ros-common']
+  openembedded: [python3-pyflakes@meta-python]
   osx:
     pip:
       packages: [pyflakes]


### PR DESCRIPTION
PYTHON_PN is deprecated in OpenEmbedded/Yocto.
There is no python2 version of the pyflakes package anymore.

@robwoolley: could you ack/nack
Although there is a more recent version of the recipe in meta-python, I would stick for now to the recipe of meta-ros.