### PR TITLE
ros2cli: 0.38.3-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7678,7 +7678,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.38.2-1
+      version: 0.38.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.38.3-2`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.38.2-1`

## ros2action

- No changes

## ros2cli

```
* check for invalid ROS discovery configuration and print warning if ne… (backport #1178 <https://github.com/ros2/ros2cli//issues/1178>) (#1179 <https://github.com/ros2/ros2cli//issues/1179>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

```
* ros2interface output the contents for each node. (#1163 <https://github.com/ros2/ros2cli//issues/1163>) (#1165 <https://github.com/ros2/ros2cli//issues/1165>)
* Contributors: mergify[bot]
```

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* Fix ParameterNameCompleter. (#1172 <https://github.com/ros2/ros2cli//issues/1172>) (#1175 <https://github.com/ros2/ros2cli//issues/1175>)
* Output node parameters upon each receipt (#1162 <https://github.com/ros2/ros2cli//issues/1162>) (#1164 <https://github.com/ros2/ros2cli//issues/1164>)
* Contributors: mergify[bot]
```

## ros2pkg

```
* Remove "rclrs" duplicate dependency (#1197 <https://github.com/ros2/ros2cli//issues/1197>) (#1198 <https://github.com/ros2/ros2cli//issues/1198>)
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
