### PR TITLE
rosdep: update libgmock-dev on nixos

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4250,7 +4250,7 @@ libgmock-dev:
   fedora: [gmock-devel]
   freebsd: [googlemock]
   gentoo: [dev-cpp/gtest]
-  nixos: [gmock]
+  nixos: [gtest]
   openembedded: [gtest@meta-oe]
   opensuse: [gmock-devel]
   rhel: [gmock-devel]


### PR DESCRIPTION
fix:
```
         at /nix/store/…/pkgs/top-level/aliases.nix:1062:11:
         1061|   gmnisrv = throw "'gmnisrv' has been removed due to lack of maintenance upstream"; # Added 2025-06-07
         1062|   gmock = throw "'gmock' has been renamed to/replaced by 'gtest'"; # Converted to throw 2024-10-17
             |           ^
         1063|   gmp4 = throw "'gmp4' is end-of-life, consider using 'gmp' instead"; # Added 2024-12-24

       error: 'gmock' has been renamed to/replaced by 'gtest'
```