### PR TITLE
yasmin: 5.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10874,16 +10874,19 @@ repositories:
     release:
       packages:
       - yasmin
+      - yasmin_cli
       - yasmin_demos
       - yasmin_editor
       - yasmin_factory
       - yasmin_msgs
+      - yasmin_pcl
+      - yasmin_plugins_manager
       - yasmin_ros
       - yasmin_viewer
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yasmin-release.git
-      version: 4.2.4-1
+      version: 5.0.0-1
     source:
       type: git
       url: https://github.com/uleroboticsgroup/yasmin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `yasmin` to `5.0.0-1`:

- upstream repository: https://github.com/uleroboticsgroup/yasmin.git
- release repository: https://github.com/ros2-gbp/yasmin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.2.4-1`

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
