### PR TITLE
ur_robot_driver: 4.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10368,7 +10368,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.5.0-1
+      version: 4.6.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10356,7 +10356,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-      version: main
+      version: kilted
     release:
       packages:
       - ur
@@ -10372,7 +10372,7 @@ repositories:
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-      version: main
+      version: kilted
     status: developed
   ur_simulation_gz:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.6.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.5.0-1`

## ur

- No changes

## ur_calibration

```
* Ensure calibration library in ur_calibration is always built as static (backport of #1667 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1667>) (#1670 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1670>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* Friction model controller (backport #1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>) (#1752 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1752>)
* [ur_controllers] Remove Werror from CMakeLists (backport #1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>) (#1729 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1729>)
* Add deprecation warning for scaled JTC (#1660 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1660>)
* Contributors: Felix Exner, mergify[bot]
```

## ur_dashboard_msgs

```
* Use integer representation of SafetyStatus.msg (backport #1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>) (#1743 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1743>)
* Services to support various dashboard calls (backport #1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>) (#1710 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1710>)
* Dashboard client new x commands (backport #1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>) (#1696 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1696>)
* Contributors: mergify[bot]
```

## ur_moveit_config

```
* Add sim_time to servo launch file (#1651 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1651>)
* Contributors: Jennifer Buehler
```

## ur_robot_driver

```
* Friction model controller (backport #1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>) (#1752 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1752>)
* Update driver to use refactored tool communication script (backport #1721 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1721>) (#1746 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1746>)
* Use integer representation of SafetyStatus.msg (backport #1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>) (#1743 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1743>)
* [ur_controllers] Remove Werror from CMakeLists (backport #1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>) (#1729 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1729>)
* Use refactored RTDE client in driver (backport #1726 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1726>) (#1733 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1733>)
* [Docs] Fix service definition of UpdateProgram (backport #1723 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1723>) (#1725 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1725>)
* Services to support various dashboard calls (backport #1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>) (#1710 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1710>)
* Use a secondary program to confirm urscript_interface initialization (backport #1685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1685>) (#1699 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1699>)
* Dashboard client new x commands (backport #1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>) (#1696 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1696>)
* Fix cleanup (backport #1683 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1683>) (#1686 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1686>)
* Update ft frame_id to tool0_controller (#1652 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1652>)
* [Driver Tests] Unlock protective stop during test case setup (#1641 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1641>)
* Contributors: Chen Chen, Felix Exner, mergify[bot]
```
