### PR TITLE
rosbridge_suite: 3.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8135,7 +8135,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `3.2.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.0-1`

## rosapi

```
* feat: Cache rosapi get/set parameter clients (backport #1201 <https://github.com/RobotWebTools/rosbridge_suite/issues/1201>) (#1211 <https://github.com/RobotWebTools/rosbridge_suite/issues/1211>)
* Contributors: Błażej Sowa
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Race condition in subscription destruction (backport #1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>) (#1207 <https://github.com/RobotWebTools/rosbridge_suite/issues/1207>)
* feat: Create topic registrations in publish when topic not previously advertised (#1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>) (#1204 <https://github.com/RobotWebTools/rosbridge_suite/issues/1204>)
* feat: Add pep8-naming checks (backport #1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>) (#1180 <https://github.com/RobotWebTools/rosbridge_suite/issues/1180>)
* fix: Deadlock in concurrent module import in ros_loader (backport #1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>) (#1178 <https://github.com/RobotWebTools/rosbridge_suite/issues/1178>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Race condition in subscription destruction (backport #1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>) (#1207 <https://github.com/RobotWebTools/rosbridge_suite/issues/1207>)
* feat: Create topic registrations in publish when topic not previously advertised (#1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>) (#1204 <https://github.com/RobotWebTools/rosbridge_suite/issues/1204>)
* fix: Prevent client destruction race condition (#1183 <https://github.com/RobotWebTools/rosbridge_suite/issues/1183>) (#1188 <https://github.com/RobotWebTools/rosbridge_suite/issues/1188>)
* fix: Race condition in websocket test (backport #1185 <https://github.com/RobotWebTools/rosbridge_suite/issues/1185>) (#1186 <https://github.com/RobotWebTools/rosbridge_suite/issues/1186>)
* feat: Add pep8-naming checks (backport #1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>) (#1180 <https://github.com/RobotWebTools/rosbridge_suite/issues/1180>)
* fix: Deadlock in concurrent module import in ros_loader (backport #1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>) (#1178 <https://github.com/RobotWebTools/rosbridge_suite/issues/1178>)
* feat: Add timeout parameters to launch (backport #1174 <https://github.com/RobotWebTools/rosbridge_suite/issues/1174>) (#1175 <https://github.com/RobotWebTools/rosbridge_suite/issues/1175>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
