### PR TITLE
rosx_introspection: 2.1.0-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8248,7 +8248,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosx_introspection-release.git
-      version: 2.1.0-1
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosx_introspection` to `2.1.0-2`:

- upstream repository: https://github.com/facontidavide/rosx_introspection.git
- release repository: https://github.com/ros2-gbp/rosx_introspection-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## rosx_introspection

```
* Fix multiple bugs in serialization, deserialization, and JSON handling
  - Fix missing throw in ROS_Deserializer::deserialize for unsupported types
  - Fix NanoCDR_Deserializer::deserializeByteSequence crash on empty sequences
  - Fix ROS_Serializer buffer resize logic and UB (const-cast, type-punning)
  - Fix Tree::find using &_root instead of _root.get() on unique_ptr
  - Fix msgpack pointer invalidation after vector resize for large messages
  - Fix blob detection in deserialize() (was restricted to OTHER type only)
  - Fix deserializeIntoJson blob skip not advancing the deserializer
  - Fix serializeFromJson: add JSON parse error checking, type-safe value
  reading with range validation, proper null handling for missing fields
  - Add complete ROS_Serializer implementation (serialize, serializeString, etc.)
  - Add comprehensive test coverage for all fixes
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
* Merge pull request #29 <https://github.com/facontidavide/rosx_introspection//issues/29> from agxeed/fix/time-duration-nsec-serialization
  fix: correct nsecs duration serialization
* Merge pull request #22 <https://github.com/facontidavide/rosx_introspection//issues/22> from amarburg/bugfix_ament_export_testing_dependencies
  Add sensor_msgs, geometry_msgs as ament dependencies when BUILD_TESTING is true
* Merge pull request #27 <https://github.com/facontidavide/rosx_introspection//issues/27> from jorritolthuis/msgpack_cpp
  Make convertToMsgPack() available in C++
* Merge pull request #30 <https://github.com/facontidavide/rosx_introspection//issues/30> from agxeed/fix/compiler-warnings
  fix: compiler warnings
* Merge pull request #32 <https://github.com/facontidavide/rosx_introspection//issues/32> from konsim83/feature/replace_rosbag2_cpp_with_rclcpp
  Use rclcpp type support instead of rosbag2_cpp
* fix: compiler warnings
* fix: correct nsecs duration serialization
* Make convertToMsgPack() available in C++
* Add sensor_msgs, geometry_msgs as ament dependencies when BUILD_TESTING
* remove ament_target_dependencies
* Contributors: Davide Faconti, Jorrit Olthuis, Konrad Simon, Rein Appeldoorn, admin
```
