### PR TITLE
Add roboplan repos for Kilted

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7424,6 +7424,26 @@ repositories:
       url: https://github.com/suchetanrs/roadmap-explorer.git
       version: main
     status: developed
+  roboplan:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan.git
+      version: main
+    status: developed
+  roboplan_ros:
+    doc:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/open-planning/roboplan-ros.git
+      version: main
+    status: developed
   robot_calibration:
     doc:
       type: git
@@ -9868,6 +9888,16 @@ repositories:
       url: https://github.com/ros-tooling/topic_tools.git
       version: rolling
     status: developed
+  toppra:
+    doc:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/hungpham2511/toppra.git
+      version: develop
+    status: maintained
   trac_ik:
     doc:
       type: git


### PR DESCRIPTION
# Please Add These Packages to be indexed in the rosdistro.

kilted

# The source is here:

- https://github.com/hungpham2511/toppra
- https://github.com/open-planning/roboplan
- https://github.com/open-planning/roboplan-ros

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro