### PR TITLE
slider_publisher: 2.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9307,7 +9307,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/slider_publisher-release.git
-      version: 2.4.1-1
+      version: 2.4.3-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.4.3-1`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/ros2-gbp/slider_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.1-1`

## slider_publisher

```
* add build status
* robust to inverted min/max
* time stamp is easier to write
* Contributors: Olivier Kermorgant
```
