### PR TITLE
hri_actions_msgs: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3913,6 +3913,20 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hri_actions_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      version: 2.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: humble-devel
   husarion_components_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_actions_msgs` to `2.5.0-1`:

- upstream repository: https://github.com/ros4hri/hri_actions_msgs.git
- release repository: https://github.com/ros4hri/hri_actions_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## hri_actions_msgs

Initial jazzy release
