### PR TITLE
rosx_introspection: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9949,7 +9949,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosx_introspection-release.git
-      version: 2.2.1-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/facontidavide/rosx_introspection.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosx_introspection` to `2.3.0-1`:

- upstream repository: https://github.com/facontidavide/rosx_introspection.git
- release repository: https://github.com/ros2-gbp/rosx_introspection-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## rosx_introspection

```
* Add Ubuntu CI workflow for non-ROS builds
* Use ament_cmake_gtest for tests in ROS2 builds
* Fix review issues: throw on bracket overflow, fix reserve, use num_brackets for estimate
* Split CI into per-distro workflows and add badges to README
* Add Rolling to CI matrix
* Add Kilted to CI matrix and bump checkout to v4
* Optimize toStr with precomputed path templates and segment table
* Make MCAP benchmark ROS-independent and add enable_testing()
* Contributors: Davide Faconti
```
