### PR TITLE
rqt_publisher: 1.9.1-4 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8677,7 +8677,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.9.0-2
+      version: 1.9.1-4
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.9.1-4`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.9.0-2`

## rqt_publisher

```
* fix setuptools deprecations (backport #52 <https://github.com/ros-visualization/rqt_publisher/issues/52>) (#53 <https://github.com/ros-visualization/rqt_publisher/issues/53>)
* Contributors: mergify[bot]
```
