### PR TITLE
rosidl_python: 0.27.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8087,7 +8087,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.26.3-1
+      version: 0.27.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.27.0-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.3-1`

## rosidl_generator_py

```
* Cast Sequence to list on assignment (with templates) (#249 <https://github.com/ros2/rosidl_python/issues/249>)
* Fix linter violations with flake8-import-order 0.19.0 (#248 <https://github.com/ros2/rosidl_python/issues/248>)
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#238 <https://github.com/ros2/rosidl_python/issues/238>)
* Contributors: Anthony Welte, Michael Carlstrom
```
