### PR TITLE
py_binding_tools: 2.1.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6208,7 +6208,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_binding_tools-release.git
-      version: 2.1.0-1
+      version: 2.1.2-2
     source:
       type: git
       url: https://github.com/ros-planning/py_binding_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_binding_tools` to `2.1.2-2`:

- upstream repository: https://github.com/ros-planning/py_binding_tools.git
- release repository: https://github.com/ros2-gbp/py_binding_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## py_binding_tools

```
* Enable type casters for ROS service+action messages too
* Contributors: Robert Haschke
```
