### PR TITLE
Add Connext 7.7.0 for Noble and Trixie

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9631,12 +9631,14 @@ rti-connext-dds-7.3.0:
     focal: null
     jammy: null
 rti-connext-dds-7.7.0:
+  debian:
+    '*': [rti-connext-dds-7.7.0-ros]
+    bookworm: null
   nixos: []
   ubuntu:
     '*': [rti-connext-dds-7.7.0-ros]
     focal: null
     jammy: null
-    noble: null
 rtklib:
   debian: [rtklib]
   fedora: [rtklib]


### PR DESCRIPTION
We have decided to import the Connext 7.7.0 debs for these platforms as well.

These packages are part of the ROS bootstrap repository, so there's no dashboard to link to. Trust me, the packages are there.