### PR TITLE
launch_ros: 0.29.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3905,7 +3905,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.6-1
+      version: 0.29.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.29.7-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.29.6-1`

## launch_ros

```
* Fix flake8 (#529 <https://github.com/ros2/launch_ros//issues/529>)
* correct typos (#524 <https://github.com/ros2/launch_ros//issues/524>)
* Fix regression (#521 <https://github.com/ros2/launch_ros//issues/521>)
* Fix rhel10 flake8 error (#515 <https://github.com/ros2/launch_ros//issues/515>)
* Contributors: Auguste Lalande, Michael Carlstrom
```

## launch_testing_ros

```
* Add tests isolation in launch_testing_ros (#528 <https://github.com/ros2/launch_ros//issues/528>)
* Surpressing multi-threaded process warning from flake8. (#520 <https://github.com/ros2/launch_ros//issues/520>)
* correct typos (#524 <https://github.com/ros2/launch_ros//issues/524>)
* Contributors: Auguste Lalande, Julien Enoch, Tomoya Fujita
```

## ros2launch

```
* correct typos (#524 <https://github.com/ros2/launch_ros//issues/524>)
* Contributors: Auguste Lalande
```
