### PR TITLE
hri_msgs: 2.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3202,6 +3202,20 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_actions_msgs.git
       version: humble-devel
+  hri_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros4hri/hri_msgs-release.git
+      version: 2.3.2-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_msgs.git
+      version: humble-devel
   hyveos_bridge:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_msgs` to `2.3.2-1`:

- upstream repository: https://github.com/ros4hri/hri_msgs.git
- release repository: https://github.com/ros4hri/hri_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## hri_msgs

Initial release in rolling
