### PR TITLE
Revert "Revert "ament_index: 1.8.3-1 in 'jazzy/distribution.yaml' [bloom]""

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -324,7 +324,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.8.2-1
+      version: 1.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Reverts ros/rosdistro#50693

The [sync is out](https://discourse.openrobotics.org/t/new-packages-for-jazzy-jalisco-2026-04-13/54004) therefore adding this back as mentioned in https://github.com/ros/rosdistro/pull/50693.