### PR TITLE
resource_retriever_service: 0.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6975,6 +6975,26 @@ repositories:
       url: https://github.com/ros/resource_retriever.git
       version: rolling
     status: maintained
+  resource_retriever_service:
+    doc:
+      type: git
+      url: https://github.com/ros2/resource_retriever_service.git
+      version: rolling
+    release:
+      packages:
+      - resource_retriever_interfaces
+      - resource_retriever_service
+      - resource_retriever_service_plugin
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/resource_retriever_service-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/resource_retriever_service.git
+      version: rolling
+    status: maintained
   rig_reconfigure:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever_service` to `0.0.1-1`:

- upstream repository: https://github.com/ros2/resource_retriever_service
- release repository: https://github.com/ros2-gbp/resource_retriever_service-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## resource_retriever_interfaces

```
* Initial release of resource_retriever_interfaces package.
```

## resource_retriever_service

```
* Initial release of resource_retriever_service package.
```

## resource_retriever_service_plugin

```
* Initial release of resource_retriever_service_plugin package.
```
