### PR TITLE
ament_cmake: 2.8.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -206,6 +206,7 @@ repositories:
       - ament_cmake_libraries
       - ament_cmake_pytest
       - ament_cmake_python
+      - ament_cmake_python_test
       - ament_cmake_target_dependencies
       - ament_cmake_test
       - ament_cmake_vendor_package
@@ -213,7 +214,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.8.6-1
+      version: 2.8.7-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -206,7 +206,6 @@ repositories:
       - ament_cmake_libraries
       - ament_cmake_pytest
       - ament_cmake_python
-      - ament_cmake_python_test
       - ament_cmake_target_dependencies
       - ament_cmake_test
       - ament_cmake_vendor_package


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake` to `2.8.7-1`:

- upstream repository: https://github.com/ament/ament_cmake.git
- release repository: https://github.com/ros2-gbp/ament_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.6-1`

## ament_cmake

- No changes

## ament_cmake_auto

- No changes

## ament_cmake_core

- No changes

## ament_cmake_export_definitions

- No changes

## ament_cmake_export_dependencies

- No changes

## ament_cmake_export_include_directories

- No changes

## ament_cmake_export_libraries

- No changes

## ament_cmake_export_link_flags

- No changes

## ament_cmake_export_targets

- No changes

## ament_cmake_gen_version_h

- No changes

## ament_cmake_gmock

```
* Use libgtest-dev and libgmock-dev (#622 <https://github.com/ament/ament_cmake//issues/622>)
* Contributors: Shane Loretz
```

## ament_cmake_google_benchmark

- No changes

## ament_cmake_gtest

```
* Use libgtest-dev and libgmock-dev (#622 <https://github.com/ament/ament_cmake//issues/622>)
* Contributors: Shane Loretz
```

## ament_cmake_include_directories

- No changes

## ament_cmake_libraries

- No changes

## ament_cmake_pytest

- No changes

## ament_cmake_python

```
* feature: allow extending a python package in ament_python_install_package (#587 <https://github.com/ament/ament_cmake//issues/587>)
* Contributors: Nadav Elkabets
```

## ament_cmake_python_test

```
* feature: allow extending a python package in ament_python_install_package (#587 <https://github.com/ament/ament_cmake//issues/587>)
* Contributors: Nadav Elkabets
```

## ament_cmake_target_dependencies

- No changes

## ament_cmake_test

- No changes

## ament_cmake_vendor_package

- No changes

## ament_cmake_version

- No changes
