### PR TITLE
Add libgtest-dev and update libgmock-dev rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4254,11 +4254,11 @@ libgmock-dev:
   gentoo: [dev-cpp/gtest]
   nixos: [gtest]
   openembedded: [gtest@meta-oe]
-  opensuse: [gmock-devel]
+  opensuse: [gmock]
+  osx:
+    homebrew: [googletest]
   rhel: [gmock-devel]
-  ubuntu:
-    '*': [libgmock-dev]
-    bionic: null
+  ubuntu: [libgmock-dev]
 libgmp:
   arch: [gmp]
   debian: [libgmp-dev]
@@ -4424,6 +4424,18 @@ libgstrtspserver-1.0-dev:
   fedora: [gstreamer1-rtsp-server-devel]
   nixos: [gst_all_1.gst-rtsp-server]
   ubuntu: [libgstrtspserver-1.0-dev]
+libgtest-dev:
+  alpine: [gtest-dev]
+  arch: [gtest]
+  debian: [libgtest-dev]
+  fedora: [gtest-devel]
+  gentoo: [dev-cpp/gtest]
+  nixos: [gtest]
+  opensuse: [gtest]
+  osx:
+    homebrew: [googletest]
+  rhel: [gtest-devel]
+  ubuntu: [libgtest-dev]
 libgtkmm:
   arch: [gtkmm]
   debian: [libgtkmm-2.4-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:
libgtest-devlibgmock-dev

## Package Upstream Source:
https://github.com/google/googletest

## Purpose of using this:
Replace the existing gtest_vendor and gmock_vendor packages https://github.com/ament/googletest/issues/37

## Distro packaging links:

( I had gemini research this, then I double checked and made a few small corrections)

Links to Distribution Packages
* Debian: https://packages.debian.org/
   * libgtest-dev: https://packages.debian.org/search?keywords=libgtest-dev
   * libgmock-dev: https://packages.debian.org/search?keywords=libgmock-dev
* Ubuntu: https://packages.ubuntu.com/
   * libgtest-dev: https://packages.ubuntu.com/search?keywords=libgtest-dev
   * libgmock-dev: https://packages.ubuntu.com/search?keywords=libgmock-dev
* Fedora: https://packages.fedoraproject.org/
   * gtest-devel: https://packages.fedoraproject.org/pkgs/gtest/gtest-devel/
   * gmock-devel: https://packages.fedoraproject.org/pkgs/gtest/gmock-devel/
* Arch: https://www.archlinux.org/packages/
   * gtest (monolithic package providing both): https://archlinux.org/packages/extra/x86_64/gtest/
* Gentoo: https://packages.gentoo.org/
   * dev-cpp/gtest (source ebuild providing both): https://packages.gentoo.org/packages/dev-cpp/gtest
* macOS: https://formulae.brew.sh/
   * googletest (formula providing both): https://formulae.brew.sh/formula/googletest
* Alpine: https://pkgs.alpinelinux.org/packages
  * gtest-dev (development headers and pkg-config for both): https://pkgs.alpinelinux.org/packages?name=gtest-dev
* NixOS/nixpkgs: https://search.nixos.org/packages
   * gtest (functional derivation providing both outputs): https://search.nixos.org/packages?query=gtest
* openSUSE: https://software.opensuse.org/package/
   * gtest https://software.opensuse.org/package/gtest
   * gmock https://software.opensuse.org/package/gmock
* rhel: https://rhel.pkgs.org/
   * gtest-devel: https://rpmfind.net/linux/rpm2html/search.php?query=gtest-devel
   * gmock-devel: https://rpmfind.net/linux/rpm2html/search.php?query=gmock-devel