### PR TITLE
gz_ros2_control: 1.2.18-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3831,7 +3831,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.17-1
+      version: 1.2.18-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.18-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.2.17-1`

## gz_ros2_control

```
* Fix race condition in RM initialization (restore 2000 ms wait) (#809 <https://github.com/ros-controls/gz_ros2_control/issues/809>) (#811 <https://github.com/ros-controls/gz_ros2_control/issues/811>)
* Precompute interface names (backport #789 <https://github.com/ros-controls/gz_ros2_control/issues/789>) (#806 <https://github.com/ros-controls/gz_ros2_control/issues/806>)
* Minor improvements (backport #800 <https://github.com/ros-controls/gz_ros2_control/issues/800>) (#803 <https://github.com/ros-controls/gz_ros2_control/issues/803>)
* Removed dead code (#791 <https://github.com/ros-controls/gz_ros2_control/issues/791>) (#798 <https://github.com/ros-controls/gz_ros2_control/issues/798>)
* Removed unnecesary defines and removed ndof attribute (#788 <https://github.com/ros-controls/gz_ros2_control/issues/788>) (#795 <https://github.com/ros-controls/gz_ros2_control/issues/795>)
* Fix return on_activate and on_deactivate (#790 <https://github.com/ros-controls/gz_ros2_control/issues/790>) (#793 <https://github.com/ros-controls/gz_ros2_control/issues/793>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Comment out initial_value in test_pendulum_effort.xacro.urdf (#832 <https://github.com/ros-controls/gz_ros2_control/issues/832>)
* Add initial_value checks to state interface tests (backport #765 <https://github.com/ros-controls/gz_ros2_control/issues/765>) (#781 <https://github.com/ros-controls/gz_ros2_control/issues/781>)
* Add a custom plugin for simulating actuator dynamics to the demos (#693 <https://github.com/ros-controls/gz_ros2_control/issues/693>) (#779 <https://github.com/ros-controls/gz_ros2_control/issues/779>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```
