### PR TITLE
nanoeigenpy: 0.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5052,7 +5052,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/nanoeigenpy-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/Simple-Robotics/nanoeigenpy.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoeigenpy` to `0.5.0-1`:

- upstream repository: https://github.com/Simple-Robotics/nanoeigenpy.git
- release repository: https://github.com/ros2-gbp/nanoeigenpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.0-1`
