### PR TITLE
Add rhel entry for libglib-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4221,6 +4221,7 @@ libglib-dev:
   gentoo: [dev-libs/glib]
   nixos: [glib]
   openembedded: [glib-2.0@openembedded-core]
+  rhel: [glib2-devel]
   ubuntu: [libglib2.0-dev, libglib2.0-dev-bin]
 libglm-dev:
   arch: [glm]


### PR DESCRIPTION
## Package name:

libglib-dev

Distro packaging links:

## Links to Distribution Packages

- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/download/glib2-devel
