### PR TITLE
Adding fusioncore 0.1.0 to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3246,6 +3246,26 @@ repositories:
       url: https://github.com/locusrobotics/fuse.git
       version: jazzy
     status: maintained
+  fusioncore:
+    doc:
+      type: git
+      url: https://github.com/manankharwar/fusioncore.git
+      version: main
+    release:
+      packages:
+      - compass_msgs
+      - fusioncore_core
+      - fusioncore_gazebo
+      - fusioncore_ros
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/manankharwar/fusioncore-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/manankharwar/fusioncore.git
+      version: main
+    status: maintained
   game_controller_spl:
     doc:
       type: git


### PR DESCRIPTION
New package release: FusionCore 0.1.0 for ROS 2 Jazzy

FusionCore is a ROS 2 Jazzy sensor fusion package replacing the deprecated robot_localization. UKF-based, 21-dimensional state vector, IMU + wheel encoder + GPS fusion at 100Hz.

Packages included:
- fusioncore_core (pure C++17, zero ROS dependency)
- fusioncore_ros (ROS 2 Jazzy lifecycle node)
- fusioncore_gazebo (Gazebo Harmonic simulation world)
- compass_msgs (ROS 2 port of ctu-vras/compass message definitions)

Release repository: https://github.com/manankharwar/fusioncore-release
Source repository: https://github.com/manankharwar/fusioncore
License: Apache 2.0