### PR TITLE
autoapms: 1.5.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -692,7 +692,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoapms-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/AutoAPMS/auto-apms.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoapms` to `1.5.1-1`:

- upstream repository: https://github.com/AutoAPMS/auto-apms.git
- release repository: https://github.com/ros2-gbp/autoapms-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.0-1`

## auto_apms_behavior_tree

```
* feature: add executor ctor accepting a shared node pointer
* Add tests for alias-only behavior resource lookup
* Fix linting
* Fix resource aliasing/lookup and shorthanding formats
* feature: allow encoding inital blackboard in entry point
* Contributors: Robin Müller
```

## auto_apms_behavior_tree_core

```
* feature: add executor ctor accepting a shared node pointer
* Add tests for alias-only behavior resource lookup
* Fix linting
* Fix resource aliasing/lookup and shorthanding formats
* fix: add namespaces to cmake macros to prevent variable leaking
* fix: allow for mixing node manifest identities and absolute paths also in register_nodes macro
* Add convenience function for getting native node model
* Update logo
* Contributors: Robin Müller
```

## auto_apms_examples

```
* feature: allow encoding inital blackboard in entry point
* Contributors: Robin Müller
```

## auto_apms_interfaces

- No changes

## auto_apms_mission

- No changes

## auto_apms_ros2behavior

- No changes

## auto_apms_util

```
* fix: add namespaces to cmake macros to prevent variable leaking
* Update logo
* Contributors: Robin Müller
```
