### PR TITLE
data_tamer_tools: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1550,7 +1550,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer_tools-release.git
-      version: 0.3.1-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://gitlab.com/jlack/data_tamer_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer_tools` to `0.4.0-1`:

- upstream repository: https://gitlab.com/jlack/data_tamer_tools.git
- release repository: https://github.com/ros2-gbp/data_tamer_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.1-1`
