### PR TITLE
toppra: 0.6.6-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9888,6 +9888,11 @@ repositories:
       type: git
       url: https://github.com/hungpham2511/toppra.git
       version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/toppra-release.git
+      version: 0.6.6-2
     source:
       type: git
       url: https://github.com/hungpham2511/toppra.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toppra` to `0.6.6-2`:

- upstream repository: https://github.com/hungpham2511/toppra.git
- release repository: https://github.com/ros2-gbp/toppra-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## toppra

```
* [cpp] Add missing cassert includes (#280 <https://github.com/hungpham2511/toppra/issues/280>)
* [cpp] Fix CMake syntax for Eigen3 version check (#279 <https://github.com/hungpham2511/toppra/issues/279>)
* [ros] Add python3-dev and eigen as a dependency in package.xml (#278 <https://github.com/hungpham2511/toppra/issues/278>)
* Contributors: Sebastian Castro
```
