### PR TITLE
Add python3-astropy support in rosdep file

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5014,6 +5014,12 @@ python3-asn1tools-pip:
     pip:
       packages: [asn1tools]
 python3-astrometry-pip: *migrate_eol_2025_04_30_python3_astrometry_pip
+python3-astropy:
+  debian: [python3-astropy]
+  ubuntu: [python3-astropy]
+  fedora: [python3-astropy]
+  arch: [python-astropy]
+  gentoo: [dev-python/astropy]
 python3-astropy-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5015,11 +5015,11 @@ python3-asn1tools-pip:
       packages: [asn1tools]
 python3-astrometry-pip: *migrate_eol_2025_04_30_python3_astrometry_pip
 python3-astropy:
-  debian: [python3-astropy]
-  ubuntu: [python3-astropy]
-  fedora: [python3-astropy]
   arch: [python-astropy]
+  debian: [python3-astropy]
+  fedora: [python3-astropy]
   gentoo: [dev-python/astropy]
+  ubuntu: [python3-astropy]
 python3-astropy-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

[Astropy](https://www.astropy.org/)

## Package Upstream Source:

https://github.com/astropy/astropy

## Purpose of using this:

Astropy is already included in rosdep but only as pip dependency. This PR adds the astropy version packaged with all major Linux distributions.

Distro packaging links:

- Ubuntu
- Debian
- Fedora
- Arch
- Gentoo

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [python3-astropy](https://packages.debian.org/search?keywords=python3-astropy)
- Ubuntu: https://packages.ubuntu.com/
  - [python3-astropy](https://launchpad.net/ubuntu/+source/astropy)
- Fedora: https://packages.fedoraproject.org/
  - [python3-astropy](https://packages.fedoraproject.org/pkgs/python-astropy/python3-astropy/index.html)
- Arch: https://www.archlinux.org/packages/
  - [python-astropy](https://archlinux.org/packages/extra/x86_64/python-astropy/)
- Gentoo: https://packages.gentoo.org/
  - [dev-python/astropy](https://gpo.zugaina.org/dev-python/astropy)

# Please Add This Package to be indexed in the rosdistro.

- jazzy
- rolling

# The source is here:

https://github.com/astropy/astropy

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro