### PR TITLE
autoware_cmake: 1.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -784,7 +784,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.2.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.0-1`

## autoware_cmake

```
* feat(autoware_cmake): support USE_SCOPED_HEADER_INSTALL_DIR in autoware_ament_auto_package (#40 <https://github.com/autowarefoundation/autoware_cmake/issues/40>)
  * feat(autoware_cmake): support USE_SCOPED_HEADER_INSTALL_DIR in autoware_ament_auto_package
  * Removed the FILES_MATCHING patterns from both install calls
  Removed unnecessary FILES_MATCHING patterns from install commands.
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
* Contributors: Vishal Chauhan
```

## autoware_lint_common

- No changes
