### PR TITLE
Revert "ament_index: 1.8.3-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -324,7 +324,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.8.3-1
+      version: 1.8.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#49694

Reverting this temporarily to avoid the regression on [behaviortree_cpp](https://github.com/BehaviorTree/BehaviorTree.CPP), it's already fixed [here](https://github.com/BehaviorTree/BehaviorTree.CPP/pull/1123) but hasn't been released. 

After the sync I'll add this back and this will go out on the next sync.