### PR TITLE
realsense2_camera: 4.57.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8193,7 +8193,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realsense-ros-release.git
-      version: 4.56.4-1
+      version: 4.57.7-1
     source:
       test_pull_requests: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.57.7-1`:

- upstream repository: https://github.com/realsenseai/realsense-ros.git
- release repository: https://github.com/ros2-gbp/realsense-ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.56.4-1`

## realsense2_camera

```
* add release noted
* Update package.xml
* Update package.xml
* Update constants.h
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3475 <https://github.com/IntelRealSense/realsense-ros/issues/3475> from remibettan: find package set to last major release version
* find package set to lrs prev major version 2
* PR #3474 <https://github.com/IntelRealSense/realsense-ros/issues/3474> from remibettan: find package set to lrs prev major version
* find package set to lrs prev major version
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* undoing the change in copyright, fixing bagfiles links
* PR #3468 <https://github.com/IntelRealSense/realsense-ros/issues/3468> from remibettan: using legacy libraries for foxy
* using legacy libraries for foxy
* code review corrections
* many intel removed and github user changed
* PR #3450 <https://github.com/IntelRealSense/realsense-ros/issues/3450> from Nir-Az: update to realsenseai
* update to realsenseai
* PR #3448 <https://github.com/IntelRealSense/realsense-ros/issues/3448> from OhadMeir: Add motion_fps to launch file
* Add motion_fps to launch file
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0 - leftovers
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* PR #3437 <https://github.com/IntelRealSense/realsense-ros/issues/3437> from Gilaadb: bug fix(rs_node_setup): Fix topic names that were improperly marked as rect (rectified)
* bug fix(rs_node_setup): Fix topic names that were improperly marked as rect (rectified)
* Contributors: Gilad Bretter, Nir Azkiel, OhadMeir, Remi Bettan, remibettan
* Update package.xml
* Update package.xml
* Update constants.h
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3475 <https://github.com/IntelRealSense/realsense-ros/issues/3475> from remibettan: find package set to last major release version
* find package set to lrs prev major version 2
* PR #3474 <https://github.com/IntelRealSense/realsense-ros/issues/3474> from remibettan: find package set to lrs prev major version
* find package set to lrs prev major version
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* undoing the change in copyright, fixing bagfiles links
* PR #3468 <https://github.com/IntelRealSense/realsense-ros/issues/3468> from remibettan: using legacy libraries for foxy
* using legacy libraries for foxy
* code review corrections
* many intel removed and github user changed
* PR #3450 <https://github.com/IntelRealSense/realsense-ros/issues/3450> from Nir-Az: update to realsenseai
* update to realsenseai
* PR #3448 <https://github.com/IntelRealSense/realsense-ros/issues/3448> from OhadMeir: Add motion_fps to launch file
* Add motion_fps to launch file
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0 - leftovers
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* PR #3437 <https://github.com/IntelRealSense/realsense-ros/issues/3437> from Gilaadb: bug fix(rs_node_setup): Fix topic names that were improperly marked as rect (rectified)
* bug fix(rs_node_setup): Fix topic names that were improperly marked as rect (rectified)
* Contributors: Gilad Bretter, Nir Azkiel, OhadMeir, Remi Bettan, remibettan
```

## realsense2_camera_msgs

```
* add release noted
* Update package.xml
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* many intel removed and github user changed
* PR #3447 <https://github.com/IntelRealSense/realsense-ros/issues/3447> from Nir-Az: Update maintainers before Realsense migration
* update maintainers list
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* Contributors: Nir Azkiel, Remi Bettan, remibettan
* Update package.xml
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* many intel removed and github user changed
* PR #3447 <https://github.com/IntelRealSense/realsense-ros/issues/3447> from Nir-Az: Update maintainers before Realsense migration
* update maintainers list
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* Contributors: Nir Azkiel, Remi Bettan, remibettan
```

## realsense2_description

```
* add release noted
* Update package.xml
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3476 <https://github.com/IntelRealSense/realsense-ros/issues/3476> from nivgo: Add support for Intel RealSense D436 Camera
* typos fix
* Add Intel realsense D436 URDF model
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* many intel removed and github user changed
* PR #3447 <https://github.com/IntelRealSense/realsense-ros/issues/3447> from Nir-Az: Update maintainers before Realsense migration
* update maintainers list
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* Contributors: Nir Azkiel, Niv Goren, Remi Bettan, remibettan
* Update package.xml
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3476 <https://github.com/IntelRealSense/realsense-ros/issues/3476> from nivgo: Add support for Intel RealSense D436 Camera
* typos fix
* Add Intel realsense D436 URDF model
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* many intel removed and github user changed
* PR #3447 <https://github.com/IntelRealSense/realsense-ros/issues/3447> from Nir-Az: Update maintainers before Realsense migration
* update maintainers list
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* Contributors: Nir Azkiel, Niv Goren, Remi Bettan, remibettan
```
