### PR TITLE
mola: 2.6.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5815,7 +5815,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.6.0-1
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.6.1-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.6.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

- No changes

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_lidar_bin_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_input_video

- No changes

## mola_kernel

```
* Merge pull request #116 <https://github.com/MOLAorg/mola/issues/116> from MOLAorg/update-rds-gui
  Update RDS gui creation to new backend agnostic API
* RDS: Fix parsing initial window pos and width
* Update RDS gui creation to new backend agnostic API
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_launcher

- No changes

## mola_metric_maps

```
* Merge pull request #119 <https://github.com/MOLAorg/mola/issues/119> from MOLAorg/fix/thread-safety
  Fix/thread safety
* mola_metric_maps: FIX potential race conditions
  They didn't happen in practice but to be safe
  code clean up
  wip
* Fix potential race in KeyframePointCloudMap::icp_get_prepared_as_global()
* Fix MRPT version required for updated insertAnotherMap() API
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* Merge pull request #116 <https://github.com/MOLAorg/mola/issues/116> from MOLAorg/update-rds-gui
  Update RDS gui creation to new backend agnostic API
* Add missing nanogui layout
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Merge pull request #114 <https://github.com/MOLAorg/mola/issues/114> from MOLAorg/feat/refactor-yaml-parser
  Refactor mola_yaml parser (faster, less memory usage, non recursive)
* Refactor mola_yaml parser (faster, less memory usage, non recursive)
* Contributors: Jose Luis Blanco-Claraco
```
