### PR TITLE
pluginlib: 5.8.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5978,7 +5978,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.8.3-1
+      version: 5.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.8.4-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.8.3-1`

## pluginlib

```
* Fix some minor issues (#292 <https://github.com/ros/pluginlib/issues/292>)
* Contributors: Alejandro Hernández Cordero
```

## ros2plugin

```
* Implement package option (#293 <https://github.com/ros/pluginlib/issues/293>)
* Contributors: Alejandro Hernández Cordero
```
