### PR TITLE
hri_rviz: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3983,6 +3983,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
   human_description:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3970,6 +3970,20 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_msgs.git
       version: humble-devel
+  hri_rviz:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros4hri/hri_rviz-release.git
+      version: 2.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/hri_rviz.git
+      version: humble-devel
   husarion_components_description:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `hri_rviz` to `2.3.0-1`:

- upstream repository: https://github.com/ros4hri/hri_rviz.git
- release repository: https://github.com/ros4hri/hri_rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## hri_rviz

First release in `jazzy`.

```
* compat jazzy
* Contributors: Séverin Lemaignan
```
