### PR TITLE
Add hatchbed_localization package with source and documentation.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3149,7 +3149,7 @@ repositories:
       url: https://github.com/hatchbed/hatchbed_common.git
       version: main
     status: developed
-hatchbed_localization:
+  hatchbed_localization:
     doc:
       type: git
       url: https://github.com/hatchbed/hatchbed_localization.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3149,6 +3149,16 @@ repositories:
       url: https://github.com/hatchbed/hatchbed_common.git
       version: main
     status: developed
+hatchbed_localization:
+    doc:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_localization.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/hatchbed/hatchbed_localization.git
+      version: main
+    status: developed
   heaphook:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/hatchbed/hatchbed_localization

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
