### PR TITLE
point_cloud_transport: 5.3.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6012,7 +6012,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.3.3-1
+      version: 5.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.3.4-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.3.3-1`

## point_cloud_transport

```
* Use new aggregate rosidl target instead of _TARGETS (#153 <https://github.com/ros-perception/point_cloud_transport/issues/153>)
  Co-authored-by: Alexis Tsogias <mailto:a.tsogias@cellumation.com>
* Improvements (#150 <https://github.com/ros-perception/point_cloud_transport/issues/150>)
* Contributors: Alejandro Hernández Cordero, Alexis Tsogias
```

## point_cloud_transport_py

```
* Use new aggregate rosidl target instead of _TARGETS (#153 <https://github.com/ros-perception/point_cloud_transport/issues/153>)
* Python improvements (#151 <https://github.com/ros-perception/point_cloud_transport/issues/151>)
* Contributors: Alejandro Hernández Cordero, Alexis Tsogias
```
