### PR TITLE
agnocast: 2.3.1-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -213,8 +213,15 @@ repositories:
       url: https://github.com/PickNikRobotics/affordance_primitives.git
       version: main
   agnocast:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/agnocast.git
+      version: main
     release:
       packages:
+      - agnocast_cie_config_msgs
+      - agnocast_cie_thread_configurator
+      - agnocast_components
       - agnocast_e2e_test
       - agnocast_ioctl_wrapper
       - agnocast_sample_application
@@ -224,7 +231,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/agnocast-release.git
-      version: 2.1.2-1
+      version: 2.3.1-3
     source:
       type: git
       url: https://github.com/autowarefoundation/agnocast.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agnocast` to `2.3.1-3`:

- upstream repository: https://github.com/tier4/agnocast.git
- release repository: https://github.com/ros2-gbp/agnocast-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.2-1`

## agnocast_cie_config_msgs

- No changes

## agnocast_cie_thread_configurator

- No changes

## agnocast_components

- No changes

## agnocast_e2e_test

- No changes

## agnocast_ioctl_wrapper

- No changes

## agnocast_sample_application

- No changes

## agnocast_sample_interfaces

- No changes

## agnocastlib

```
* fix(agnocastlib): use correct rosdep key libgoogle-glog-dev (#1184 <https://github.com/autowarefoundation/agnocast/issues/1184>)
* feat(agnocastlib): add timer init tracepoint (#1178 <https://github.com/autowarefoundation/agnocast/issues/1178>)
* fix(bridge): persist callback_group in performance bridge to prevent premature destruction (#1171 <https://github.com/autowarefoundation/agnocast/issues/1171>)
```

## ros2agnocast

- No changes
