### PR TITLE
rviz: 15.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9023,12 +9023,11 @@ repositories:
       - rviz_ogre_vendor
       - rviz_rendering
       - rviz_rendering_tests
-      - rviz_resource_interfaces
       - rviz_visual_testing_framework
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.1.19-1
+      version: 15.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.0-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `15.1.19-1`

## rviz2

- No changes

## rviz_common

```
* Removed Qt6 warnings (#1704 <https://github.com/ros2/rviz/issues/1704>)
* Fixed regresion is RHEL (#1703 <https://github.com/ros2/rviz/issues/1703>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_default_plugins

```
* Removed Qt6 warnings (#1704 <https://github.com/ros2/rviz/issues/1704>)
* Contributors: Alejandro Hernández Cordero
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
