### PR TITLE
Change ros_babel_fish source version from 'rolling' to 'kilted'

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7886,7 +7886,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
-      version: rolling
+      version: kilted
     release:
       packages:
       - ros_babel_fish
@@ -7898,7 +7898,7 @@ repositories:
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git
-      version: rolling
+      version: kilted
     status: developed
   ros_battery_monitoring:
     doc:


### PR DESCRIPTION
Currently, the automated builds fail because they track rolling rather than the kilted branch, and rolling just had interface changes that are incompatible with kilted.
https://build.ros2.org/job/Kdev__ros_babel_fish__ubuntu_noble_amd64/15/console