### PR TITLE
ur_msgs: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12937,7 +12937,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `2.5.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.0-1`

## ur_msgs

```
* Add service for setting gravity vector (#39 <https://github.com/ros-industrial/ur_msgs/issues/39>)
* Contributors: AdamPettinger
```