### PR TITLE
Add NixOS entry for libcpp-httplib-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3524,6 +3524,7 @@ libcpp-httplib-dev:
     bullseye: null
   fedora: [cpp-httplib-devel]
   gentoo: [cpp-httplib]
+  nixos: [httplib]
   osx:
     homebrew:
       packages: [cpp-httplib]


### PR DESCRIPTION
See https://search.nixos.org/packages?channel=unstable&query=httplib&show=httplib. This points to the same repository as https://packages.ubuntu.com/noble/libcpp-httplib-dev.