### PR TITLE
ros_gz: 3.0.8-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7883,7 +7883,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.7-1
+      version: 3.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.8-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.7-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Bridge DVL messages (backport #789 <https://github.com/gazebosim/ros_gz/issues/789>) (#868 <https://github.com/gazebosim/ros_gz/issues/868>)
* fix(ros_gz_bridge)!: Fixed BridgeConfig initializer args (#866 <https://github.com/gazebosim/ros_gz/issues/866>)
* test(ros_gz_bridge): Added tests for per-bridge frame_id setting from launch action. (#864 <https://github.com/gazebosim/ros_gz/issues/864>)
* Pass frame_id per-bridge as ROS parameter. (#854 <https://github.com/gazebosim/ros_gz/issues/854>)
* fix: Node level lazy parameter fix (#852 <https://github.com/gazebosim/ros_gz/issues/852>)
* ros_gz_bridge improvements (#850 <https://github.com/gazebosim/ros_gz/issues/850>)
* Contributors: Alejandro Hernández Cordero, Gilbert Tanner, Martin Pecka, mergify[bot]
```

## ros_gz_image

```
* feat: Added lazy subscribe support for GZ image bridge (#851 <https://github.com/gazebosim/ros_gz/issues/851>)
* Contributors: Gilbert Tanner
```

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* ros_gz_bridge improvements (#850 <https://github.com/gazebosim/ros_gz/issues/850>)
* Contributors: Alejandro Hernández Cordero
```

## ros_gz_sim_demos

```
* Bridge DVL messages (backport #789 <https://github.com/gazebosim/ros_gz/issues/789>) (#868 <https://github.com/gazebosim/ros_gz/issues/868>)
* Contributors: mergify[bot]
```
