### PR TITLE
rc_genicam_driver: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7801,7 +7801,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
-      version: 0.3.2-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_driver` to `0.4.0-1`:

- upstream repository: https://github.com/roboception/rc_genicam_driver_ros2.git
- release repository: https://github.com/ros2-gbp/rc_genicam_driver_ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.2-1`

## rc_genicam_driver

```
* Added parameters for binning and triggering
* Added service call for software triggering of cameras
* For supporting USB cameras, made getting MAC, IP and GEV package size from nodemap optional
* Fixed undeclaring parameters for cases where node has to reconnect
* Made setting of GenICam parameters more robust against failures
```
