### PR TITLE
mola_sm_loop_closure: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4639,6 +4639,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_sm_loop_closure.git
       version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_sm_loop_closure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_sm_loop_closure` to `1.0.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_sm_loop_closure.git
- release repository: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## mola_sm_loop_closure

```
* package.xml: add missing test-dep
* add unit tests
* cli: use output directory as default for debug output files, not input
* Install pipelines so they are accessible under 'share'
* Make the package discoverage by ament
* Merge pull request #6 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/6> from MOLAorg/save-ram
  F2F algorithm: save ram in offline runs
* More memory efficient loop
* Bump minimum cmake version to 3.7
* Reuse mp2p_icp::update_velocity_buffer_from_obs() from mp2p_icp
  Removes duplicated code in this repo now that mp2p_icp>=2.5.0 is available in all distributions
* Fix build against mp2p_icp <2.6.0
* icp debug log files: save only good edges
* F2F algorithm: save ram in offline runs
* sm2mm pipeline yaml: expose more params via env vars
* Expose more parameters for F2F algorithm
* Debug feature: enable saving 3Dscene files per optimization round
* Use Graduated Non-Convexity (GNC) optimizer for superior outlier rejection
* FIX: Reverted logic in formula for adaptive threshold
* Add formal CLA
* Merge pull request #5 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/5> from MOLAorg/feat/smart-ram-lazy-unload
  Lazy unload keyframe clouds to keep RAM usage bounded
* Contributors: Jose Luis Blanco-Claraco
```
