### PR TITLE
urdf: 2.13.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10421,7 +10421,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.13.1-1
+      version: 2.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf` to `2.13.2-1`:

- upstream repository: https://github.com/ros2/urdf.git
- release repository: https://github.com/ros2-gbp/urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.13.1-1`

## urdf

```
* Remove ``urdf_world/types.h`` deprecation (#54 <https://github.com/ros2/urdf/issues/54>)
* Contributors: Alejandro Hernández Cordero
```

## urdf_parser_plugin

```
* Remove ``urdf_world/types.h`` deprecation (#54 <https://github.com/ros2/urdf/issues/54>)
* Contributors: Alejandro Hernández Cordero
```
