### PR TITLE
Add robotis_interfaces package to jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8889,6 +8889,16 @@ repositories:
       url: https://github.com/clearpathrobotics/robot_upstart.git
       version: foxy-devel
     status: developed
+  robotis_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_interfaces.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/robotis_interfaces.git
+      version: jazzy
+    status: developed
   robotraconteur:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

jazzy

# The source is here:

https://github.com/ROBOTIS-GIT/robotis_interfaces

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
