### PR TITLE
mujoco_vendor: 0.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4984,7 +4984,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_vendor-release.git
-      version: 0.0.7-1
+      version: 0.0.8-1
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.0.8-1`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.7-1`

## mujoco_vendor

```
* Fix the build tree mujoco binary directory (#8 <https://github.com/pal-robotics/mujoco_vendor/issues/8>)
* Contributors: Sai Kishor Kothakota
```
