### PR TITLE
novatel_oem7_driver: 24.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6381,7 +6381,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 24.2.0-1
+      version: 24.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `24.2.1-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `24.2.0-1`

## novatel_oem7_driver

```
Move towards Rolling support
Modifications:
* Removes ament_target_dependencies, which is removed in ROS2 rolling (#100 <https://github.com/novatel/novatel_oem7_driver/pull/100>)
```
