### PR TITLE
log_view: 0.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4197,7 +4197,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/log_view-release.git
-      version: 0.2.7-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.3.0-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/ros2-gbp/log_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.7-1`

## log_view

```
* Add details panel with per-message metadata display.
* Enable static analysis and linting tests.
* Contributors: Marc Alban
```
