### PR TITLE
rmw_fastrtps: 9.4.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7396,7 +7396,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.6-3
+      version: 9.4.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.7-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.4.6-3`

## rmw_fastrtps_cpp

```
* Remove warning when compiling with ``lcang`` (#876 <https://github.com/ros2/rmw_fastrtps/issues/876>)
* Contributors: Alejandro Hernández Cordero
```
