### PR TITLE
Add robotmem_ros release for humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9456,6 +9456,20 @@ repositories:
       url: https://github.com/clearpathrobotics/robot_upstart.git
       version: foxy-devel
     status: maintained
+  robotmem_ros:
+    release:
+      packages:
+      - robotmem_msgs
+      - robotmem_ros
+      tags:
+        release: release/humble/{{package}}/{{version}}
+      url: https://github.com/robotmem/robotmem_ros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/robotmem/robotmem_ros.git
+      version: main
+    status: maintained
   robotont_driver:
     doc:
       type: git


### PR DESCRIPTION
## Summary

- Add `robotmem_ros` (robotmem_msgs + robotmem_ros) to humble distribution
- Release repository: https://github.com/robotmem/robotmem_ros-release
- Source repository: https://github.com/robotmem/robotmem_ros
- Version: 0.1.0-1

## Package Info

robotmem is a robot experience memory system — persistent memory for robot learning.

- `robotmem_msgs`: Message and service definitions
- `robotmem_ros`: ROS 2 node (7 Services + perception stream)

## Release Info

- bloom-generated release branches and debian tags in robotmem_ros-release
- CI passing on Humble/Jazzy/Rolling: https://github.com/robotmem/robotmem_ros/actions
- Related rosdep PR: #50206
