### PR TITLE
rviz_2d_overlay_plugins: 1.4.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8942,7 +8942,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
-      version: 1.3.1-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_2d_overlay_plugins` to `1.4.1-1`:

- upstream repository: https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git
- release repository: https://github.com/ros2-gbp/rviz_2d_overlay_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.1-1`

## rviz_2d_overlay_msgs

- No changes

## rviz_2d_overlay_plugins

```
* added missing QRegularExpression include for jazzy #25 <https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/25>
* removed unused headers_to_moc var #25 <https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/25>
* enable automoc #25 <https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins/issues/25>
* Contributors: Henning Klatt
```
