### PR TITLE
realtime_tools: 5.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6913,7 +6913,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 5.1.0-1
+      version: 5.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `5.2.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.0-1`

## realtime_tools

```
* Use realtime mutex and also try-lock while setting feedback (#490 <https://github.com/ros-controls/realtime_tools/issues/490>)
* Use atomic to have lock-free feedback setting from RT loop (#486 <https://github.com/ros-controls/realtime_tools/issues/486>)
* Update ThreadSafeBox Tests (#459 <https://github.com/ros-controls/realtime_tools/issues/459>)
* Contributors: Brian Jin, Sai Kishor Kothakota
```
