### PR TITLE
mola_state_estimation: 2.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4519,7 +4519,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.1.0-1`

## mola_georeferencing

```
* Merge pull request #18 <https://github.com/MOLAorg/mola_state_estimation/issues/18> from MOLAorg/fix/should-fail-on-missing-mm
  Add guards against failures for missing input .mm files
* Add guards against failures for missing input .mm files
* Merge pull request #17 <https://github.com/MOLAorg/mola_state_estimation/issues/17> from MOLAorg/feat/mm-add-geodetic-handle-null-geodetics
  mola-mm-add-geodetic: Don't create output map if input geodetics are …
* mola-mm-add-geodetic: Don't create output map if input geodetics are missing.
  We may still have a valid input .georef, obtained from IMU only, but without geodetics coordinates
* Merge pull request #16 <https://github.com/MOLAorg/mola_state_estimation/issues/16> from MOLAorg/feat/imu-align-without-gps
  Use IMU even without GPS data
* improved unit tests
* fix potential UB
* Use IMU even without GPS data
* IMU frames: use averaged gravity measurements per key-frame
* Merge pull request #15 <https://github.com/MOLAorg/mola_state_estimation/issues/15> from MOLAorg/fix/use-lvb
  georeferencing: correctly use IMU data in the LocalVelocityBuffer too…
* georeferencing: correctly use IMU data in the LocalVelocityBuffer too for gravity alignment
* Merge pull request #14 <https://github.com/MOLAorg/mola_state_estimation/issues/14> from MOLAorg/feature/use-imu-for-georef-hint
  Feature/use-imu-for-georef-hint
* Fix potential errors
* georeferencing now optionally uses IMU acceleration measurements to help with gravity-alignment
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

- No changes

## mola_state_estimation_smoother

```
* Merge pull request #14 <https://github.com/MOLAorg/mola_state_estimation/issues/14> from MOLAorg/feature/use-imu-for-georef-hint
  Feature/use-imu-for-georef-hint
* clang-format
* Contributors: Jose Luis Blanco-Claraco
```
