### PR TITLE
rqt_plot: 1.6.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8662,7 +8662,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.6.3-1
+      version: 1.6.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.6.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.3-1`

## rqt_plot

```
* fix setuptools deprecations (backport #123 <https://github.com/ros-visualization/rqt_plot/issues/123>) (#124 <https://github.com/ros-visualization/rqt_plot/issues/124>)
* Added missing test dependency (backport #118 <https://github.com/ros-visualization/rqt_plot/issues/118>) (#119 <https://github.com/ros-visualization/rqt_plot/issues/119>)
* Contributors: mergify[bot]
```
