### PR TITLE
ur_msgs: 2.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12076,7 +12076,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `2.4.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## ur_msgs

```
* Add a service to set friction model parameters (#40 <https://github.com/ros-industrial/ur_msgs/issues/40>)
* Contributors: Rune Søe-Knudsen
```