### PR TITLE
ur_robot_driver: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10383,7 +10383,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.5.0-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `5.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.5.0-1`

## ur

- No changes

## ur_calibration

```
* Ensure calibration library in ur_calibration is always built as static (#1667 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1667>)
* Contributors: Silvio Traversaro
```

## ur_controllers

```
* Improved controller usage documentation (#1754 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1754>)
* Friction model controller (#1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>)
* Remove Werror from CMakeLists (#1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>)
* Do not install moveit dependencies (#1671 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1671>)
* Add deprecation warning for scaled JTC (#1660 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1660>)
* Contributors: Felix Exner, Rune Søe-Knudsen
```

## ur_dashboard_msgs

```
* Use integer representation of SafetyStatus.msg (#1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>)
* Services to support various dashboard calls (#1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>)
* Dashboard client new x commands (#1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>)
* Contributors: Felix Exner, URJala
```

## ur_moveit_config

```
* Add sim_time to servo launch file (#1651 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1651>)
* Contributors: Jennifer Buehler
```

## ur_robot_driver

```
* Improved controller usage documentation (#1754 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1754>)
* Friction model controller (#1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>)
* Add deprecation warning for tool comm script (#1747 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1747>)
* Fix formatting issues introduced earlier (#1748 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1748>)
* Update driver to use refactored tool communication script (#1721 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1721>)
* Use integer representation of SafetyStatus.msg (#1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>)
* Use refactored RTDE client in driver (#1726 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1726>)
* Pass controller config to spawners (#1719 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1719>)
* [Docs] Fix service definition of UpdateProgram (#1723 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1723>)
* [ur_controllers] Remove Werror from CMakeLists (#1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>)
* Services to support various dashboard calls (#1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>)
* Use a secondary program to confirm urscript_interface initialization (#1685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1685>)
* Dashboard client new x commands (#1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>)
* Fix cleanup (#1683 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1683>)
* Update forward command controller types (#1661 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1661>)
* Update ft frame_id to tool0_controller (#1652 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1652>)
* [Driver Tests] Unlock protective stop during test case setup (#1641 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1641>)
* Contributors: Chen Chen, Felix Exner, Rune Søe-Knudsen, Sergi Romero, URJala
```
