### PR TITLE
point_cloud_transport_plugins: 6.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6087,7 +6087,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 6.0.1-1
+      version: 6.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `6.1.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.0.1-1`

## draco_point_cloud_transport

```
* Update API (#79 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/79>)
* Contributors: Alejandro Hernández Cordero
```

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

```
* Update API (#79 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/79>)
* add missing include for gcc15 (#75 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/75>)
* Contributors: Alejandro Hernández Cordero, Guilhem Saurel
```

## zstd_point_cloud_transport

```
* Update API (#79 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/79>)
* Contributors: Alejandro Hernández Cordero
```
