### PR TITLE
ewellix_lift_common: 0.2.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2646,7 +2646,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/ewellix_lift_common-release.git
-      version: 0.2.0-1
+      version: 0.2.1-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/ewellix_lift_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ewellix_lift_common` to `0.2.1-2`:

- upstream repository: https://github.com/clearpathrobotics/ewellix_lift_common.git
- release repository: https://github.com/clearpath-gbp/ewellix_lift_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.0-1`

## ewellix_description

```
* Pass encoder limits to hardware interface
* Contributors: Luis Camero
```

## ewellix_interfaces

- No changes

## ewellix_lift_common

- No changes

## ewellix_moveit_config

- No changes

## ewellix_sim

- No changes

## ewellix_viz

- No changes
