### PR TITLE
play_motion2: 1.8.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5878,7 +5878,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/play_motion2-release.git
-      version: 1.8.3-1
+      version: 1.8.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `play_motion2` to `1.8.4-1`:

- upstream repository: https://github.com/pal-robotics/play_motion2.git
- release repository: https://github.com/ros2-gbp/play_motion2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.8.3-1`

## play_motion2

```
* Check all positions are safe when using planning
* Contributors: Noel Jimenez
```

## play_motion2_cli

- No changes

## play_motion2_msgs

- No changes
