### PR TITLE
Add python3-qt-bindings with sipbuild, pyside6, shiboken6 for upcomming distros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9598,7 +9598,7 @@ python3-qt5-bindings:
   rhel:
     '*': [python3-qt5-devel, python3-sip-devel, libXext-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
-    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', 'python%{python3_pkgversion}-sip6', libXext-devel, redhat-rpm-config]
+    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9581,7 +9581,7 @@ python3-qrcode:
   ubuntu: [python3-qrcode]
 python3-qt-bindings:
   debian:
-    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild]
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
@@ -9590,7 +9590,7 @@ python3-qt-bindings:
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
   ubuntu:
-    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, shiboken6, python3-sipbuild, python3-pyqtbuild]
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     jammy: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
     noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9587,9 +9587,9 @@ python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
   debian:
-    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
-  fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
+  fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel, python3-sip6]
   freebsd: [devel/pyside2, devel/shiboken2]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
@@ -9598,10 +9598,10 @@ python3-qt5-bindings:
   rhel:
     '*': [python3-qt5-devel, python3-sip-devel, libXext-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
-    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', 'python%{python3_pkgversion}-sip6', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu:
-    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9579,6 +9579,21 @@ python3-qrcode:
   rhel:
     '8': [python3-qrcode]
   ubuntu: [python3-qrcode]
+python3-qt-bindings:
+  debian:
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qtbase6-dev, shiboken6, python3-sipbuild]
+    'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
+    'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
+  fedora: [python3-qt5-devel, libXext-devel, python3-sip6]
+  rhel:
+    '*': [python3-qt6-devel, sip6, libXext-devel]
+    '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
+    '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
+  ubuntu:
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, shiboken6, python3-sipbuild]
+    focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
+    jammy: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
+    noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
 python3-qt-material-pip:
   '*':
     pip:
@@ -9587,21 +9602,21 @@ python3-qt5-bindings:
   alpine: [py3-qt5]
   arch: [python-pyqt5]
   debian:
-    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
     stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
-  fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel, python3-sip6]
+  fedora: [python3-qt5-devel, python3-sip-devel, libXext-devel]
   freebsd: [devel/pyside2, devel/shiboken2]
   gentoo: [dev-python/PyQt5]
   nixos: [python3Packages.pyqt5]
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
+    '*': [python3-qt5-devel, python3-sip-devel, libXext-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
   ubuntu:
-    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
 python3-qt5-bindings-gl:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9581,7 +9581,7 @@ python3-qrcode:
   ubuntu: [python3-qrcode]
 python3-qt-bindings:
   debian:
-    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qtbase6-dev, shiboken6, python3-sipbuild]
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild]
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-qt5-devel, libXext-devel, python3-sip6]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9584,9 +9584,9 @@ python3-qt-bindings:
     '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild]
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
-  fedora: [python3-qt5-devel, libXext-devel, python3-sip6]
+  fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
   rhel:
-    '*': [python3-qt6-devel, sip6, libXext-devel]
+    '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9596,7 +9596,7 @@ python3-qt5-bindings:
   openembedded: [python3-pyqt5@meta-qt5]
   opensuse: [python3-qt5]
   rhel:
-    '*': [python3-qt5-devel, python3-sip-devel, libXext-devel]
+    '*': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
     '7': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9581,16 +9581,16 @@ python3-qrcode:
   ubuntu: [python3-qrcode]
 python3-qt-bindings:
   debian:
-    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild]
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild]
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
   rhel:
-    '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6]
+    '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-Builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
   ubuntu:
-    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, shiboken6, python3-sipbuild]
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, shiboken6, python3-sipbuild, python3-pyqtbuild]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     jammy: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
     noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9618,7 +9618,6 @@ python3-qt5-bindings:
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
-    focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9603,6 +9603,7 @@ python3-qt5-bindings:
   ubuntu:
     '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
     bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]


### PR DESCRIPTION
Please update the following dependency in the rosdep database.

## Package name:

