### PR TITLE
qt_gui_core: 2.10.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6431,7 +6431,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.10.2-1
+      version: 2.10.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.10.3-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.10.2-1`

## qt_dotgraph

```
* Ignore case when asserting snippet presence in tests (#314 <https://github.com/ros-visualization/qt_gui_core/issues/314>)
* Contributors: Scott K Logan
```

## qt_gui

```
* fix(qt_gui): __builtin__ -> builtins (#315 <https://github.com/ros-visualization/qt_gui_core/issues/315>)
* Contributors: Matthijs van der Burgh
```

## qt_gui_app

- No changes

## qt_gui_core

```
* Update qt_gui_core to package.xml version 2. (#319 <https://github.com/ros-visualization/qt_gui_core/issues/319>)
* Contributors: Chris Lalancette
```

## qt_gui_cpp

```
* Use new aggregate rosidl target instead of _TARGETS (#325 <https://github.com/ros-visualization/qt_gui_core/issues/325>)
* remove unsued setup.py (#323 <https://github.com/ros-visualization/qt_gui_core/issues/323>)
* Contributors: Alexis Tsogias, Michael Carlstrom
```

## qt_gui_py_common

```
* remove unsued setup.py (#323 <https://github.com/ros-visualization/qt_gui_core/issues/323>)
* Contributors: Michael Carlstrom
```
