### PR TITLE
Add socketcan adapter

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11489,6 +11489,16 @@ repositories:
       url: https://github.com/MetroRobots/social_nav_ros.git
       version: main
     status: developed
+  socketcan_adapter:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    status: maintained
   sol_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10772,6 +10772,16 @@ repositories:
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
       version: rolling
     status: developed
+  socketcan_adapter:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    status: maintained
   sol_vendor:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9327,6 +9327,16 @@ repositories:
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
       version: rolling
     status: developed
+  socketcan_adapter:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    status: maintained
   sol_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9307,6 +9307,16 @@ repositories:
       url: https://github.com/ros-sports/soccer_vision_3d_rviz_markers.git
       version: rolling
     status: developed
+  socketcan_adapter:
+    doc:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/polymathrobotics/socketcan_adapter.git
+      version: main
+    status: maintained
   sol_vendor:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro

`socketcan_adapter`

# The source is here:

https://github.com/polymathrobotics/socketcan_adapter

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
