### PR TITLE
class_loader: 2.9.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1140,7 +1140,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.9.2-1
+      version: 2.9.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.9.3-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.2-1`

## class_loader

```
* Remove ament_cmake_ros dependency (#226 <https://github.com/ros/class_loader/issues/226>)
  The dependent ament_cmake_ros package transitively pulls in RMW-layer packages which is unnecessarily heavy to class_loader that is supposed to be an independent plugin loading library. This commit removes the ament_cmake_ros dependency and replaces with a plain ament_cmake with an explicit SHARED library type to keep the dependency minimal.
* Improvements (#225 <https://github.com/ros/class_loader/issues/225>)
* Clean up tests (#224 <https://github.com/ros/class_loader/issues/224>)
* Contributors: Alejandro Hernández Cordero, CY Chen
```
