### PR TITLE
sb3-contrib pip key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9964,6 +9964,10 @@ python3-ruff-pip:
   ubuntu:
     pip:
       packages: [ruff]
+python3-sb3-contrib-pip:
+  "*":
+    pip:
+      packages: [sb3-contrib]
 python3-sbp-pip: *migrate_eol_2027_04_30_python3_sbp_pip
 python3-scapy:
   debian: [python3-scapy]


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

sb3-contrib

## Package Upstream Source:

https://github.com/Stable-Baselines-Team/stable-baselines3-contrib

## Purpose of using this:

We already have an entry for stable-baselines3. the contrib package offers more community content, such as a MaskableActorCritic policy, which I intend to use in the next release of the clips_executive package.

Distro packaging links:

## Links to Distribution Packages

https://pypi.org/project/sb3-contrib/