### PR TITLE
Add mrpt3 for indexing (source/doc) in Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6147,6 +6147,16 @@ repositories:
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
       version: main
     status: maintained
+  mrpt3:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    status: developed
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/MRPT/mrpt

**NOTE:** This new source package is now pointing to the 3.x development branch of MRPT, now intended to be built directly by colcon and the one having the package.xml files, etc. 

**Transition:** After making binary releases of this new package, we'll update all mrpt-dependent packages to rely on this new packages and `mrpt_ros` will become EOL and obsolete.

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
