### PR TITLE
camera_aravis2: 1.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -976,6 +976,14 @@ repositories:
       type: git
       url: https://github.com/FraunhoferIOSB/camera_aravis2.git
       version: main
+    release:
+      packages:
+      - camera_aravis2
+      - camera_aravis2_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/camera_aravis2-release.git
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/camera_aravis2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_aravis2` to `1.2.0-1`:

- upstream repository: https://github.com/FraunhoferIOSB/camera_aravis2.git
- release repository: https://github.com/ros2-gbp/camera_aravis2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## camera_aravis2

```
* other: add miguel as maintainer
* feat: enable manual param order in BEGIN and END
  Use the prefix #NN_ to preserve the order. For example:
  `#1 <https://github.com/FraunhoferIOSB/camera_aravis2/issues/1>`__FirstParam
  `#2 <https://github.com/FraunhoferIOSB/camera_aravis2/issues/2>`__SecondParam
  OtherParamsThatAreAlphabeticallyOrdered
* Contributors: Miguel Granero
```

## camera_aravis2_msgs

```
* other: add miguel as maintainer
* Contributors: Miguel Granero
```
