### PR TITLE
interactive_markers: 2.8.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3480,7 +3480,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.8.2-1
+      version: 2.8.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `interactive_markers` to `2.8.3-2`:

- upstream repository: https://github.com/ros-visualization/interactive_markers.git
- release repository: https://github.com/ros2-gbp/interactive_markers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.8.2-1`

## interactive_markers

```
* Use new ROSIDL aggregate CMake target (#119 <https://github.com/ros-visualization/interactive_markers/issues/119>)
* Contributors: Emerson Knapp
```
