### PR TITLE
[jazzy] depthai_ros_v3: release 3.1.1-2

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2094,6 +2094,30 @@ repositories:
       url: https://github.com/luxonis/depthai-ros.git
       version: jazzy
     status: developed
+  depthai_ros_v3:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3-jazzy
+    release:
+      packages:
+      - depthai_bridge_v3
+      - depthai_descriptions_v3
+      - depthai_examples_v3
+      - depthai_filters_v3
+      - depthai_ros_driver_v3
+      - depthai_ros_msgs_v3
+      - depthai_ros_v3
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-v3-release.git
+      version: 3.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3-jazzy
+    status: developed
   depthai_v3:
     release:
       tags:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2111,7 +2111,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.1.1-1
+      version: 3.1.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This PR adds the Jazzy release entry for `depthai_ros_v3` and its `_v3` packages.

Release repository: https://github.com/luxonis/depthai-ros-v3-release.git
Upstream repository: https://github.com/luxonis/depthai-ros.git
Upstream source tag: `v3.1.1-jazzy.4`
Release version: `3.1.1-2`

Packages:
- depthai_ros_v3
- depthai_bridge_v3
- depthai_descriptions_v3
- depthai_examples_v3
- depthai_filters_v3
- depthai_ros_driver_v3
- depthai_ros_msgs_v3
