### PR TITLE
[openembedded] missing qt6 packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6599,6 +6599,7 @@ libqt6gui6t64:
   debian: [libqt6gui6]
   fedora: [qt6-qtbase-gui]
   nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase-gui]
     '8': null
@@ -6612,6 +6613,7 @@ libqt6opengl6t64:
   debian: [libqt6opengl6]
   fedora: [qt6-qtbase]
   nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
     '8': null
@@ -6647,6 +6649,7 @@ libqt6widgets6t64:
   debian: [libqt6widgets6]
   fedora: [qt6-qtbase-gui]
   nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
   rhel:
     '*': [qt6-qtbase]
     '8': null


### PR DESCRIPTION
* libqt6gui6t64: gui is a PACKAGECONFIG of qtbase and default enabled
* libqt6opengl6t64: opengl is a PACKAGECONFIG of qtbase and default enable if opengl is in DISTRO_FEATURES
* libqt6widgets6t64: widgets is a PACKAGECONFIG of qtbase and default enabled

@robwoolley: could you ack/nack?  It's work we will need for qt6 and prevents a hack in `ros-distro.inc`