### PR TITLE
camera_aravis2: 1.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1150,7 +1150,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/camera_aravis2-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis2` to `1.2.0-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis2.git
- release repository: https://github.com/ros2-gbp/camera_aravis2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.0-1`

## camera_aravis2

```
* other: add miguel as maintainer
* feat: enable manual param order in BEGIN and END
  Use the prefix #NN_ to preserve the order. For example:
  `#1 <https://github.com/FraunhoferIOSB/camera_aravis2/issues/1>`__FirstParam
  `#2 <https://github.com/FraunhoferIOSB/camera_aravis2/issues/2>`__SecondParam
  OtherParamsThatAreAlphabeticallyOrdered
* Contributors: Miguel Granero
```

## camera_aravis2_msgs

```
* other: add miguel as maintainer
* Contributors: Miguel Granero
```
