### PR TITLE
Add Mesh Tools to humble and jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5546,6 +5546,12 @@ repositories:
       url: https://github.com/open-rmf/menge_vendor.git
       version: humble
     status: developed
+  mesh_tools:
+    source:
+      type: git
+      url: https://github.com/naturerobots/mesh_tools.git
+      version: main
+    status: developed
   message_filters:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5336,6 +5336,12 @@ repositories:
       url: https://github.com/open-rmf/menge_vendor.git
       version: jazzy
     status: developed
+  mesh_tools:
+    source:
+      type: git
+      url: https://github.com/naturerobots/mesh_tools.git
+      version: main
+    status: developed
   message_filters:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

* humble
* jazzy

# The source is here:

https://github.com/naturerobots/mesh_tools

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
