### PR TITLE
bag2_to_image: 0.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -910,7 +910,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/bag2_to_image-release.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       type: git
       url: https://github.com/wep21/bag2_to_image.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bag2_to_image` to `0.1.2-1`:

- upstream repository: https://github.com/wep21/bag2_to_image.git
- release repository: https://github.com/ros2-gbp/bag2_to_image-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.1-1`

## bag2_to_image

```
* build(deps): Bump actions/upload-artifact from 4 to 7 (#7 <https://github.com/wep21/bag2_to_image/issues/7>)
* fix: modify compile error caused by rosidl_buffer introduction (#8 <https://github.com/wep21/bag2_to_image/issues/8>)
* Contributors: Michal Sojka, dependabot[bot]
```
