### PR TITLE
ros_gz: 2.1.16-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7923,7 +7923,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.15-1
+      version: 2.1.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `2.1.16-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.15-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Bridge DVL messages (backport #789 <https://github.com/gazebosim/ros_gz/issues/789>) (#869 <https://github.com/gazebosim/ros_gz/issues/869>)
* ros_gz_bridge: Allow setting QoS profile from YAML files and launch action. (#865 <https://github.com/gazebosim/ros_gz/issues/865>)
* test(ros_gz_bridge): Added tests for per-bridge frame_id setting from launch action. (#860 <https://github.com/gazebosim/ros_gz/issues/860>)
* feat(ros_gz_bridge): Pass frame_id per-bridge as ROS parameter. (#854 <https://github.com/gazebosim/ros_gz/issues/854>) (#858 <https://github.com/gazebosim/ros_gz/issues/858>)
* Contributors: Martin Pecka, mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

```
* Bridge DVL messages (backport #789 <https://github.com/gazebosim/ros_gz/issues/789>) (#869 <https://github.com/gazebosim/ros_gz/issues/869>)
* Contributors: mergify[bot]
```
