### PR TITLE
laser_geometry: 2.11.3-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3761,7 +3761,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.11.2-1
+      version: 2.11.3-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_geometry` to `2.11.3-4`:

- upstream repository: https://github.com/ros-perception/laser_geometry.git
- release repository: https://github.com/ros2-gbp/laser_geometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.11.2-1`

## laser_geometry

```
* Use new ROSIDL aggregate CMake target (#115 <https://github.com/ros-perception/laser_geometry/issues/115>)
* Contributors: Emerson Knapp
```
