### PR TITLE
system_webview: 0.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9548,7 +9548,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/system_webview-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/namo-robotics/ros2_system_webview.git


### PR DESCRIPTION
Increasing version of package(s) in repository `system_webview` to `0.0.3-1`:

- upstream repository: https://github.com/namo-robotics/ros2_system_webview.git
- release repository: https://github.com/ros2-gbp/system_webview-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.0.2-1`

## system_webview

```
* fix lint errors
* add per-node resource monitoring
* Refactor HTML and TypeScript configuration for improved readability
  - Updated the HTML structure in index.html for better formatting and consistency.
  - Simplified the TypeScript configuration in tsconfig.json by consolidating array elements for "lib" and "paths" options.
* Contributors: David Brown
```
