### PR TITLE
rqt_graph: 1.8.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8580,7 +8580,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.8.1-1
+      version: 1.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.8.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.8.1-1`

## rqt_graph

```
* Fix: broken dependency (#115 <https://github.com/ros-visualization/rqt_graph//issues/115>)
* Support Qt6 (#114 <https://github.com/ros-visualization/rqt_graph//issues/114>)
* Contributors: Alejandro Hernández Cordero, Matthew Foran
```
