### PR TITLE
raph_robot: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7749,11 +7749,13 @@ repositories:
     release:
       packages:
       - raph_bringup
+      - raph_fw
+      - raph_oak
       - raph_robot
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raph_robot-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/RaphRover/raph_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raph_robot` to `1.1.0-1`:

- upstream repository: https://github.com/RaphRover/raph_robot
- release repository: https://github.com/ros2-gbp/raph_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`

## raph_bringup

```
* feat: Add ruff and pre-commit config (#9 <https://github.com/Rapha-Rover/rapha_robot/issues/9>)
* feat: Add custom OAK wrapper (#8 <https://github.com/Rapha-Rover/rapha_robot/issues/8>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## raph_fw

```
* feat: Add raph_fw package (#10 <https://github.com/Rapha-Rover/rapha_robot/issues/10>)
* Contributors: Błażej Sowa
```

## raph_oak

```
* feat: Add ruff and pre-commit config (#9 <https://github.com/Rapha-Rover/rapha_robot/issues/9>)
* feat: Add custom OAK wrapper (#8 <https://github.com/Rapha-Rover/rapha_robot/issues/8>)
* Contributors: Aleksander Szymański, Błażej Sowa
```

## raph_robot

```
* feat: Add ruff and pre-commit config (#9 <https://github.com/Rapha-Rover/rapha_robot/issues/9>)
* Contributors: Błażej Sowa
```
