### PR TITLE
rclpy: 10.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6702,7 +6702,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.5-1
+      version: 10.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.6-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.0.5-1`

## rclpy

```
* Fix incorrect action client/server callback type hints (#1616 <https://github.com/ros2/rclpy/issues/1616>)
* avoid stale parameter events in content filter tests. (#1615 <https://github.com/ros2/rclpy/issues/1615>)
* fix violations (#1614 <https://github.com/ros2/rclpy/issues/1614>)
* Typing Regression Fixes (#1612 <https://github.com/ros2/rclpy/issues/1612>)
* CFT is only supported rmw_fastrtps and rmw_connextdds. (#1611 <https://github.com/ros2/rclpy/issues/1611>)
* Contributors: Błażej Sowa, Michael Carlstrom, Tomoya Fujita
```
