### PR TITLE
ament_package: 0.18.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -359,7 +359,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.18.2-1
+      version: 0.18.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.18.3-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.18.2-1`

## ament_package

```
* feat: add support for fish (#164 <https://github.com/ament/ament_package/issues/164>)
* Fix flake8 (#163 <https://github.com/ament/ament_package/issues/163>)
* Contributors: Michael Carlstrom, SPeak
```
