### PR TITLE
rosbridge_suite: 4.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8132,7 +8132,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 4.0.0-1
+      version: 4.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `4.1.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.0.0-1`

## rosapi

```
* feat: Cache rosapi get/set parameter clients (#1201 <https://github.com/RobotWebTools/rosbridge_suite/issues/1201>)
* Contributors: Błażej Sowa
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Race condition in subscription destruction (#1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>)
* feat: Create topic registrations in publish when topic not previously advertised (#1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>)
* feat: Add pep8-naming checks (#1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>)
* fix: Deadlock in concurrent module import in ros_loader (#1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>)
* feat: Drop support for BSON (#1172 <https://github.com/RobotWebTools/rosbridge_suite/issues/1172>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Race condition in subscription destruction (#1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>)
* feat: Create topic registrations in publish when topic not previously advertised (#1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>)
* fix: Prevent client destruction race condition (#1183 <https://github.com/RobotWebTools/rosbridge_suite/issues/1183>)
* fix: Race condition in websocket test (#1185 <https://github.com/RobotWebTools/rosbridge_suite/issues/1185>)
* feat: Add pep8-naming checks (#1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>)
* fix: Deadlock in concurrent module import in ros_loader (#1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>)
* feat: Add timeout parameters to launch (#1174 <https://github.com/RobotWebTools/rosbridge_suite/issues/1174>)
* feat: Drop support for BSON (#1172 <https://github.com/RobotWebTools/rosbridge_suite/issues/1172>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
