### PR TITLE
mrpt_navigation: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4919,7 +4919,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.3.1-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.3.0-1`

## mrpt_map_server

- No changes

## mrpt_msgs_bridge

- No changes

## mrpt_nav_interfaces

- No changes

## mrpt_navigation

```
* Merge pull request #157 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/157> from r-aguilera/ros2
  Add missing deps to metapackage and sort entries
* Add missing deps to metapackage and sort entries
  Missing:
  - mrpt_msgs_bridge
  - mrpt_tps_astar_planner
* Contributors: Jose Luis Blanco-Claraco, Raúl Aguilera López
```

## mrpt_pf_localization

```
* Add missing <test_depend> on ament_cmake_gtest
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

- No changes

## mrpt_reactivenav2d

- No changes

## mrpt_tps_astar_planner

- No changes

## mrpt_tutorials

```
* FIX: astar demo should use PF for localization
* Contributors: Jose Luis Blanco-Claraco
```
