### PR TITLE
fusioncore: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3260,7 +3260,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fusioncore` to `0.1.1-1`:

- upstream repository: https://github.com/manankharwar/fusioncore
- release repository: https://github.com/manankharwar/fusioncore-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-1`
