### PR TITLE
ur_client_library: 2.10.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13043,7 +13043,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.10.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.9.0-1`

## ur_client_library

```
* [primary] Add new fields to ConfigurationData object (#485 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/485>)
* Fix traj point time precision (#482 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/482>)
* Add parsing of safety mode messages to the primary interface (#480 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/480>)
* Capitalize constexpr variables in direct torque example (#481 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/481>)
* tool_communication.py: Add error handling for non-existing parent (#477 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/477>)
* Fix rtde client shutdown (#474 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/474>)
* Contributors: Felix Exner, URJala, dependabot[bot]
```
