### PR TITLE
mp2p_icp: 2.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4691,7 +4691,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.7.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.0-1`

## mp2p_icp

```
* Merge pull request #45 <https://github.com/MOLAorg/mp2p_icp/issues/45> from MOLAorg/feat/mm2grid
  Add new cli app: mm2grid
* Add new cli app: mm2grid
* Merge pull request #44 <https://github.com/MOLAorg/mp2p_icp/issues/44> from MOLAorg/feat/view-vector
  Generators now optionally generate a 'view' direction vector per point
* FilterMLS: now uses the view-direction vectors to ensure normals point outwards
* Generator: add safety consistency check
* Generators are now also included into sm2mm profiler
* Generators now optionally generate a 'view' direction vector per point
* mm-viewer: FIX: show/hide all buttons did not apply to extra viz layers
* mm-georef: Fix creation of empty output map if input didn't exist
* mm2txt: Fix wrong console message saying mm-info instead of mm2txt
* mm-viewer UI: show XY grid plane at the root frame of reference (ENU or map)
* Merge pull request #43 <https://github.com/MOLAorg/mp2p_icp/issues/43> from MOLAorg/feat/export-enu-frame
  Export tools now accept "--frame enu" to generate XYZ data in ENU frame
* Export tools now accept "--frame enu" to generate XYZ data in ENU frame
* Contributors: Jose Luis Blanco-Claraco
```
