### PR TITLE
rcl_interfaces: 2.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6687,7 +6687,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 2.4.3-1
+      version: 2.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `2.4.4-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.3-1`

## rosgraph_msgs

```
* Add Graph description messages to ``rosgraph_msgs`` (#188 <https://github.com/ros2/rcl_interfaces/issues/188>)
* Contributors: Emerson Knapp
```

## test_msgs

```
* Add ``ament_cmake_mypy`` to ``test_msgs`` (#187 <https://github.com/ros2/rcl_interfaces/issues/187>)
* Contributors: Michael Carlstrom
```
