### PR TITLE
ign_ros2_control: 0.7.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4239,7 +4239,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.18-1
+      version: 0.7.19-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.19-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.18-1`

## gz_ros2_control

```
* Precompute interface names (backport #789 <https://github.com/ros-controls/gz_ros2_control/issues/789>) (#807 <https://github.com/ros-controls/gz_ros2_control/issues/807>)
* Minor improvements (backport #800 <https://github.com/ros-controls/gz_ros2_control/issues/800>) (#804 <https://github.com/ros-controls/gz_ros2_control/issues/804>)
* Removed dead code (#791 <https://github.com/ros-controls/gz_ros2_control/issues/791>) (#799 <https://github.com/ros-controls/gz_ros2_control/issues/799>)
* Fix return on_activate and on_deactivate (#790 <https://github.com/ros-controls/gz_ros2_control/issues/790>) (#792 <https://github.com/ros-controls/gz_ros2_control/issues/792>)
* Contributors: mergify[bot]
```

## gz_ros2_control_demos

```
* Comment out initial_value in test_pendulum_effort.xacro.urdf (#832 <https://github.com/ros-controls/gz_ros2_control/issues/832>) (#835 <https://github.com/ros-controls/gz_ros2_control/issues/835>)
* Add initial_value checks to state interface tests (backport #765 <https://github.com/ros-controls/gz_ros2_control/issues/765> to Humble) (#822 <https://github.com/ros-controls/gz_ros2_control/issues/822>)
* Add a custom plugin for simulating actuator dynamics to the demos (backport #693 <https://github.com/ros-controls/gz_ros2_control/issues/693>) (#780 <https://github.com/ros-controls/gz_ros2_control/issues/780>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```

## gz_ros2_control_tests

```
* Add initial_value checks to state interface tests (backport #765 <https://github.com/ros-controls/gz_ros2_control/issues/765> to Humble) (#822 <https://github.com/ros-controls/gz_ros2_control/issues/822>)
* Add a custom plugin for simulating actuator dynamics to the demos (backport #693 <https://github.com/ros-controls/gz_ros2_control/issues/693>) (#780 <https://github.com/ros-controls/gz_ros2_control/issues/780>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```

## ign_ros2_control

- No changes

## ign_ros2_control_demos

- No changes
