### PR TITLE
control_toolbox: 6.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1411,7 +1411,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 6.1.0-1
+      version: 6.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `6.2.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.1.0-1`

## control_toolbox

```
* Add string() methods to get the printable information (#547 <https://github.com/ros-controls/control_toolbox/issues/547>)
* Use tl_expected from libexpected-dev instead (#572 <https://github.com/ros-controls/control_toolbox/issues/572>)
* Fix BSD license text (#563 <https://github.com/ros-controls/control_toolbox/issues/563>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```
