### PR TITLE
rosbag2: 0.33.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8050,7 +8050,7 @@ repositories:
       version: rolling
     release:
       packages:
-      - liblz4_vendor
+      - lz4_cmake_module
       - mcap_vendor
       - ros2bag
       - rosbag2
@@ -8071,12 +8071,11 @@ repositories:
       - rosbag2_test_msgdefs
       - rosbag2_tests
       - rosbag2_transport
-      - sqlite3_vendor
-      - zstd_vendor
+      - zstd_cmake_module
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.33.0-1
+      version: 0.33.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.33.1-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.33.0-1`

## mcap_vendor

```
* Update mcap dependency to version 2.1.3 (#2355 <https://github.com/ros2/rosbag2/issues/2355>)
* Remove lz4 vendor package (#2165 <https://github.com/ros2/rosbag2/issues/2165>)
* Replace ``zstd_vendor`` with ``zstd_cmake_module`` (#2166 <https://github.com/ros2/rosbag2/issues/2166>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Backport missing ``cstdint`` include (#2008 <https://github.com/ros2/rosbag2/issues/2008>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette, David Anthony, mosfet80
```

## ros2bag

```
* Add ``--repeat-all-transient-local`` flag for automatic transient-local topic detection (#2391 <https://github.com/ros2/rosbag2/issues/2391>)
* Repeat transient-local topics: Recorder, CLI, and Python bindings (#2387 <https://github.com/ros2/rosbag2/issues/2387>)
* Suppress multi-threaded process warning from rosbag2 flake8 (#2329 <https://github.com/ros2/rosbag2/issues/2329>)
* Remove deprecated arguments and options from ``ros2bag`` (#2328 <https://github.com/ros2/rosbag2/issues/2328>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Improve ``ros2 bag convert`` performance for fragment cutting and add ``--input-options`` (#2325 <https://github.com/ros2/rosbag2/issues/2325>)
* Add static topics feature for recorder (#2319 <https://github.com/ros2/rosbag2/issues/2319>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Add rosbag2_storage_default_plugins to exec_depend of ros2bag (#2227 <https://github.com/ros2/rosbag2/issues/2227>)
* Add ``input_serialization_format`` and ``output_serialization_format`` to ``RecordOptions``, deprecating ``rmw_serialization_format`` (#2215 <https://github.com/ros2/rosbag2/issues/2215>)
* Publish messages lost statistics to 'events/messages_lost' topic (#2150 <https://github.com/ros2/rosbag2/issues/2150>)
* Expose more of the player and recorder API to Python, and improve signal handling (#2062 <https://github.com/ros2/rosbag2/issues/2062>)
* Fix setuptools deprecations (#2087 <https://github.com/ros2/rosbag2/issues/2087>)
* Refactor Python player and recorder APIs into classes (#2047 <https://github.com/ros2/rosbag2/issues/2047>)
* Contributors: Christophe Bedard, Luke Sy, Michael Orlov, Tomoya Fujita, Tony Najjar, mosfet80
```

## rosbag2

```
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Contributors: mosfet80
```

## rosbag2_compression

```
* Add validation for empty file path in compression process (#2398 <https://github.com/ros2/rosbag2/issues/2398>)
* Fix a possible race condition in compression writer on close (#2362 <https://github.com/ros2/rosbag2/issues/2362>)
* Update Rosbag2 filename format to ``index+name+timestamp`` (#2265 <https://github.com/ros2/rosbag2/issues/2265>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Make topics persistent between writer's close() and open() API calls (#2229 <https://github.com/ros2/rosbag2/issues/2229>)
* Address recorder test flakiness by increasing cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Add message loss statistics callbacks and logging (#2039 <https://github.com/ros2/rosbag2/issues/2039>)
* Introduce new ``BaseWriteInterface`` methods ``write_messages`` and ``write_message`` to provide operation status, deprecating old write APIs (#2030 <https://github.com/ros2/rosbag2/issues/2030>)
* Contributors: Daisuke Sato, Luke Sy, Michael Orlov, mosfet80
```

## rosbag2_compression_zstd

```
* Replace ``zstd_vendor`` with ``zstd_cmake_module`` (#2166 <https://github.com/ros2/rosbag2/issues/2166>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Contributors: Alejandro Hernández Cordero, mosfet80
```

## rosbag2_cpp

```
* Implement ``transient-local topic`` repetition for Writer API and split/snapshot integration (#2386 <https://github.com/ros2/rosbag2/issues/2386>)
* Add TransientLocalMessagesCache and RecordOptions for repeating transient-local topics (#2385 <https://github.com/ros2/rosbag2/issues/2385>)
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Fix a possible race condition in compression writer on close (#2362 <https://github.com/ros2/rosbag2/issues/2362>)
* Fix incorrect serialization format in metadata (#2372 <https://github.com/ros2/rosbag2/issues/2372>)
* Update Rosbag2 filename format to ``index+name+timestamp`` (#2265 <https://github.com/ros2/rosbag2/issues/2265>)
* Support relative includes for IDL in local message definition (#2241 <https://github.com/ros2/rosbag2/issues/2241>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Workaround flaky ``bagsize_split_is_at_least_specified_size`` test (#2311 <https://github.com/ros2/rosbag2/issues/2311>)
* Incorporate upstream minor fixes from Apex.AI (#2240 <https://github.com/ros2/rosbag2/issues/2240>)
* Update deprecated ament_index_cpp API (#2268 <https://github.com/ros2/rosbag2/issues/2268>)
* Make topics persistent between writer's close() and open() API calls (#2229 <https://github.com/ros2/rosbag2/issues/2229>)
* Add nullptr check when pushing new messages to the message cache (#2219 <https://github.com/ros2/rosbag2/issues/2219>)
* Address recorder test flakiness by increasing cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>)
* Log reasoning for not found message definition only in debug log (#2183 <https://github.com/ros2/rosbag2/issues/2183>)
* Improve error handling in rosbag2_cpp with null checks and exception throwing (#2127 <https://github.com/ros2/rosbag2/issues/2127>)
* Add null pointer checks in ``Reader`` constructor and ``open()`` method (#2135 <https://github.com/ros2/rosbag2/issues/2135>)
* Use ``rclcpp typesupport helpers`` in ``rosbag2_cpp`` (#2017 <https://github.com/ros2/rosbag2/issues/2017>)
* Fix callback not called for MESSAGES_LOST event (#2105 <https://github.com/ros2/rosbag2/issues/2105>)
* Improve recorder's MessageCache performance (#2104 <https://github.com/ros2/rosbag2/issues/2104>)
* Fix reindex duration bug when bag file durations overlap (#2036 <https://github.com/ros2/rosbag2/issues/2036>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Add support for searching message definitions in nested subdirectories (#2055 <https://github.com/ros2/rosbag2/issues/2055>)
* Add message loss statistics callbacks and logging (#2039 <https://github.com/ros2/rosbag2/issues/2039>)
* Use cache to determine action interface inner types (#2052 <https://github.com/ros2/rosbag2/issues/2052>)
* Fix service/action message definition issue (#2041 <https://github.com/ros2/rosbag2/issues/2041>)
* Introduce new ``BaseWriteInterface`` methods ``write_messages`` and ``write_message`` to provide operation status, deprecating old write APIs (#2030 <https://github.com/ros2/rosbag2/issues/2030>)
* Improve message publishing timing by avoiding sporadic wakeups and fixing incorrect intervals on player start (#2025 <https://github.com/ros2/rosbag2/issues/2025>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Chui Vanfleet, Daisuke Sato, Emerson Knapp, Hunter L. Allen, José Faria, Luke Sy, Michael Orlov, Tomoya Fujita, Tony Najjar, YuJin Hong, mosfet80
```

## rosbag2_examples_cpp

```
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Update subscription callback signatures (#2225 <https://github.com/ros2/rosbag2/issues/2225>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Add examples for compressing bag files (#1956 <https://github.com/ros2/rosbag2/issues/1956>)
* Contributors: Emerson Knapp, Maxime Fleury, mini-1235, mosfet80
```

## rosbag2_examples_py

```
* Fix setuptools deprecation by removing ``tests_require`` (#2092 <https://github.com/ros2/rosbag2/issues/2092>)
* Add examples for compressing bag files (#1956 <https://github.com/ros2/rosbag2/issues/1956>)
* Contributors: Maxime Fleury, mosfet80
```

## rosbag2_interfaces

```
* Add support for time based Resume service (#2357 <https://github.com/ros2/rosbag2/issues/2357>)
* Allow pause/resume service calls while not in recording (#2349 <https://github.com/ros2/rosbag2/issues/2349>)
* Implement delayed and time-based recorder and player services, adding new bag split modes (#2330 <https://github.com/ros2/rosbag2/issues/2330>)
* Add error return code to the ~/stop service request (#2312 <https://github.com/ros2/rosbag2/issues/2312>)
* Add Record, Stop, StartDiscovery, StopDiscovery, and IsDiscoveryRunning services for Recorder (#2248 <https://github.com/ros2/rosbag2/issues/2248>)
* Publish messages lost statistics to 'events/messages_lost' topic (#2150 <https://github.com/ros2/rosbag2/issues/2150>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Contributors: Michael Orlov, carlos-apex, mosfet80
```

## rosbag2_performance_benchmarking

```
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Remove unnecessary dependencies on ``yaml_cpp_vendor`` (#2353 <https://github.com/ros2/rosbag2/issues/2353>)
* Fix warning by initializing number_of_threads (#2121 <https://github.com/ros2/rosbag2/issues/2121>)
* Enable ``rosbag2_performance_benchmarking`` package to be built by default (#2093 <https://github.com/ros2/rosbag2/issues/2093>)
* Fix performance benchmarking data generation and environment variable handling (#2078 <https://github.com/ros2/rosbag2/issues/2078>)
* Fix failure in ``benchmark_launch`` when calling ``Process.wait()`` twice (#2076 <https://github.com/ros2/rosbag2/issues/2076>)
* Fix incorrect results from ``prosbag2_performance_benchmarking`` for high-frequency topics (#2077 <https://github.com/ros2/rosbag2/issues/2077>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Contributors: Chris Lalancette, Cristóbal Arroyo, Emerson Knapp, Michael Orlov, mosfet80
```

## rosbag2_performance_benchmarking_msgs

```
* Enable ``rosbag2_performance_benchmarking`` package to be built by default (#2093 <https://github.com/ros2/rosbag2/issues/2093>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Contributors: Michael Orlov, mosfet80
```

## rosbag2_py

```
* Add ``--repeat-all-transient-local`` flag for automatic transient-local topic detection (#2391 <https://github.com/ros2/rosbag2/issues/2391>)
* Repeat transient-local topics: Recorder, CLI, and Python bindings (#2387 <https://github.com/ros2/rosbag2/issues/2387>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Move to ``build_depend`` (#2332 <https://github.com/ros2/rosbag2/issues/2332>)
* Improve ``ros2 bag convert`` performance for fragment cutting and add ``--input-options`` (#2325 <https://github.com/ros2/rosbag2/issues/2325>)
* Add static topics feature for recorder (#2319 <https://github.com/ros2/rosbag2/issues/2319>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Incorporate upstream minor fixes from Apex.AI (#2240 <https://github.com/ros2/rosbag2/issues/2240>)
* Add ``input_serialization_format`` and ``output_serialization_format`` to ``RecordOptions``, deprecating ``rmw_serialization_format`` (#2215 <https://github.com/ros2/rosbag2/issues/2215>)
* Use pybind11 from deb or pixi (#2154 <https://github.com/ros2/rosbag2/issues/2154>)
* Publish messages lost statistics to 'events/messages_lost' topic (#2150 <https://github.com/ros2/rosbag2/issues/2150>)
* Ensure test topic discovery by recorder in ``rosbag2_py`` test (#2132 <https://github.com/ros2/rosbag2/issues/2132>)
* Fix CMake list append for env vars in rosbag2_py with clang (#2116 <https://github.com/ros2/rosbag2/issues/2116>)
* Add public API for player's starting time and playback duration (#2095 <https://github.com/ros2/rosbag2/issues/2095>)
* Expose more of the player and recorder API to Python, and improve signal handling (#2062 <https://github.com/ros2/rosbag2/issues/2062>)
* Add ``send_timestamp`` to Python interface for reading serialized messages (#2061 <https://github.com/ros2/rosbag2/issues/2061>)
* Refactor Python player and recorder APIs into classes (#2047 <https://github.com/ros2/rosbag2/issues/2047>)
* Fix service/action message definition issue (#2041 <https://github.com/ros2/rosbag2/issues/2041>)
* Contributors: Alejandro Hernández Cordero, Barry Xu, Christophe Bedard, Luke Sy, Michael Carlstrom, Michael Orlov, Om Shivam Verma, Tony Najjar
```

## rosbag2_storage

```
* Add TransientLocalMessagesCache and RecordOptions for repeating transient-local topics (#2385 <https://github.com/ros2/rosbag2/issues/2385>)
* Implement delayed and time-based recorder and player services, adding new bag split modes (#2330 <https://github.com/ros2/rosbag2/issues/2330>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Improve ``ros2 bag convert`` performance for fragment cutting and add ``--input-options`` (#2325 <https://github.com/ros2/rosbag2/issues/2325>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Throw ``YAML::Exception`` during conversion if the data type mismatches (#2262 <https://github.com/ros2/rosbag2/issues/2262>)
* Fix decoder and encode mismatch in YAML deserialization (#2277 <https://github.com/ros2/rosbag2/issues/2277>)
* Incorporate upstream minor fixes from Apex.AI (#2240 <https://github.com/ros2/rosbag2/issues/2240>)
* Fix memory leak on ``make_empty_serialized_message()`` (#2253 <https://github.com/ros2/rosbag2/issues/2253>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Introduce new ``BaseWriteInterface`` methods ``write_messages`` and ``write_message`` to provide operation status, deprecating old write APIs (#2030 <https://github.com/ros2/rosbag2/issues/2030>)
* Fix undefined behavior in the ``rosbag2_storage`` and ``rosbag2_storage_sqlite3`` packages (#1997 <https://github.com/ros2/rosbag2/issues/1997>)
* Contributors: Luke Sy, Michael Orlov, Tomoya Fujita, Tony Najjar, carlos-apex, mosfet80
```

## rosbag2_storage_default_plugins

```
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Contributors: mosfet80
```

## rosbag2_storage_mcap

```
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Remove unnecessary dependencies on ``yaml_cpp_vendor`` (#2353 <https://github.com/ros2/rosbag2/issues/2353>)
* Fix MCAPStorage::seek(time) to advance when timestamp matches current time (#2157 <https://github.com/ros2/rosbag2/issues/2157>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Introduce new ``BaseWriteInterface`` methods ``write_messages`` and ``write_message`` to provide operation status, deprecating old write APIs (#2030 <https://github.com/ros2/rosbag2/issues/2030>)
* Update ``index.ros.org/p/`` links for ``rosbag2_storage_mcap`` (#2034 <https://github.com/ros2/rosbag2/issues/2034>)
* Contributors: Chris Lalancette, Christophe Bedard, Emerson Knapp, Michael Orlov, mosfet80
```

## rosbag2_storage_sqlite3

```
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Fix vulnerable string concatenation by using parameterized queries (#2290 <https://github.com/ros2/rosbag2/issues/2290>)
* Remove sqlite3_vendor (#2164 <https://github.com/ros2/rosbag2/issues/2164>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Introduce new ``BaseWriteInterface`` methods ``write_messages`` and ``write_message`` to provide operation status, deprecating old write APIs (#2030 <https://github.com/ros2/rosbag2/issues/2030>)
* Fix undefined behavior in the ``rosbag2_storage`` and ``rosbag2_storage_sqlite3`` packages (#1997 <https://github.com/ros2/rosbag2/issues/1997>)
* Contributors: Alejandro Hernández Cordero, Emerson Knapp, Luke Sy, Michael Orlov, Tomoya Fujita, mosfet80
```

## rosbag2_test_common

```
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Update Rosbag2 filename format to ``index+name+timestamp`` (#2265 <https://github.com/ros2/rosbag2/issues/2265>)
* Update subscription callback signatures (#2225 <https://github.com/ros2/rosbag2/issues/2225>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Address test flakiness by waiting for executor spin (#2001 <https://github.com/ros2/rosbag2/issues/2001>)
* Contributors: Daisuke Sato, Emerson Knapp, Michael Orlov, mini-1235, mosfet80
```

## rosbag2_test_msgdefs

```
* Support relative includes for IDL in local message definition (#2241 <https://github.com/ros2/rosbag2/issues/2241>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Add support for searching message definitions in nested subdirectories (#2055 <https://github.com/ros2/rosbag2/issues/2055>)
* Contributors: Hunter L. Allen, Michael Orlov, mosfet80
```

## rosbag2_tests

```
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Update Rosbag2 filename format to ``index+name+timestamp`` (#2265 <https://github.com/ros2/rosbag2/issues/2265>)
* Add static topics feature for recorder (#2319 <https://github.com/ros2/rosbag2/issues/2319>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Workaround flaky ``bagsize_split_is_at_least_specified_size`` test (#2311 <https://github.com/ros2/rosbag2/issues/2311>)
* Add ``input_serialization_format`` and ``output_serialization_format`` to ``RecordOptions``, deprecating ``rmw_serialization_format`` (#2215 <https://github.com/ros2/rosbag2/issues/2215>)
* Address recorder test flakiness by increasing cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>)
* Use ``rclcpp typesupport helpers`` in ``rosbag2_cpp`` (#2017 <https://github.com/ros2/rosbag2/issues/2017>)
* Expose more of the player and recorder API to Python, and improve signal handling (#2062 <https://github.com/ros2/rosbag2/issues/2062>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Fix deadlocks in Rosbag2 player when calling stop API (#2057 <https://github.com/ros2/rosbag2/issues/2057>)
* Introduce new ``BaseWriteInterface`` methods ``write_messages`` and ``write_message`` to provide operation status, deprecating old write APIs (#2030 <https://github.com/ros2/rosbag2/issues/2030>)
* Address test flakiness by waiting for executor spin (#2001 <https://github.com/ros2/rosbag2/issues/2001>)
* Contributors: Christophe Bedard, Daisuke Sato, Emerson Knapp, Michael Orlov, mosfet80
```

## rosbag2_transport

```
* Refactor transient-local topic detection and logging in RecorderImpl (#2395 <https://github.com/ros2/rosbag2/issues/2395>)
* Fix race condition in ``RecordSrvsSimTimeTest`` by waiting for clock subscriber (#2396 <https://github.com/ros2/rosbag2/issues/2396>)
* Add ``--repeat-all-transient-local`` flag for automatic transient-local topic detection (#2391 <https://github.com/ros2/rosbag2/issues/2391>)
* Repeat transient-local topics: Recorder, CLI, and Python bindings (#2387 <https://github.com/ros2/rosbag2/issues/2387>)
* Implement ``transient-local topic`` repetition for Writer API and split/snapshot integration (#2386 <https://github.com/ros2/rosbag2/issues/2386>)
* Add TransientLocalMessagesCache and RecordOptions for repeating transient-local topics (#2385 <https://github.com/ros2/rosbag2/issues/2385>)
* Use new ROSIDL aggregate CMake target (#2384 <https://github.com/ros2/rosbag2/issues/2384>)
* Address flakiness in the ``rosbag2_transport::test_record_services`` tests (#2368 <https://github.com/ros2/rosbag2/issues/2368>)
* Add support for time based Resume service (#2357 <https://github.com/ros2/rosbag2/issues/2357>)
* Address race condition in the ``wait_for_playback_to_start()`` function (#2344 <https://github.com/ros2/rosbag2/issues/2344>)
* Add ``set_on_start_recording_callback()`` to set the callback for when recording starts (#2340 <https://github.com/ros2/rosbag2/issues/2340>)
* Remove unnecessary dependencies on ``yaml_cpp_vendor`` (#2353 <https://github.com/ros2/rosbag2/issues/2353>)
* Allow pause/resume service calls while not in recording (#2349 <https://github.com/ros2/rosbag2/issues/2349>)
* Implement delayed and time-based recorder and player services, adding new bag split modes (#2330 <https://github.com/ros2/rosbag2/issues/2330>)
* Update Rosbag2 filename format to ``index+name+timestamp`` (#2265 <https://github.com/ros2/rosbag2/issues/2265>)
* Address a possible deadlock in ``seek(timestamp)`` (#2345 <https://github.com/ros2/rosbag2/issues/2345>)
* Add missing fields to ``RecordOptions`` YAML encode/decode functions and include a compile-time safeguard (#2334 <https://github.com/ros2/rosbag2/issues/2334>)
* Implement circular logging by split count (--max-bag-files) (#2218 <https://github.com/ros2/rosbag2/issues/2218>)
* Improve ``ros2 bag convert`` performance for fragment cutting and add ``--input-options`` (#2325 <https://github.com/ros2/rosbag2/issues/2325>)
* Add static topics feature for recorder (#2319 <https://github.com/ros2/rosbag2/issues/2319>)
* Add --max-cache-duration option for time-bounded snapshots (#2289 <https://github.com/ros2/rosbag2/issues/2289>)
* Fix the flaky ``can_record_again_after_stop`` test (#2313 <https://github.com/ros2/rosbag2/issues/2313>)
* Add error return code to the ~/stop service request (#2312 <https://github.com/ros2/rosbag2/issues/2312>)
* Add Record, Stop, StartDiscovery, StopDiscovery, and IsDiscoveryRunning services for Recorder (#2248 <https://github.com/ros2/rosbag2/issues/2248>)
* Use QoS override settings for inner Rosbag2 publishing topics (#2286 <https://github.com/ros2/rosbag2/issues/2286>)
* Fix decoder and encode mismatch in YAML deserialization (#2277 <https://github.com/ros2/rosbag2/issues/2277>)
* Incorporate upstream minor fixes from Apex.AI (#2240 <https://github.com/ros2/rosbag2/issues/2240>)
* Fix macOS build: Disable thread-safety annotations in ``locked_priority_queue.hpp`` (#2245 <https://github.com/ros2/rosbag2/issues/2245>)
* Fix C++ Recorder failure when stop() then record() are called with the same bag name (#2224 <https://github.com/ros2/rosbag2/issues/2224>)
* Add a direct API for ``rosbag2_transport::Recorder`` (#2221 <https://github.com/ros2/rosbag2/issues/2221>)
* Add ``input_serialization_format`` and ``output_serialization_format`` to ``RecordOptions``, deprecating ``rmw_serialization_format`` (#2215 <https://github.com/ros2/rosbag2/issues/2215>)
* Enable RMW communication isolation in rosbag2_transport tests (#2190 <https://github.com/ros2/rosbag2/issues/2190>)
* Add topic name and type delimiter for hash map keys to avoid collisions (#2210 <https://github.com/ros2/rosbag2/issues/2210>)
* Add cache for ``TopicFilter`` to avoid performance burden on discovery (#1486 <https://github.com/ros2/rosbag2/issues/1486>)
* Address recorder test flakiness by increasing cache size (#2203 <https://github.com/ros2/rosbag2/issues/2203>)
* Reduce CPU overhead in Rosbag2 recorder discovery by improving discovery logic (#2201 <https://github.com/ros2/rosbag2/issues/2201>)
* Fix data races in ``PlayerProgressBar`` using atomic variables (#2194 <https://github.com/ros2/rosbag2/issues/2194>)
* Fix data races in tests with ``MockSequentialWriter`` (#2192 <https://github.com/ros2/rosbag2/issues/2192>)
* Player now respects original message order for same timestamps (#2172 <https://github.com/ros2/rosbag2/issues/2172>)
* Return player storage options by value in ``get_storage_options()`` to avoid dangling reference (#2181 <https://github.com/ros2/rosbag2/issues/2181>)
* Fix player not playing when ``read_ahead_queue_size`` equals 1 (#2174 <https://github.com/ros2/rosbag2/issues/2174>)
* Fix multiple race conditions and a deadlock in the player (#2171 <https://github.com/ros2/rosbag2/issues/2171>)
* Fix multibag replay stagnation and improve playback performance by managing chronological message order with ``ReadersManager`` (#2158 <https://github.com/ros2/rosbag2/issues/2158>)
* Fix MCAPStorage::seek(time) to advance when timestamp matches current time (#2157 <https://github.com/ros2/rosbag2/issues/2157>)
* Publish messages lost statistics to 'events/messages_lost' topic (#2150 <https://github.com/ros2/rosbag2/issues/2150>)
* Add ``RecorderEventNotifier`` class (#2144 <https://github.com/ros2/rosbag2/issues/2144>)
* Resolve deadlock during multibag replay and update ``wait_for_playback_to_start`` (#2143 <https://github.com/ros2/rosbag2/issues/2143>)
* Use ``rclcpp typesupport helpers`` in ``rosbag2_cpp`` (#2017 <https://github.com/ros2/rosbag2/issues/2017>)
* Fix callback not called for MESSAGES_LOST event (#2105 <https://github.com/ros2/rosbag2/issues/2105>)
* Add public API for player's starting time and playback duration (#2095 <https://github.com/ros2/rosbag2/issues/2095>)
* Fix CMAKE deprecation (#2067 <https://github.com/ros2/rosbag2/issues/2067>)
* Fix deadlocks in Rosbag2 player when calling stop API (#2057 <https://github.com/ros2/rosbag2/issues/2057>)
* Add message loss statistics callbacks and logging (#2039 <https://github.com/ros2/rosbag2/issues/2039>)
* Skip flaky can_record_again_after_stop test (#2031 <https://github.com/ros2/rosbag2/issues/2031>)
* Fix ``cout`` output when progress bar is disabled (#2024 <https://github.com/ros2/rosbag2/issues/2024>)
* Improve message publishing timing by avoiding sporadic wakeups and fixing incorrect intervals on player start (#2025 <https://github.com/ros2/rosbag2/issues/2025>)
* Fix ``playing_respects_delay`` test flakiness (#2016 <https://github.com/ros2/rosbag2/issues/2016>)
* Address test flakiness by waiting for executor spin (#2001 <https://github.com/ros2/rosbag2/issues/2001>)
* Avoid sending non-existent cancel requests (#2005 <https://github.com/ros2/rosbag2/issues/2005>)
* Contributors: Barry Xu, Chris Lalancette, Daisuke Sato, Dhruv Patel, Emerson Knapp, Luke Sy, Michael Orlov, Scott K Logan, Shane Loretz, Tomoya Fujita, Tony Najjar, baranbologur, carlos-apex, mosfet80
```
