### PR TITLE
bond_core: 4.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -929,7 +929,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/bond_core-release.git
-      version: 4.1.2-2
+      version: 4.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bond_core` to `4.3.0-1`:

- upstream repository: https://github.com/ros/bond_core.git
- release repository: https://github.com/ros2-gbp/bond_core-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.1.2-2`

## bond

- No changes

## bond_core

- No changes

## bondcpp

```
* Check the availability of mutex before locking it. (#111 <https://github.com/ros/bond_core/issues/111>)
* Contributors: ChenYing Kuo (CY)
```

## bondpy

- No changes

## smclib

- No changes
