### PR TITLE
rqt_tf_tree: 1.0.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8826,7 +8826,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.0.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros2-gbp/rqt_tf_tree-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.5-1`

## rqt_tf_tree

```
* int object has no attribute strip (#52 <https://github.com/ros-visualization/rqt_tf_tree//issues/52>)
* Capability: Add CI  (#54 <https://github.com/ros-visualization/rqt_tf_tree//issues/54>)
* Capability: Add CI using ICI (similar to https://github.com/ros-visualization/rqt_robot_steering/pull/27)
* Contributors: Alejandro Hernández Cordero, Isaac Saito
```
