### PR TITLE
urdfdom_headers: 2.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10527,7 +10527,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `2.1.1-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.0-1`

## urdfdom_headers

```
* Clean up declaration of ModelInterface's SharedPtrs (#99 <https://github.com/ros/urdfdom_headers/issues/99>)
* Revert cleanup of ModelInterface's SharedPtrs (#33 <https://github.com/ros/urdfdom_headers/issues/33>)
* Revert fix for assumption that CMAKE_INSTALL_*DIR paths are relative (#90 <https://github.com/ros/urdfdom_headers/issues/90>) (#97 <https://github.com/ros/urdfdom_headers/issues/97>)
* Clean up declaration of ModelInterface's SharedPtrs (#33 <https://github.com/ros/urdfdom_headers/issues/33>)
* Fix assumption that CMAKE_INSTALL_*DIR paths are relative (#90 <https://github.com/ros/urdfdom_headers/issues/90>)
* Extend ``JointLimits`` class to include acceleration, deceleration and jerk limits (#83 <https://github.com/ros/urdfdom_headers/issues/83>)
* Contributors: Alejandro Hernández Cordero, Michal Sojka, Robert Haschke, Sai Kishor Kothakota
```
