### PR TITLE
gz_ros2_control: 2.0.15-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3112,7 +3112,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.14-1
+      version: 2.0.15-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.15-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.0.14-1`

## gz_ros2_control

```
* Fix race condition in RM initialization (restore 2000 ms wait) (#809 <https://github.com/ros-controls/gz_ros2_control/issues/809>) (#810 <https://github.com/ros-controls/gz_ros2_control/issues/810>)
* Precompute interface names (backport #789 <https://github.com/ros-controls/gz_ros2_control/issues/789>) (#805 <https://github.com/ros-controls/gz_ros2_control/issues/805>)
* Minor improvements (backport #800 <https://github.com/ros-controls/gz_ros2_control/issues/800>) (#802 <https://github.com/ros-controls/gz_ros2_control/issues/802>)
* Removed dead code (#791 <https://github.com/ros-controls/gz_ros2_control/issues/791>) (#797 <https://github.com/ros-controls/gz_ros2_control/issues/797>)
* Removed unnecesary defines and removed ndof attribute (#788 <https://github.com/ros-controls/gz_ros2_control/issues/788>) (#796 <https://github.com/ros-controls/gz_ros2_control/issues/796>)
* Fix return on_activate and on_deactivate (#790 <https://github.com/ros-controls/gz_ros2_control/issues/790>) (#794 <https://github.com/ros-controls/gz_ros2_control/issues/794>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Comment out initial_value in test_pendulum_effort.xacro.urdf (#832 <https://github.com/ros-controls/gz_ros2_control/issues/832>) (#834 <https://github.com/ros-controls/gz_ros2_control/issues/834>)
* Add initial_value checks to state interface tests (backport #765 <https://github.com/ros-controls/gz_ros2_control/issues/765>) (#830 <https://github.com/ros-controls/gz_ros2_control/issues/830>)
* Add a custom plugin for simulating actuator dynamics to the demos (#693 <https://github.com/ros-controls/gz_ros2_control/issues/693>) (#778 <https://github.com/ros-controls/gz_ros2_control/issues/778>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```
