### PR TITLE
Add libxcb-cursor0 to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7511,7 +7511,6 @@ libxcb-cursor0:
   debian: [libxcb-cursor0]
   fedora: [xcb-util-cursor]
   gentoo: [xcb-util-cursor]
-  macports: [xorg-xcb-util-cursor]
   nixos: [xcb-util-cursor-HEAD]
   opensuse: [libxcb-cursor0]
   osx:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7506,6 +7506,18 @@ libxaw:
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
 libxcb-cursor0:
+  alpine: [xcb-util-cursor]
+  arch: [xcb-util-cursor]
+  debian: [libxcb-cursor0]
+  fedora: [xcb-util-cursor]
+  gentoo: [xcb-util-cursor]
+  macports: [xorg-xcb-util-cursor]
+  nixos: [xcb-util-cursor-HEAD]
+  opensuse: [libxcb-cursor0]
+  osx:
+    homebrew:
+      packages: [xcb-util-cursor]
+  rhel: [xcb-util-cursor]
   ubuntu: [libxcb-cursor0]
 libxcb-randr0-dev:
   alpine: [libxcb-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7505,6 +7505,8 @@ libxaw:
   opensuse: [xorg-x11-devel]
   rhel: [libXaw-devel]
   ubuntu: [libxaw7-dev]
+libxcb-cursor0:
+  ubuntu: [libxcb-cursor0]
 libxcb-randr0-dev:
   alpine: [libxcb-dev]
   arch: [libxcb]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

# Please add the following dependency to the rosdep database.

## Package name:

libxcb-cursor0

## Package Upstream Source:

https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor

## Purpose of using this:

This dependency is necessary for running PySide6 applications. When installing PySide6 via the rosdep pip package, this dependency does not come with it. PySide6 is used to build graphical applications for ros. 

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libxcb-cursor0
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/libxcb-cursor0
  - https://packages.ubuntu.com/noble/libxcb-cursor0
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/xcb-util-cursor/xcb-util-cursor/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/xcb-util-cursor/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/x11-libs/xcb-util-cursor
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/xcb-util-cursor#default
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/xcb-util-cursor
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.11&query=xcb-util-cursor
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/libxcb-cursor0
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/8/epel-x86_64/xcb-util-cursor-0.1.3-9.el8.x86_64.rpm.html

## Other

I've tested that the different os's resolve via rosdep and tested it using pytest.
