### PR TITLE
tensorrt_cmake_module: 0.0.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9534,7 +9534,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
-      version: 0.0.4-3
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/tier4/tensorrt_cmake_module.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tensorrt_cmake_module` to `0.0.5-1`:

- upstream repository: https://github.com/tier4/tensorrt_cmake_module.git
- release repository: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.4-3`

## tensorrt_cmake_module

```
* feat: add tensorrt-10 support (#3 <https://github.com/tier4/tensorrt_cmake_module//issues/3>)
  Co-authored-by: Amadeusz Szymko <mailto:amadeuszszymko@gmail.com>
* Contributors: Mark Jin
```
