### PR TITLE
humble: add depthai_v3 and depthai_ros_v3 releases

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2298,8 +2298,6 @@ repositories:
       url: https://github.com/luxonis/depthai-core.git
       version: v3_humble
     release:
-      packages:
-      - depthai_v3
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-core-v3-release.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2268,6 +2268,48 @@ repositories:
       url: https://github.com/luxonis/depthai-ros.git
       version: humble
     status: developed
+  depthai_ros_v3:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3_humble
+    release:
+      packages:
+      - depthai_bridge_v3
+      - depthai_descriptions_v3
+      - depthai_examples_v3
+      - depthai_filters_v3
+      - depthai_ros_driver_v3
+      - depthai_ros_msgs_v3
+      - depthai_ros_v3
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/luxonis/depthai-ros-v3-release.git
+      version: 3.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3_humble
+    status: developed
+  depthai_v3:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: v3_humble
+    release:
+      packages:
+      - depthai_v3
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/luxonis/depthai-core-v3-release.git
+      version: 3.2.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: v3_humble
+    status: developed
   depthimage_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
## Summary
- add new `depthai_v3` Humble release entry (`3.2.2-1`) from `luxonis/depthai-core-v3-release`
- add new `depthai_ros_v3` Humble release entry (`3.1.1-1`) from `luxonis/depthai-ros-v3-release`
- include source/doc entries on `v3_humble` branches for both repositories

## Context
These are the v3 packages for Humble, kept separately from existing v2 `depthai` / `depthai-ros` to avoid breaking existing users.

`depthai_ros_v3` includes upstream `v3_humble` updates needed for Humble rollout, including metapackage rename to underscore form and the model alias update used by the driver path for newer OAK naming.

## Release repos
- https://github.com/luxonis/depthai-core-v3-release
- https://github.com/luxonis/depthai-ros-v3-release
