### PR TITLE
Add NixOS key for python3-qt-bindings

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9591,6 +9591,7 @@ python3-qt-bindings:
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
+  nixos: [python-qt-bindings-deps]
   rhel:
     '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-Builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9592,6 +9592,7 @@ python3-qt-bindings:
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-builder]
+  nixos: [python-qt-bindings-deps]
   rhel:
     '*': [python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]


### PR DESCRIPTION
This is meant to be used in relation with https://github.com/lopsided98/nix-ros-overlay/pull/833.

Unlike in other distros, on NixOS, we depend on just one "meta package", which will then inject the required dependencies (Qt5 or Qt6) depending on the compilation context. This is explained more in the referenced PR, and the short summary is that on NixOS, we don't use different versions of the underlying distribution so we cannot determine the Qt version based on that.
