### PR TITLE
rqt_service_caller: 1.4.1-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8783,7 +8783,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.4.0-2
+      version: 1.4.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `1.4.1-2`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-2`

## rqt_service_caller

```
* fix setuptools deprecations (backport #33 <https://github.com/ros-visualization/rqt_service_caller/issues/33>) (#34 <https://github.com/ros-visualization/rqt_service_caller/issues/34>)
* Contributors: mergify[bot]
```
