### PR TITLE
robotmem: Add source and doc entry to humble distribution

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9456,6 +9456,16 @@ repositories:
       url: https://github.com/clearpathrobotics/robot_upstart.git
       version: foxy-devel
     status: maintained
+  robotmem:
+    doc:
+      type: git
+      url: https://github.com/robotmem/robotmem.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/robotmem/robotmem.git
+      version: main
+    status: developed
   robotont_driver:
     doc:
       type: git


### PR DESCRIPTION
## Summary

Add source and documentation entries for [robotmem](https://github.com/robotmem/robotmem) to the Humble distribution.

**robotmem** is a robot experience memory system — persistent cross-episode memory for robot LLMs. "Learn once, remember forever, transfer across environments."

### Packages

| Package | Type | Description |
|---------|------|-------------|
| `robotmem_msgs` | ament_cmake | ROS 2 message/service definitions (3 msg + 7 srv) |
| `robotmem_ros` | ament_python | ROS 2 node — 7 Services + 1 Topic, SDK thin wrapper |

### Review Checklist

- [x] Top-level LICENSE file: `Apache-2.0`
- [x] License is [OSI-approved](https://opensource.org/licenses): Apache License 2.0
- [x] License correctly listed in package.xmls: `<license>Apache-2.0</license>`
- [x] Public source repo: https://github.com/robotmem/robotmem
- [x] Source repository contains ROS packages (2 packages with `package.xml`)
- [x] Each package meets [REP-144](https://reps.openrobotics.org/rep-0144/) naming conventions

### Package Details

```console
$ find ros/ -name "package.xml" -exec grep -e "<name>" "{}" ";"
  <name>robotmem_msgs</name>
  <name>robotmem_ros</name>
```

```console
$ find ros/ -name "package.xml" -exec grep -e "<license>" "{}" "+"
  <license>Apache-2.0</license>
  <license>Apache-2.0</license>
```

### Note

This PR adds **source and doc entries only** (no binary release). `robotmem_ros` depends on `python3-robotmem-pip` (rosdep key submitted in #50206). Binary release will follow once the rosdep key is merged.