### PR TITLE
ur_client_library: 2.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12067,7 +12067,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.8.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-1`

## ur_client_library

```
* Improve cleanup of trajectory buffer  (#466 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/466>)
* Fix documentation of direct_torque example (#467 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/467>)
* Direct torque friction scales support (#445 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/445>)
* If no new commands are received, halt (#440 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/440>)
* Add check to make sure that program name and save path is specified w… (#447 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/447>)
  …hen downloading program.
* Update gtest to fix MacOS build warnings (#464 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/464>)
* Fix windows compile warnings (#451 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/451>)
  Fix windows compile warnings and from now all warnings are treated as errors.
* Fix setGravity comments to be correct directionality (#462 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/462>)
* Robustify TCPServer implementation for thread safety and windows support (#458 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/458>)
* Add implementation of creating ExampleRobotWrapper with recipe vectors (#456 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/456>)
* Rename endian.h to portable_endian.h (#442 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/442>)
* [primary] Print a warning on additional data in RobotState submessages (#460 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/460>)
* Replace TEST with TEST_F to ensure teardown (#459 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/459>)
* [start_ursim.sh] Do not remove trailing "e" for PolyScope X (#461 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/461>)
* Add doxygen to new dashboard X calls (#455 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/455>)
* Improve socket connection robustness in external_control.urscript (#453 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/453>)
* Fix filesystem linking on GCC 8 and add RHEL CI workflow (#454 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/454>)
* Fix flakyness in ReverseInterfaceTest.handle_program_state (#430 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/430>)
* Added ScriptCommandInterface command setTcpOffset (#444 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/444>)
* Refactor rtde parsing for RT and performance improvements (#419 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/419>)
* Contributors: AdamPettinger, David Karlsböck, Felix Exner, Rune Søe-Knudsen, Sergi Romero, URJala, dependabot[bot]
```
