### PR TITLE
qml6_ros2_plugin: 4.26.30-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6329,7 +6329,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 3.26.30-1
+      version: 4.26.30-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `4.26.30-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.26.30-1`

## qml6_ros2_plugin

```
* Added missing build export depends.
* Contributors: Stefan Fabian
```
