### PR TITLE
Add platforms for Lyrical Luth to rosdep_repo_check

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -35,6 +35,11 @@ package_sources:
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/crb
     - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+    '10':
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/crb
+    - !rpm_mirrorlist_url https://mirrors.almalinux.org/mirrorlist/$releasever/extras
   - !rpm_mirrorlist_url https://mirrors.rpmfusion.org/mirrorlist?repo=free-el-updates-released-$releasever&arch=$basearch
   ubuntu:
   - !deb_base_url http://archive.ubuntu.com/ubuntu main
@@ -65,6 +70,7 @@ supported_versions:
   - ''
   debian:
   - bookworm
+  - trixie
   fedora:
   - '42'
   - '43'
@@ -75,10 +81,12 @@ supported_versions:
   rhel:
   - '8'
   - '9'
+  - '10'
   ubuntu:
   - focal
   - jammy
   - noble
+  - resolute
 
 supported_arches:
   alpine:
@@ -112,5 +120,8 @@ name_replacements:
       '%{__isa_name}': 'x86'
       '%{python3_pkgversion}': '3'
     '9':
+      '%{__isa_name}': 'x86'
+      '%{python3_pkgversion}': '3'
+    '10':
       '%{__isa_name}': 'x86'
       '%{python3_pkgversion}': '3'


### PR DESCRIPTION
For Ubuntu Resolute, the number of invalid rules increased to 419, which is 65 more than Noble:

<details>

