### PR TITLE
mp2p_icp: 2.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4846,7 +4846,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.7.1-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.8.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.1-1`

## mp2p_icp

```
* BUGFIX: Fix potential crash (regression in former voxel parallelization)
* Merge pull request #50 <https://github.com/MOLAorg/mp2p_icp/issues/50> from MOLAorg/fix/ram-usage
  Fix/ram usage
* Process points by chunks to limit RAM usage
* reduce memory allocations in voxel views
* Smarter usage of reserve() in tsl maps
* Add agents.md
* Merge pull request #49 <https://github.com/MOLAorg/mp2p_icp/issues/49> from MOLAorg/mm2las/georef
  mm2las: export flag '--frame geodetic' for georeferenced clouds
* Use geodetic coords cache
* Correctly honor exportGeodetic
* mm2las: Add sanity checks
* Fix: X=lon, Y=lat coord order for WKT2
* mm2las: export flag '--frame geodetic' for georeferenced clouds
* Contributors: Jose Luis Blanco-Claraco
```
