### PR TITLE
ur_robot_driver: 3.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12273,7 +12273,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 3.7.0-1
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `3.8.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.7.0-1`

## ur

- No changes

## ur_calibration

```
* Ensure calibration library in ur_calibration is always built as static (backport #1667 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1667>) (#1669 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1669>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* Friction model controller (backport #1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>) (#1751 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1751>)
* Remove Werror from CMakeLists (backport #1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>) (#1728 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1728>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

```
* Use integer representation of SafetyStatus.msg (backport #1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>) (#1742 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1742>)
* Services to support various dashboard calls (backport #1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>) (#1709 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1709>)
* Dashboard client new x commands (backport #1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>) (#1695 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1695>)
* Contributors: mergify[bot]
```

## ur_moveit_config

```
* Add sim_time to servo launch file (backport #1651 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1651>) (#1655 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1655>)
* Contributors: mergify[bot]
```

## ur_robot_driver

```
* Friction model controller (backport #1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>) (#1751 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1751>)
* Use integer representation of SafetyStatus.msg (backport #1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>) (#1742 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1742>)
* Update driver to use refactored tool communication script (backport #1721 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1721>) (#1745 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1745>)
* [ur_controllers] Remove Werror from CMakeLists (backport #1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>) (#1728 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1728>)
* Use refactored RTDE client in driver (backport #1726 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1726>) (#1732 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1732>)
* [Docs] Fix service definition of UpdateProgram (backport #1723 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1723>) (#1724 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1724>)
* Services to support various dashboard calls (backport #1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>) (#1709 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1709>)
* Use a secondary program to confirm urscript_interface initialization (backport #1685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1685>) (#1698 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1698>)
* Dashboard client new x commands (backport #1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>) (#1695 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1695>)
* Add component lifecycle test to CMakeLists.txt (#1684 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1684>)
* Update ft frame_id to tool0_controller (backport #1652 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1652>) (#1654 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1654>)
* [Driver Tests] Unlock protective stop during test case setup (backport #1641 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1641>) (#1647 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1647>)
* Contributors: Felix Exner, mergify[bot]
```
