### PR TITLE
linear_feedback_controller: 3.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4123,6 +4123,15 @@ repositories:
       version: rolling
     status: maintained
   linear_feedback_controller:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/linear-feedback-controller-release.git
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/loco-3d/linear-feedback-controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller` to `3.1.0-1`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
