### PR TITLE
rqt_topic: 2.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8846,7 +8846,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 2.0.1-1
+      version: 2.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `2.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.1-1`

## rqt_topic

```
* Support Qt6 (#67 <https://github.com/ros-visualization/rqt_topic/issues/67>)
* Add Qt6 compatibility (#66 <https://github.com/ros-visualization/rqt_topic/issues/66>)
* Tweak expected error in test for Pydantic v2 compat (#65 <https://github.com/ros-visualization/rqt_topic/issues/65>)
* Contributors: Alejandro Hernández Cordero, Scott K Logan, Shane Loretz
```
