### PR TITLE
ros2_control: 4.45.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9036,7 +9036,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.44.0-1
+      version: 4.45.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.45.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.44.0-1`

## controller_interface

```
* Add test_utils file for transition tests (backport #3048 <https://github.com/ros-controls/ros2_control/issues/3048>) (#3216 <https://github.com/ros-controls/ros2_control/issues/3216>)
* Contributors: mergify[bot]
```

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* lexical_casts: use gMock instead of gTest (#3204 <https://github.com/ros-controls/ros2_control/issues/3204>) (#3205 <https://github.com/ros-controls/ros2_control/issues/3205>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix RCLCPP_VERSION_GTE for add_node (backport #3198 <https://github.com/ros-controls/ros2_control/issues/3198>) (#3200 <https://github.com/ros-controls/ros2_control/issues/3200>)
* Fix API breaking change of Executor::add_node (backport #3080 <https://github.com/ros-controls/ros2_control/issues/3080>) (#3190 <https://github.com/ros-controls/ros2_control/issues/3190>)
* Contributors: mergify[bot]
```

## joint_limits

- No changes

## ros2_control

- No changes

## ros2_control_test_assets

```
* Unify transmission tests using shared minimal robot URDF in test assets (backport #3031 <https://github.com/ros-controls/ros2_control/issues/3031>) (#3217 <https://github.com/ros-controls/ros2_control/issues/3217>)
* Add 6D robot description to ros2_control_test_assets (backport #3032 <https://github.com/ros-controls/ros2_control/issues/3032>) (#3226 <https://github.com/ros-controls/ros2_control/issues/3226>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

```
* Unify transmission tests using shared minimal robot URDF in test assets (backport #3031 <https://github.com/ros-controls/ros2_control/issues/3031>) (#3217 <https://github.com/ros-controls/ros2_control/issues/3217>)
* Contributors: mergify[bot]
```
