### PR TITLE
simple_launch: 1.11.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9262,7 +9262,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simple_launch-release.git
-      version: 1.11.3-1
+      version: 1.11.4-1
     source:
       type: git
       url: https://github.com/oKermorgant/simple_launch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simple_launch` to `1.11.4-1`:

- upstream repository: https://github.com/oKermorgant/simple_launch.git
- release repository: https://github.com/ros2-gbp/simple_launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.11.3-1`

## simple_launch

```
* handle local or global namespace when adding groups with events
* remap /zstd sup-topic for gz image bridge
* add build status
* gz launch robust to commas vs quotation marks
* Merge pull request #8 <https://github.com/oKermorgant/simple_launch/issues/8> from aurzenligl/devel
  add group to parent rather than root group, fixes nested groups
* Contributors: Krzysztof Laskowski, Olivier Kermorgant
```
