### PR TITLE
add jig

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4486,6 +4486,12 @@ repositories:
       url: https://github.com/JafarAbdi/jacro.git
       version: main
     status: developed
+  jig:
+    source:
+      type: git
+      url: https://github.com/nineyards-robotics/jig.git
+      version: humble
+    status: maintained
   joint_state_publisher:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4377,6 +4377,12 @@ repositories:
       url: https://github.com/JafarAbdi/jacro.git
       version: main
     status: maintained
+  jig:
+    source:
+      type: git
+      url: https://github.com/nineyards-robotics/jig.git
+      version: jazzy
+    status: maintained
   joint_state_publisher:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3519,6 +3519,12 @@ repositories:
       url: https://github.com/JafarAbdi/jacro.git
       version: main
     status: maintained
+  jig:
+    source:
+      type: git
+      url: https://github.com/nineyards-robotics/jig.git
+      version: kilted
+    status: maintained
   joint_state_publisher:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jig

# The source is here:

https://github.com/nineyards-robotics/jig

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
