### PR TITLE
ros2_controllers: 2.52.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9613,7 +9613,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.52.0-1
+      version: 2.52.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.52.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.52.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Check robot description validity in AdmittanceController (backport #2009 <https://github.com/ros-controls/ros2_controllers/issues/2009>) (#2112 <https://github.com/ros-controls/ros2_controllers/issues/2112>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## diff_drive_controller

```
* Fix the teardown of the diff_drive_controller test (backport #2183 <https://github.com/ros-controls/ros2_controllers/issues/2183>) (#2184 <https://github.com/ros-controls/ros2_controllers/issues/2184>)
* docs: diff_drive_controller - complete wheel_separation_multiplier description and fix then→than typo (backport #2108 <https://github.com/ros-controls/ros2_controllers/issues/2108>) (#2119 <https://github.com/ros-controls/ros2_controllers/issues/2119>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2194 <https://github.com/ros-controls/ros2_controllers/issues/2194>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2194 <https://github.com/ros-controls/ros2_controllers/issues/2194>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2194 <https://github.com/ros-controls/ros2_controllers/issues/2194>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Bump version of pre-commit hooks (backport #2140 <https://github.com/ros-controls/ros2_controllers/issues/2140>) (#2141 <https://github.com/ros-controls/ros2_controllers/issues/2141>)
* Contributors: mergify[bot]
```

## rqt_joint_trajectory_controller

- No changes

## steering_controllers_library

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2194 <https://github.com/ros-controls/ros2_controllers/issues/2194>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2194 <https://github.com/ros-controls/ros2_controllers/issues/2194>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
