### PR TITLE
rmw_fastrtps: 9.4.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7361,7 +7361,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.4-1
+      version: 9.4.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.5-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.4.4-1`

## rmw_fastrtps_cpp

```
* Use new aggregate rosidl target instead of _TARGETS (#870 <https://github.com/ros2/rmw_fastrtps/issues/870>)
* Enable content filtering flag (#869 <https://github.com/ros2/rmw_fastrtps/issues/869>)
* fix: remove superflous buildtool_export_depend. (#852 <https://github.com/ros2/rmw_fastrtps/issues/852>)
* Contributors: Alexis Tsogias, Barry Xu, Tomoya Fujita
```

## rmw_fastrtps_dynamic_cpp

```
* Use new aggregate rosidl target instead of _TARGETS (#870 <https://github.com/ros2/rmw_fastrtps/issues/870>)
* fix: remove superflous buildtool_export_depend. (#852 <https://github.com/ros2/rmw_fastrtps/issues/852>)
* Contributors: Alexis Tsogias, Tomoya Fujita
```

## rmw_fastrtps_shared_cpp

```
* Added tracepoint to loaned take (#868 <https://github.com/ros2/rmw_fastrtps/issues/868>)
* fix: remove superflous buildtool_export_depend. (#852 <https://github.com/ros2/rmw_fastrtps/issues/852>)
* Contributors: Oren Bell PhD, Tomoya Fujita
```
