### PR TITLE
human_description: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3275,6 +3275,21 @@ repositories:
       type: git
       url: https://github.com/ros4hri/hri_rviz.git
       version: humble-devel
+  human_description:
+    doc:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/human_description-release.git
+      version: 2.0.2-1
+    source:
+      type: git
+      url: https://github.com/ros4hri/human_description.git
+      version: humble-devel
+    status: developed
   hyveos_bridge:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `human_description` to `2.0.2-1`:

- upstream repository: https://github.com/ros4hri/human_description.git
- release repository: https://github.com/ros2-gbp/human_description-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## human_description

Initial release in `rolling`.

```
* fix joint limits for the arms
  the joint limits for the arms were wrong, as they did not really
  reflect the range of movements a human is able to perform. This
  commit introduces realistic joint limits for human arms.
* Contributors: lorenzoferrini
```
