### PR TITLE
gz_sim_vendor: 0.0.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3791,7 +3791,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
-      version: 0.0.9-1
+      version: 0.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_sim_vendor` to `0.0.10-1`:

- upstream repository: https://github.com/gazebo-release/gz_sim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_sim_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.9-1`

## gz_sim_vendor

```
* Bump version to 8.11.0 (#24 <https://github.com/gazebo-release/gz_sim_vendor/issues/24>)
  * Bump version to 8.11.0
  * Fix linter
  ---------
* Contributors: Addisu Z. Taddese
```
