### PR TITLE
ros_gz: 1.0.22-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9346,7 +9346,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 1.0.21-1
+      version: 1.0.22-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `1.0.22-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.21-1`

## ros_gz

- No changes

## ros_gz_bridge

```
* Bridge DVL messages (#789 <https://github.com/gazebosim/ros_gz/issues/789>)
* ros_gz_bridge: Allow setting QoS profile from YAML files and launch action. (#867 <https://github.com/gazebosim/ros_gz/issues/867>)
* test(ros_gz_bridge): Added tests for per-bridge frame_id setting from launch action. (#863 <https://github.com/gazebosim/ros_gz/issues/863>)
* Contributors: Carlos Agüero, Martin Pecka
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

- No changes

## ros_gz_sim_demos

```
* Bridge DVL messages (#789 <https://github.com/gazebosim/ros_gz/issues/789>)
* Contributors: Carlos Agüero
```
