### PR TITLE
Add onnxruntime_vendor doc/source to jazzy, kilted and rolling

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6614,6 +6614,16 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
+  onnxruntime_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    status: developed
   open_manipulator:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5531,6 +5531,16 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
+  onnxruntime_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    status: developed
   open_manipulator:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5462,6 +5462,16 @@ repositories:
       url: https://github.com/ompl/ompl.git
       version: main
     status: developed
+  onnxruntime_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    status: developed
   open3d_vendor:
     doc:
       type: git
@@ -5477,16 +5487,6 @@ repositories:
       url: https://github.com/christian-rauch/open3d_colcon.git
       version: main
     status: maintained
-  onnxruntime_vendor:
-    doc:
-      type: git
-      url: https://github.com/ros-controls/onnxruntime_vendor.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/ros-controls/onnxruntime_vendor.git
-      version: main
-    status: developed
   open_manipulator:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5477,6 +5477,16 @@ repositories:
       url: https://github.com/christian-rauch/open3d_colcon.git
       version: main
     status: maintained
+  onnxruntime_vendor:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/ros-controls/onnxruntime_vendor.git
+      version: main
+    status: developed
   open_manipulator:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# :bow: Please Add This Package to be indexed in the rosdistro. :bow: 

onnxruntime_vendor

# The source is here:

https://github.com/ros-controls/onnxruntime_vendor.git

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
