### PR TITLE
message_filters: 4.3.16-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5555,7 +5555,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 4.3.15-1
+      version: 4.3.16-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `4.3.16-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.3.15-1`

## message_filters

```
* DeltaFilter(C++): Add DeltaFilter class. (backport #273 <https://github.com/ros2/message_filters/issues/273>) (#276 <https://github.com/ros2/message_filters/issues/276>)
* Contributors: mergify[bot]
```
