### PR TITLE
mapviz: 2.6.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4122,7 +4122,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.6.1-1
+      version: 2.6.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.6.2-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.1-1`

## mapviz

- No changes

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Fixed bad yaml read for doubles (#866 <https://github.com/swri-robotics/mapviz/issues/866>)
* Contributors: Alex Youngs
```

## multires_image

- No changes

## tile_map

- No changes
