### PR TITLE
realtime_tools: 4.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6925,7 +6925,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 4.7.1-1
+      version: 4.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `4.8.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.7.1-1`

## realtime_tools

```
* Use realtime mutex and also try-lock while setting feedback (backport #490 <https://github.com/ros-controls/realtime_tools/issues/490>) (#495 <https://github.com/ros-controls/realtime_tools/issues/495>)
* Use atomic to have lock-free feedback setting from RT loop (backport #486 <https://github.com/ros-controls/realtime_tools/issues/486>) (#488 <https://github.com/ros-controls/realtime_tools/issues/488>)
* Update ThreadSafeBox Tests (backport #459 <https://github.com/ros-controls/realtime_tools/issues/459>) (#468 <https://github.com/ros-controls/realtime_tools/issues/468>)
* Contributors: mergify[bot]
```
