### PR TITLE
register ros2_eventdispatch source repo to humble/kilted/rolling distros

### DIFF
--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2659,6 +2659,12 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: dashing
     status: developed
+  ros2_eventdispatch:
+    source:
+      type: git
+      url: https://github.com/cyan-at/ros2_eventdispatch.git
+      version: main
+    status: developed
   ros2_intel_realsense:
     doc:
       type: git

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -2659,12 +2659,6 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: dashing
     status: developed
-  ros2_eventdispatch:
-    source:
-      type: git
-      url: https://github.com/cyan-at/ros2_eventdispatch.git
-      version: main
-    status: developed
   ros2_intel_realsense:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9777,6 +9777,12 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: humble
     status: developed
+  ros2_eventdispatch:
+    source:
+      type: git
+      url: https://github.com/cyan-at/ros2_eventdispatch.git
+      version: main
+    status: developed
   ros2_fmt_logger:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7682,6 +7682,12 @@ repositories:
       url: https://github.com/felixdivo/ros2-easy-test.git
       version: main
     status: developed
+  ros2_eventdispatch:
+    source:
+      type: git
+      url: https://github.com/cyan-at/ros2_eventdispatch.git
+      version: main
+    status: developed
   ros2_fmt_logger:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7678,6 +7678,12 @@ repositories:
       url: https://github.com/felixdivo/ros2-easy-test.git
       version: main
     status: developed
+  ros2_eventdispatch:
+    source:
+      type: git
+      url: https://github.com/cyan-at/ros2_eventdispatch.git
+      version: main
+    status: developed
   ros2_fmt_logger:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

HUMBLE / DASHING / KILTED / ROLLING

# The source is here:

https://github.com/cyan-at/ros2_eventdispatch

# Checks
 - [ X ] All packages have a declared license in the package.xml
 - [ X ] This repository has a LICENSE file
 - [ X ] This package is expected to build on the submitted rosdistro
