### PR TITLE
ros2_control: 5.13.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7586,7 +7586,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.12.0-1
+      version: 5.13.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.13.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.12.0-1`

## controller_interface

```
* Add pal_statistics as explicit dependency (#3163 <https://github.com/ros-controls/ros2_control/issues/3163>) (#3168 <https://github.com/ros-controls/ros2_control/issues/3168>)
* Add new API for chainable controller interface exporting (backport #2988 <https://github.com/ros-controls/ros2_control/issues/2988>) (#3051 <https://github.com/ros-controls/ros2_control/issues/3051>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Activate hardware components by group sequentially (#2984 <https://github.com/ros-controls/ros2_control/issues/2984>) (#3170 <https://github.com/ros-controls/ros2_control/issues/3170>)
* [Spawner] Allow parsing the parameter files parsed from spawner to controllers (#3136 <https://github.com/ros-controls/ros2_control/issues/3136>) (#3152 <https://github.com/ros-controls/ros2_control/issues/3152>)
* [Spawner] Allow arguments per controller instead of global args (#2895 <https://github.com/ros-controls/ros2_control/issues/2895>) (#3053 <https://github.com/ros-controls/ros2_control/issues/3053>)
* [Spawner] Fix exception of time.sleep in spawner (backport #3124 <https://github.com/ros-controls/ros2_control/issues/3124>) (#3126 <https://github.com/ros-controls/ros2_control/issues/3126>)
* [Spawner] Block further SIGINTs with unload_on_kill option (#3075 <https://github.com/ros-controls/ros2_control/issues/3075>) (#3078 <https://github.com/ros-controls/ros2_control/issues/3078>)
* Add new API for chainable controller interface exporting (backport #2988 <https://github.com/ros-controls/ros2_control/issues/2988>) (#3051 <https://github.com/ros-controls/ros2_control/issues/3051>)
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3118 <https://github.com/ros-controls/ros2_control/issues/3118>)
* Protect controller switching, when switching from nonRT loop (#3060 <https://github.com/ros-controls/ros2_control/issues/3060>) (#3112 <https://github.com/ros-controls/ros2_control/issues/3112>)
* Fix the conditioning in extract_command_interfaces_for_controller method (#3109 <https://github.com/ros-controls/ros2_control/issues/3109>) (#3114 <https://github.com/ros-controls/ros2_control/issues/3114>)
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3067 <https://github.com/ros-controls/ros2_control/issues/3067>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

```
* Remove linters from msg package (#3059 <https://github.com/ros-controls/ros2_control/issues/3059>) (#3064 <https://github.com/ros-controls/ros2_control/issues/3064>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* hardware_interface: Fix build error with GCC 15 (#3174 <https://github.com/ros-controls/ros2_control/issues/3174>) (#3177 <https://github.com/ros-controls/ros2_control/issues/3177>)
* fix(hardware_interface): include component name in parsing error messages (#3144 <https://github.com/ros-controls/ros2_control/issues/3144>) (#3162 <https://github.com/ros-controls/ros2_control/issues/3162>)
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3118 <https://github.com/ros-controls/ros2_control/issues/3118>)
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3067 <https://github.com/ros-controls/ros2_control/issues/3067>)
* Cache interface name to avoid failing at the destruction time (#3043 <https://github.com/ros-controls/ros2_control/issues/3043>) (#3046 <https://github.com/ros-controls/ros2_control/issues/3046>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3118 <https://github.com/ros-controls/ros2_control/issues/3118>)
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3067 <https://github.com/ros-controls/ros2_control/issues/3067>)
* Bump version of pre-commit hooks (#3055 <https://github.com/ros-controls/ros2_control/issues/3055>) (#3058 <https://github.com/ros-controls/ros2_control/issues/3058>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3067 <https://github.com/ros-controls/ros2_control/issues/3067>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3118 <https://github.com/ros-controls/ros2_control/issues/3118>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

```
* [rqt_controller_manager] show update_rate and is_async in details window (#3154 <https://github.com/ros-controls/ros2_control/issues/3154>) (#3159 <https://github.com/ros-controls/ros2_control/issues/3159>)
* Contributors: mergify[bot]
```

## transmission_interface

```
* Export information of supported interfaces from transmissions (#3049 <https://github.com/ros-controls/ros2_control/issues/3049>) (#3156 <https://github.com/ros-controls/ros2_control/issues/3156>)
* Contributors: mergify[bot]
```
