### PR TITLE
ament_lint: 0.20.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -332,7 +332,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.20.3-1
+      version: 0.20.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_lint` to `0.20.4-1`:

- upstream repository: https://github.com/ament/ament_lint.git
- release repository: https://github.com/ros2-gbp/ament_lint-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.20.3-1`

## ament_clang_format

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_clang_tidy

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_cmake_clang_format

- No changes

## ament_cmake_clang_tidy

- No changes

## ament_cmake_copyright

- No changes

## ament_cmake_cppcheck

- No changes

## ament_cmake_cpplint

- No changes

## ament_cmake_flake8

- No changes

## ament_cmake_lint_cmake

- No changes

## ament_cmake_mypy

```
* [ament_mypy] Add --ament-strict flag for more strict type checking. (#573 <https://github.com/ament/ament_lint/issues/573>)
* Contributors: Michael Carlstrom
```

## ament_cmake_pclint

- No changes

## ament_cmake_pep257

- No changes

## ament_cmake_pycodestyle

- No changes

## ament_cmake_pyflakes

- No changes

## ament_cmake_uncrustify

- No changes

## ament_cmake_xmllint

- No changes

## ament_copyright

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Remove importlib_metadata (#564 <https://github.com/ament/ament_lint/issues/564>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_cppcheck

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_cpplint

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_flake8

```
* [ament_mypy] Add --ament-strict flag for more strict type checking. (#573 <https://github.com/ament/ament_lint/issues/573>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_lint

```
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof
```

## ament_lint_auto

- No changes

## ament_lint_cmake

```
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof
```

## ament_lint_common

- No changes

## ament_mypy

```
* Allow unused ignores (#575 <https://github.com/ament/ament_lint/issues/575>)
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* [ament_mypy] Add --ament-strict flag for more strict type checking. (#573 <https://github.com/ament/ament_lint/issues/573>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_pclint

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_pep257

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_pycodestyle

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_pyflakes

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_uncrustify

```
* [ament_mypy] Fix config for ament_cmake packages and type entrypoints (#574 <https://github.com/ament/ament_lint/issues/574>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom
```

## ament_xmllint

```
* [ament_mypy] Add --ament-strict flag for more strict type checking. (#573 <https://github.com/ament/ament_lint/issues/573>)
* xmllint: fetch external schemas via Python (#570 <https://github.com/ament/ament_lint/issues/570>)
* Drop setuptools from install_requires (#566 <https://github.com/ament/ament_lint/issues/566>)
* Contributors: Jochen Sprickerhof, Michael Carlstrom, Michael Carroll
```
