### PR TITLE
ros2_controllers: 4.39.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9030,7 +9030,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.38.0-1
+      version: 4.39.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.39.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.38.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Fix open-loop odometry by applying SpeedLimiter first (backport #2260 <https://github.com/ros-controls/ros2_controllers/issues/2260>) (#2277 <https://github.com/ros-controls/ros2_controllers/issues/2277>)
* Remove unnecessary publish_limited_velocity_ member (backport #2266 <https://github.com/ros-controls/ros2_controllers/issues/2266>) (#2268 <https://github.com/ros-controls/ros2_controllers/issues/2268>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

```
* Remove ament linters (backport #2267 <https://github.com/ros-controls/ros2_controllers/issues/2267>) (#2270 <https://github.com/ros-controls/ros2_controllers/issues/2270>)
* Contributors: mergify[bot]
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* Remove ament linters (backport #2267 <https://github.com/ros-controls/ros2_controllers/issues/2267>) (#2270 <https://github.com/ros-controls/ros2_controllers/issues/2270>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* [JSB] Fix joint_state message corruption issue (backport #2217 <https://github.com/ros-controls/ros2_controllers/issues/2217>) (#2218 <https://github.com/ros-controls/ros2_controllers/issues/2218>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Add decelerate to stop functionality when trajectory is canceled or preempted (backport #2163 <https://github.com/ros-controls/ros2_controllers/issues/2163>) (#2222 <https://github.com/ros-controls/ros2_controllers/issues/2222>)
* Scaled jtc (backport #1191 <https://github.com/ros-controls/ros2_controllers/issues/1191>) (#2105 <https://github.com/ros-controls/ros2_controllers/issues/2105>)
* GPL custom validator: Use tl_expected from libexpected-dev instead (backport #2212 <https://github.com/ros-controls/ros2_controllers/issues/2212>) (#2239 <https://github.com/ros-controls/ros2_controllers/issues/2239>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

```
* Remove ament linters (backport #2267 <https://github.com/ros-controls/ros2_controllers/issues/2267>) (#2270 <https://github.com/ros-controls/ros2_controllers/issues/2270>)
* Contributors: mergify[bot]
```

## parallel_gripper_controller

- No changes

## pid_controller

```
* [PID Controllers] Set first set point to current measurement (backport #2205 <https://github.com/ros-controls/ros2_controllers/issues/2205>) (#2210 <https://github.com/ros-controls/ros2_controllers/issues/2210>)
* Contributors: mergify[bot]
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* rqt_jtc: Check for interface type when adding joint names (backport #2231 <https://github.com/ros-controls/ros2_controllers/issues/2231>) (#2241 <https://github.com/ros-controls/ros2_controllers/issues/2241>)
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
