### PR TITLE
rclcpp: 16.0.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8778,7 +8778,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 16.0.18-1
+      version: 16.0.19-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `16.0.19-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `16.0.18-1`

## rclcpp

```
* Remove duplicate test cases in TestAnySubscriptionCallback::is_serialized_message_callback (backport #3104 <https://github.com/ros2/rclcpp/issues/3104>) (#3108 <https://github.com/ros2/rclcpp/issues/3108>)
* keep the event alive throught the assertion, preveiting the race. (#3099 <https://github.com/ros2/rclcpp/issues/3099>) (#3101 <https://github.com/ros2/rclcpp/issues/3101>)
* fix: Use default rcl allocator if allocator is std::allocator (#3069 <https://github.com/ros2/rclcpp/issues/3069>) (#3072 <https://github.com/ros2/rclcpp/issues/3072>)
* fix: Various data races in test cases (#3057 <https://github.com/ros2/rclcpp/issues/3057>) (#3063 <https://github.com/ros2/rclcpp/issues/3063>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Avoid unecessary creation of MultiThreadedExecutor (#3090 <https://github.com/ros2/rclcpp/issues/3090>) (#3096 <https://github.com/ros2/rclcpp/issues/3096>)
* Fix component registering in subdirectories (#3064 <https://github.com/ros2/rclcpp/issues/3064>) (#3076 <https://github.com/ros2/rclcpp/issues/3076>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

- No changes
