### PR TITLE
mobile_robot_simulator: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5291,6 +5291,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mobile_robot_simulator:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/nobleo/mobile_robot_simulator-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: main
+    status: maintained
   mocap4r2_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_robot_simulator` to `2.0.0-1`:

- upstream repository: https://github.com/nobleo/mobile_robot_simulator.git
- release repository: https://github.com/nobleo/mobile_robot_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## mobile_robot_simulator

```
* Feature: use_sim_time
* Port mobile_robot_simulator_node to ROS2
* Contributors: Ramon Wijnands, Richard, Richard van de Ketterij, Tim Clephas
```
