### PR TITLE
gps_umd: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2659,7 +2659,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `2.1.2-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.1-1`

## gps_msgs

- No changes

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

```
* Fixing time conversion (#117 <https://github.com/swri-robotics/gps_umd/issues/117>)
* Contributors: David Anthony
```
