### PR TITLE
rviz: 15.1.19-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8942,7 +8942,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.18-1
+      version: 15.1.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.1.19-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.18-1`

## rviz2

```
* Use new ROSIDL aggregate CMake target (#1688 <https://github.com/ros2/rviz/issues/1688>)
* Fix Qt version resolution when both Qt5 and Qt6 are installed - CMake defaults to ascending resolution and Qt5 will be found when Qt6 is desired (Rolling, L-Turtle, and beyond). (#1689 <https://github.com/ros2/rviz/issues/1689>)
* Contributors: Emerson Knapp, Nathan Brooks
```

## rviz_common

```
* Use new ROSIDL aggregate CMake target (#1688 <https://github.com/ros2/rviz/issues/1688>)
* Fix Qt version resolution when both Qt5 and Qt6 are installed - CMake defaults to ascending resolution and Qt5 will be found when Qt6 is desired (Rolling, L-Turtle, and beyond). (#1689 <https://github.com/ros2/rviz/issues/1689>)
* Cleanups in rviz_common (#1686 <https://github.com/ros2/rviz/issues/1686>)
* Add tests for shallow and deep copy in Config (#1682 <https://github.com/ros2/rviz/issues/1682>)
* Build performance optimizations for rviz_common (#1677 <https://github.com/ros2/rviz/issues/1677>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp, Michael Carroll, Nathan Brooks, Oscmoar07
```

## rviz_default_plugins

```
* Use new ROSIDL aggregate CMake target (#1688 <https://github.com/ros2/rviz/issues/1688>)
* Fix Qt version resolution when both Qt5 and Qt6 are installed - CMake defaults to ascending resolution and Qt5 will be found when Qt6 is desired (Rolling, L-Turtle, and beyond). (#1689 <https://github.com/ros2/rviz/issues/1689>)
* Remove redundant compilation of test fixtures (#1673 <https://github.com/ros2/rviz/issues/1673>)
* Contributors: Emerson Knapp, Michael Carroll, Nathan Brooks
```

## rviz_ogre_vendor

```
* Bump cmake version and suppress warning for rviz_ogre_vendor (#1684 <https://github.com/ros2/rviz/issues/1684>)
* Contributors: Shane Loretz
```

## rviz_rendering

```
* Fix Qt version resolution when both Qt5 and Qt6 are installed - CMake defaults to ascending resolution and Qt5 will be found when Qt6 is desired (Rolling, L-Turtle, and beyond). (#1689 <https://github.com/ros2/rviz/issues/1689>)
* Contributors: Nathan Brooks
```

## rviz_rendering_tests

```
* Fix Qt version resolution when both Qt5 and Qt6 are installed - CMake defaults to ascending resolution and Qt5 will be found when Qt6 is desired (Rolling, L-Turtle, and beyond). (#1689 <https://github.com/ros2/rviz/issues/1689>)
* Contributors: Nathan Brooks
```

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

```
* Use new ROSIDL aggregate CMake target (#1688 <https://github.com/ros2/rviz/issues/1688>)
* Fix Qt version resolution when both Qt5 and Qt6 are installed - CMake defaults to ascending resolution and Qt5 will be found when Qt6 is desired (Rolling, L-Turtle, and beyond). (#1689 <https://github.com/ros2/rviz/issues/1689>)
* Contributors: Emerson Knapp, Nathan Brooks
```
