### PR TITLE
mola: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5396,7 +5396,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.6.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.5.0-1`

## kitti_metrics_eval

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola

- No changes

## mola_bridge_ros2

```
* Remove now obsolete version check macro
* Merge pull request #108 <https://github.com/MOLAorg/mola/issues/108> from MOLAorg/feat/use-gps-msgs
  Support gps_msgs data types too for ROS2
* Support gps_msgs as alternative to NavSatFix
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

```
* Merge pull request #108 <https://github.com/MOLAorg/mola/issues/108> from MOLAorg/feat/use-gps-msgs
  Support gps_msgs data types too for ROS2
* Remove useless cmake macro argument
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* FIX: Exception in mulran dataset source with current mrpt version
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Support Zstd-compressed rawlog files too
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* Support Zstd-compressed rawlog files too
* Merge pull request #108 <https://github.com/MOLAorg/mola/issues/108> from MOLAorg/feat/use-gps-msgs
  Support gps_msgs data types too for ROS2
* Support gps_msgs as alternative to NavSatFix
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Merge pull request #106 <https://github.com/MOLAorg/mola/issues/106> from MOLAorg/refactor-rosbag2dataset
  Refactor code for handling sensors
* Refactor code for handling sensors
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Merge pull request #113 <https://github.com/MOLAorg/mola/issues/113> from MOLAorg/feat/kf-map-view-vectors
  Feat:kf map view vectors filter for NN search
* comments formatting
* Merge pull request #109 <https://github.com/MOLAorg/mola/issues/109> from MOLAorg/feat/support-imgui
  Feature: GUI backend agnostic API in mola_kernel (Step towards supporting imgui)
* safer multithread
* Several visual and safety fixes in the new GUI interface
* minor fixes
* Add support for menu bars
* VizInterface made backend agnostic (ImGUI and Nanogui)
* Merge pull request #108 <https://github.com/MOLAorg/mola/issues/108> from MOLAorg/feat/use-gps-msgs
  Support gps_msgs data types too for ROS2
* Support gps_msgs as alternative to NavSatFix
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix typo in comments
* add missing new cpp
* Update coyright notes
* fix clang-tidy warnings
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Merge pull request #113 <https://github.com/MOLAorg/mola/issues/113> from MOLAorg/feat/kf-map-view-vectors
  Feat:kf map view vectors filter for NN search
* Honor the documented disable semantics for max_view_angle_deg
* NDT tests: fix clang-tidy warnings
* view-direction NN filter; add KF map unit tests
* Fix: possible invalid deref
* Better criterion to select active frames
* KeyFramePointCloudMap: Add two debug env vars to control visualization
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* BUG FIX: creationOptions were not loaded from ini file in KeyframePointCloudMap
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

```
* Fix clang-tidy warnings
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Merge pull request #113 <https://github.com/MOLAorg/mola/issues/113> from MOLAorg/feat/kf-map-view-vectors
  Feat:kf map view vectors filter for NN search
* comments formatting
* Merge pull request #109 <https://github.com/MOLAorg/mola/issues/109> from MOLAorg/feat/support-imgui
  Feature: GUI backend agnostic API in mola_kernel (Step towards supporting imgui)
* safer multithread
* Several visual and safety fixes in the new GUI interface
* Use safer livestring registry
* minor fixes
* Add support for menu bars
* MolaViz implements the new backend agnostic API
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* Refactor decay-clouds so they are invariant to wallclock incoming speed
* Update coyright notes
* fix clang-tidy warnings
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Merge pull request #107 <https://github.com/MOLAorg/mola/issues/107> from MOLAorg/fix/viz-decay-clouds
  Fix/viz-decay-clouds
* fix clang-tidy warning: avoid std::endl
* Update coyright notes
* Contributors: Jose Luis Blanco-Claraco
```
