### PR TITLE
ros4hri: update release repo URLs to use ros2-gbp

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4054,7 +4054,7 @@ repositories:
       - pyhri
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros4hri/libhri-release.git
+      url: https://github.com/ros2-gbp/libhri-release.git
       version: 2.6.1-1
     source:
       type: git
@@ -4069,7 +4069,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      url: https://github.com/ros2-gbp/hri_actions_msgs-release.git
       version: 2.2.0-1
     source:
       type: git
@@ -4109,7 +4109,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros4hri/hri_msgs-release.git
+      url: https://github.com/ros2-gbp/hri_msgs-release.git
       version: 2.1.0-1
     source:
       type: git
@@ -4139,7 +4139,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros4hri/hri_rviz-release.git
+      url: https://github.com/ros2-gbp/hri_rviz-release.git
       version: 2.1.0-1
     source:
       type: git
@@ -4153,7 +4153,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/ros4hri/human_description-release.git
+      url: https://github.com/ros2-gbp/human_description-release.git
       version: 2.0.2-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4035,7 +4035,7 @@ repositories:
       - pyhri
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros4hri/libhri-release.git
+      url: https://github.com/ros2-gbp/libhri-release.git
       version: 2.9.0-1
     source:
       type: git
@@ -4049,7 +4049,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      url: https://github.com/ros2-gbp/hri_actions_msgs-release.git
       version: 2.5.0-1
     source:
       type: git
@@ -4063,7 +4063,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros4hri/hri_msgs-release.git
+      url: https://github.com/ros2-gbp/hri_msgs-release.git
       version: 2.3.2-1
     source:
       type: git
@@ -4077,7 +4077,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros4hri/hri_rviz-release.git
+      url: https://github.com/ros2-gbp/hri_rviz-release.git
       version: 2.3.0-1
     source:
       type: git
@@ -4091,7 +4091,7 @@ repositories:
     release:
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/ros4hri/human_description-release.git
+      url: https://github.com/ros2-gbp/human_description-release.git
       version: 2.0.2-1
     source:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3217,7 +3217,7 @@ repositories:
       - pyhri
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros4hri/libhri-release.git
+      url: https://github.com/ros2-gbp/libhri-release.git
       version: 2.9.0-1
     source:
       type: git
@@ -3231,7 +3231,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros4hri/hri_actions_msgs-release.git
+      url: https://github.com/ros2-gbp/hri_actions_msgs-release.git
       version: 2.5.0-1
     source:
       type: git
@@ -3245,7 +3245,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/ros4hri/hri_msgs-release.git
+      url: https://github.com/ros2-gbp/hri_msgs-release.git
       version: 2.3.2-1
     source:
       type: git


### PR DESCRIPTION
Following the migration of several  `ros4hri` release repo from `github.com/ros4hri` to `github.com/ros2-gbp`, update the release repos for the impacted packages. This applies accross all ROS2 releases (humble, jazzy, rolling)