### PR TITLE
generate_parameter_library: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2524,7 +2524,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.7.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.8.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.0-1`

## generate_parameter_library

```
* Use libexpected-dev instead of tl_expected (#322 <https://github.com/PickNikRobotics/generate_parameter_library/issues/322>)
* Contributors: Christoph Fröhlich
```

## generate_parameter_library_py

```
* Fix nested mappings double dot bug (#329 <https://github.com/PickNikRobotics/generate_parameter_library/issues/329>)
  Co-authored-by: Nathan <mailto:50861188+natrad100@users.noreply.github.com>
* Fix nested mapped parameters map (#306 <https://github.com/PickNikRobotics/generate_parameter_library/issues/306>)
* Remove unused variables in pytest (#317 <https://github.com/PickNikRobotics/generate_parameter_library/issues/317>)
* Contributors: Christoph Fröhlich, Nick Laurenson
```

## parameter_traits

- No changes
