### PR TITLE
srdfdom: 2.0.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9468,7 +9468,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/srdfdom-release.git
-      version: 2.0.8-1
+      version: 2.0.9-1
     source:
       type: git
       url: https://github.com/ros-planning/srdfdom.git


### PR DESCRIPTION
Increasing version of package(s) in repository `srdfdom` to `2.0.9-1`:

- upstream repository: https://github.com/moveit/srdfdom.git
- release repository: https://github.com/ros2-gbp/srdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.8-1`

## srdfdom

```
* Use tinyxml2 package instead of deprecated tinyxml2_vendor (#137 <https://github.com/ros-planning/srdfdom/issues/137>)
* Use correct target for console_bridge (#136 <https://github.com/ros-planning/srdfdom/issues/136>)
* Contributors: Daisuke Nishimatsu, Robert Haschke, mosfet80
```
