### PR TITLE
ur_robot_driver: 2.13.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13091,7 +13091,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.13.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.12.0-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

```
* Ensure calibration library in ur_calibration is always built as static (backport #1667 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1667>) (#1668 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1668>)
* Contributors: mergify[bot]
```

## ur_controllers

```
* Update scaled JTC (#1753 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1753>)
* Friction model controller (backport #1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>) (#1750 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1750>)
* Remove Werror from CMakeLists (backport #1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>) (#1727 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1727>)
* Contributors: Felix Exner, mergify[bot]
```

## ur_dashboard_msgs

```
* Use integer representation of SafetyStatus.msg (backport #1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>) (#1741 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1741>)
* Services to support various dashboard calls (backport #1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>) (#1708 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1708>)
* Dashboard client new x commands (backport #1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>) (#1694 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1694>)
* Contributors: mergify[bot]
```

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Friction model controller (backport #1704 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1704>) (#1750 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1750>)
* Update driver to use refactored tool communication script (backport #1721 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1721>) (#1744 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1744>)
* Use integer representation of SafetyStatus.msg (backport #1734 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1734>) (#1741 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1741>)
* [Docs] Fix linked service definition for update_program service (#1730 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1730>)
* [ur_controllers] Remove Werror from CMakeLists (backport #1720 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1720>) (#1727 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1727>)
* Use refactored RTDE client in driver (backport #1726 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1726>) (#1731 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1731>)
* Services to support various dashboard calls (backport #1674 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1674>) (#1708 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1708>)
* Dashboard client new x commands (backport #1679 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1679>) (#1694 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1694>)
* Use a secondary program to confirm urscript_interface initialization (backport #1685 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1685>) (#1697 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1697>)
* Add component lifecycle test to CMakeLists.txt (backport #1684 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1684>) (#1687 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1687>)
* Update ft frame_id to tool0_controller (backport #1652 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1652>) (#1653 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1653>)
* [Driver Tests] Unlock protective stop during test case setup (backport #1641 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1641>) (#1646 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1646>)
* Contributors: Felix Exner, mergify[bot]
```