### PR TITLE
data_tamer_tools: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1978,7 +1978,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer_tools-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://gitlab.com/jlack/data_tamer_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer_tools` to `0.4.0-1`:

- upstream repository: https://gitlab.com/jlack/data_tamer_tools.git
- release repository: https://github.com/ros2-gbp/data_tamer_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-1`
