### PR TITLE
rosidl: 5.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8089,7 +8089,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.1.2-1
+      version: 5.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.1.3-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.2-1`

## rosidl_adapter

```
* Fix future regressions on flake8 (#936 <https://github.com/ros2/rosidl//issues/936>)
* Contributors: Michael Carlstrom
```

## rosidl_cli

```
* Fix future regressions on flake8 (#936 <https://github.com/ros2/rosidl//issues/936>)
* Contributors: Michael Carlstrom
```

## rosidl_cmake

```
* Create an aggregate target for rosidl generated interfaces targets (#947 <https://github.com/ros2/rosidl//issues/947>)
* Contributors: Emerson Knapp
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

```
* Use IWYU pragma export to avoid clangd warnings for generated headers (#902 <https://github.com/ros2/rosidl//issues/902>)
* rosidl_generator_cpp: constexpr message traits and to_tuple_ref for generated structs (#928 <https://github.com/ros2/rosidl//issues/928>)
* Make data_type and name traits constexpr (#929 <https://github.com/ros2/rosidl//issues/929>)
* Contributors: Adam Leeper, Michael Carlstrom, Øystein Sture
```

## rosidl_generator_type_description

```
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#910 <https://github.com/ros2/rosidl//issues/910>)
* Contributors: Anthony Welte
```

## rosidl_parser

```
* Fix future regressions on flake8 (#936 <https://github.com/ros2/rosidl//issues/936>)
* Contributors: Michael Carlstrom
```

## rosidl_pycommon

```
* Fix future regressions on flake8 (#936 <https://github.com/ros2/rosidl//issues/936>)
* Contributors: Michael Carlstrom
```

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

```
* rosidl_generator_cpp: constexpr message traits and to_tuple_ref for generated structs (#928 <https://github.com/ros2/rosidl//issues/928>)
* Make data_type and name traits constexpr (#929 <https://github.com/ros2/rosidl//issues/929>)
* Contributors: Michael Carlstrom, Øystein Sture
```

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

```
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#910 <https://github.com/ros2/rosidl//issues/910>)
* Contributors: Anthony Welte
```

## rosidl_typesupport_introspection_cpp

```
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#910 <https://github.com/ros2/rosidl//issues/910>)
* Contributors: Anthony Welte
```