```diff
--- noble	2026-04-03 11:26:14.919429915 -0500
+++ resolute	2026-04-03 11:26:32.913434147 -0500
@@ -4,3 +4,3 @@
 - Package arista for rosdep key arista
-- Package awscli for rosdep key awscli
+- Package bzr for rosdep key bazaar
 - Package coinor-libcbc3 for rosdep key coinor-libcbc3
@@ -11,4 +11,7 @@
 - Package disper for rosdep key disper
+- Package docker-compose for rosdep key docker-compose
 - Package exfat-utils for rosdep key exfat-utils
 - Package ffmpeg2theora for rosdep key ffmpeg2theora
+- Package fonts-roboto-hinted for rosdep key fonts-roboto
+- Package fsharp for rosdep key fsharp
 - Package g++-5-arm-linux-gnueabihf for rosdep key g++-5-arm-linux-gnueabihf
@@ -20,3 +23,5 @@
 - Package gksu for rosdep key gksu
-- Package grip for rosdep key python3-grip
+- Package google-perftools for rosdep key gperftools
+- Package gpac for rosdep key gpac
+- Package graphicsmagick-libmagick-dev-compat for rosdep key graphicsmagick
 - Package gstreamer0.10-plugins-good for rosdep key gstreamer0.10-plugins-good
@@ -24,6 +29,9 @@
 - Package ipython for rosdep key ipython
-- Package kgraphviewer for rosdep key kgraphviewer
 - Package libapache2-mod-fastcgi for rosdep key fcgi
 - Package libaria-dev for rosdep key libaria
+- Package libatlas-base-dev for rosdep key atlas
+- Package libcegui-mk2-dev for rosdep key libcegui-mk2-dev
+- Package libcgal-qt5-dev for rosdep key cgal-qt5-dev
 - Package libcoin60-dev for rosdep key libcoin60-dev
+- Package libcollada-dom2.4-dp-dev for rosdep key collada-dom
 - Package libeigen2-dev for rosdep key eigen2
@@ -45,2 +53,6 @@
 - Package libjson0-dev for rosdep key libjson0-dev
+- Package libjsoncpp25 for rosdep key libjsoncpp
+- Package liblinphone-dev for rosdep key liblinphone-dev
+- Package libmongoclient-dev for rosdep key libmongoclient-dev
+- Package libmongoclient-dev for rosdep key mongodb-dev
 - Package libmpich2-dev for rosdep key libmpich2-dev
@@ -53,2 +65,3 @@
 - Package libpcre++-dev for rosdep key pcre-dev
+- Package libpcre3-dev for rosdep key pcre
 - Package libphonon-dev for rosdep key libphonon-dev
@@ -58,2 +71,3 @@
 - Package libportaudio-dev for rosdep key portaudio
+- Package libpostproc-dev for rosdep key ffmpeg-dev
 - Package libprocps-dev for rosdep key libprocps-dev
@@ -61,2 +75,4 @@
 - Package libpyside-dev for rosdep key python-qt-bindings
+- Package libpyside2-dev for rosdep key python3-pyside2
+- Package libpyside2-dev for rosdep key python3-qt5-bindings
 - Package libqrencode3 for rosdep key libqrencode
@@ -71,2 +87,3 @@
 - Package libqt4-xml for rosdep key libqt4
+- Package libqt5gstreamer-dev for rosdep key libqt5-gstreamer-dev
 - Package libqtcore4 for rosdep key libqt4
@@ -79,4 +96,9 @@
 - Package libshiboken-dev for rosdep key python-qt-bindings
+- Package libshiboken2-dev for rosdep key libshiboken2-dev
+- Package libshiboken2-dev for rosdep key python3-pyside2
+- Package libshiboken2-dev for rosdep key python3-qt5-bindings
 - Package libsoqt4-dev for rosdep key libsoqt4-dev
 - Package libsrtp0-dev for rosdep key libsrtp0-dev
+- Package libstdc++5 for rosdep key libstdc++5
+- Package libtar-dev for rosdep key tar
 - Package libtiff4-dev for rosdep key libtiff4-dev
@@ -87,2 +109,3 @@
 - Package libxenomai-dev for rosdep key libxenomai-dev
+- Package libxmlrpc-c++8-dev for rosdep key libxmlrpc-c++
 - Package libzmqpp-dev for rosdep key libzmqpp-dev
@@ -90,6 +113,14 @@
 - Package linphone for rosdep key linphone
+- Package m2r for rosdep key m2r
+- Package mayavi2 for rosdep key mayavi
+- Package mono-complete for rosdep key mono-complete
+- Package multistrap for rosdep key multistrap
 - Package nite-dev for rosdep key nite-dev
 - Package nodejs-legacy for rosdep key nodejs-legacy
+- Package ntp for rosdep key ntp
+- Package ntpdate for rosdep key ntpdate
 - Package openjdk-6-jdk for rosdep key openjdk-6-jdk
 - Package phantomjs for rosdep key phantomjs
+- Package platformio for rosdep key platformio
+- Package postgresql-contrib for rosdep key postgresql
 - Package ps-engine for rosdep key ps-engine
@@ -336,7 +367,34 @@
 - Package python3-catkin-tools for rosdep key python3-catkin-tools
-- Package python3-numba for rosdep key python3-numba
+- Package python3-future for rosdep key python3-future
+- Package python3-mapnik for rosdep key python3-mapnik
+- Package python3-nose-parameterized for rosdep key python3-nose-parameterized
+- Package python3-nose-yanc for rosdep key python3-nose-yanc
 - Package python3-numpy-stl for rosdep key python3-numpy-stl
-- Package python3-pymodbus for rosdep key python3-pymodbus
-- Package python3-torch for rosdep key python3-torch
+- Package python3-oauth2client for rosdep key python3-oauth2client
+- Package python3-pydub for rosdep key python3-pydub
+- Package python3-pyqt5.qtwebkit for rosdep key python3-qt5-bindings-webkit
+- Package python3-pyside2.qtcore for rosdep key python3-pyside2
+- Package python3-pyside2.qtcore for rosdep key python3-pyside2.qtcore
+- Package python3-pyside2.qtgui for rosdep key python3-pyside2
+- Package python3-pyside2.qtgui for rosdep key python3-pyside2.qtgui
+- Package python3-pyside2.qthelp for rosdep key python3-pyside2
+- Package python3-pyside2.qtnetwork for rosdep key python3-pyside2
+- Package python3-pyside2.qtopengl for rosdep key python3-pyside2.qtopengl
+- Package python3-pyside2.qtprintsupport for rosdep key python3-pyside2
+- Package python3-pyside2.qtqml for rosdep key python3-pyside2.qtqml
+- Package python3-pyside2.qtquick for rosdep key python3-pyside2.qtquick
+- Package python3-pyside2.qtsvg for rosdep key python3-pyside2
+- Package python3-pyside2.qtsvg for rosdep key python3-qt5-bindings
+- Package python3-pyside2.qttest for rosdep key python3-pyside2
+- Package python3-pyside2.qtuitools for rosdep key python3-pyside2.qtuitools
+- Package python3-pyside2.qtwidgets for rosdep key python3-pyside2
+- Package python3-pyside2.qtwidgets for rosdep key python3-pyside2.qtwidgets
+- Package python3-pyside2.qtxml for rosdep key python3-pyside2
+- Package python3-sip-dev for rosdep key python3-pyqt5
+- Package python3-sip-dev for rosdep key python3-qt5-bindings
+- Package python3-sip-dev for rosdep key python3-sip
+- Package python3-thriftpy for rosdep key python3-thriftpy
 - Package python3-torchvision for rosdep key python3-torchvision
+- Package python3-whichcraft for rosdep key python3-whichcraft
+- Package qemu-user-static for rosdep key qemu-user-static
 - Package qt4-dev-tools for rosdep key qt4-dev-tools
@@ -345,3 +403,7 @@
 - Package robotino-api2 for rosdep key robotino-api2
+- Package rti-connext-dds-6.0.1 for rosdep key rti-connext-dds-6.0.1
+- Package rti-connext-dds-7.3.0-ros for rosdep key rti-connext-dds-7.3.0
 - Package shiboken for rosdep key python-qt-bindings
+- Package shiboken2 for rosdep key python3-pyside2
+- Package shiboken2 for rosdep key python3-qt5-bindings
 - Package sixad for rosdep key sixad
@@ -349,2 +411,3 @@
 - Package tilestache for rosdep key tilestache
+- Package touchegg for rosdep key touchegg
 - Package ttf-kochi-gothic for rosdep key ttf-kochi-gothic
@@ -353,2 +416,4 @@
 - Package ttf-sazanami-mincho for rosdep key ttf-sazanami-mincho
+- Package wireless-tools for rosdep key wireless-tools
+- Package wkhtmltopdf for rosdep key wkhtmltopdf
 - Package x11proto-print-dev for rosdep key x11proto-print-dev
```

