### PR TITLE
Add roboplan repos for Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8740,6 +8740,26 @@ repositories:
       url: https://github.com/suchetanrs/roadmap-explorer.git
       version: main
     status: developed
+  roboplan:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    status: developed
+  roboplan_ros:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    status: developed
   robosoft_openai:
     doc:
       type: git
@@ -11472,6 +11492,16 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: jazzy
     status: developed
+  toppra:
+    doc:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
# Please Add These Packages to be indexed in the rosdistro.

jazzy

# The source is here:

- https://github.com/hungpham2511/toppra
- https://github.com/open-planning/roboplan
- https://github.com/open-planning/roboplan-ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro