### PR TITLE
realtime_tools: 3.11.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8289,7 +8289,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_tools-release.git
-      version: 3.10.1-1
+      version: 3.11.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_tools` to `3.11.0-1`:

- upstream repository: https://github.com/ros-controls/realtime_tools.git
- release repository: https://github.com/ros2-gbp/realtime_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.10.1-1`

## realtime_tools

```
* Use realtime mutex and also try-lock while setting feedback (backport #490 <https://github.com/ros-controls/realtime_tools/issues/490>) (#494 <https://github.com/ros-controls/realtime_tools/issues/494>)
* Use atomic to have lock-free feedback setting from RT loop (backport #486 <https://github.com/ros-controls/realtime_tools/issues/486>) (#487 <https://github.com/ros-controls/realtime_tools/issues/487>)
* Update ThreadSafeBox Tests (backport #459 <https://github.com/ros-controls/realtime_tools/issues/459>) (#467 <https://github.com/ros-controls/realtime_tools/issues/467>)
* Contributors: mergify[bot]
```