python3-qt5-bindings

## Package Upstream Source:

https://github.com/Python-SIP/sip

## Purpose of using this:

This PR adds a new`python3-qt-bindings` key that works for both Qt5 and Qt6 using sip-build for https://github.com/ros-visualization/python_qt_binding/pull/157 .


Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

* Debian:
    * https://packages.debian.org/sid/libpyside2-dev
    * https://packages.debian.org/sid/libpyside6-dev
    * https://packages.debian.org/sid/libshiboken2-dev
    * https://packages.debian.org/sid/libshiboken6-dev
    * https://packages.debian.org/sid/pyqt5-dev
    * https://packages.debian.org/sid/pyqt6-dev
    * https://packages.debian.org/sid/python3-pyqt5
    * https://packages.debian.org/sid/python3-pyqt5.qtsvg
    * https://packages.debian.org/sid/python3-pyqt6
    * https://packages.debian.org/sid/python3-pyqt6.qtsvg
    * https://packages.debian.org/sid/python3-pyside2.qtsvg
    * https://packages.debian.org/sid/python3-pyside6.qtsvg
    * https://packages.debian.org/sid/python3-sip-dev
    * https://packages.debian.org/sid/python3-sipbuild
    * https://packages.debian.org/sid/qtbase5-dev
    * https://packages.debian.org/sid/qt6-base-dev
    * https://packages.debian.org/sid/shiboken2
    * https://packages.debian.org/sid/shiboken6
    * https://packages.debian.org/sid/python3-pyqtbuild
* Ubuntu:
    * https://packages.ubuntu.com/noble/libpyside2-dev
    * https://packages.ubuntu.com/resolute/libpyside6-dev
    * https://packages.ubuntu.com/noble/libshiboken2-dev
    * https://packages.ubuntu.com/resolute/libshiboken6-dev
    * https://packages.ubuntu.com/noble/pyqt5-dev
    * https://packages.ubuntu.com/resolute/pyqt6-dev
    * https://packages.ubuntu.com/noble/python3-pyqt5
    * https://packages.ubuntu.com/noble/python3-pyqt5.qtsvg
    * https://packages.ubuntu.com/resolute/python3-pyqt6
    * https://packages.ubuntu.com/resolute/python3-pyqt6.qtsvg
    * https://packages.ubuntu.com/noble/python3-pyside2.qtsvg
    * https://packages.ubuntu.com/resolute/python3-pyside6.qtsvg
    * https://packages.ubuntu.com/noble/python3-sip-dev
    * https://packages.ubuntu.com/resolute/python3-sipbuild
    * https://packages.ubuntu.com/noble/shiboken2
    * https://packages.ubuntu.com/resolute/shiboken6
    * https://packages.ubuntu.com/resolute/python3-pyqtbuild
* Fedora:
    * https://packages.fedoraproject.org/pkgs/python-pyqt6/python3-pyqt6-devel/
    * https://packages.fedoraproject.org/pkgs/python-pyqt6-sip/python3-pyqt6-sip/
    * https://packages.fedoraproject.org/pkgs/sip6/sip6
    * https://packages.fedoraproject.org/pkgs/PyQt-builder/PyQt-builder/
* rhel:
    * https://almalinux.pkgs.org/9/almalinux-crb-aarch64/python3-qt5-devel-5.15.9-1.el9.aarch64.rpm.html
    * https://almalinux.pkgs.org/10/almalinux-appstream-aarch64/python3-pyqt6-devel-6.9.0-1.el10.aarch64.rpm.html
    * https://almalinux.pkgs.org/10/almalinux-appstream-aarch64/python3-pyqt6-sip-13.9.1-1.el10.aarch64.rpm.html
    * https://almalinux.pkgs.org/9/almalinux-crb-aarch64/python3-sip-devel-4.19.25-2.el9.aarch64.rpm.html
    * https://almalinux.pkgs.org/9/almalinux-appstream-aarch64/sip6-6.6.2-2.el9.aarch64.rpm.html