### PR TITLE
Add robotmem_ros release for rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7,6 +7,20 @@ release_platforms:
   - bookworm
   rhel:
   - '9'
+  robotmem_ros:
+    release:
+      packages:
+      - robotmem_msgs
+      - robotmem_ros
+      tags:
+        release: release/rolling/{{package}}/{{version}}
+      url: https://github.com/robotmem/robotmem_ros-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/robotmem/robotmem_ros.git
+      version: main
+    status: maintained
   ubuntu:
   - noble
 repositories:


### PR DESCRIPTION
## Summary

- Add `robotmem_ros` (robotmem_msgs + robotmem_ros) to rolling distribution
- Release repository: https://github.com/robotmem/robotmem_ros-release
- Source repository: https://github.com/robotmem/robotmem_ros
- Version: 0.1.0-1

## Package Info

robotmem is a robot experience memory system — persistent memory for robot learning.

- `robotmem_msgs`: Message and service definitions
- `robotmem_ros`: ROS 2 node (7 Services + perception stream)

## Release Info

- bloom-generated release branches and debian tags in robotmem_ros-release
- CI passing on Humble/Jazzy/Rolling: https://github.com/robotmem/robotmem_ros/actions
- Related rosdep PR: #50206
