### PR TITLE
nixos: add libx11 as dependency for nixos

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6937,7 +6937,7 @@ libspnav-dev:
   debian: [libspnav-dev, libx11-dev]
   fedora: [libspnav-devel, libX11-devel]
   gentoo: [dev-libs/libspnav]
-  nixos: [libspnav]
+  nixos: [libspnav, libx11]
   rhel: [libspnav-devel, libX11-devel]
   ubuntu: [libspnav-dev, libx11-dev]
 libsqlite3-dev:


### PR DESCRIPTION
this adds `libx11` as dependency for `spacenav` which is needed for compiling the package on nixos via the nix-ros-overlay and also fixes the [PR](https://github.com/lopsided98/nix-ros-overlay/pull/821).
