### PR TITLE
ros2_control: 4.44.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8969,7 +8969,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.43.0-1
+      version: 4.44.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.44.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.43.0-1`

## controller_interface

```
* Add pal_statistics as explicit dependency (#3163 <https://github.com/ros-controls/ros2_control/issues/3163>) (#3167 <https://github.com/ros-controls/ros2_control/issues/3167>)
* Add new API for chainable controller interface exporting (backport #2988 <https://github.com/ros-controls/ros2_control/issues/2988>) (#3050 <https://github.com/ros-controls/ros2_control/issues/3050>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Activate hardware components by group sequentially (#2984 <https://github.com/ros-controls/ros2_control/issues/2984>) (#3169 <https://github.com/ros-controls/ros2_control/issues/3169>)
* [Spawner] Allow parsing the parameter files parsed from spawner to controllers (#3136 <https://github.com/ros-controls/ros2_control/issues/3136>) (#3151 <https://github.com/ros-controls/ros2_control/issues/3151>)
* [Spawner] Allow arguments per controller instead of global args (backport #2895 <https://github.com/ros-controls/ros2_control/issues/2895>) (#3052 <https://github.com/ros-controls/ros2_control/issues/3052>)
* [Spawner] Fix exception of time.sleep in spawner (backport #3124 <https://github.com/ros-controls/ros2_control/issues/3124>) (#3125 <https://github.com/ros-controls/ros2_control/issues/3125>)
* [Spawner] Block further SIGINTs with unload_on_kill option (#3075 <https://github.com/ros-controls/ros2_control/issues/3075>) (#3077 <https://github.com/ros-controls/ros2_control/issues/3077>)
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3117 <https://github.com/ros-controls/ros2_control/issues/3117>)
* Add new API for chainable controller interface exporting (backport #2988 <https://github.com/ros-controls/ros2_control/issues/2988>) (#3050 <https://github.com/ros-controls/ros2_control/issues/3050>)
* Fix the conditioning in extract_command_interfaces_for_controller method (#3109 <https://github.com/ros-controls/ros2_control/issues/3109>) (#3113 <https://github.com/ros-controls/ros2_control/issues/3113>)
* Protect controller switching, when switching from nonRT loop (#3060 <https://github.com/ros-controls/ros2_control/issues/3060>) (#3111 <https://github.com/ros-controls/ros2_control/issues/3111>)
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3066 <https://github.com/ros-controls/ros2_control/issues/3066>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

```
* Remove linters from msg package (#3059 <https://github.com/ros-controls/ros2_control/issues/3059>) (#3063 <https://github.com/ros-controls/ros2_control/issues/3063>)
* Contributors: mergify[bot]
```

## hardware_interface

```
* fix(hardware_interface): include component name in parsing error messages (#3144 <https://github.com/ros-controls/ros2_control/issues/3144>) (#3161 <https://github.com/ros-controls/ros2_control/issues/3161>)
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3066 <https://github.com/ros-controls/ros2_control/issues/3066>)
* Cache interface name to avoid failing at the destruction time (backport #3043 <https://github.com/ros-controls/ros2_control/issues/3043>) (#3047 <https://github.com/ros-controls/ros2_control/issues/3047>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3117 <https://github.com/ros-controls/ros2_control/issues/3117>)
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3066 <https://github.com/ros-controls/ros2_control/issues/3066>)
* Bump version of pre-commit hooks (#3055 <https://github.com/ros-controls/ros2_control/issues/3055>) (#3057 <https://github.com/ros-controls/ros2_control/issues/3057>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Consistently add <cmath> include with define for windows (backport #3061 <https://github.com/ros-controls/ros2_control/issues/3061>) (#3066 <https://github.com/ros-controls/ros2_control/issues/3066>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Fix forwarding handle_exceptions parameter to resource manager (#3107 <https://github.com/ros-controls/ros2_control/issues/3107>) (#3117 <https://github.com/ros-controls/ros2_control/issues/3117>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

```
* [rqt_controller_manager] show update_rate and is_async in details window (#3154 <https://github.com/ros-controls/ros2_control/issues/3154>) (#3158 <https://github.com/ros-controls/ros2_control/issues/3158>)
* Contributors: mergify[bot]
```

## transmission_interface

```
* Export information of supported interfaces from transmissions (#3049 <https://github.com/ros-controls/ros2_control/issues/3049>) (#3155 <https://github.com/ros-controls/ros2_control/issues/3155>)
* Contributors: mergify[bot]
```
