### PR TITLE
rtest: 0.2.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8862,6 +8862,15 @@ repositories:
       version: master
     status: maintained
   rtest:
+    doc:
+      type: git
+      url: https://github.com/Beam-and-Spyrosoft/rtest.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/rtest-release.git
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/Beam-and-Spyrosoft/rtest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtest` to `0.2.1-1`:

- upstream repository: https://github.com/Beam-and-Spyrosoft/rtest.git
- release repository: https://github.com/ros2-gbp/rtest-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rtest

```
* Fix missing includes (#110 <https://github.com/Beam-and-Spyrosoft/rtest/issues/110>)
* Fix REP url locations (#106 <https://github.com/Beam-and-Spyrosoft/rtest/issues/106>)
* Add wait_for_service to ServiceClientMock (#101 <https://github.com/Beam-and-Spyrosoft/rtest/issues/101>)
* Add auto linking of GTest::gmock target (#102 <https://github.com/Beam-and-Spyrosoft/rtest/issues/102>)
* Trigger timer callbacks when time is moved (#98 <https://github.com/Beam-and-Spyrosoft/rtest/issues/98>)
  Co-authored-by: Sławek Cielepak <mailto:slawomir.cielepak@gmail.com>
* Fix install cmake path (#99 <https://github.com/Beam-and-Spyrosoft/rtest/issues/99>)
* Typo fix: namme -> name  (#90 <https://github.com/Beam-and-Spyrosoft/rtest/issues/90>)
* Add MockRegistryCleaner utility to reset StaticMocksRegistry (#85 <https://github.com/Beam-and-Spyrosoft/rtest/issues/85>)
* Add build dependency to ros_environment (#88 <https://github.com/Beam-and-Spyrosoft/rtest/issues/88>)
* #79 <https://github.com/Beam-and-Spyrosoft/rtest/issues/79> Docs/publisher tutorial (#80 <https://github.com/Beam-and-Spyrosoft/rtest/issues/80>)
* Contributors: Kuo, Mei-Chun, Sławomir Cielepak, Tim Clephas, Wiktor Bajor, gmcross, rik-winters
```
