### PR TITLE
bond_core: 4.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1096,7 +1096,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.2-1
+      version: 4.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.2.0-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.2-1`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Check the availability of mutex before locking it. (#111 <https://github.com/ros/bond_core/issues/111>)
* Contributors: ChenYing Kuo (CY)
```

## bondpy

- No changes

## smclib

- No changes
