### PR TITLE
simulation_interfaces: 1.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9309,7 +9309,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.3.0-1
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.6.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.3.0-1`

## simulation_interfaces

```
* Add ``SpawnEntities`` service for spawning multiple entities in a single call (#20 <https://github.com/ros-simulation/simulation_interfaces/issues/20>, #25 <https://github.com/ros-simulation/simulation_interfaces/issues/25>) (#24 <https://github.com/ros-simulation/simulation_interfaces/issues/24>)
* Contributors: Michał Pełka <mailto:michal.pelka@robotec.ai>, Mateusz Żak <mailto:mateusz.zak@robotec.ai>
```
