### PR TITLE
rosbag2: 0.26.10-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9585,7 +9585,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.10-1
+      version: 0.26.10-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.10-2`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.10-1`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Fix for a possible race condition in compression writer on close
  (#2362 <https://github.com/ros2/rosbag2/issues/2362>)
  (#2381 <https://github.com/ros2/rosbag2/issues/2381>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Fix for a possible race condition in compression writer on close
  (#2362 <https://github.com/ros2/rosbag2/issues/2362>)
  (#2381 <https://github.com/ros2/rosbag2/issues/2381>)
* [jazzy] Add accidentally deleted typesupport_helper.{cpp}hpp files
  (#2320 <https://github.com/ros2/rosbag2/issues/2320>)
  * Added back, accidentally deleted typesupport_helper.{cpp}hpp files
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, mergify[bot]
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [jazzy] Add on start recording callback for Recorder
  (backport #2340 <https://github.com/ros2/rosbag2/issues/2340>)
* [jazzy] Address race condition in the "wait_for_playback_to_start()"
  (backport #2344 <https://github.com/ros2/rosbag2/issues/2344>)
  (#2359 <https://github.com/ros2/rosbag2/issues/2359>)
* Address a possible deadlock in seek(timestamp) (#2345 <https://github.com/ros2/rosbag2/issues/2345>) (#2348 <https://github.com/ros2/rosbag2/issues/2348>)
* [jazzy] Add missing "RecordOptions" fields to the encode/decode functions (backport #2334 <https://github.com/ros2/rosbag2/issues/2334>) (#2338 <https://github.com/ros2/rosbag2/issues/2338>)
* Contributors: Michael Orlov <mailto:morlovmr@gmail.com>, mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
