### PR TITLE
Add pfs to the buildfarm

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5725,6 +5725,16 @@ repositories:
       url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
       version: rolling
     status: maintained
+  pfs:
+    doc:
+      type: git
+      url: https://github.com/dtrugman/pfs.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/dtrugman/pfs.git
+      version: main
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

**pfs**
Not ours, we we made it ROS compatible and aligned the version numbers:
https://github.com/dtrugman/pfs/pull/47
https://github.com/dtrugman/pfs/pull/76

## Package Upstream Source:

https://github.com/dtrugman/pfs

## Purpose of using this:

procfs parsing library in C++
We use it for a diagnostics utility.

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
