### PR TITLE
qml6_ros2_plugin: 1.26.30-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7487,7 +7487,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 1.26.10-1
+      version: 1.26.30-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `1.26.30-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.26.10-1`

## qml6_ros2_plugin

```
* Fix yaml conversion not handling QJSValue correctly.
* Updated documentation.
* Fix BGR color swap and added support for NV21. (#18 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/18>)
  * Fix BGR color swap and added support for NV21.
* Use a symlink instead of installing twice. (#14 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/14>)
  * Use a symlink instead of installing twice.
  This fixes issues where an application may link against both files through plugins which separates the singletons as they exist per inode and creates complex issues.
* Don't pass QJSValue between threads (#9 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/9>)
  * Move all QJSValue to data structures and only pass id for retrieval to fix threading segmentation faults.
  Also fixes check service ready being called while object is already destructed.
  * Fixed deprecation of ament_index_cpp methods.  Change ament_index_cpp method based on available version.
* Added funding details.
* Contributors: Stefan Fabian
```
