### PR TITLE
control_msgs: 4.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1944,7 +1944,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 4.8.0-1
+      version: 4.9.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `4.9.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.8.0-1`

## control_msgs

```
* Remove linters dependencies (#298 <https://github.com/ros-controls/control_msgs/issues/298>) (#299 <https://github.com/ros-controls/control_msgs/issues/299>)
* Remove linter dependencies (#297 <https://github.com/ros-controls/control_msgs/issues/297>)
* Contributors: Christoph Fröhlich, mergify[bot]
```
