### PR TITLE
bag2_to_image: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -978,7 +978,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/bag2_to_image-release.git
-      version: 0.1.0-5
+      version: 0.1.1-1
     source:
       type: git
       url: https://github.com/wep21/bag2_to_image.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bag2_to_image` to `0.1.1-1`:

- upstream repository: https://github.com/wep21/bag2_to_image.git
- release repository: https://github.com/ros2-gbp/bag2_to_image-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.0-5`

## bag2_to_image

```
* fix: modify compile error in Jazzy (#5 <https://github.com/wep21/bag2_to_image/issues/5>)
* ci: update actions (#6 <https://github.com/wep21/bag2_to_image/issues/6>)
* build(deps): Bump actions/upload-artifact from 3 to 4 (#3 <https://github.com/wep21/bag2_to_image/issues/3>)
  Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 3 to 4.
  - [Release notes](https://github.com/actions/upload-artifact/releases)
  - [Commits](https://github.com/actions/upload-artifact/compare/v3...v4)
  ---
  updated-dependencies:
  - dependency-name: actions/upload-artifact
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* build(deps): Bump ros-tooling/action-ros-ci from 0.2 to 0.3 (#2 <https://github.com/wep21/bag2_to_image/issues/2>)
  Bumps [ros-tooling/action-ros-ci](https://github.com/ros-tooling/action-ros-ci) from 0.2 to 0.3.
  - [Release notes](https://github.com/ros-tooling/action-ros-ci/releases)
  - [Commits](https://github.com/ros-tooling/action-ros-ci/compare/v0.2...v0.3)
  ---
  updated-dependencies:
  - dependency-name: ros-tooling/action-ros-ci
  dependency-type: direct:production
  update-type: version-update:semver-minor
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Contributors: Daisuke Nishimatsu, Michal Sojka, dependabot[bot]
```
