### PR TITLE
ament_package: 0.17.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -355,7 +355,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.17.2-2
+      version: 0.17.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.17.3-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.17.2-2`

## ament_package

```
* Remove unneeded deps (#161 <https://github.com/ament/ament_package/issues/161>) (#162 <https://github.com/ament/ament_package/issues/162>)
* fix setuptools deprecations (#156 <https://github.com/ament/ament_package/issues/156>) (#158 <https://github.com/ament/ament_package/issues/158>)
* Contributors: mergify[bot]
```
