### PR TITLE
launch_pal: 0.20.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3811,6 +3811,21 @@ repositories:
       url: https://github.com/ros-tooling/launch_frontend_py.git
       version: main
     status: developed
+  launch_pal:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/launch_pal-release.git
+      version: 0.20.3-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/launch_pal.git
+      version: master
+    status: developed
   launch_param_builder:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.20.3-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/ros2-gbp/launch_pal-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## launch_pal

```
* fix: only shutdown rclpy if initialized locally
* Contributors: Noel Jimenez
```
