### PR TITLE
qml_ros2_plugin: 1.26.31-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8306,7 +8306,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
-      version: 1.25.2-1
+      version: 1.26.31-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml_ros2_plugin` to `1.26.31-1`:

- upstream repository: https://github.com/StefanFabian/qml_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml_ros2_plugin-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.25.2-1`

## qml_ros2_plugin

```
* Revert humble incompatible changes.
* Contributors: Stefan Fabian
```
