### PR TITLE
hri: 2.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3913,6 +3913,23 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hri:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: humble-devel
+    release:
+      packages:
+      - hri
+      - pyhri
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros4hri/libhri-release.git
+      version: 2.9.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/libhri.git
+      version: humble-devel
   hri_actions_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri` to `2.9.0-1`:

- upstream repository: https://github.com/ros4hri/libhri.git
- release repository: https://github.com/ros4hri/libhri-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## hri

-- initial release in `jazzy`

```
* jazzy compat
* update URLs and authors in package.xml
* [doc] minor doc
* [doc] minor doc
* Contributors: Séverin Lemaignan
```

## pyhri

-- initial release in `jazzy`
```
* ensure numpy headers are found
* update URLs and authors in package.xml
* Contributors: Séverin Lemaignan
```
