### PR TITLE
mrpt_path_planning: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6186,7 +6186,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.2.5-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `0.3.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.5-1`

## mrpt_path_planning

```
* copyright year bump
* Integrate vscode config to build with colcon
* Add basic unit tests
* add params for ackermann
* Fix potential wrong lattice coordinates due to bad rounding
* Fix: use smooth quadratic cost
* Fix potential phi angle comparison wraps
* Docs: explain optimality criterion
* tune params and add more examples in readme
* fix potential non-optimal path search
* fix build against modern mvsim
* Add ARQUITECTURE.md
* Contributors: Jose Luis Blanco-Claraco
```
