### PR TITLE
pluginlib: 5.4.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7153,7 +7153,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.4.4-1
+      version: 5.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pluginlib` to `5.4.5-1`:

- upstream repository: https://github.com/ros/pluginlib.git
- release repository: https://github.com/ros2-gbp/pluginlib-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.4.4-1`

## pluginlib

- No changes

## ros2plugin

```
* Implement package option (#293 <https://github.com/ros/pluginlib/issues/293>) (#295 <https://github.com/ros/pluginlib/issues/295>)
* Contributors: mergify[bot]
```
