### PR TITLE
rcl: 10.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6571,7 +6571,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.3.2-1
+      version: 10.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.4.0-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.3.2-1`

## rcl

```
* Add API for client libraries to set action server goal expiration callbacks (#1295 <https://github.com/ros2/rcl/issues/1295>)
* Fujitatomoya/improve rcl test graph (#1296 <https://github.com/ros2/rcl/issues/1296>)
* Add content filtering support check for subscriptions (#1293 <https://github.com/ros2/rcl/issues/1293>)
* Contributors: Barry Xu, Skyler Medeiros, Tomoya Fujita
```

## rcl_action

```
* Add API for client libraries to set action server goal expiration callbacks (#1295 <https://github.com/ros2/rcl/issues/1295>)
* support rcl_action_count_clients and rcl_action_count_servers. (#1294 <https://github.com/ros2/rcl/issues/1294>)
* Contributors: Skyler Medeiros, Tomoya Fujita
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

```
* Use the POSIX locale to parse YAML double (#1292 <https://github.com/ros2/rcl/issues/1292>)
* Contributors: Hugal31
```
