### PR TITLE
Add python3-dotenv support in rosdep file

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5833,6 +5833,12 @@ python3-docutils:
   nixos: [python3Packages.docutils]
   openembedded: [python3-docutils@openembedded-core]
   ubuntu: [python3-docutils]
+python3-dotenv:
+  arch: [python-dotenv]
+  debian: [python3-dotenv]
+  fedora: [python3-dotenv]
+  gentoo: [dev-python/python-dotenv]
+  ubuntu: [python3-dotenv]
 python3-dubins-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-dotenv

## Package Upstream Source:

https://github.com/theskumar/python-dotenv

## Purpose of using this:

This dependency provides support for reading key-value pairs from `.env` files and loading them into environment variables in Python applications. It is already packaged by multiple Linux distributions, including Debian, Ubuntu, Fedora, Arch Linux, and Gentoo.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - [python3-dotenv](https://packages.debian.org/sid/python3-dotenv)
- Ubuntu: https://packages.ubuntu.com/
  - [python3-dotenv](https://packages.ubuntu.com/noble/python3-dotenv)
- Fedora: https://packages.fedoraproject.org/
  - [python3-dotenv](https://packages.fedoraproject.org/pkgs/python-dotenv/python3-dotenv/)
- Arch: https://www.archlinux.org/packages/
  - [python-dotenv](https://archlinux.org/packages/extra/any/python-dotenv/)
- Gentoo: https://packages.gentoo.org/
  - [dev-python/python-dotenv](https://packages.gentoo.org/packages/dev-python/python-dotenv)