</details>

For RHEL 10, the number of invalid rules increased to 126, which is 102 more than RHEL 9:

<details>

```diff
--- rhel9	2026-04-03 11:35:17.247302494 -0500
+++ rhel10	2026-04-03 11:35:10.760304454 -0500
@@ -1,4 +1,82 @@
+- Package GeographicLib for rosdep key geographiclib-tools
+- Package GeographicLib-devel for rosdep key geographiclib
+- Package OpenSceneGraph for rosdep key libopenscenegraph
+- Package OpenSceneGraph-devel for rosdep key libopenscenegraph
+- Package OpenThreads for rosdep key libopenscenegraph
+- Package OpenThreads-devel for rosdep key libopenscenegraph
+- Package PyQt-Builder for rosdep key python3-qt-bindings
+- Package atlas-devel for rosdep key atlas
+- Package autossh for rosdep key autossh
+- Package bullet-devel for rosdep key bullet
+- Package bullet-extras-devel for rosdep key bullet-extras
+- Package ceres-solver for rosdep key libceres
+- Package ceres-solver-devel for rosdep key libceres-dev
+- Package cxxopts-devel for rosdep key libcxxopts-dev
 - Package devilspie2 for rosdep key devilspie2
+- Package fcl for rosdep key libfcl
+- Package fcl-devel for rosdep key libfcl-dev
+- Package flann for rosdep key libflann
+- Package flann-devel for rosdep key libflann-dev
+- Package freeimage for rosdep key libfreeimage
+- Package freeimage-devel for rosdep key freeimage
+- Package freeimage-devel for rosdep key libfreeimage-dev
+- Package fswebcam for rosdep key fswebcam
+- Package gnome-terminal for rosdep key gnome-terminal
+- Package inxi for rosdep key inxi
+- Package jack-audio-connection-kit-devel for rosdep key libjack-dev
+- Package libQGLViewer-qt5 for rosdep key libqglviewer2-qt5
+- Package libQGLViewer-qt5-devel for rosdep key libqglviewer-dev-qt5
+- Package libccd-devel for rosdep key libccd-dev
+- Package libfreenect-devel for rosdep key libfreenect-dev
+- Package libfreenect-openni for rosdep key libopenni2-dev
+- Package libserialport-devel for rosdep key libserialport-dev
+- Package libtins-devel for rosdep key libtins-dev
+- Package libusb-devel for rosdep key libusb-dev
+- Package libyuv-devel for rosdep key libyuv-dev
+- Package log4cplus-devel for rosdep key log4cplus
+- Package matio-devel for rosdep key matio
+- Package octomap-devel for rosdep key liboctomap-dev
+- Package ode-devel for rosdep key opende
+- Package paho-cpp for rosdep key libpaho-mqttpp
+- Package paho-cpp-devel for rosdep key libpaho-mqttpp-dev
+- Package pcl for rosdep key libpcl-all
+- Package pcl for rosdep key libpcl-apps
+- Package pcl for rosdep key libpcl-common
+- Package pcl for rosdep key libpcl-features
+- Package pcl for rosdep key libpcl-filters
+- Package pcl for rosdep key libpcl-io
+- Package pcl for rosdep key libpcl-kdtree
+- Package pcl for rosdep key libpcl-keypoints
+- Package pcl for rosdep key libpcl-ml
+- Package pcl for rosdep key libpcl-octree
+- Package pcl for rosdep key libpcl-outofcore
+- Package pcl for rosdep key libpcl-people
+- Package pcl for rosdep key libpcl-recognition
+- Package pcl for rosdep key libpcl-registration
+- Package pcl for rosdep key libpcl-sample-consensus
+- Package pcl for rosdep key libpcl-search
+- Package pcl for rosdep key libpcl-segmentation
+- Package pcl for rosdep key libpcl-stereo
+- Package pcl for rosdep key libpcl-surface
+- Package pcl for rosdep key libpcl-tracking
+- Package pcl for rosdep key libpcl-visualization
+- Package pcl-devel for rosdep key libpcl-all-dev
+- Package pcl-tools for rosdep key libpcl-all
+- Package pcre-devel for rosdep key pcre
+- Package pcre-devel for rosdep key pcre-dev
+- Package poco-devel for rosdep key libpoco-dev
+- Package pstoedit for rosdep key pstoedit
+- Package pyqtwebengine-devel for rosdep key python3-pyqt5.qtwebengine
 - Package pyside2-tools for rosdep key python3-pyside2
+- Package python3-GeographicLib for rosdep key python3-geographiclib
+- Package python3-bitstring for rosdep key python3-bitstring
+- Package python3-catkin_lint for rosdep key python3-catkin-lint
+- Package python3-cbor2 for rosdep key python3-cbor2
+- Package python3-collada for rosdep key python3-collada
+- Package python3-django-rest-framework for rosdep key python3-djangorestframework
+- Package python3-elasticsearch for rosdep key python3-elasticsearch
+- Package python3-emoji for rosdep key python3-emoji
+- Package python3-fabric for rosdep key python3-fabric
 - Package python3-fiona for rosdep key python3-fiona
+- Package python3-flake8-docstrings for rosdep key python3-flake8-docstrings
 - Package python3-flask-cors for rosdep key python3-flask-cors
@@ -6,8 +84,15 @@
 - Package python3-flask-sqlalchemy for rosdep key python3-flask-sqlalchemy
-- Package python3-google-auth-oauthlib for rosdep key python3-google-auth-oauthlib
+- Package python3-future for rosdep key python3-future
 - Package python3-ifcfg for rosdep key python3-ifcfg
+- Package python3-img2pdf for rosdep key python3-img2pdf
+- Package python3-influxdb for rosdep key python3-influxdb
+- Package python3-libtmux for rosdep key python3-libtmux
 - Package python3-mock for rosdep key python3-mock
+- Package python3-munkres for rosdep key python3-munkres
 - Package python3-nose for rosdep key python3-nose
-- Package python3-pandas for rosdep key python3-pandas
+- Package python3-ntplib for rosdep key python3-ntplib
+- Package python3-paho-mqtt for rosdep key python3-paho-mqtt
 - Package python3-pydbus for rosdep key python3-pydbus
+- Package python3-pydocstyle for rosdep key pydocstyle
+- Package python3-pyproj for rosdep key python3-pyproj
 - Package python3-pyside2 for rosdep key python3-pyside2
@@ -19,2 +104,7 @@
 - Package python3-pyside2-devel for rosdep key python3-pyside2
+- Package python3-qt5-webengine for rosdep key python3-pyqt5.qtwebengine
+- Package python3-qt6-devel for rosdep key python3-qt-bindings
+- Package python3-rosinstall_generator for rosdep key python3-rosinstall-generator
+- Package python3-rtree for rosdep key python3-rtree
+- Package python3-selenium for rosdep key python3-selenium
 - Package python3-shiboken2 for rosdep key python3-pyside2
@@ -22,3 +112,15 @@
 - Package python3-shiboken2-devel for rosdep key python3-pyside2
+- Package python3-sip-devel for rosdep key python3-pyqt5
+- Package python3-sip-devel for rosdep key python3-qt5-bindings
+- Package python3-sysv_ipc for rosdep key python3-sysv-ipc
+- Package python3-toml for rosdep key python3-toml
 - Package python3-whichcraft for rosdep key python3-whichcraft
+- Package python3-xlib for rosdep key python3-xlib
+- Package qt5-qtwebengine-devel for rosdep key qtwebengine5-dev
 - Package shiboken2 for rosdep key python3-pyside2
+- Package spacenavd for rosdep key spacenavd
+- Package urdfdom for rosdep key liburdfdom-tools
+- Package urdfdom-devel for rosdep key liburdfdom-dev
+- Package websocketpp-devel for rosdep key libwebsocketpp-dev
+- Package xorg-x11-server-Xvfb for rosdep key xvfb
+- Package xtensor-devel for rosdep key xtensor
```

