### PR TITLE
gstreamer_ros_babel_fish: 1.26.40-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2878,6 +2878,17 @@ repositories:
       url: https://github.com/ros-drivers/gscam.git
       version: ros2
     status: developed
+  gstreamer_ros_babel_fish:
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/gstreamer_ros_babel_fish-release.git
+      version: 1.26.40-1
+    source:
+      type: git
+      url: https://github.com/StefanFabian/gstreamer_ros_babel_fish.git
+      version: main
+    status: developed
   gtsam:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gstreamer_ros_babel_fish` to `1.26.40-1`:

- upstream repository: https://github.com/StefanFabian/gstreamer_ros_babel_fish
- release repository: https://github.com/ros2-gbp/gstreamer_ros_babel_fish-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## gstreamer_ros_babel_fish

```
* Use framerate in caps if known.
* Round in framerate determination and improve PTS robustness.
  This avoids exotic framerates that are incompatible with most pipeline elements.
  Previously the pts was starting at 0 from the first pushed frame but when determining, we drop a few frames and when we continue, the running time of the pipeline may already >100ms and the buffers are dropped due to lateness if sync is true on the sink. Now the ROS <-> gstreamer offset is computed to the running time.
* Register plugin path as gstreamer plugin subdirectory instead of lib dir.
* Added enable-nv-formats property to sink which defaults to false as cv bridge can not handle those formats.
* Initial release.
* Contributors: Stefan Fabian
```
