### PR TITLE
data_tamer_tools: 0.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1541,6 +1541,21 @@ repositories:
       url: https://github.com/PickNikRobotics/data_tamer.git
       version: main
     status: developed
+  data_tamer_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/jlack/data_tamer_tools.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/data_tamer_tools-release.git
+      version: 0.3.1-1
+    source:
+      type: git
+      url: https://gitlab.com/jlack/data_tamer_tools.git
+      version: main
+    status: developed
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer_tools` to `0.3.1-1`:

- upstream repository: https://gitlab.com/jlack/data_tamer_tools.git
- release repository: https://github.com/ros2-gbp/data_tamer_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
