### PR TITLE
ros_babel_fish: 4.26.41-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7923,10 +7923,11 @@ repositories:
       packages:
       - ros_babel_fish
       - ros_babel_fish_test_msgs
+      - ros_babel_fish_tools
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 4.26.40-1
+      version: 4.26.41-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `4.26.41-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.26.40-1`

## ros_babel_fish

```
* Reduce array size to prevent compile errors on MSVC.
* Added conversion to YAML, JSON and an echo node as example. (#16 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/16>)
  * Added conversion to YAML, JSON and an echo node as example.
* Add a deserialize method to Subscription (#19 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/19>)
  * Add a deserialize method to Subscription to enable users to use a SerializedMessage and deserialize later.
  * Catch exceptions when deserializing.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes

## ros_babel_fish_tools

```
* Added conversion to YAML, JSON and an echo node as example. (#16 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/16>)
  * Added conversion to YAML, JSON and an echo node as example.
* Contributors: Stefan Fabian
```
