### PR TITLE
generate_parameter_library: 0.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3291,7 +3291,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.7.1-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.0-1`

## generate_parameter_library

- No changes

## generate_parameter_library_py

```
* Fix nested mappings double dot bug and add tests (backport #327 <https://github.com/PickNikRobotics/generate_parameter_library/issues/327> #329 <https://github.com/PickNikRobotics/generate_parameter_library/issues/329>) (#331 <https://github.com/PickNikRobotics/generate_parameter_library/issues/331>)
  Co-authored-by: Mat198 <mailto:44040676+Mat198@users.noreply.github.com>
  Co-authored-by: Nathan <mailto:50861188+natrad100@users.noreply.github.com>
* Fix nested mapped parameters map (backport #306 <https://github.com/PickNikRobotics/generate_parameter_library/issues/306>)
* Remove unused variables in pytest (backport #317 <https://github.com/PickNikRobotics/generate_parameter_library/issues/317>)
* Contributors: Christoph Froehlich, Christoph Fröhlich
```

## parameter_traits

- No changes
