### PR TITLE
resource_retriever: 3.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6958,7 +6958,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.9.2-1
+      version: 3.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.9.3-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.2-1`

## resource_retriever

```
* Removed python2 code (#121 <https://github.com/ros/resource_retriever/issues/121>)
* Delete resource_retriever/setup.py (#120 <https://github.com/ros/resource_retriever/issues/120>)
* Contributors: Alejandro Hernández Cordero, Michael Carlstrom
```
