### PR TITLE
system_webview: 0.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9534,7 +9534,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_webview-release.git
-      version: 0.0.1-1
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/namo-robotics/ros2_system_webview.git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_webview` to `0.0.2-1`:

- upstream repository: https://github.com/namo-robotics/ros2_system_webview.git
- release repository: https://github.com/ros2-gbp/system_webview-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.1-1`

## system_webview

```
* update resource monitor screenshot
* feat: add build and SSG manifests, update index files, and enhance system types
  - Introduced _buildManifest.js and _ssgManifest.js for improved static generation.
  - Updated index.html to reflect new resource paths and maintain consistency.
  - Modified index.txt to align with the latest changes in the application structure.
  - Enhanced UsbBusStats interface in system.ts to include real-time USB traffic metrics.
* feat: update index.html and index.txt for new styles and scripts; add network and USB stats interfaces
  - Updated index.html to include new stylesheet and script references.
  - Modified index.txt to reflect changes in the app page structure.
  - Removed 'peer' property from several dependencies in package-lock.json.
  - Added new interfaces for NetworkStats, UsbDeviceStats, and UsbBusStats in system.ts to enhance system monitoring capabilities.
* Contributors: David Brown
```
