### PR TITLE
moveit_task_constructor: 0.1.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4816,7 +4816,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_task_constructor-release.git
-      version: 0.1.4-2
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.5-1`:

- upstream repository: https://github.com/moveit/moveit_task_constructor.git
- release repository: https://github.com/ros2-gbp/moveit_task_constructor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.4-2`

## moveit_task_constructor_capabilities

```
* Add missing package dependency: controller_manager
* Contributors: Robert Haschke
```

## moveit_task_constructor_core

```
* Replace deprecated rclcpp::spin_some()
* Fix #737 <https://github.com/moveit/moveit_task_constructor/issues/737> (pruning in fallback stages with a connect stage) (#742 <https://github.com/moveit/moveit_task_constructor/issues/742>)
* Directly lift solutions of SerialContainer (#730 <https://github.com/moveit/moveit_task_constructor/issues/730>)
* Mention InitStageException's type in its what() method (#738 <https://github.com/moveit/moveit_task_constructor/issues/738>)
* Remove unused setup.py
* Add link rotation cost (#726 <https://github.com/moveit/moveit_task_constructor/issues/726>)
* Support for optimising IK solvers (#724 <https://github.com/moveit/moveit_task_constructor/issues/724>)
* Contributors: Demonmasterlqx, Michael Görner, Robert Haschke, joseph-moore-CO
```

## moveit_task_constructor_demo

```
* Fix demo/README.md
* Add link rotation cost (#726 <https://github.com/moveit/moveit_task_constructor/issues/726>)
* Add missing package dependency: controller_manager
* Contributors: Robert Haschke
```

## moveit_task_constructor_msgs

- No changes

## moveit_task_constructor_visualization

- No changes

## rviz_marker_tools

- No changes
