### PR TITLE
ros2_controllers: 4.38.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8826,6 +8826,7 @@ repositories:
       - joint_state_broadcaster
       - joint_trajectory_controller
       - mecanum_drive_controller
+      - motion_primitives_controllers
       - omni_wheel_drive_controller
       - parallel_gripper_controller
       - pid_controller
@@ -8843,7 +8844,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.37.0-1
+      version: 4.38.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.38.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `4.37.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Fix dynamic allocation in admittance_rule (backport #2150 <https://github.com/ros-controls/ros2_controllers/issues/2150>) (#2154 <https://github.com/ros-controls/ros2_controllers/issues/2154>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Fix the teardown of the controller tests (backport #2183 <https://github.com/ros-controls/ros2_controllers/issues/2183>) (#2185 <https://github.com/ros-controls/ros2_controllers/issues/2185>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Bump version of pre-commit hooks (backport #2188 <https://github.com/ros-controls/ros2_controllers/issues/2188>) (#2190 <https://github.com/ros-controls/ros2_controllers/issues/2190>)
* Contributors: mergify[bot]
```

## gpio_controllers

```
* fix(gpio_controllers): resolve build failure (backport #2128 <https://github.com/ros-controls/ros2_controllers/issues/2128>) (#2170 <https://github.com/ros-controls/ros2_controllers/issues/2170>)
* Contributors: mergify[bot]
```

## gps_sensor_broadcaster

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2195 <https://github.com/ros-controls/ros2_controllers/issues/2195>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Add test to check JSB is not throwing when there is a boolean interface (backport #2115 <https://github.com/ros-controls/ros2_controllers/issues/2115>) (#2158 <https://github.com/ros-controls/ros2_controllers/issues/2158>)
* Contributors: Noel Jiménez García
```

## joint_trajectory_controller

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2195 <https://github.com/ros-controls/ros2_controllers/issues/2195>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2195 <https://github.com/ros-controls/ros2_controllers/issues/2195>)
* Contributors: mergify[bot]
```

## motion_primitives_controllers

```
* Add motion_primitives_forward_controller for interfacing motion primitive messages with hardware interfaces (backport #1636 <https://github.com/ros-controls/ros2_controllers/issues/1636>) (#2175 <https://github.com/ros-controls/ros2_controllers/issues/2175>)
* Contributors: mergify[bot]
```

## omni_wheel_drive_controller

```
* Fix the teardown of the controller tests (backport #2183 <https://github.com/ros-controls/ros2_controllers/issues/2183>) (#2185 <https://github.com/ros-controls/ros2_controllers/issues/2185>)
* Contributors: mergify[bot]
```

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2195 <https://github.com/ros-controls/ros2_controllers/issues/2195>)
* Contributors: mergify[bot]
```

## tricycle_controller

```
* Consistently add <cmath> include with define for windows (backport #2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>) (#2195 <https://github.com/ros-controls/ros2_controllers/issues/2195>)
* Contributors: mergify[bot]
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
