### PR TITLE
rcl: 10.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6650,7 +6650,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.4.1-1
+      version: 10.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.4.2-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.4.1-1`

## rcl

```
* Improved documentation of rcl_XYZ_set_on_new_XYZ_callback (#1289 <https://github.com/ros2/rcl/issues/1289>)
* Add rcl_subscription_options_set_acceptable_buffer_backends with proper lifetime management (#1308 <https://github.com/ros2/rcl/issues/1308>)
* Added tracepoint to rcl_take_loaned_message (#1300 <https://github.com/ros2/rcl/issues/1300>)
* Apply change from "Use new aggregate rosidl target instead of _TARGETS (#1302 <https://github.com/ros2/rcl/issues/1302>)" on some leftovers (#1309 <https://github.com/ros2/rcl/issues/1309>)
* Contributors: Alexis Tsogias, CY Chen, Oren Bell PhD, Rushhaank Sahay
```

## rcl_action

```
* fix(rcl_action): use RMW isolation for cross-node tests (#1311 <https://github.com/ros2/rcl/issues/1311>)
* Add 2 interfaces for configuring action client feedback subscription contents filter (#1287 <https://github.com/ros2/rcl/issues/1287>)
* Apply change from "Use new aggregate rosidl target instead of _TARGETS (#1302 <https://github.com/ros2/rcl/issues/1302>)" on some leftovers (#1309 <https://github.com/ros2/rcl/issues/1309>)
* Contributors: Alexis Tsogias, Barry Xu, Yuyuan Yuan
```

## rcl_lifecycle

```
* Apply change from "Use new aggregate rosidl target instead of _TARGETS (#1302 <https://github.com/ros2/rcl/issues/1302>)" on some leftovers (#1309 <https://github.com/ros2/rcl/issues/1309>)
* Contributors: Alexis Tsogias
```

## rcl_yaml_param_parser

```
* fix (#1310 <https://github.com/ros2/rcl/issues/1310>)
* Contributors: Michael Carlstrom
```
