### PR TITLE
ros2_controllers: 6.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7652,7 +7652,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.4.0-1
+      version: 6.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.5.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.4.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Fix open-loop odometry by applying SpeedLimiter first (#2260 <https://github.com/ros-controls/ros2_controllers/issues/2260>)
* Remove unnecessary publish_limited_velocity member (#2266 <https://github.com/ros-controls/ros2_controllers/issues/2266>)
* Deprecate publish_rate and resolve initialization anti-pattern in diff_drive_controller (#2245 <https://github.com/ros-controls/ros2_controllers/issues/2245>)
* Contributors: Bhavin Umatiya, Sai Teja Bojja, Zack Lain
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

```
* Remove ament linters (#2267 <https://github.com/ros-controls/ros2_controllers/issues/2267>)
* Contributors: Ivane Kotanov
```

## imu_sensor_broadcaster

```
* Remove ament linters (#2267 <https://github.com/ros-controls/ros2_controllers/issues/2267>)
* Contributors: Ivane Kotanov
```

## joint_state_broadcaster

```
* [JSB] Fix joint_state message corruption issue (#2217 <https://github.com/ros-controls/ros2_controllers/issues/2217>)
* Deprecate publish_dynamic_joint_states parameter in joint_state_broadcaster (#2107 <https://github.com/ros-controls/ros2_controllers/issues/2107>)
* Contributors: Bence Magyar, Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* GPL custom validator: Use tl_expected from libexpected-dev (#2212 <https://github.com/ros-controls/ros2_controllers/issues/2212>)
* Add decelerate to stop functionality when trajectory is canceled or preempted (#2163 <https://github.com/ros-controls/ros2_controllers/issues/2163>)
* Contributors: Christoph Fröhlich, Marq Rasmussen
```

## mecanum_drive_controller

```
* mecanum_drive_controller: Don't require std_srvs (#2213 <https://github.com/ros-controls/ros2_controllers/issues/2213>)
* Contributors: Michal Sojka
```

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

```
* Remove ament linters (#2267 <https://github.com/ros-controls/ros2_controllers/issues/2267>)
* Contributors: Ivane Kotanov
```

## parallel_gripper_controller

- No changes

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* rqt_jtc: Check for interface type when adding joint names (#2231 <https://github.com/ros-controls/ros2_controllers/issues/2231>)
* Contributors: Felix Exner
```

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

```
* set odometry service addition - steering controllers library (#2244 <https://github.com/ros-controls/ros2_controllers/issues/2244>)
* Contributors: Ege Kural
```

## tricycle_controller

```
* reset odometry service update - tricycle controller (#2081 <https://github.com/ros-controls/ros2_controllers/issues/2081>)
* Contributors: Ege Kural
```

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
