### PR TITLE
ros2_tracing: 8.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7607,7 +7607,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.9.0-1
+      version: 8.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.10.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.9.0-1`

## lttngpy

```
* Use <lttng/lttng.h> in lttngpy and clean up includes (#222 <https://github.com/ros2/ros2_tracing/issues/222>)
* Contributors: RHolland
```

## ros2trace

```
* Ignore A0005 (#237 <https://github.com/ros2/ros2_tracing/issues/237>)
* Contributors: Michael Carlstrom
```

## tracetools

```
* Support tracepoints for complex message flow annotation used by ROS 2 plugin of Eclipse Trace Compass (#233 <https://github.com/ros2/ros2_tracing/issues/233>)
* Removed warning (#225 <https://github.com/ros2/ros2_tracing/issues/225>)
* Contributors: Alejandro Hernández Cordero, Raphael van Kempen
```

## tracetools_launch

```
* tracetools_launch: use parse_if_substitutions for non-string action params (#234 <https://github.com/ros2/ros2_tracing/issues/234>)
* Contributors: Sarthak Bagga
```

## tracetools_read

```
* Ignore A0005 (#237 <https://github.com/ros2/ros2_tracing/issues/237>)
* Contributors: Michael Carlstrom
```

## tracetools_test

```
* Set default values on TraceTestCase to avoid errors on >=8.2.0 pytest (#236 <https://github.com/ros2/ros2_tracing/issues/236>)
* Contributors: Clara Berendsen
```

## tracetools_trace

```
* Support tracepoints for complex message flow annotation used by ROS 2 plugin of Eclipse Trace Compass (#233 <https://github.com/ros2/ros2_tracing/issues/233>)
* Ignore A0005 (#237 <https://github.com/ros2/ros2_tracing/issues/237>)
* Add exec_depend on procps to tracetools_trace for ps command (#227 <https://github.com/ros2/ros2_tracing/issues/227>)
* Handle SIGTERM and gracefully stop tracing in interactive tracing mode (#219 <https://github.com/ros2/ros2_tracing/issues/219>)
* Contributors: Christophe Bedard, Michael Carlstrom, Raphael van Kempen
```
