### PR TITLE
Update python3-git entry for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6596,7 +6596,7 @@ python3-git:
   debian: [python3-git]
   fedora: [python3-GitPython]
   gentoo: [dev-python/git-python]
-  nixos: [python3Packages.GitPython]
+  nixos: [python3Packages.gitpython]
   openembedded: [python3-git@openembedded-core]
   rhel:
     '*': [python3-GitPython]


### PR DESCRIPTION
The attribute has been renamed to lower-case. See
https://github.com/NixOS/nixpkgs/blob/5347fa062a03abe81946b5b5ec05dfe049850288/pkgs/top-level/python-aliases.nix#L224.

