### PR TITLE
Add NixOS entries for libopencv-* and libsystemd-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5286,6 +5286,7 @@ libopencv-core:
     bullseye: [libopencv-core45]
     trixie: [libopencv-core410]
   fedora: [opencv-core]
+  nixos: [opencv]
   rhel: [opencv-core]
   ubuntu:
     jammy: [libopencv-core4.5d]
@@ -5294,6 +5295,7 @@ libopencv-core:
 libopencv-core-dev:
   debian: [libopencv-core-dev]
   fedora: [opencv-devel]
+  nixos: [opencv]
   rhel: [opencv-devel]
   ubuntu: [libopencv-core-dev]
 libopencv-dev:
@@ -5315,6 +5317,7 @@ libopencv-highgui:
     bookworm: [libopencv-highgui406]
     bullseye: [libopencv-highgui4.5]
   fedora: [opencv-highgui]
+  nixos: [opencv]
   rhel:
     '*': [opencv-highgui]
     '8': [opencv-core]
@@ -5330,6 +5333,7 @@ libopencv-imgcodecs:
     bullseye: [libopencv-imgcodecs45]
     trixie: [libopencv-imgcodecs410]
   fedora: [opencv-imgcodecs]
+  nixos: [opencv]
   rhel:
     '*': [opencv-imgcodecs]
     '8': [opencv-core]
@@ -5341,6 +5345,7 @@ libopencv-imgcodecs:
 libopencv-imgcodecs-dev:
   debian: [libopencv-imgcodecs-dev]
   fedora: [opencv-devel]
+  nixos: [opencv]
   rhel: [opencv-devel]
   ubuntu: [libopencv-imgcodecs-dev]
 libopencv-imgproc:
@@ -5349,6 +5354,7 @@ libopencv-imgproc:
     bullseye: [libopencv-imgproc45]
     trixie: [libopencv-imgproc410]
   fedora: [opencv-imgproc]
+  nixos: [opencv]
   rhel:
     '*': [opencv-imgproc]
     '8': [opencv-core]
@@ -5372,6 +5378,7 @@ libopencv-videoio:
     bookworm: [libopencv-videoio406]
     bullseye: [libopencv-videoio4.5]
   fedora: [opencv-videoio]
+  nixos: [opencv]
   rhel:
     '*': [opencv-videoio]
     '8': [opencv-core]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7051,6 +7051,7 @@ libsystemd-dev:
   arch: [systemd-libs]
   debian: [libsystemd-dev]
   fedora: [systemd-devel]
+  nixos: [systemd]
   openembedded: [systemd@openembedded-core]
   ubuntu:
     '*': [libsystemd-dev]


### PR DESCRIPTION
This should solve evaluation failures in https://github.com/lopsided98/nix-ros-overlay/pull/826.