### PR TITLE
cloudini: 1.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1219,7 +1219,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/facontidavide/cloudini-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/facontidavide/cloudini.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `1.0.4-1`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.3-1`

## cloudini_lib

- No changes

## cloudini_ros

```
* fix(ros): use ament_target_dependencies for pcl_conversions
  pcl_conversions 2.8.0 on Kilted switched from
  ament_export_include_directories to ament_export_targets, making
  ${pcl_conversions_INCLUDE_DIRS} empty and breaking the buildfarm.
  Use ament_target_dependencies which handles both old-style
  (INCLUDE_DIRS) and new-style (TARGETS) exports idiomatically.
  Co-Authored-By: Claude Opus 4.6 (1M context) <mailto:noreply@anthropic.com>
* Contributors: Davide Faconti
```
