### PR TITLE
ros2_medkit: 0.3.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8996,6 +8996,23 @@ repositories:
       version: main
     status: developed
   ros2_medkit:
+    doc:
+      type: git
+      url: https://github.com/selfpatch/ros2_medkit.git
+      version: main
+    release:
+      packages:
+      - ros2_medkit_diagnostic_bridge
+      - ros2_medkit_fault_manager
+      - ros2_medkit_fault_reporter
+      - ros2_medkit_gateway
+      - ros2_medkit_integration_tests
+      - ros2_medkit_msgs
+      - ros2_medkit_serialization
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_medkit-release.git
+      version: 0.3.0-3
     source:
       type: git
       url: https://github.com/selfpatch/ros2_medkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_medkit` to `0.3.0-3`:

- upstream repository: https://github.com/selfpatch/ros2_medkit.git
- release repository: https://github.com/ros2-gbp/ros2_medkit-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ros2_medkit_diagnostic_bridge

```
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda
```

## ros2_medkit_fault_manager

```
* Accurate HIGHEST_SEVERITY reassignment and stale ``fault_to_cluster_`` cleanup (#221 <https://github.com/selfpatch/ros2_medkit/pull/221>)
* Clean up ``pending_clusters_`` when fault cleared before ``min_count`` (#211 <https://github.com/selfpatch/ros2_medkit/pull/211>)
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda, @eclipse0922
```

## ros2_medkit_fault_reporter

```
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda
```

## ros2_medkit_gateway

```
* Gateway plugin framework with dynamic C++ plugin loading (#237 <https://github.com/selfpatch/ros2_medkit/pull/237>)
* Software updates plugin with 8 SOVD-compliant endpoints (#237 <https://github.com/selfpatch/ros2_medkit/pull/237>, #231 <https://github.com/selfpatch/ros2_medkit/pull/231>)
* SSE-based periodic data subscriptions for real-time streaming without polling (#223 <https://github.com/selfpatch/ros2_medkit/pull/223>)
* Global ``DELETE /api/v1/faults`` endpoint (#228 <https://github.com/selfpatch/ros2_medkit/pull/228>)
* Return HEALED/PREPASSED faults via status filter (#218 <https://github.com/selfpatch/ros2_medkit/pull/218>)
* Bulk data upload and delete endpoints (#216 <https://github.com/selfpatch/ros2_medkit/pull/216>)
* Token-bucket rate limiting middleware, configurable per-endpoint (#220 <https://github.com/selfpatch/ros2_medkit/pull/220>)
* Reduce lock contention in ConfigurationManager (#194 <https://github.com/selfpatch/ros2_medkit/pull/194>)
* Cache component topic map to avoid per-request graph rebuild (#212 <https://github.com/selfpatch/ros2_medkit/pull/212>)
* Require cpp-httplib >= 0.14 in pkg-config check (#230 <https://github.com/selfpatch/ros2_medkit/pull/230>)
* Add missing ``ament_index_cpp`` dependency to ``package.xml`` (#191 <https://github.com/selfpatch/ros2_medkit/pull/191>)
* Unit tests for HealthHandlers, DataHandlers, and AuthHandlers (#232 <https://github.com/selfpatch/ros2_medkit/pull/232>, #234 <https://github.com/selfpatch/ros2_medkit/pull/234>, #233 <https://github.com/selfpatch/ros2_medkit/pull/233>)
* Standardize include guards to ``#pragma once`` (#192 <https://github.com/selfpatch/ros2_medkit/pull/192>)
* Use ``foreach`` loop for CMake coverage flags (#193 <https://github.com/selfpatch/ros2_medkit/pull/193>)
* Migrate ``ament_target_dependencies`` to compat shim for Rolling (#242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda, @eclipse0922, @mfaferek93
```

## ros2_medkit_integration_tests

```
* Refactored integration test suite into dedicated ``ros2_medkit_integration_tests`` package (#227 <https://github.com/selfpatch/ros2_medkit/pull/227>)
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda
```

## ros2_medkit_msgs

```
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda
```

## ros2_medkit_serialization

```
* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (#219 <https://github.com/selfpatch/ros2_medkit/pull/219>, #242 <https://github.com/selfpatch/ros2_medkit/pull/242>)
* Contributors: @bburda
```
