### PR TITLE
mp2p_icp: 2.7.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4722,7 +4722,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.7.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.7.0-1`

## mp2p_icp

```
* Merge pull request #48 <https://github.com/MOLAorg/mp2p_icp/issues/48> from MOLAorg/fix/filter-adaptive-avoid-fpe
  FIX: Avoid potential division by zero in FilterDecimateAdaptive
* Update minimum required MRPT version 2.15.0
* FIX: Avoid potential division by zero in FilterDecimateAdaptive
* Merge pull request #47 <https://github.com/MOLAorg/mp2p_icp/issues/47> from MOLAorg/fix/georef-yaml-missing-fields
  FIX: georeferencing yaml serialization missed orientation fields
* FIX: georeferencing yaml serialization missed orientation fields
* Merge pull request #46 <https://github.com/MOLAorg/mp2p_icp/issues/46> from MOLAorg/feat/sm2mm-in-enu-frame
  sm2mm: new  feature to directly use georef as input and produce maps (and apply filters!) in ENU frame
* sm2mm: new  feature to directly use georef as input and produce maps in ENU frame
* Contributors: Jose Luis Blanco-Claraco
```
