### PR TITLE
novatel_oem7_driver: 4.3.0-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5310,6 +5310,14 @@ repositories:
       type: git
       url: https://github.com/novatel/novatel_oem7_driver.git
       version: kilted
+    release:
+      packages:
+      - novatel_oem7_driver
+      - novatel_oem7_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
+      version: 4.3.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `4.3.0-2`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## novatel_oem7_driver

```
* ISA 100C data changed in src/novatel_oem7_driver/config/oem7_supported_imus.yaml
* CMake error fix in docker/Dockerfile.build
* CONNECTIMU command and CORRIMUSB comment added in src/novatel_oem7_driver/config/std_init_commands.yaml
```
