### PR TITLE
event_camera_tools: 3.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2709,7 +2709,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_tools-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_tools` to `3.1.2-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_tools.git
- release repository: https://github.com/ros2-gbp/event_camera_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.1.1-1`

## event_camera_tools

```
* rely on event_camera_codecs and _msgs packages
* Remove unused include of rosbag2_cpp/typesupport_helpers.hpp
  This header file was removed in Jazzy (rosbag2 release 0.26.10). Since
  nothing seems to use this header file, let's remove it.
  This fixes the following compile error:
  In file included from src/raw_to_bag.cpp:20:
  include/event_camera_tools/ros_compat.h:29:10: fatal error:
  rosbag2_cpp/typesupport_helpers.hpp: No such file or directory
  29 | #include <rosbag2_cpp/typesupport_helpers.hpp>
  |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
* added sanity checks for event_statistics
* use header for raw_to_bag
* improve trigger delay, compute stddev of delay
* added jitter measurement
* Contributors: Bernd Pfrommer, Michal Sojka
```
