### PR TITLE
demos: 0.37.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1586,7 +1586,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.37.6-1
+      version: 0.37.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.37.7-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.37.6-1`

## action_tutorials_cpp

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## action_tutorials_py

```
* action_tutorials_py: add ament_mypy support (#775 <https://github.com/ros2/demos//issues/775>)
* Contributors: mohit
```

## composition

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Add tests isolation in test_dlopen_composition.py.in and test_linktime_composition.py.in (#764 <https://github.com/ros2/demos//issues/764>)
* Contributors: Emerson Knapp, Julien Enoch
```

## demo_nodes_cpp

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* add child logger under parent node, with different log levels. (#772 <https://github.com/ros2/demos//issues/772>)
* Contributors: Emerson Knapp, Tomoya Fujita
```

## demo_nodes_cpp_native

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## demo_nodes_py

```
* add child logger under parent node, with different log levels. (#772 <https://github.com/ros2/demos//issues/772>)
* Fix deprecated RcutilsLogger::warn() usage in LoggerServiceNode (#773 <https://github.com/ros2/demos//issues/773>)
* Ignore A005 (#771 <https://github.com/ros2/demos//issues/771>)
* Contributors: Barry Xu, Michael Carlstrom, Tomoya Fujita
```

## dummy_map_server

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## dummy_robot_bringup

- No changes

## dummy_sensors

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## image_tools

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Don't use libopencv-dev for exec (#760 <https://github.com/ros2/demos//issues/760>)
* Contributors: Emerson Knapp, Michael Carlstrom
```

## intra_process_demo

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Don't use libopencv-dev for exec (#760 <https://github.com/ros2/demos//issues/760>)
* Contributors: Emerson Knapp, Michael Carlstrom
```

## lifecycle

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## lifecycle_py

```
* Revert lifecycle_py accidental merge - ament_mypy (#777 <https://github.com/ros2/demos//issues/777>)
* action_tutorials_py: add ament_mypy support (#775 <https://github.com/ros2/demos//issues/775>)
* Contributors: mohit
```

## logging_demo

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## pendulum_control

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```

## quality_of_service_demo_py

- No changes

## topic_monitor

```
* Add mypy config (#776 <https://github.com/ros2/demos//issues/776>)
* Contributors: Dan Mascarenhas
```

## topic_statistics_demo

```
* Use new ROSIDL aggregate CMake target (#781 <https://github.com/ros2/demos//issues/781>)
* Contributors: Emerson Knapp
```
