### PR TITLE
rcl: 10.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6660,7 +6660,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.4.2-1
+      version: 10.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.4.3-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `10.4.2-1`

## rcl

```
* Preserve ``rmw_create_node`` error state in ``rcl_node_init`` by using ``RCL_EXPECT_ERROR_IS_SET`` (#1313 <https://github.com/ros2/rcl/issues/1313>)
* Remove clang warnings (#1315 <https://github.com/ros2/rcl/issues/1315>)
* Add RCL_EXPECT_ERROR_IS_SET macro (#1312 <https://github.com/ros2/rcl/issues/1312>)
* Contributors: Akihiko Komada, Alejandro Hernández Cordero, Shane Loretz
```

## rcl_yaml_param_parser

```
* Remove clang warnings (#1315 <https://github.com/ros2/rcl/issues/1315>)
* Contributors: Alejandro Hernández Cordero
```
