### PR TITLE
rpyutils: 0.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8443,7 +8443,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rpyutils-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rpyutils` to `0.7.2-1`:

- upstream repository: https://github.com/ros2/rpyutils.git
- release repository: https://github.com/ros2-gbp/rpyutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.1-1`

## rpyutils

```
* Enforce ament_mypy --ament-strict (#22 <https://github.com/ros2/rpyutils/issues/22>)
* Contributors: Michael Carlstrom
```
