### PR TITLE
qml6_ros2_plugin: 0.26.30-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8291,7 +8291,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 0.25.121-1
+      version: 0.26.30-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `0.26.30-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.25.121-1`

## qml6_ros2_plugin

```
* Fix yaml conversion not handling QJSValue correctly.
* Updated documentation.
* Fix BGR color swap and added support for NV21. (#18 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/18>)
  * Fix BGR color swap and added support for NV21.
* Use a symlink instead of installing twice. (#14 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/14>)
  * Use a symlink instead of installing twice.
  This fixes issues where an application may link against both files through plugins which separates the singletons as they exist per inode and creates complex issues.
* [Backport humble] Don't pass QJSValue between threads (#10 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/10>)
  * Don't pass QJSValue between threads (#9 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/9>)
  * Move all QJSValue to data structures and only pass id for retrieval to fix threading segmentation faults.
  Also fixes check service ready being called while object is already destructed.
  * Fixed deprecation of ament_index_cpp methods.  Change ament_index_cpp method based on available version.
  * Remove version checks and use old method signature for humble
* Fixed segfault if Service or ActionClient are no longer associated with qjsEngine when callback is invoked.
* Improved image conversion to also deal with infinite values in depth images.
* Fixed crash when ServiceClient is processing request while client is destroyed.
  Use QPointer for callbacks to prevent crashes due to the object being destroyed while an asynchronous operation is still in progress.
* Contributors: Stefan Fabian
```
