### PR TITLE
foxglove-sdk: 3.2.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2422,7 +2422,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.2.4-1
+      version: 3.2.6-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.2.6-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.2.4-1`

## foxglove_bridge

```
* Fix ROS rolling build for rclcpp 31.0.0
```

## foxglove_msgs

```
* Add CompressedPointCloud schema
* Add heading and velocity to LocationFix
* Add NV12 encoding documentation to RawImage schema
```
