### PR TITLE
rqt_msg: 1.6.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8647,7 +8647,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.6.0-2
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `1.6.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-2`

## rqt_msg

```
* fix setuptools deprecations (backport #23 <https://github.com/ros-visualization/rqt_msg/issues/23>) (#24 <https://github.com/ros-visualization/rqt_msg/issues/24>)
* Remove CODEOWNERS (#20 <https://github.com/ros-visualization/rqt_msg/issues/20>)
* Contributors: Alejandro Hernández Cordero, mergify[bot]
```
