### PR TITLE
ros2cli: 0.32.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9011,7 +9011,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.32.8-1
+      version: 0.32.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.32.9-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.32.8-1`

## ros2action

- No changes

## ros2cli

```
* check for invalid ROS discovery configuration and print warning if ne… (backport #1178 <https://github.com/ros2/ros2cli//issues/1178>) (#1180 <https://github.com/ros2/ros2cli//issues/1180>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

- No changes

## ros2pkg

```
* Remove "rclrs" duplicate dependency (#1197 <https://github.com/ros2/ros2cli//issues/1197>) (#1199 <https://github.com/ros2/ros2cli//issues/1199>)
* Contributors: mergify[bot]
```

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
