### PR TITLE
geometry2: 0.36.20-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3356,7 +3356,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.19-1
+      version: 0.36.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.36.20-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.36.19-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* local variable tf2 no longer shadows the tf2:: (#903 <https://github.com/ros2/geometry2/issues/903>) (#917 <https://github.com/ros2/geometry2/issues/917>)
* Fix misleading extrapolation time in buffer_core (#832 <https://github.com/ros2/geometry2/issues/832>) (#896 <https://github.com/ros2/geometry2/issues/896>) (#898 <https://github.com/ros2/geometry2/issues/898>)
* Contributors: mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* prevent AttributeError when static_only=true (backport #906 <https://github.com/ros2/geometry2/issues/906>) (#914 <https://github.com/ros2/geometry2/issues/914>)
* Contributors: mergify[bot]
```

## tf2_ros_py

```
* prevent AttributeError when static_only=true (backport #906 <https://github.com/ros2/geometry2/issues/906>) (#914 <https://github.com/ros2/geometry2/issues/914>)
* fixed typoe in buffer.py (#905 <https://github.com/ros2/geometry2/issues/905>) (#911 <https://github.com/ros2/geometry2/issues/911>)
* Contributors: mergify[bot]
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
