### PR TITLE
event_image_reconstruction_fibar: 3.0.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2040,7 +2040,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_image_reconstruction_fibar` to `3.0.4-1`:

- upstream repository: https://github.com/ros-event-camera/event_image_reconstruction_fibar.git
- release repository: https://github.com/ros2-gbp/event_image_reconstruction_fibar-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.3-1`

## event_image_reconstruction_fibar

```
* remove vcs repos: all in rosdistro now
* removed include of rosbag2 typesupport_helpers.hpp
* Contributors: Bernd Pfrommer
```
