### PR TITLE
ros_babel_fish: 2.26.40-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9408,10 +9408,11 @@ repositories:
       packages:
       - ros_babel_fish
       - ros_babel_fish_test_msgs
+      - ros_babel_fish_tools
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 2.25.111-1
+      version: 2.26.40-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `2.26.40-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.25.111-1`

## ros_babel_fish

```
* [Backport jazzy] Added conversion to YAML, JSON and an echo node as example. (#17 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/17>)
  * Changes from #16 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/16>.
  * Changes for jazzy compatibility.
* Add a deserialize method to Subscription (#19 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/19>)
  * Add a deserialize method to Subscription to enable users to use a SerializedMessage and deserialize later.
  * Catch exceptions when deserializing.
* Fix MSVC build error: std::array size exceeds 32-bit limit (#14 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/14>)
  * Fix MSVC build error: reduce std::array placeholder size to comply with 32-bit limit
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

```
* [Backport jazzy] Added conversion to YAML, JSON and an echo node as example. (#17 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/17>)
  * Changes from #16 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/16>.
  * Changes for jazzy compatibility.
* Contributors: Stefan Fabian
```

## ros_babel_fish_tools

```
* [Backport jazzy] Added conversion to YAML, JSON and an echo node as example. (#17 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/17>)
  * Changes from #16 <https://github.com/LOEWE-emergenCITY/ros_babel_fish/issues/16>.
  * Changes for jazzy compatibility.
* Contributors: Stefan Fabian
```
