### PR TITLE
rosidl_python: 0.27.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8268,7 +8268,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.27.0-1
+      version: 0.27.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_python` to `0.27.1-1`:

- upstream repository: https://github.com/ros2/rosidl_python.git
- release repository: https://github.com/ros2-gbp/rosidl_python-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.27.0-1`

## rosidl_generator_py

```
* Feature: add depends flag for ament_python_install_package (#254 <https://github.com/ros2/rosidl_python/issues/254>)
* Add support for rosidl::Buffer in rosidl Python path for rclpy (#250 <https://github.com/ros2/rosidl_python/issues/250>)
* Contributors: CY Chen, Nadav Elkabets
```
