### PR TITLE
rcl_logging: 3.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6603,7 +6603,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 3.4.0-1
+      version: 3.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_logging` to `3.4.1-1`:

- upstream repository: https://github.com/ros2/rcl_logging.git
- release repository: https://github.com/ros2-gbp/rcl_logging-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.0-1`

## rcl_logging_implementation

- No changes

## rcl_logging_interface

- No changes

## rcl_logging_noop

- No changes

## rcl_logging_spdlog

```
* feat: add env variable to configure flushing interval (#139 <https://github.com/ros2/rcl_logging/issues/139>)
* Contributors: Achille Verheye
```
