### PR TITLE
rosbridge_suite: 2.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10273,7 +10273,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.0.6-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.5-1`

## rosapi

- No changes

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Race condition in subscription destruction (backport #1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>) (#1209 <https://github.com/RobotWebTools/rosbridge_suite/issues/1209>)
* feat: Create topic registrations in publish when topic not previously advertised (backport #1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>) (#1206 <https://github.com/RobotWebTools/rosbridge_suite/issues/1206>)
* chore: Re-enable skipped tests (#1198 <https://github.com/RobotWebTools/rosbridge_suite/issues/1198>)
* fix: Deadlock in concurrent module import in ros_loader (backport #1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>) (#1179 <https://github.com/RobotWebTools/rosbridge_suite/issues/1179>) (#1196 <https://github.com/RobotWebTools/rosbridge_suite/issues/1196>)
* feat: Add pep8-naming checks (backport #1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>) (#1182 <https://github.com/RobotWebTools/rosbridge_suite/issues/1182>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* fix: Race condition in subscription destruction (backport #1194 <https://github.com/RobotWebTools/rosbridge_suite/issues/1194>) (#1209 <https://github.com/RobotWebTools/rosbridge_suite/issues/1209>)
* feat: Create topic registrations in publish when topic not previously advertised (backport #1203 <https://github.com/RobotWebTools/rosbridge_suite/issues/1203>) (#1206 <https://github.com/RobotWebTools/rosbridge_suite/issues/1206>)
* fix: Race condition in websocket test (backport #1185 <https://github.com/RobotWebTools/rosbridge_suite/issues/1185>) (#1197 <https://github.com/RobotWebTools/rosbridge_suite/issues/1197>)
* fix: Deadlock in concurrent module import in ros_loader (backport #1173 <https://github.com/RobotWebTools/rosbridge_suite/issues/1173>) (#1179 <https://github.com/RobotWebTools/rosbridge_suite/issues/1179>) (#1196 <https://github.com/RobotWebTools/rosbridge_suite/issues/1196>)
* feat: Add timeout parameters to launch (backport #1174 <https://github.com/RobotWebTools/rosbridge_suite/issues/1174>) (#1195 <https://github.com/RobotWebTools/rosbridge_suite/issues/1195>)
* fix: Reduce idle CPU consumption of websocket server (backport #1040 <https://github.com/RobotWebTools/rosbridge_suite/issues/1040>) (#1171 <https://github.com/RobotWebTools/rosbridge_suite/issues/1171>)
* fix: Prevent client destruction race condition (backport #1183 <https://github.com/RobotWebTools/rosbridge_suite/issues/1183>) (#1190 <https://github.com/RobotWebTools/rosbridge_suite/issues/1190>)
* feat: Add pep8-naming checks (backport #1177 <https://github.com/RobotWebTools/rosbridge_suite/issues/1177>) (#1182 <https://github.com/RobotWebTools/rosbridge_suite/issues/1182>)
* Contributors: Błażej Sowa, FieldSwan
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
