### PR TITLE
rclpy: 3.3.21-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8728,7 +8728,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 3.3.20-1
+      version: 3.3.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `3.3.21-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.20-1`

## rclpy

```
* Fix issues with resuming async tasks awaiting a future (backport #1469 <https://github.com/ros2/rclpy/issues/1469>) (#1582 <https://github.com/ros2/rclpy/issues/1582>)
* Contributors: Błażej Sowa
```
