### PR TITLE
hri_actions_msgs: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3188,6 +3188,20 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hri_actions_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      version: 2.5.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_actions_msgs.git
+      version: humble-devel
   hyveos_bridge:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_actions_msgs` to `2.5.0-1`:

- upstream repository: https://github.com/ros4hri/hri_actions_msgs.git
- release repository: https://github.com/ros4hri/hri_actions_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## hri_actions_msgs

intial release in rolling
