### PR TITLE
cras_ros_utils: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1464,7 +1464,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/cras_ros_utils-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/ctu-vras/ros-utils.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cras_ros_utils` to `3.0.2-1`:

- upstream repository: https://github.com/ctu-vras/ros-utils.git
- release repository: https://github.com/ros2-gbp/cras_ros_utils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `3.0.1-1`

## cras_bag_tools

```
* Try fixing readme rendering on index.ros.org
* Updated ROS 2 website links to point to index.ros.org
* Contributors: Martin Pecka
```

## cras_cpp_common

```
* Fixed compatibility with Rolling.
* Try fixing readme rendering on index.ros.org
* Updated ROS 2 website links to point to index.ros.org
* Contributors: Martin Pecka
```

## cras_lint

```
* Updated ROS 2 website links to point to index.ros.org
* Contributors: Martin Pecka
```

## cras_topic_tools

```
* Try fixing readme rendering on index.ros.org
* Updated ROS 2 website links to point to index.ros.org
* Contributors: Martin Pecka
```
