### PR TITLE
cloudini: 1.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1209,7 +1209,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/facontidavide/cloudini-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/facontidavide/cloudini.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `1.0.3-1`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.2-1`
