### PR TITLE
Add python3-robotmem-pip rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9837,6 +9837,10 @@ python3-robyn-pip:
   '*':
     pip:
       packages: [robyn]
+python3-robotmem-pip:
+  '*':
+    pip:
+      packages: [robotmem]
 python3-rocker:
   debian: [python3-rocker]
   ubuntu: [python3-rocker]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9833,14 +9833,14 @@ python3-robodk-pip:
   ubuntu:
     pip:
       packages: [robodk]
-python3-robyn-pip:
-  '*':
-    pip:
-      packages: [robyn]
 python3-robotmem-pip:
   '*':
     pip:
       packages: [robotmem]
+python3-robyn-pip:
+  '*':
+    pip:
+      packages: [robyn]
 python3-rocker:
   debian: [python3-rocker]
   ubuntu: [python3-rocker]


### PR DESCRIPTION
## Summary

Add rosdep key `python3-robotmem-pip` for the [robotmem](https://pypi.org/project/robotmem/) Python package.

**robotmem** is a robot experience memory system that provides persistent cross-episode memory for robot LLMs. It's used as a runtime dependency by [robotmem_ros](https://github.com/robotmem/robotmem) ROS 2 packages.

## Details

- PyPI package: [`robotmem`](https://pypi.org/project/robotmem/) (v0.1.0)
- License: Apache-2.0
- rosdep key: `python3-robotmem-pip`
- Install method: pip (all platforms)

## Changes

- `rosdep/python.yaml`: Added `python3-robotmem-pip` entry with `'*'` platform wildcard pointing to pip package `robotmem`