### PR TITLE
ai_worker: 1.1.20-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -161,7 +161,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ai_worker-release.git
-      version: 1.1.16-1
+      version: 1.1.20-1
     source:
       type: git
       url: https://github.com/ROBOTIS-GIT/ai_worker.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ai_worker` to `1.1.20-1`:

- upstream repository: https://github.com/ROBOTIS-GIT/ai_worker.git
- release repository: https://github.com/ros2-gbp/ai_worker-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.16-1`

## ffw

```
* Fixed version of docker image in docker-compose.yml
* Added a notice in container.sh when update is available
* Contributors: Hyungyu Kim
```

## ffw_bringup

```
* None
```

## ffw_description

```
* None
```

## ffw_joint_trajectory_command_broadcaster

```
* None
```

## ffw_joystick_controller

```
* None
```

## ffw_moveit_config

```
* None
```

## ffw_navigation

```
* None
```

## ffw_robot_manager

```
* None
```

## ffw_spring_actuator_controller

```
* None
```

## ffw_swerve_drive_controller

```
* None
```

## ffw_teleop

```
* None
```
