### PR TITLE
geometry2: 0.41.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2658,7 +2658,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.41.6-1
+      version: 0.41.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.41.7-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.41.6-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* local variable tf2 no longer shadows the tf2:: (#903 <https://github.com/ros2/geometry2/issues/903>) (#916 <https://github.com/ros2/geometry2/issues/916>)
* Fix misleading extrapolation time in buffer_core (#832 <https://github.com/ros2/geometry2/issues/832>) (#896 <https://github.com/ros2/geometry2/issues/896>) (#897 <https://github.com/ros2/geometry2/issues/897>)
* Contributors: mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

```
* added toMsg for eigen-accel as well as its tests (#887 <https://github.com/ros2/geometry2/issues/887>) (#890 <https://github.com/ros2/geometry2/issues/890>)
* Contributors: mergify[bot]
```

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

```
* prevent AttributeError when static_only=true (#906 <https://github.com/ros2/geometry2/issues/906>) (#913 <https://github.com/ros2/geometry2/issues/913>)
* fixed typoe in buffer.py (#905 <https://github.com/ros2/geometry2/issues/905>) (#910 <https://github.com/ros2/geometry2/issues/910>)
* Contributors: mergify[bot]
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
