### PR TITLE
Index package nebula

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6252,6 +6252,16 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jazzy
     status: maintained
+  nebula:
+    doc:
+      type: git
+      url: https://github.com/tier4/nebula.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/tier4/nebula.git
+      version: main
+    status: developed
   neo_nav2_bringup:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

* jazzy

This adds the source and documentation entries for Nebula on Jazzy.

# The source is here:

https://github.com/tier4/nebula

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro