### PR TITLE
Fix PyTrees docs versions on Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8147,7 +8147,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
-      version: release/2.2.x
+      version: devel
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -8163,7 +8163,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git
-      version: release/0.6.x
+      version: devel
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -8179,7 +8179,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros.git
-      version: release/2.2.x
+      version: devel
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -8195,7 +8195,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
-      version: release/2.1.x
+      version: devel
     release:
       tags:
         release: release/humble/{package}/{version}


### PR DESCRIPTION
Closes https://github.com/splintered-reality/py_trees_ros/issues/248

The development version of PyTrees packages 100% support ROS 2 Humble at the moment.