### PR TITLE
ros_babel_fish: 4.26.40-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7886,7 +7886,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 3.26.30-1
+      version: 4.26.40-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `4.26.40-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.26.30-1`

## ros_babel_fish

```
* Sync with rolling before Lyrical release. (#18 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/18>)
  * Synced with rolling implementation of communication interfaces to preserve full compatibility and fix latest breaking change.
  * Updated CI, added pre-commit config and formatting.
  * Fix clang-format version used to 20.
  * Use testing sources in CI.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* Sync with rolling before Lyrical release. (#18 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/18>)
  * Synced with rolling implementation of communication interfaces to preserve full compatibility and fix latest breaking change.
  * Updated CI, added pre-commit config and formatting.
  * Fix clang-format version used to 20.
  * Use testing sources in CI.
* Contributors: Stefan Fabian
```
