### PR TITLE
python3-revpimodio2-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9761,6 +9761,10 @@ python3-reedsolo-pip:
   '*':
     pip:
       packages: [reedsolo]
+python3-revpimodio2-pip:
+  '*':
+    pip:
+      packages: [revpimodio2]
 python3-regex:
   arch: [python-regex]
   debian: [python3-regex]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9761,10 +9761,6 @@ python3-reedsolo-pip:
   '*':
     pip:
       packages: [reedsolo]
-python3-revpimodio2-pip:
-  '*':
-    pip:
-      packages: [revpimodio2]
 python3-regex:
   arch: [python-regex]
   debian: [python3-regex]
@@ -9834,6 +9830,10 @@ python3-retrying:
     pip:
       packages: [retrying]
   ubuntu: [python3-retrying]
+python3-revpimodio2-pip:
+  '*':
+    pip:
+      packages: [revpimodio2]
 python3-rich:
   debian: [python3-rich]
   fedora: [python3-rich]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

revpimodio2

## Package Upstream Source:

https://github.com/naruxde/revpimodio2

## Purpose of using this:

For the revpi5-io module. It's an industrial rasperry5.
