### PR TITLE
ros2_controllers: 6.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7552,7 +7552,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.3.0-1
+      version: 6.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `6.3.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Consistently add <cmath> include with define for windows (#2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>)
* [Admittance] applies control frame transform to mass matrix (#1139 <https://github.com/ros-controls/ros2_controllers/issues/1139>)
* Fix dynamic allocation in admittance_rule (#2150 <https://github.com/ros-controls/ros2_controllers/issues/2150>)
* Contributors: Christoph Fröhlich, Marco Magri, Surya!
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Fix deprecation warning in diff_drive_controller (#2174 <https://github.com/ros-controls/ros2_controllers/issues/2174>)
* Fix the teardown of the controller tests (#2183 <https://github.com/ros-controls/ros2_controllers/issues/2183>)
* Unit tests for the new odometry implementation in diff_drive_controller (#2099 <https://github.com/ros-controls/ros2_controllers/issues/2099>)
* Silence -Wdeprecated-declarations in diff_drive_controller (#2139 <https://github.com/ros-controls/ros2_controllers/issues/2139>)
* Add set_odometry service to diff drive controller (#2096 <https://github.com/ros-controls/ros2_controllers/issues/2096>)
* Contributors: Christoph Fröhlich, Ege Kural, Jiayi Cai, Sai Kishor Kothakota, Vedh
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

```
* Bump version of pre-commit hooks (#2188 <https://github.com/ros-controls/ros2_controllers/issues/2188>)
* Contributors: github-actions[bot]
```

## gpio_controllers

```
* fix(gpio_controllers): resolve build failure (#2128 <https://github.com/ros-controls/ros2_controllers/issues/2128>)
* Contributors: Ishan Pathak
```

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

```
* Consistently add <cmath> include with define for windows (#2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Consistently add <cmath> include with define for windows (#2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>)
* Fix JTC test speed scaling publisher (#2153 <https://github.com/ros-controls/ros2_controllers/issues/2153>)
* Contributors: Christoph Fröhlich, Marq Rasmussen
```

## mecanum_drive_controller

```
* Consistently add <cmath> include with define for windows (#2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>)
* Add set_odometry service to mecanum drive controller (#2110 <https://github.com/ros-controls/ros2_controllers/issues/2110>)
* Contributors: Christoph Fröhlich, Ege Kural
```

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

```
* Fix the teardown of the controller tests (#2183 <https://github.com/ros-controls/ros2_controllers/issues/2183>)
* Add set_odometry service - omni wheel drive controller (#2148 <https://github.com/ros-controls/ros2_controllers/issues/2148>)
* Contributors: Ege Kural, Sai Kishor Kothakota
```

## parallel_gripper_controller

- No changes

## pid_controller

```
* [PID Controllers] Set first set point to current measurement (#2205 <https://github.com/ros-controls/ros2_controllers/issues/2205>)
* Contributors: Sai Kishor Kothakota
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

- No changes

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

```
* Consistently add <cmath> include with define for windows (#2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>)
* Contributors: Christoph Fröhlich
```

## tricycle_controller

```
* Consistently add <cmath> include with define for windows (#2193 <https://github.com/ros-controls/ros2_controllers/issues/2193>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
