### PR TITLE
simulation_interfaces: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9292,7 +9292,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `2.1.0-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.0-1`

## simulation_interfaces

```
* Rename ``level_resource`` to ``world_resource`` in ``LoadWorld`` and ``WorldResource`` for consistent terminology (#13 <https://github.com/ros-simulation/simulation_interfaces/issues/13>)
* Add ``SpawnEntities`` service for spawning multiple entities in a single call (#20 <https://github.com/ros-simulation/simulation_interfaces/issues/20>, #25 <https://github.com/ros-simulation/simulation_interfaces/issues/25>)
* Make setting entity values optional via boolean flags in ``SetEntityState`` (#21 <https://github.com/ros-simulation/simulation_interfaces/issues/21>)
* Add links to example implementations in README (#19 <https://github.com/ros-simulation/simulation_interfaces/issues/19>)
* Contributors: Adam Dąbrowski, Luca Della Vedova, Mateusz Żak, Michał Pełka, Norbert Prokopiuk
```
