### PR TITLE
rosidl_typesupport: 3.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8320,7 +8320,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport` to `3.4.2-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.4.1-1`

## rosidl_typesupport_c

```
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#168 <https://github.com/ros2/rosidl_typesupport/issues/168>)
* Contributors: Anthony Welte
```

## rosidl_typesupport_cpp

```
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#168 <https://github.com/ros2/rosidl_typesupport/issues/168>)
* Contributors: Anthony Welte
```
