### PR TITLE
rqt_py_console: 1.5.2-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8695,7 +8695,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.5.1-1
+      version: 1.5.2-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `1.5.2-2`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros2-gbp/rqt_py_console-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.5.1-1`

## rqt_py_console

```
* Add Qt6 compatibility (#25 <https://github.com/ros-visualization/rqt_py_console/issues/25>)
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: Shane Loretz
```
