### PR TITLE
qt_gui_core: 2.10.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6461,7 +6461,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.10.3-1
+      version: 2.10.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.10.4-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.10.3-1`

## qt_dotgraph

```
* Support qt6 (#293 <https://github.com/ros-visualization/qt_gui_core/issues/293>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui

```
* Support qt6 (#293 <https://github.com/ros-visualization/qt_gui_core/issues/293>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Support qt6 (#293 <https://github.com/ros-visualization/qt_gui_core/issues/293>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_py_common

```
* Support qt6 (#293 <https://github.com/ros-visualization/qt_gui_core/issues/293>)
* Contributors: Alejandro Hernández Cordero
```
