### PR TITLE
python: add unified-planning pip dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -11059,6 +11059,10 @@ python3-unidiff:
   opensuse: [python-unidiff]
   rhel: [python3-unidiff]
   ubuntu: [python3-unidiff]
+python3-unified-planning-pip:
+  "*":
+    pip:
+      packages: [unified-planning]
 python3-urchin-pip:
   '*':
     pip:


### PR DESCRIPTION
Please add the following dependencies to the rosdep database.

## Package name:

unified-planning

## Package Upstream Source:

https://github.com/aiplan4eu/unified-planning

## Purpose of using this:

The unified-planning framework was introduced within the AIPlan4EU project as a state-of-the-art planning framework.
I am preparing a new release of the clips_executive reasoning framework that makes use of unified-planning to handle PDDL planning problems.

## Links to Distribution Packages

https://pypi.org/project/unified-planning/