### PR TITLE
gz_ros2_control: 3.0.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3033,7 +3033,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 3.0.6-1
+      version: 3.0.7-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `3.0.7-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.6-1`

## gz_ros2_control

```
* Fix race condition in RM initialization (restore 2000 ms wait) (#809 <https://github.com/ros-controls/gz_ros2_control/issues/809>)
* Precompute interface names (#789 <https://github.com/ros-controls/gz_ros2_control/issues/789>)
* Minor improvements (#800 <https://github.com/ros-controls/gz_ros2_control/issues/800>)
* Removed dead code (#791 <https://github.com/ros-controls/gz_ros2_control/issues/791>)
* Fix return on_activate and on_deactivate (#790 <https://github.com/ros-controls/gz_ros2_control/issues/790>)
* Removed unnecesary defines and removed ndof attribute (#788 <https://github.com/ros-controls/gz_ros2_control/issues/788>)
* Only set_value if the interface is valid (#771 <https://github.com/ros-controls/gz_ros2_control/issues/771>)
* Migrate to the new Handles API with variants in the Hardware Components (#763 <https://github.com/ros-controls/gz_ros2_control/issues/763>)
* Contributors: Alejandro Hernández Cordero, José Luis Pérez Martín, Sai Kishor Kothakota
```

## gz_ros2_control_demos

```
* Add missing tests for pendulum and gripper (position and effort) (#814 <https://github.com/ros-controls/gz_ros2_control/issues/814>)
* Add initial_value checks to state interface tests  (#765 <https://github.com/ros-controls/gz_ros2_control/issues/765>)
* Migrate to the new Handles API with variants in the Hardware Components (#763 <https://github.com/ros-controls/gz_ros2_control/issues/763>)
* Contributors: José Luis Pérez Martín, Sai Kishor Kothakota
```
