### PR TITLE
move_base_flex: 1.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5480,7 +5480,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/move_base_flex-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `1.0.5-1`:

- upstream repository: https://github.com/naturerobots/move_base_flex.git
- release repository: https://github.com/ros2-gbp/move_base_flex-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.4-1`

## mbf_abstract_core

- No changes

## mbf_abstract_nav

- No changes

## mbf_msgs

- No changes

## mbf_simple_core

- No changes

## mbf_simple_nav

- No changes

## mbf_test_utility

- No changes

## mbf_utility

- No changes

## move_base_flex

- No changes

## rviz_mbf_plugins

```
* fixed missing dependency, see #378
```
