### PR TITLE
control_toolbox: 4.10.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1744,7 +1744,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 4.9.0-1
+      version: 4.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_toolbox` to `4.10.0-1`:

- upstream repository: https://github.com/ros-controls/control_toolbox.git
- release repository: https://github.com/ros2-gbp/control_toolbox-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.9.0-1`

## control_toolbox

```
* Add string() methods to get the printable information (backport #547 <https://github.com/ros-controls/control_toolbox/issues/547>) (#583 <https://github.com/ros-controls/control_toolbox/issues/583>)
* Use tl_expected from libexpected-dev instead (backport #572 <https://github.com/ros-controls/control_toolbox/issues/572>) (#581 <https://github.com/ros-controls/control_toolbox/issues/581>)
* Contributors: mergify[bot]
```
