### PR TITLE
pangolin: 0.9.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5743,7 +5743,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Pangolin-release.git
-      version: 0.9.4-1
+      version: 0.9.5-1
     source:
       type: git
       url: https://github.com/stevenlovegrove/Pangolin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pangolin` to `0.9.5-1`:

- upstream repository: https://github.com/stevenlovegrove/Pangolin.git
- release repository: https://github.com/ros2-gbp/Pangolin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.9.4-1`
