### PR TITLE
kinematic_pose_msgs: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4469,6 +4469,11 @@ repositories:
       version: jazzy
     status: developed
   kinematic_pose_msgs:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/kinematic_pose_msgs-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/qleonardolp/kinematic_pose_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematic_pose_msgs` to `1.0.0-1`:

- upstream repository: https://github.com/qleonardolp/kinematic_pose_msgs.git
- release repository: https://github.com/ros2-gbp/kinematic_pose_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## kinematic_pose_msgs

```
* Add description on README
* Add KinematicPose message
* Contributors: Leonardo F. dos Santos
```
