### PR TITLE
rqt_bag: 2.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8510,7 +8510,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.2.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.1-1`

## rqt_bag

```
* Support Qt6 (#206 <https://github.com/ros-visualization/rqt_bag/issues/206>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_bag_plugins

```
* Support Qt6 (#206 <https://github.com/ros-visualization/rqt_bag/issues/206>)
* Contributors: Alejandro Hernández Cordero
```
