### PR TITLE
geometry2: 0.25.20-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3624,7 +3624,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.19-1
+      version: 0.25.20-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.25.20-2`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.25.19-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* local variable tf2 no longer shadows the tf2:: (#903 <https://github.com/ros2/geometry2/issues/903>) (#918 <https://github.com/ros2/geometry2/issues/918>)
* Fix misleading extrapolation time in buffer_core (#832 <https://github.com/ros2/geometry2/issues/832>) (backport #896 <https://github.com/ros2/geometry2/issues/896>) (#899 <https://github.com/ros2/geometry2/issues/899>)
* Contributors: mergify[bot]
```

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

- No changes

## tf2_ros_py

```
* prevent AttributeError when static_only=true (backport #906 <https://github.com/ros2/geometry2/issues/906>) (#915 <https://github.com/ros2/geometry2/issues/915>)
* fixed typo in buffer.py (backport #905 <https://github.com/ros2/geometry2/issues/905>) (#912 <https://github.com/ros2/geometry2/issues/912>)
* Contributors: mergify[bot]
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
