### PR TITLE
ros_gz: 0.244.24-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10012,7 +10012,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.244.23-1
+      version: 0.244.24-1
     source:
       type: git
       url: https://github.com/gazebosim/ros_gz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `0.244.24-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.244.23-1`

## ros_gz

- No changes

## ros_gz_bridge

- No changes

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Bugfix: if "false" is always True (#617 <https://github.com/gazebosim/ros_gz/issues/617>) (#859 <https://github.com/gazebosim/ros_gz/issues/859>)
* Contributors: mergify[bot]
```

## ros_gz_sim_demos

- No changes

## ros_ign

- No changes

## ros_ign_bridge

- No changes

## ros_ign_gazebo

- No changes

## ros_ign_gazebo_demos

- No changes

## ros_ign_image

- No changes

## ros_ign_interfaces

- No changes
