### PR TITLE
rosidl_typesupport_fastrtps: 3.9.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8339,7 +8339,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.9.3-1
+      version: 3.9.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.9.4-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.9.3-1`

## rosidl_typesupport_fastrtps_c

```
* Add support for rosidl::Buffer type serialization (#144 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/144>)
* use variable to control shared/static build type (#138 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/138>)
* Contributors: Anthony Welte, CY Chen, Jay Sridharan
```

## rosidl_typesupport_fastrtps_cpp

```
* Add support for rosidl::Buffer type serialization (#144 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/144>)
* use variable to control shared/static build type (#138 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/138>)
* Add DEPENDS_EXPLICIT_ONLY to remove implicit dependencies (#136 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/136>)
* Contributors: Anthony Welte, CY Chen, Jay Sridharan
```
