### PR TITLE
qt_gui_core: 2.7.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7641,7 +7641,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.7.5-1
+      version: 2.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.7.6-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.5-1`

## qt_dotgraph

- No changes

## qt_gui

```
* fix(qt_gui): __builtin__ -> builtins (#315 <https://github.com/ros-visualization/qt_gui_core/issues/315>) (#317 <https://github.com/ros-visualization/qt_gui_core/issues/317>)
* Contributors: mergify[bot]
```

## qt_gui_app

- No changes

## qt_gui_core

```
* Update qt_gui_core to package.xml version 2. (#319 <https://github.com/ros-visualization/qt_gui_core/issues/319>) (#321 <https://github.com/ros-visualization/qt_gui_core/issues/321>)
* Contributors: mergify[bot]
```

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
