### PR TITLE
hri_rviz: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3247,7 +3247,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros4hri/hri_rviz-release.git
+      url: https://github.com/ros2-gbp/hri_rviz-release.git
       version: 2.3.0-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3239,6 +3239,20 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git
       version: humble-devel
+  hri_rviz:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros4hri/hri_rviz-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
   hyveos_bridge:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_rviz` to `2.3.0-1`:

- upstream repository: https://github.com/ros4hri/hri_rviz.git
- release repository: https://github.com/ros4hri/hri_rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## hri_rviz

First release in `rolling`.

```
* compat jazzy
* Contributors: Séverin Lemaignan
```
