### PR TITLE
image_transport_plugins: 6.2.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3408,7 +3408,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 6.2.2-1
+      version: 6.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `6.2.3-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.2.2-1`

## compressed_depth_image_transport

```
* Update API (#217 <https://github.com/ros-perception/image_transport_plugins/issues/217>)
* Publish with uniqueptr for efficiency (#216 <https://github.com/ros-perception/image_transport_plugins/issues/216>)
* Contributors: Alejandro Hernández Cordero, Maurice Alexander Purnawan
```

## compressed_image_transport

```
* Update API (#217 <https://github.com/ros-perception/image_transport_plugins/issues/217>)
* Publish with uniqueptr for efficiency (#216 <https://github.com/ros-perception/image_transport_plugins/issues/216>)
* Contributors: Alejandro Hernández Cordero, Maurice Alexander Purnawan
```

## image_transport_plugins

- No changes

## theora_image_transport

```
* Update API (#217 <https://github.com/ros-perception/image_transport_plugins/issues/217>)
* Publish with uniqueptr for efficiency (#216 <https://github.com/ros-perception/image_transport_plugins/issues/216>)
* Contributors: Alejandro Hernández Cordero, Maurice Alexander Purnawan
```

## zstd_image_transport

```
* Update API (#217 <https://github.com/ros-perception/image_transport_plugins/issues/217>)
* Publish with uniqueptr for efficiency (#216 <https://github.com/ros-perception/image_transport_plugins/issues/216>)
* Cleanup bsd 3 clause license usage (#212 <https://github.com/ros-perception/image_transport_plugins/issues/212>)
* Contributors: Alejandro Hernández Cordero, Maurice Alexander Purnawan
```
