### PR TITLE
Add roboplan repos for Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9431,6 +9431,26 @@ repositories:
       url: https://github.com/suchetanrs/roadmap-explorer.git
       version: main
     status: developed
+  roboplan:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    status: developed
+  roboplan_ros:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    status: developed
   robosoft_openai:
     doc:
       type: git
@@ -12313,6 +12333,16 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: humble
     status: developed
+  toppra:
+    doc:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    status: maintained
   tracetools_acceleration:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7411,6 +7411,26 @@ repositories:
       url: https://github.com/ros2/rmw_zenoh.git
       version: rolling
     status: developed
+  roboplan:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan
+      version: main
+    status: developed
+  roboplan_ros:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros
+      version: main
+    status: developed
   robot_calibration:
     doc:
       type: git
@@ -9828,6 +9848,16 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: rolling
     status: developed
+  toppra:
+    doc:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    status: maintained
   trac_ik:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7411,26 +7411,6 @@ repositories:
       url: https://github.com/ros2/rmw_zenoh.git
       version: rolling
     status: developed
-  roboplan:
-    doc:
-      type: git
-      url: https://github.com/open-planning/roboplan
-      version: main
-    source:
-      type: git
-      url: https://github.com/open-planning/roboplan
-      version: main
-    status: developed
-  roboplan_ros:
-    doc:
-      type: git
-      url: https://github.com/open-planning/roboplan-ros
-      version: main
-    source:
-      type: git
-      url: https://github.com/open-planning/roboplan-ros
-      version: main
-    status: developed
   robot_calibration:
     doc:
       type: git
@@ -9848,16 +9828,6 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: rolling
     status: developed
-  toppra:
-    doc:
-      type: git
-      url: https://github.com/hungpham2511/toppra.git
-      version: develop
-    source:
-      type: git
-      url: https://github.com/hungpham2511/toppra.git
-      version: develop
-    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
# Please Add These Packages to be indexed in the rosdistro.

humble

# The source is here:

- https://github.com/hungpham2511/toppra
- https://github.com/open-planning/roboplan
- https://github.com/open-planning/roboplan-ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
