### PR TITLE
mrpt_ros_bridge: 3.5.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4925,7 +4925,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.5.0-1
+      version: 3.5.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.5.1-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.0-1`

## mrpt_libros_bridge

```
* Merge pull request #6 <https://github.com/MRPT/mrpt_ros_bridge/issues/6> from MRPT/fix/new-mrpt-api
  Update to build against mrpt >=2.15.13
* Update to build against mrpt >=2.15.13 (pointcloud field names as std::string instead of string_view)
* Merge pull request #5 <https://github.com/MRPT/mrpt_ros_bridge/issues/5> from MRPT/feat/new-gps-obs-fields
  Support new MRPT 2.15.11 GPS data fields
* Support new MRPT 2.15.11 GPS data fields
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

- No changes
