### PR TITLE
ros2_medkit: 0.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9705,6 +9705,35 @@ repositories:
       url: https://github.com/Kinovarobotics/ros2_kortex.git
       version: main
     status: developed
+  ros2_medkit:
+    doc:
+      type: git
+      url: https://github.com/selfpatch/ros2_medkit.git
+      version: main
+    release:
+      packages:
+      - ros2_medkit_beacon_common
+      - ros2_medkit_cmake
+      - ros2_medkit_diagnostic_bridge
+      - ros2_medkit_fault_manager
+      - ros2_medkit_fault_reporter
+      - ros2_medkit_gateway
+      - ros2_medkit_graph_provider
+      - ros2_medkit_integration_tests
+      - ros2_medkit_linux_introspection
+      - ros2_medkit_msgs
+      - ros2_medkit_param_beacon
+      - ros2_medkit_serialization
+      - ros2_medkit_topic_beacon
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/selfpatch/ros2_medkit.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/selfpatch/ros2_medkit.git
+      version: main
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_medkit` to `0.4.0-1`:

- upstream repository: https://github.com/selfpatch/ros2_medkit.git
- release repository: https://github.com/selfpatch/ros2_medkit.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## ros2_medkit_beacon_common

```
* Initial release - shared utilities for beacon discovery plugins
* ``BeaconHintStore`` with TTL-based hint transitions and thread safety
* ``BeaconValidator`` input validation gate
* ``BeaconEntityMapper`` to convert discovery hints into ``IntrospectionResult``
* ``build_beacon_response()`` shared response builder
* ``BeaconPlugin`` base class for topic and parameter beacon plugins
* ``TokenBucket`` rate limiter with thread-safe access
* Contributors: @bburda
```

## ros2_medkit_cmake

```
* Initial release - shared cmake modules extracted from gateway package (#294 <https://github.com/selfpatch/ros2_medkit/pull/294>)
* ``ROS2MedkitCcache.cmake`` - auto-detect ccache for faster incremental rebuilds
* ``ROS2MedkitLinting.cmake`` - centralized clang-tidy configuration (opt-in locally, mandatory in CI)
* ``ROS2MedkitCompat.cmake`` - multi-distro compatibility shims for ROS 2 Humble/Jazzy/Rolling
* Contributors: @bburda
```

## ros2_medkit_diagnostic_bridge

```
* Build: use shared cmake modules from ``ros2_medkit_cmake`` package
* Build: auto-detect ccache, centralized clang-tidy configuration
* Contributors: @bburda
```

## ros2_medkit_fault_manager

```
* Per-entity confirmation and healing thresholds via manifest configuration (#269 <https://github.com/selfpatch/ros2_medkit/pull/269>)
* Default rosbag storage format changed from ``sqlite3`` to ``mcap``
* Support for namespaced fault manager nodes - gateway resolves service/topic names when the fault manager runs in a custom namespace
* Build: use shared cmake modules from ``ros2_medkit_cmake`` package
* Build: centralized clang-tidy configuration
* Contributors: @bburda
```

## ros2_medkit_fault_reporter

```
* Build: use shared cmake modules from ``ros2_medkit_cmake`` package
* Build: auto-detect ccache, centralized clang-tidy configuration
* Contributors: @bburda
```

## ros2_medkit_gateway

```
**Breaking Changes:**
* ``GET /version-info`` response key renamed from ``sovd_info`` to ``items`` for SOVD alignment (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* ``GET /`` root endpoint restructured: ``endpoints`` is now a flat string array, added ``capabilities`` object, ``api_base`` field, and ``name``/``version`` top-level fields (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* Default rosbag storage format changed from ``sqlite3`` to ``mcap`` (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* Plugin API version bumped to v4 - added ``ScriptProvider``, locking API, and extended ``PluginContext`` with entity snapshot, fault listing, and sampler registration
* ``GraphProviderPlugin`` extracted to separate ``ros2_medkit_graph_provider`` package
**Features:**
*Discovery & Merge Pipeline:*
* Layered merge pipeline for hybrid discovery with per-layer, per-field-group merge policies (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* Gap-fill configuration: control heuristic entity creation with ``allow_heuristic_*`` options and namespace filtering (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* Plugin layer: ``IntrospectionProvider`` now wired into discovery pipeline via ``PluginLayer`` (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* ``/health`` endpoint includes merge pipeline diagnostics (layers, conflicts, gap-fill stats) (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* Entity detail responses now include ``logs``, ``bulk-data``, ``cyclic-subscriptions`` URIs (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* Entity capabilities fix: areas and functions now report correct resource collections (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* ``discovery.manifest.enabled`` / ``discovery.runtime.enabled`` parameters for hybrid mode
* ``NewEntities.functions`` - plugins can now produce Function entities
* ``GET /apps/{id}/is-located-on`` endpoint for reverse host lookup (app to component)
* Beacon discovery plugin system - push-based entity enrichment via ROS 2 topic
* ``x-medkit-topic-beacon`` and ``x-medkit-param-beacon`` vendor extension REST endpoints
* Linux introspection plugins: procfs, systemd, and container plugins via ``x-medkit-*`` vendor endpoints (#263 <https://github.com/selfpatch/ros2_medkit/pull/263>)
*Locking:*
* SOVD-compliant resource locking: acquire, release, extend with session tracking and expiration
* Lock enforcement on all mutating handlers (PUT, POST, DELETE)
* Per-entity lock configuration via manifest YAML with ``required_scopes``
* Lock API exposed to plugins via ``PluginContext``
* Automatic cyclic subscription cleanup on lock expiry
* ``LOCKS`` capability in entity descriptions
*Scripts:*
* SOVD script execution endpoints: CRUD for scripts and executions with subprocess execution
* ``ScriptProvider`` plugin interface for custom script backends
* ``DefaultScriptProvider`` with manifest + filesystem CRUD, argument passing, and timeout
* Manifest-defined scripts: ``ManifestParser`` populates ``ScriptsConfig.entries`` from manifest YAML
* ``allow_uploads`` config toggle for hardened deployments
* RBAC integration for script operations
*Logging:*
* ``LogProvider`` plugin interface for custom log backends (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
* ``LogManager`` with ``/rosout`` ring buffer and plugin delegation
* ``/logs`` and ``/logs/configuration`` endpoints
* ``LOGS`` capability in discovery responses
* Configurable log buffer size via parameters
* Area and function log endpoints with namespace aggregation (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
*Triggers:*
* Condition-based triggers with CRUD endpoints, SSE event streaming, and hierarchy matching
* ``TriggerManager`` with ``ConditionEvaluator`` interface and 4 built-in evaluators (OnChange, OnChangeTo, EnterRange, LeaveRange)
* ``ResourceChangeNotifier`` for async dispatch from FaultManager, UpdateManager, and OperationManager
* ``TriggerTopicSubscriber`` for data trigger ROS 2 topic subscriptions
* Persistent trigger storage via SQLite with restore-on-restart support
* ``TriggerTransportProvider`` plugin interface for custom trigger delivery
*OpenAPI & Documentation:*
* ``RouteRegistry`` as single source of truth for routes and OpenAPI metadata
* ``OpenApiSpecBuilder`` for full OpenAPI 3.1.0 document assembly with ``SchemaBuilder`` and ``PathBuilder``
* Compile-time Swagger UI embedding (``ENABLE_SWAGGER_UI``)
* Named component schemas with ``$ref``, clean ``operationId`` values, endpoint descriptions, ``GenericError`` schema refs, ``info.contact``, Spectral-clean output, multipart upload schemas, static spec caching
* SOVD compliance documentation with resource collection support matrix (#258 <https://github.com/selfpatch/ros2_medkit/pull/258>)
*Other:*
* Multi-collection cyclic subscription support (data, faults, logs, configurations, update-status)
* Generation-based caching for capability responses via ``CapabilityGenerator``
* ``PluginContext::get_child_apps()`` for Component-level aggregation
* Sub-resource RBAC patterns for all collections
* Auto-populate gateway version from ``package.xml`` via CMake
* Namespaced fault manager integration - ``FaultManagerPaths`` resolves service/topic names for custom namespaces
* Grouped ``fault_manager.*`` parameter namespace for cleaner configuration
**Build:**
* Extracted shared cmake modules into ``ros2_medkit_cmake`` package (#294 <https://github.com/selfpatch/ros2_medkit/pull/294>)
* Auto-detect ccache for faster incremental rebuilds
* Precompiled headers for gateway package
* Centralized clang-tidy configuration (opt-in locally, mandatory in CI)
**Tests:**
* Unit tests for DiscoveryHandlers, OperationHandlers, ScriptHandlers, LockHandlers, LockManager, ScriptManager, DefaultScriptProvider
* Comprehensive integration tests for locking, scripts, graph provider plugin, beacon plugins, OpenAPI/docs, logging, namespaced fault manager
* Contributors: @bburda
```

## ros2_medkit_graph_provider

```
* Initial release - extracted from ``ros2_medkit_gateway`` package
* ``GraphProviderPlugin`` for ROS 2 graph-based entity introspection
* Standalone external plugin package with independent build and test
* Locking support via ``PluginContext`` API
* Contributors: @bburda
```

## ros2_medkit_integration_tests

```
* Integration tests for SOVD resource locking (acquire, release, extend, fault clear with locks, expiration, parent propagation)
* Integration tests for SOVD script execution endpoints (all formats, params, output, failure, lifecycle)
* Integration tests for graph provider plugin (external plugin loading, entity introspection)
* Integration tests for beacon discovery plugins (topic beacon, parameter beacon)
* Integration tests for OpenAPI/docs endpoint
* Integration tests for logging endpoints (``/logs``, ``/logs/configuration``)
* Integration tests for linux introspection plugins (launch_testing and Docker-based)
* Port isolation per integration test via CMake-assigned unique ports
* ``ROS_DOMAIN_ID`` isolation for integration tests
* Build: use shared cmake modules from ``ros2_medkit_cmake`` package
* Contributors: @bburda
```

## ros2_medkit_linux_introspection

```
* Initial release - Linux process introspection plugins for ros2_medkit gateway
* ``procfs_plugin`` - process-level diagnostics via ``/proc`` filesystem (CPU, memory, threads, file descriptors)
* ``systemd_plugin`` - systemd unit status and resource usage via D-Bus
* ``container_plugin`` - container runtime detection and cgroup resource limits
* ``PidCache`` with TTL-based refresh for efficient PID-to-node mapping
* ``proc_reader`` and ``cgroup_reader`` utilities with configurable proc root
* Cross-distro support for ROS 2 Humble, Jazzy, and Rolling
* Contributors: @bburda
```

## ros2_medkit_msgs

```
* ``MedkitDiscoveryHint`` message type for beacon discovery publishers
* Contributors: @bburda
```

## ros2_medkit_param_beacon

```
* Initial release - parameter-based beacon discovery plugin
* ``ParameterBeaconPlugin`` with pull-based parameter reading for entity enrichment
* ``x-medkit-param-beacon`` vendor extension REST endpoint
* Poll target discovery from ROS graph in non-hybrid mode
* ``ParameterClientInterface`` for testable parameter access
* Contributors: @bburda
```

## ros2_medkit_serialization

```
* Enable ``POSITION_INDEPENDENT_CODE`` for MODULE target compatibility
* Build: use shared cmake modules from ``ros2_medkit_cmake`` package
* Build: auto-detect ccache, centralized clang-tidy configuration
* Contributors: @bburda
```

## ros2_medkit_topic_beacon

```
* Initial release - topic-based beacon discovery plugin
* ``TopicBeaconPlugin`` with push-based topic subscription for entity enrichment
* ``x-medkit-topic-beacon`` vendor extension REST endpoint
* Stamp-based TTL for topic beacon hints
* Diagnostic logging for beacon hint processing
* Contributors: @bburda
```
