### PR TITLE
rosdep: add Ubuntu resolute OpenCV rules and adjust Qt6 t64 mapping

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5289,6 +5289,7 @@ libopencv-core:
   ubuntu:
     jammy: [libopencv-core4.5d]
     noble: [libopencv-core406t64]
+    resolute: [libopencv-core410]
 libopencv-core-dev:
   debian: [libopencv-core-dev]
   fedora: [opencv-devel]
@@ -5335,6 +5336,7 @@ libopencv-imgcodecs:
   ubuntu:
     jammy: [libopencv-imgcodecs4.5d]
     noble: [libopencv-imgcodecs406t64]
+    resolute: [libopencv-imgcodecs410]
 libopencv-imgcodecs-dev:
   debian: [libopencv-imgcodecs-dev]
   fedora: [opencv-devel]
@@ -5353,6 +5355,7 @@ libopencv-imgproc:
   ubuntu:
     jammy: [libopencv-imgproc4.5d]
     noble: [libopencv-imgproc406t64]
+    resolute: [libopencv-imgproc410]
 libopencv-imgproc-dev:
   arch: [opencv]
   debian: [libopencv-imgproc-dev]
@@ -6603,9 +6606,10 @@ libqt6gui6t64:
     '*': [qt6-qtbase-gui]
     '8': null
   ubuntu:
-    '*': [libqt6gui6t64]
+    '*': [libqt6gui6]
     'focal': null
     'jammy': [libqt6gui6]
+    'noble': [libqt6gui6t64]
 libqt6opengl6t64:
   alpine: [qt6-qtbase]
   arch: [qt6-base]
@@ -6616,9 +6620,10 @@ libqt6opengl6t64:
     '*': [qt6-qtbase]
     '8': null
   ubuntu:
-    '*': [libqt6opengl6t64]
+    '*': [libqt6opengl6]
     'focal': null
     'jammy': [libqt6opengl6]
+    'noble': [libqt6opengl6t64]
 libqt6statemachine6:
   arch: [qt6-scxml]
   debian: [libqt6statemachine6]
@@ -6651,9 +6656,10 @@ libqt6widgets6t64:
     '*': [qt6-qtbase]
     '8': null
   ubuntu:
-    '*': [libqt6widgets6t64]
+    '*': [libqt6widgets6]
     'focal': null
     'jammy': [libqt6widgets6]
+    'noble': [libqt6widgets6t64]
 libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

Updates to existing rosdep keys:

- `libopencv-core` (add Ubuntu `resolute`)
- `libopencv-imgcodecs` (add Ubuntu `resolute`)
- `libopencv-imgproc` (add Ubuntu `resolute`)
- `libqt6gui6t64` (Ubuntu default/non-`t64` + explicit `noble` `t64`)
- `libqt6opengl6t64` (Ubuntu default/non-`t64` + explicit `noble` `t64`)
- `libqt6widgets6t64` (Ubuntu default/non-`t64` + explicit `noble` `t64`)

## Package Upstream Source:

- OpenCV: https://github.com/opencv/opencv
- Qt 6 (qtbase): https://code.qt.io/cgit/qt/qtbase.git/

## Purpose of using this:

This PR updates existing rosdep core rules to support Ubuntu `resolute` OpenCV binary
package names (`*410`) and align Qt6 `t64` mapping behavior across Ubuntu releases.

The change ensures rosdep resolves correctly for newer Ubuntu targets (including
`resolute`) while preserving compatibility on `focal` and `jammy` (non-`t64`) and
explicitly mapping `noble` to `t64` package names.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/search?keywords=libopencv-core410
 - REQUIRED
- Ubuntu: https://packages.ubuntu.com/search?keywords=libopencv-core410
 - REQUIRED
