### PR TITLE
simulation_interfaces: 1.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10911,7 +10911,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.2.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.5.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.0-1`

## simulation_interfaces

```
* Add ``SpawnEntities`` service for spawning multiple entities in a single call (#20 <https://github.com/ros-simulation/simulation_interfaces/issues/20>, #25 <https://github.com/ros-simulation/simulation_interfaces/issues/25>) (#23 <https://github.com/ros-simulation/simulation_interfaces/issues/23>)
* Contributors: Michał Pełka <mailto:michal.pelka@robotec.ai>, Mateusz Żak <mailto:mateusz.zak@robotec.ai>
```
