### PR TITLE
kinematics_interface: 0.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4629,7 +4629,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 0.4.1-1
+      version: 0.4.2-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `0.4.2-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.4.1-1`

## kinematics_interface

```
* Update maintainers (backport #198 <https://github.com/ros-controls/kinematics_interface/issues/198>) (#200 <https://github.com/ros-controls/kinematics_interface/issues/200>)
* Contributors: mergify[bot]
```

## kinematics_interface_kdl

```
* Update maintainers (backport #198 <https://github.com/ros-controls/kinematics_interface/issues/198>) (#200 <https://github.com/ros-controls/kinematics_interface/issues/200>)
* Contributors: mergify[bot]
```
