### PR TITLE
rqt_bag: 2.0.3-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8507,7 +8507,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.0.2-2
+      version: 2.0.3-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.0.3-2`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.2-2`

## rqt_bag

```
* fix setuptools deprecations (backport #185 <https://github.com/ros-visualization/rqt_bag/issues/185>) (#202 <https://github.com/ros-visualization/rqt_bag/issues/202>)
* Better handling of large bag files (backport #178 <https://github.com/ros-visualization/rqt_bag/issues/178>) (#200 <https://github.com/ros-visualization/rqt_bag/issues/200>)
* Display roll, pitch, yaw values for quaternions (backport #179 <https://github.com/ros-visualization/rqt_bag/issues/179>) (#198 <https://github.com/ros-visualization/rqt_bag/issues/198>)
* Improved raw view to better handle arrays and time objects (backport #173 <https://github.com/ros-visualization/rqt_bag/issues/173>) (#193 <https://github.com/ros-visualization/rqt_bag/issues/193>)
* plot_view: Fixed display of initial message (backport #180 <https://github.com/ros-visualization/rqt_bag/issues/180>) (#186 <https://github.com/ros-visualization/rqt_bag/issues/186>)
* Contributors: mergify[bot]
```

## rqt_bag_plugins

```
* fix setuptools deprecations (backport #185 <https://github.com/ros-visualization/rqt_bag/issues/185>) (#202 <https://github.com/ros-visualization/rqt_bag/issues/202>)
  Co-authored-by: mosfet80 <mailto:10235105+mosfet80@users.noreply.github.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Display roll, pitch, yaw values for quaternions (backport #179 <https://github.com/ros-visualization/rqt_bag/issues/179>) (#198 <https://github.com/ros-visualization/rqt_bag/issues/198>)
  Display roll, pitch, yaw values for quaternions (#179 <https://github.com/ros-visualization/rqt_bag/issues/179>)
  (cherry picked from commit 4593d82d2b23a322119c6a518befec970db7d54e)
  Co-authored-by: Martin Pecka <mailto:peckama2@fel.cvut.cz>
* Fixed image helper and added support for PNG-coded compressedDepth (backport #176 <https://github.com/ros-visualization/rqt_bag/issues/176>) (#190 <https://github.com/ros-visualization/rqt_bag/issues/190>)
  Fixed image helper and added support for PNG-coded compressedDepth (#176 <https://github.com/ros-visualization/rqt_bag/issues/176>)
  (cherry picked from commit 6e68aed3db4fd3efbfd542d12e4e39d44d82580a)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Improve plot view (backport #174 <https://github.com/ros-visualization/rqt_bag/issues/174>) (#188 <https://github.com/ros-visualization/rqt_bag/issues/188>)
  Improve plot view (#174 <https://github.com/ros-visualization/rqt_bag/issues/174>)
  (cherry picked from commit ed713b596bbe7d7b484556974e80dbcad83c009b)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* plot_view: Fixed display of initial message (backport #180 <https://github.com/ros-visualization/rqt_bag/issues/180>) (#186 <https://github.com/ros-visualization/rqt_bag/issues/186>)
  plot_view: Fixed display of initial message (#180 <https://github.com/ros-visualization/rqt_bag/issues/180>)
  (cherry picked from commit 9ff337266e97143c2ec9eef6f9aa03bde2b31997)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
* Contributors: mergify[bot]
```
