### PR TITLE
mvsim: 1.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4971,7 +4971,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `1.3.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.2.0-1`

## mvsim

```
* docs: add logo to web
* Modernize README
* Clean up leftovers from temporary benchmark code
* Creation of .rawlog files use ZStd if available
* walls demo world: make all walls same thickness, and expose optional env var
* Add MVSIM_SAVE_RAWLOG_FILENAME env var to some demo worlds
* XML parser: env vars now can have a default value
* docs: fix wrong referenc for {} usage
* remove leftover dep
* Merge pull request #95 <https://github.com/MRPT/mvsim/issues/95> from MRPT/nav-benchmark-greenhouse
  Nav benchmark greenhouse
* Merge branch 'develop' into nav-benchmark-greenhouse
* Add auto_start_recording property to vehicles
* logistic center demo: add lidar sensors
* Remove temporary adaptative friction class
* remove temporary deps
* Refactoring to use CsvLogger (by Claude Opus)
* Refactor torque calculation by removing comments and logger
  Removed logging and comments related to torque calculation.
* Changes for control benchmark paper
* Contributors: Fernando Cañadas Aránega, Jose Luis Blanco-Claraco
```
