### PR TITLE
ros2_control: 6.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7632,7 +7632,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.5.1-1
+      version: 6.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.5.1-1`

## controller_interface

```
* Add test_utils file for transition tests (#3048 <https://github.com/ros-controls/ros2_control/issues/3048>)
* Contributors: Christoph Fröhlich
```

## controller_manager

```
* [CM] Migrate controllers_lock_ to RT-safe PI recursive mutex (#3197 <https://github.com/ros-controls/ros2_control/issues/3197>)
* Contributors: Shlok Mehndiratta
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* lexical_casts: use gMock instead of gTest (#3204 <https://github.com/ros-controls/ros2_control/issues/3204>)
* Contributors: Christoph Fröhlich
```

## hardware_interface_testing

```
* Fix RCLCPP_VERSION_GTE for add_node (#3198 <https://github.com/ros-controls/ros2_control/issues/3198>)
* Contributors: Christoph Fröhlich
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add 6D robot description to ros2_control_test_assets (#3032 <https://github.com/ros-controls/ros2_control/issues/3032>)
* Unify transmission tests using shared minimal robot URDF in test assets (#3031 <https://github.com/ros-controls/ros2_control/issues/3031>)
* Contributors: Naitik
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Unify transmission tests using shared minimal robot URDF in test assets (#3031 <https://github.com/ros-controls/ros2_control/issues/3031>)
* Contributors: Naitik
```
