### PR TITLE
rmw_zenoh: 0.10.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7450,7 +7450,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.10.2-1
+      version: 0.10.3-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.10.3-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.10.2-1`

## rmw_zenoh_cpp

```
* Bump Zenoh to 1.8.0, fix Windows shutdown hang, and resolve synchronization with ``undeclare`` (#964 <https://github.com/ros2/rmw_zenoh/issues/964>)
* Revert changes to build against rust >= 1.75 and bump zenoh to 1.8.0 (#960 <https://github.com/ros2/rmw_zenoh/issues/960>)
* Prevent deadlock by not holding both locks when processing event data (#937 <https://github.com/ros2/rmw_zenoh/issues/937>)
* Bump zenoh to 1.8.0 (#935 <https://github.com/ros2/rmw_zenoh/issues/935>)
* Explicitly set false for the content filtering feature (#938 <https://github.com/ros2/rmw_zenoh/issues/938>)
* Add deadline/liveliness QoS events to ``rmw_zenoh_cpp`` (#934 <https://github.com/ros2/rmw_zenoh/issues/934>)
* Catch ``PackageNotFoundError`` during default config URI loading to prevent crash (#915 <https://github.com/ros2/rmw_zenoh/issues/915>)
* Populate ``reception_sequence_number`` and ``advertise_sequence_number`` features (#920 <https://github.com/ros2/rmw_zenoh/issues/920>)
* Use ``get_package_share_path`` (#913 <https://github.com/ros2/rmw_zenoh/issues/913>)
* Address outstanding TODO items (#896 <https://github.com/ros2/rmw_zenoh/issues/896>)
* Expose zenoh session (#865 <https://github.com/ros2/rmw_zenoh/issues/865>)
* Fix config loading with incorrect path variable (#898 <https://github.com/ros2/rmw_zenoh/issues/898>)
* Fix build binary workflow (#895 <https://github.com/ros2/rmw_zenoh/issues/895>)
* Fix line ending in session open error message (#888 <https://github.com/ros2/rmw_zenoh/issues/888>)
* Update deprecated ``ament_index_cpp`` API (#879 <https://github.com/ros2/rmw_zenoh/issues/879>)
* Remove ``default`` from switch with enum to enable compiler warnings (#871 <https://github.com/ros2/rmw_zenoh/issues/871>)
* Use shared SHM transport provider instead of creating a new instance (#857 <https://github.com/ros2/rmw_zenoh/issues/857>)
* Bump ``zenoh`` to 1.7.1 (#870 <https://github.com/ros2/rmw_zenoh/issues/870>)
* Contributors: Alejandro Hernández Cordero, Hervé Audren, Julien Enoch, Nikola Banović, Shane Loretz, Skyler Medeiros, Tomoya Fujita, Yuyuan Yuan, jordanburklund, yellowhatter
```

## zenoh_cpp_vendor

```
* Bump Zenoh to 1.8.0, fix Windows shutdown hang, and resolve synchronization with ``undeclare`` (#964 <https://github.com/ros2/rmw_zenoh/issues/964>)
* Revert changes to build against rust >= 1.75 and bump zenoh to 1.8.0 (#960 <https://github.com/ros2/rmw_zenoh/issues/960>)
* Revert patch of Cargo.lock with new Zenoh commit due to Windows test failures (#959 <https://github.com/ros2/rmw_zenoh/issues/959>)
* Update Cargo.lock with new Zenoh commit (#957 <https://github.com/ros2/rmw_zenoh/issues/957>)
* Build against ``rust >= 1.75`` for ROS Lyrical (#945 <https://github.com/ros2/rmw_zenoh/issues/945>)
* Bump zenoh to 1.8.0 (#935 <https://github.com/ros2/rmw_zenoh/issues/935>)
* Allow use of non-vendored Zenoh if present (#908 <https://github.com/ros2/rmw_zenoh/issues/908>)
* Bump ``zenoh`` to 1.7.1 (#870 <https://github.com/ros2/rmw_zenoh/issues/870>)
* Contributors: Julien Enoch, Shane Loretz, Yuyuan Yuan, Øystein Sture
```

## zenoh_security_tools

```
* Address outstanding TODO items (#896 <https://github.com/ros2/rmw_zenoh/issues/896>)
* Contributors: Tomoya Fujita
```
