### PR TITLE
qml6_ros2_plugin: 2.26.40-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6449,7 +6449,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 2.26.31-1
+      version: 2.26.40-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `2.26.40-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.26.31-1`

## qml6_ros2_plugin

```
* Added bandwidth and frequency to Subscription. (#50 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/50>)
  * Added bandwidth and frequency to Subscription. Refactored logic for computation affecting TfBuffer as well.
* Ensure tf transform is always updated when target or source frame changes.
* Added TfBuffer element with namespaced tf support (#42 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/42>)
  * Added TfBuffer to be able to get transforms from namespaced tf and additional information such as frame info.
* Improved robustness of image transport property change handling. (#38 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/38>)
  * Improved robustness of image transport property change handling.
  Properly reset old properties when topic or transport is changed.
  * Fix no image timer not being started if subscription was reset.
* Switch to ros2 testing sources for CI to get newest packages.
* Small documentation fixes.
* Contributors: Stefan Fabian
```
