### PR TITLE
control_toolbox: 5.9.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1367,7 +1367,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 5.8.3-1
+      version: 5.9.1-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `5.9.1-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.8.3-1`

## control_toolbox

```
* Add string() methods to get the printable information (#547 <https://github.com/ros-controls/control_toolbox/issues/547>) (#584 <https://github.com/ros-controls/control_toolbox/issues/584>)
* Use tl_expected from libexpected-dev instead (backport #572 <https://github.com/ros-controls/control_toolbox/issues/572>) (#582 <https://github.com/ros-controls/control_toolbox/issues/582>)
* Contributors: mergify[bot]
```
