### PR TITLE
qt_gui_core: 2.2.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8415,7 +8415,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.2.4-1
+      version: 2.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.2.5-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.4-1`

## qt_dotgraph

- No changes

## qt_gui

```
* fix(qt_gui): __builtin__ -> builtins (#315 <https://github.com/ros-visualization/qt_gui_core/issues/315>) (#318 <https://github.com/ros-visualization/qt_gui_core/issues/318>)
* Contributors: mergify[bot]
```

## qt_gui_app

- No changes

## qt_gui_core

```
* Update qt_gui_core to package.xml version 2. (#319 <https://github.com/ros-visualization/qt_gui_core/issues/319>) (#322 <https://github.com/ros-visualization/qt_gui_core/issues/322>)
* Contributors: mergify[bot]
```

## qt_gui_cpp

- No changes

## qt_gui_py_common

- No changes
