### PR TITLE
rqt_tf_tree: 1.0.6-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8828,7 +8828,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.5-2
+      version: 1.0.6-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.0.6-2`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros2-gbp/rqt_tf_tree-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.5-2`

## rqt_tf_tree

```
* int object has no attribute strip (#52 <https://github.com/ros-visualization/rqt_tf_tree//issues/52>)
* Capability: Add CI  (#54 <https://github.com/ros-visualization/rqt_tf_tree//issues/54>)
* Capability: Add CI using ICI (similar to https://github.com/ros-visualization/rqt_robot_steering/pull/27)
* Contributors: Alejandro Hernández Cordero, Isaac Saito
```
