### PR TITLE
mujoco_ros2_control: 0.0.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4919,10 +4919,11 @@ repositories:
       - mujoco_ros2_control
       - mujoco_ros2_control_demos
       - mujoco_ros2_control_msgs
+      - mujoco_ros2_control_plugins
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
-      version: 0.0.1-2
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_ros2_control` to `0.0.2-1`:

- upstream repository: https://github.com/ros-controls/mujoco_ros2_control.git
- release repository: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.1-2`

## mujoco_ros2_control

```
* Update internal links for myst-parser readthedocs (#148 <https://github.com/ros-controls/mujoco_ros2_control/issues/148>)
* Fix reset simulation service for robots using PID control (#140 <https://github.com/ros-controls/mujoco_ros2_control/issues/140>)
* throw on failing init of mujoco_ros2_control_plugins (#136 <https://github.com/ros-controls/mujoco_ros2_control/issues/136>)
* Cleanup duplicate files (#146 <https://github.com/ros-controls/mujoco_ros2_control/issues/146>)
* Export mujoco_ros2_control_plugins (#138 <https://github.com/ros-controls/mujoco_ros2_control/issues/138>)
* [URDF->MJCF] fixed path for urdf with test (#127 <https://github.com/ros-controls/mujoco_ros2_control/issues/127>)
* Set MuJoCo install include dirs (#135 <https://github.com/ros-controls/mujoco_ros2_control/issues/135>)
* [Feature] MuJoCo ros2 control plugins (#133 <https://github.com/ros-controls/mujoco_ros2_control/issues/133>)
* Use pixi-build-ros as the backend for pixi builds (#130 <https://github.com/ros-controls/mujoco_ros2_control/issues/130>)
* Rename default node to mujoco_ros2_control_node (#132 <https://github.com/ros-controls/mujoco_ros2_control/issues/132>)
* Changes necessary to also work for MuJoCo 3.5.0 (#123 <https://github.com/ros-controls/mujoco_ros2_control/issues/123>)
* Update license name to SPDX standard (#129 <https://github.com/ros-controls/mujoco_ros2_control/issues/129>)
* Add minor fixes to the conversion methods (#125 <https://github.com/ros-controls/mujoco_ros2_control/issues/125>)
* Update RPATH of the mujoco_vendor libraries (#122 <https://github.com/ros-controls/mujoco_ros2_control/issues/122>)
* Improve testing for URDF->MJCF tooling (#119 <https://github.com/ros-controls/mujoco_ros2_control/issues/119>)
* Add git dependency (#121 <https://github.com/ros-controls/mujoco_ros2_control/issues/121>)
* Contributors: Christoph Fröhlich, Erik Holum, Julia Jia, Ortisa, Sai Kishor Kothakota, Nathan Dunkelberger, Jordan Palacios
```

## mujoco_ros2_control_demos

```
* Fix reset simulation service for robots using PID control (#140 <https://github.com/ros-controls/mujoco_ros2_control/issues/140>)
* Cleanup duplicate files (#146 <https://github.com/ros-controls/mujoco_ros2_control/issues/146>)
* Remove deprecated JointGroupPositionController with ForwardCommandController (#147 <https://github.com/ros-controls/mujoco_ros2_control/issues/147>)
* [URDF->MJCF] fixed path for urdf with test (#127 <https://github.com/ros-controls/mujoco_ros2_control/issues/127>)
* [Feature] MuJoCo ros2 control plugins (#133 <https://github.com/ros-controls/mujoco_ros2_control/issues/133>)
* Use pixi-build-ros as the backend for pixi builds (#130 <https://github.com/ros-controls/mujoco_ros2_control/issues/130>)
* Contributors: Christoph Fröhlich, Erik Holum, Ortisa, Sai Kishor Kothakota
```

## mujoco_ros2_control_msgs

```
* Use pixi-build-ros as the backend for pixi builds (#130 <https://github.com/ros-controls/mujoco_ros2_control/issues/130>)
* Update license name to SPDX standard (#129 <https://github.com/ros-controls/mujoco_ros2_control/issues/129>)
* Contributors: Erik Holum, Sai Kishor Kothakota
```

## mujoco_ros2_control_plugins

```
* [Feature] MuJoCo ros2 control plugins (#133 <https://github.com/ros-controls/mujoco_ros2_control/issues/133>)
* Contributors: Sai Kishor Kothakota, Erik Holum
```
