### PR TITLE
launch: 3.9.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3840,7 +3840,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.6-1
+      version: 3.9.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.7-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.6-1`

## launch

```
* Correct typos (#961 <https://github.com/ros2/launch/issues/961>)
* hotfix (#950 <https://github.com/ros2/launch/issues/950>)
* Declare Boolean Launch Argument (#944 <https://github.com/ros2/launch/issues/944>)
* Support frontends for PathJoinSubstitution (#943 <https://github.com/ros2/launch/issues/943>)
* Contributors: Auguste Lalande, Christophe Bedard, David V. Lu!!, Michael Carlstrom
```

## launch_pytest

```
* fix regressions (#959 <https://github.com/ros2/launch/issues/959>)
* fix: add get_launch_test_fixture_scope for pytest compatibility (#949 <https://github.com/ros2/launch/issues/949>)
* Contributors: Daisuke Nishimatsu, Michael Carlstrom
```

## launch_testing

```
* Correct typos (#961 <https://github.com/ros2/launch/issues/961>)
* Fix test_io_tests for Ubuntu26 (#960 <https://github.com/ros2/launch/issues/960>)
* Fix flake8 (#952 <https://github.com/ros2/launch/issues/952>)
* Contributors: Auguste Lalande, Michael Carlstrom
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Correct typos (#961 <https://github.com/ros2/launch/issues/961>)
* Support frontends for PathJoinSubstitution (#943 <https://github.com/ros2/launch/issues/943>)
* Contributors: Auguste Lalande, Christophe Bedard
```

## launch_yaml

```
* Correct typos (#961 <https://github.com/ros2/launch/issues/961>)
* Support frontends for PathJoinSubstitution (#943 <https://github.com/ros2/launch/issues/943>)
* Contributors: Auguste Lalande, Christophe Bedard
```
