### PR TITLE
ublox_dgnss: 0.7.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10274,7 +10274,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.7.4-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.7.3-1`

## ntrip_client_node

- No changes

## ublox_dgnss

- No changes

## ublox_dgnss_node

```
* Merge pull request #62 <https://github.com/aussierobots/ublox_dgnss/issues/62> from gakutasu/fix/init-attach
  Fix USB hotplug attach skip on startup by initializing attached_
* fix init
* Contributors: Nick Hortovanyi, gakutasu
```

## ublox_nav_sat_fix_hp_node

- No changes

## ublox_ubx_interfaces

- No changes

## ublox_ubx_msgs

- No changes
