### PR TITLE
Add roboplan repos for Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7411,6 +7411,26 @@ repositories:
       url: https://github.com/ros2/rmw_zenoh.git
       version: rolling
     status: developed
+  roboplan:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    status: developed
+  roboplan_ros:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    status: developed
   robot_calibration:
     doc:
       type: git
@@ -9828,6 +9848,16 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: rolling
     status: developed
+  toppra:
+    doc:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
# Please Add These Packages to be indexed in the rosdistro.

rolling

# The source is here:

- https://github.com/hungpham2511/toppra
- https://github.com/open-planning/roboplan
- https://github.com/open-planning/roboplan-ros


# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
