### PR TITLE
bond_core: 4.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -929,7 +929,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.2-2
+      version: 4.1.3-1
     source:
       test_pull_requests: true
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -918,7 +918,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/bond_core.git
-      version: ros2
+      version: kilted
     release:
       packages:
       - bond
@@ -934,7 +934,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
-      version: ros2
+      version: kilted
     status: maintained
   boost_geometry_util:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.1.3-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.2-2`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* memory safe subscription callback (#108 <https://github.com/ros/bond_core//issues/108>)
* Check the availability of mutex before locking it. (#111 <https://github.com/ros/bond_core//issues/111>)
* Contributors: ChenYing Kuo (CY), ewak
```

## bondpy

- No changes

## smclib

- No changes
