### PR TITLE
human_description: 2.0.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3970,6 +3970,20 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git
       version: humble-devel
+  human_description:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros4hri/human_description-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: humble-devel
   husarion_components_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `human_description` to `2.0.2-1`:

- upstream repository: https://github.com/ros4hri/human_description.git
- release repository: https://github.com/ros4hri/human_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## human_description

First `jazzy` release

```
* fix joint limits for the arms
  the joint limits for the arms were wrong, as they did not really
  reflect the range of movements a human is able to perform. This
  commit introduces realistic joint limits for human arms.
* Contributors: lorenzoferrini
```
