### PR TITLE
mp2p_icp: 2.8.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6118,7 +6118,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.8.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.8.0-1`

## mp2p_icp

```
* Merge pull request #51 <https://github.com/MOLAorg/mp2p_icp/issues/51> from MOLAorg/fix/new-mrpt-api
  Update to build against mrpt >=2.15.13
* Update to build against mrpt >=2.15.13 (pointcloud field names as std::string instead of string_view)
* Contributors: Jose Luis Blanco-Claraco
```
