### PR TITLE
ros2_snapshot: 0.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7634,7 +7634,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_snapshot-release.git
-      version: 0.0.3-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/cnurobotics/ros2_snapshot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_snapshot` to `0.0.5-1`:

- upstream repository: https://github.com/cnurobotics/ros2_snapshot.git
- release repository: https://github.com/ros2-gbp/ros2_snapshot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.3-1`

## ros2_snapshot

```
* Restore multi-distro snapshot compatibility
* Tighten and expand ros2_snapshot test coverage
* Preserve ROS type ambiguities explicitly
* Guard workspace modeler against symlink cycles
* Harden snapshot and model handling
* move to ros2_snapshot folder for distribution
```
