### PR TITLE
rclcpp: 31.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6766,7 +6766,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 31.0.1-1
+      version: 31.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `31.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `31.0.1-1`

## rclcpp

```
* feat: Add per-node log level support via NodeOptions (#3092 <https://github.com/ros2/rclcpp/issues/3092>)
* Improve error message when parameter value is missing (#3093 <https://github.com/ros2/rclcpp/issues/3093>)
* Fix incorrect internal clear inside RingBufferImplementation (#3116 <https://github.com/ros2/rclcpp/issues/3116>)
* Add acceptable_buffer_backends field in SubscriptionOptionsBase (#3098 <https://github.com/ros2/rclcpp/issues/3098>)
* Remove comment about removed StaticSingleThreadedExecutor (#3121 <https://github.com/ros2/rclcpp/issues/3121>)
* Added tracepoint (#3103 <https://github.com/ros2/rclcpp/issues/3103>)
* Add ConstRefCallback in take_shared_method (#3066 <https://github.com/ros2/rclcpp/issues/3066>)
* Replace mispelled "${rcl_interfaces_TARGES}" by rcl_interfaces::rcl_interfaces (#3112 <https://github.com/ros2/rclcpp/issues/3112>)
* Contributors: Alexis Tsogias, CY Chen, Maurice Alexander Purnawan, Michael Carlstrom, Oren Bell, Peng Wang, Yadnyeshwar Amol Sakhare
```

## rclcpp_action

```
* publish_feedback should effect only on executing state. (#3118 <https://github.com/ros2/rclcpp/issues/3118>)
* Support to configure feedback subscription content filter for action client (#3034 <https://github.com/ros2/rclcpp/issues/3034>)
* Contributors: Barry Xu, Tomoya Fujita
```

## rclcpp_components

```
* feat: Add per-node log level support via NodeOptions (#3092 <https://github.com/ros2/rclcpp/issues/3092>)
* Contributors: Peng Wang
```

## rclcpp_lifecycle

- No changes
