### PR TITLE
image_common: 6.4.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3335,7 +3335,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.5-1
+      version: 6.4.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.6-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.4.5-1`

## camera_calibration_parsers

```
* Use new ROSIDL aggregate CMake target (#396 <https://github.com/ros-perception/image_common/issues/396>)
* Delete camera_calibration_parsers/setup.py (#393 <https://github.com/ros-perception/image_common/issues/393>)
* Contributors: Emerson Knapp, Michael Carlstrom
```

## camera_info_manager

```
* Use new ROSIDL aggregate CMake target (#396 <https://github.com/ros-perception/image_common/issues/396>)
* Added camera info manager unit test (#358 <https://github.com/ros-perception/image_common/issues/358>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Use new ROSIDL aggregate CMake target (#396 <https://github.com/ros-perception/image_common/issues/396>)
* Contributors: Emerson Knapp
```

## image_transport_py

```
* Use new ROSIDL aggregate CMake target (#396 <https://github.com/ros-perception/image_common/issues/396>)
* Contributors: Emerson Knapp
```
