### PR TITLE
rosbridge_suite: 2.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9626,7 +9626,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.6.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.0-1`

## rosapi

```
* feat: Cache rosapi get/set parameter clients (backport #1201 <https://github.com/RobotWebTools/rosbridge_suite/issues/1201>) (#1212 <https://github.com/RobotWebTools/rosbridge_suite/issues/1212>)
* Contributors: Błażej Sowa
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Race condition in subscription destruction (backport #1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>) (#1208 <https://github.com/RobotWebTools/rosbridge_suite/issues/1208>)
* feat: Create topic registrations in publish when topic not previously advertised (backport #1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>) (#1205 <https://github.com/RobotWebTools/rosbridge_suite/issues/1205>)
* feat: Add pep8-naming checks (backport #1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>) (#1181 <https://github.com/RobotWebTools/rosbridge_suite/issues/1181>)
* fix: Deadlock in concurrent module import in ros_loader (backport #1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>) (#1179 <https://github.com/RobotWebTools/rosbridge_suite/issues/1179>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Race condition in subscription destruction (backport #1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>) (#1208 <https://github.com/RobotWebTools/rosbridge_suite/issues/1208>)
* feat: Create topic registrations in publish when topic not previously advertised (backport #1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>) (#1205 <https://github.com/RobotWebTools/rosbridge_suite/issues/1205>)
* fix: Prevent client destruction race condition (backport #1183 <https://github.com/RobotWebTools/rosbridge_suite/issues/1183>) (#1189 <https://github.com/RobotWebTools/rosbridge_suite/issues/1189>)
* fix: Race condition in websocket test (backport #1185 <https://github.com/RobotWebTools/rosbridge_suite/issues/1185>) (#1187 <https://github.com/RobotWebTools/rosbridge_suite/issues/1187>)
* feat: Add pep8-naming checks (backport #1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>) (#1181 <https://github.com/RobotWebTools/rosbridge_suite/issues/1181>)
* fix: Deadlock in concurrent module import in ros_loader (backport #1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>) (#1179 <https://github.com/RobotWebTools/rosbridge_suite/issues/1179>)
* feat: Add timeout parameters to launch (backport #1174 <https://github.com/RobotWebTools/rosbridge_suite/issues/1174>) (#1176 <https://github.com/RobotWebTools/rosbridge_suite/issues/1176>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
