### PR TITLE
rosidl_runtime_py: 0.15.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8284,7 +8284,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.15.1-1
+      version: 0.15.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.15.2-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.15.1-1`

## rosidl_runtime_py

```
* Add support for rosidl::Buffer in rosidl Python path for rclpy (#39 <https://github.com/ros2/rosidl_runtime_py/issues/39>)
* Fix flake8 (#40 <https://github.com/ros2/rosidl_runtime_py/issues/40>)
* Add py.typed to the package (#37 <https://github.com/ros2/rosidl_runtime_py/issues/37>)
* Contributors: CY Chen, Michael Carlstrom, Vladimir Gerts
```
