### PR TITLE
simulation_interfaces: 1.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11434,7 +11434,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.1.0-1
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.4.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.0-1`

## simulation_interfaces

```
* Add ``SpawnEntities`` service for spawning multiple entities in a single call (#20 <https://github.com/ros-simulation/simulation_interfaces/issues/20>, #25 <https://github.com/ros-simulation/simulation_interfaces/issues/25>) (#22 <https://github.com/ros-simulation/simulation_interfaces/issues/22>)
* Contributors: Michał Pełka <mailto:michal.pelka@robotec.ai>, Mateusz Żak <mailto:mateusz.zak@robotec.ai>
```
