### PR TITLE
rmw_fastrtps: 9.4.6-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7386,7 +7386,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.5-1
+      version: 9.4.6-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.6-3`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.4.5-1`

## rmw_fastrtps_cpp

```
* Add support for rosidl::Buffer-aware per-endpoint pub/sub (#867 <https://github.com/ros2/rmw_fastrtps/issues/867>)
* Contributors: CY Chen
```

## rmw_fastrtps_dynamic_cpp

```
* Add support for rosidl::Buffer-aware per-endpoint pub/sub (#867 <https://github.com/ros2/rmw_fastrtps/issues/867>)
* Contributors: CY Chen
```

## rmw_fastrtps_shared_cpp

```
* feat: set collection header element_flags TryConstructFailAction::DISCARD instead of 0 (#875 <https://github.com/ros2/rmw_fastrtps/issues/875>)
* Add support for rosidl::Buffer-aware per-endpoint pub/sub (#867 <https://github.com/ros2/rmw_fastrtps/issues/867>)
* Added rmw_take tracepoint, because it wasn't being triggered for successful takes (#871 <https://github.com/ros2/rmw_fastrtps/issues/871>)
* Contributors: CY Chen, Daisuke Nishimatsu, Oren Bell
```
