### PR TITLE
robot_state_publisher: 3.5.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7505,7 +7505,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.5.4-1
+      version: 3.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.5.5-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.5.4-1`

## robot_state_publisher

```
* Use new ROSIDL aggregate CMake target (#246 <https://github.com/ros/robot_state_publisher/issues/246>)
* Improvements (#245 <https://github.com/ros/robot_state_publisher/issues/245>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp
```
