### PR TITLE
automatika_embodied_agents: 0.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -872,7 +872,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.5.1-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_embodied_agents` to `0.6.0-1`:

- upstream repository: https://github.com/automatika-robotics/ros-agents.git
- release repository: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.1-1`

## automatika_embodied_agents

```
* (docs) Adds advanced guides
* (docs) Adds developer docs
* (refactor) Adds sherpa-onnx for stt and tts local models
* (refactor) Adds ggml based local llm and vlm models with llama cpp
* (feature) Adds config option to strip think tokens
* (fix) Fixes execution provider setup when executor is set to be cpu
* (refactor) Standardizes local model handling in vision model
* (docs) Updates fallback example and adds new local model fallback recipe
* (feature) Adds fallback_to_local as a model component action for switching to local model on the fly
* (chore) Adds markers for running tests that require model serving
* (chore) Adds comprehensive test coverage for components
* (fix) Fixes bug in model components
* (fix) Fixes init of local LLM in semantic router for multiprocessing setup
* (feature) Adds local models for STT and TTS
* (feature) Enables local llm in semantic router component
* (feature) Adds moondream as local vlm for VLM component
* (feature) Adds local llm model for LLM component
* (fix) Adds extra check in rgbd callback
* (refactor) Adds warning for timed components when calling take_picture or record_video
* (docs) Updates vlm based planning recipe
* Contributors: ahr, mkabtoul
```
