### PR TITLE
rcutils: 7.0.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6859,7 +6859,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.0.8-1
+      version: 7.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.0.9-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `7.0.8-1`

## rcutils

```
* Remove ``ament_export_link_flags()`` for atomic operations (#528 <https://github.com/ros2/rcutils/issues/528>)
* Use less common variable name in macro (#550 <https://github.com/ros2/rcutils/issues/550>)
* Contributors: Shane Loretz, Tomoya Fujita
```
