### PR TITLE
urdfdom: 5.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10511,7 +10511,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 5.1.0-1
+      version: 5.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `5.1.1-1`:

- upstream repository: https://github.com/ros/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.0-1`

## urdfdom

```
* Prevent CI from failing fast to allow all builds to complete (#254 <https://github.com/ros/urdfdom/issues/254>)
* Remove ``urdf_world/types.h`` deprecation (#251 <https://github.com/ros/urdfdom/issues/251>)
* Extend parsing of acceleration, deceleration and jerk limits from ``limit`` tag (#212 <https://github.com/ros/urdfdom/issues/212>)
* ROS 2 CI: build urdfdom_headers from source (#246 <https://github.com/ros/urdfdom/issues/246>)
* Disable system workflow because ``urdfdom_headers`` isn't available on Ubuntu 24.04 (#240 <https://github.com/ros/urdfdom/issues/240>)
* Fix ROS 2 CI workflow by updating Ubuntu version and checkout action (#239 <https://github.com/ros/urdfdom/issues/239>)
* Contributors: Alejandro Hernández Cordero, Sai Kishor Kothakota, Steve Peters
```
