### PR TITLE
launch_pal: 0.20.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4549,6 +4549,21 @@ repositories:
       url: https://github.com/ros-tooling/launch_frontend_py.git
       version: main
     status: developed
+  launch_pal:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_pal-release.git
+      version: 0.20.2-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: master
+    status: developed
   launch_param_builder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.20.2-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/ros2-gbp/launch_pal-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## launch_pal

```
* Throw when trying to merge a yaml file that does not contain a dict
* Contributors: Noel Jimenez
```
