### PR TITLE
rcutils: 7.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6770,7 +6770,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.0.6-1
+      version: 7.0.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.0.7-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.0.6-1`

## rcutils

```
* Fix gcc 15.2.1 warning for discarding 'const' qualifier (#547 <https://github.com/ros2/rcutils/issues/547>)
* Disable warning C5105 for older Windows SDKs in base64.c (#544 <https://github.com/ros2/rcutils/issues/544>)
* Contributors: Barry Xu, EddyGharib
```
