### PR TITLE
Add so_arm_100 packages to jazzy (doc/source)

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10889,6 +10889,16 @@ repositories:
       url: https://github.com/PickNikRobotics/snowbot_operating_system.git
       version: ros2
     status: maintained
+  so_arm_100:
+    doc:
+      type: git
+      url: https://github.com/brukg/SO-100-arm.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/brukg/SO-100-arm.git
+      version: main
+    status: developed
   so_arm_100_hardware:
     doc:
       type: git


### PR DESCRIPTION
Add doc and source entries for the SO-100 arm packages to the jazzy distribution.

Packages:
- so_arm_100 (metapackage)
- so_arm_100_description (URDF, meshes, xacro)
- so_arm_100_bringup (launch files for Gazebo and hardware)
- so_arm_100_moveit_config (MoveIt configuration)

Source: https://github.com/brukg/SO-100-arm

The hardware interface package (so_arm_100_hardware) is already in the index with a full release. These packages provide the robot description, simulation, and MoveIt integration for the SO-ARM100 5-DOF manipulator.