### PR TITLE
ur_client_library: 2.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12067,7 +12067,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.8.0-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.9.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.0-1`

## ur_client_library

```
* [RTDEClient] stop producer on destruction (#472 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/472>)
* Primary Client power on improvements (#473 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/473>)
* Move TCPServer disconnection log events from Info to Debug (#471 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/471>)
* Refactor tool communication into standalone socat initialization script (#470 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/470>)
* Contributors: Felix Exner, JohnN193, Rune Søe-Knudsen, Sergi Romero
```