### PR TITLE
persist_parameter_server: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7637,7 +7637,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/persist_parameter_server-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `persist_parameter_server` to `1.0.5-1`:

- upstream repository: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
- release repository: https://github.com/ros2-gbp/persist_parameter_server-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.4-1`

## persist_parameter_server

```
* fix redundant and unexpected mergify configuration for barckports. (#87 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/87>)
* Add save on update argument (#73 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/73>)
  * Add must save on update possibility
  * Lint
  * removed result as it is useless
  * Update readme
  * start test case
  * Modified test cases
  * Simplified cases
* create downstream branches, apply corresponding changes to workflow. (#79 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/79>)
* enable mergifyio and added appropriate labels. (#75 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/75>)
  * enable mergifyio and added appropriate labels.
  * address Copilot review comments.
  ---------
* Upgrade github action/run-gemini-cli workflows. (#71 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/71>)
* doc,fix: link in readme pointing to valid URL (#68 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/68>)
  The URL to how to install ROS 2 has changed a while back.
* enable actions/stale to close issues and PRs. (#70 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/70>)
* Contributors: Nicolas Daube, Simon Gene Gottlieb, Tomoya Fujita
```
