### PR TITLE
rqt: 1.10.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8476,7 +8476,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.10.2-1
+      version: 1.10.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.10.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.10.2-1`

## rqt

```
* fix setuptools deprecations (#334 <https://github.com/ros-visualization/rqt/issues/334>)
* Contributors: mosfet80
```

## rqt_gui

- No changes

## rqt_gui_cpp

```
* Support Qt6 (#339 <https://github.com/ros-visualization/rqt/issues/339>)
* Removed deprecated header (#340 <https://github.com/ros-visualization/rqt/issues/340>)
* Use qt6 as the default dependency from rosdep (#337 <https://github.com/ros-visualization/rqt/issues/337>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_gui_py

```
* Support Qt6 (#339 <https://github.com/ros-visualization/rqt/issues/339>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_py_common

```
* Support Qt6 (#339 <https://github.com/ros-visualization/rqt/issues/339>)
* Contributors: Alejandro Hernández Cordero
```
