### PR TITLE
multisensor_calibration: 2.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4948,7 +4948,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/multisensor_calibration-release.git
-      version: 2.0.4-2
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `multisensor_calibration` to `2.1.0-1`:

- upstream repository: https://github.com/FraunhoferIOSB/multisensor_calibration.git
- release repository: https://github.com/ros2-gbp/multisensor_calibration-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.4-2`

## multisensor_calibration

```
* feat: add camera-camera extrinsic calibration
* refactor: clean calibration inheritance structure
* Contributors: Miguel Granero
```

## multisensor_calibration_interface

- No changes

## small_gicp_vendor

- No changes
