### PR TITLE
rosx_introspection: 2.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10504,7 +10504,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rosx_introspection-release.git
-      version: 2.2.0-1
+      version: 2.2.1-2
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosx_introspection` to `2.2.1-2`:

- upstream repository: https://github.com/facontidavide/rosx_introspection.git
- release repository: https://github.com/ros2-gbp/rosx_introspection-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## rosx_introspection

```
* Merge pull request #39 <https://github.com/facontidavide/rosx_introspection//issues/39> from gasmith/fix-test-deps
* cmake: Don't export test dependencies to downstream consumers
* Update variant.hpp
* Contributors: Davide Faconti, Greg Smith
```