</details>

For Debian Trixie, the number of invalid rules increased to 395, which is 46 more than Bookworm:

<details>

```diff
--- bookworm	2026-04-03 12:19:14.885224695 -0500
+++ trixie	2026-04-03 12:19:00.890223126 -0500
@@ -1,3 +1,5 @@
 - Package ack-grep for rosdep key ack-grep
+- Package alsa-oss for rosdep key alsa-oss
 - Package arduino-core for rosdep key arduino-core
+- Package coinor-libcbc3 for rosdep key coinor-libcbc3
 - Package couchdb for rosdep key couchdb
@@ -13,4 +15,7 @@
 - Package ffmpeg2theora for rosdep key ffmpeg2theora
+- Package fonts-roboto-hinted for rosdep key fonts-roboto
 - Package fsharp for rosdep key fsharp
+- Package gamin for rosdep key gamin
 - Package gccxml for rosdep key gccxml
+- Package gforth for rosdep key gforth
 - Package gksu for rosdep key gksu
@@ -18,2 +23,3 @@
 - Package hddtemp for rosdep key hddtemp
+- Package intel-opencl-icd for rosdep key intel-opencl-icd
 - Package ipython for rosdep key ipython
@@ -21,7 +27,14 @@
 - Package libapache2-mod-fastcgi for rosdep key fcgi
+- Package libapache2-mod-python for rosdep key libapache2-mod-python
 - Package libaravis-0.6-0 for rosdep key aravis
 - Package libaria-dev for rosdep key libaria
+- Package libatlas-base-dev for rosdep key atlas
 - Package libav-tools for rosdep key libav
+- Package libcgal-qt5-dev for rosdep key cgal-qt5-dev
 - Package libesd0-dev for rosdep key libesd0-dev
 - Package libfftw3-3 for rosdep key libfftw3
+- Package libfltk1.1-dev for rosdep key fltk
+- Package libfltk1.1-dev for rosdep key fluid
+- Package libfreetype6-dev for rosdep key libfreetype6-dev
+- Package libgconf-2-4 for rosdep key libgconf2
 - Package libgfortran3 for rosdep key libgfortran3
@@ -33,3 +46,4 @@
 - Package libjsoncpp1 for rosdep key libjsoncpp
-- Package libmlpack-dev for rosdep key libmlpack-dev
+- Package libmongoclient-dev for rosdep key libmongoclient-dev
+- Package libmongoclient-dev for rosdep key mongodb-dev
 - Package libmpich2-dev for rosdep key libmpich2-dev
@@ -41,2 +55,3 @@
 - Package libpcre++-dev for rosdep key pcre-dev
+- Package libpcre3-dev for rosdep key pcre
 - Package libphonon-dev for rosdep key libphonon-dev
@@ -58,2 +73,3 @@
 - Package libqt4-xml for rosdep key libqt4
+- Package libqt5gstreamer-dev for rosdep key libqt5-gstreamer-dev
 - Package libqtcore4 for rosdep key libqt4
@@ -64,10 +80,23 @@
 - Package libqwtplot3d-qt4-dev for rosdep key libqwtplot3d-qt4-dev
+- Package libreadline-java for rosdep key libreadline-java
+- Package libsdformat-dev for rosdep key sdformat
+- Package libsensors4-dev for rosdep key libsensors4-dev
 - Package libsoqt4-dev for rosdep key libsoqt4-dev
 - Package libsrtp0-dev for rosdep key libsrtp0-dev
+- Package libstdc++5 for rosdep key libstdc++5
+- Package libtar-dev for rosdep key tar
 - Package libtiff4-dev for rosdep key libtiff4-dev
 - Package libv8-dev for rosdep key xulrunner-dev
+- Package libxmlrpc-c++8-dev for rosdep key libxmlrpc-c++
+- Package linphone for rosdep key linphone
+- Package m2r for rosdep key m2r
+- Package mayavi2 for rosdep key mayavi
+- Package multistrap for rosdep key multistrap
 - Package nite-dev for rosdep key nite-dev
 - Package nodejs-legacy for rosdep key nodejs-legacy
+- Package ntp for rosdep key ntp
+- Package ntpdate for rosdep key ntpdate
 - Package nuitka for rosdep key nuitka
 - Package pep8 for rosdep key python-pep8
+- Package postgresql-contrib for rosdep key postgresql
 - Package ps-engine for rosdep key ps-engine
@@ -336,3 +365,18 @@
 - Package python2-pyro4 for rosdep key pyro4
+- Package python3-catkin-tools for rosdep key python3-catkin-tools
+- Package python3-funcsigs for rosdep key python3-funcsigs
+- Package python3-future for rosdep key python3-future
+- Package python3-nose for rosdep key python3-nose
+- Package python3-nose-parameterized for rosdep key python3-nose-parameterized
+- Package python3-nose-yanc for rosdep key python3-nose-yanc
 - Package python3-numpy-stl for rosdep key python3-numpy-stl
+- Package python3-oauth2client for rosdep key python3-oauth2client
+- Package python3-pydub for rosdep key python3-pydub
+- Package python3-pyqt5.qtwebkit for rosdep key python3-qt5-bindings-webkit
+- Package python3-pyzbar for rosdep key python3-pyzbar
+- Package python3-sip-dev for rosdep key python3-pyqt5
+- Package python3-sip-dev for rosdep key python3-qt5-bindings
+- Package python3-sip-dev for rosdep key python3-sip
+- Package python3-thriftpy for rosdep key python3-thriftpy
+- Package python3-whichcraft for rosdep key python3-whichcraft
 - Package qt4-dev-tools for rosdep key qt4-dev-tools
@@ -347,2 +391,4 @@
 - Package ttf-sazanami-mincho for rosdep key ttf-sazanami-mincho
+- Package unoconv for rosdep key unoconv
+- Package wkhtmltopdf for rosdep key wkhtmltopdf
 - Package x11proto-print-dev for rosdep key x11proto-print-dev
```

</details>