### PR TITLE
lvr2: 25.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5262,7 +5262,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/lvr2-release.git
-      version: 25.2.1-1
+      version: 25.2.2-1
     source:
       type: git
       url: https://github.com/uos/lvr2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lvr2` to `25.2.2-1`:

- upstream repository: https://github.com/uos/lvr2.git
- release repository: https://github.com/ros2-gbp/lvr2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `25.2.1-1`

## lvr2

```
* Use the vertex's normal in calcVertexHeightDifferences() to define the local plane
* Removed panic exception from BaseHandle since it makes semantically no sense since optionals are used
```
