### PR TITLE
rqml: 3.26.41-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8494,6 +8494,20 @@ repositories:
       version: rolling
     status: developed
   rqml:
+    doc:
+      type: git
+      url: https://github.com/StefanFabian/rqml.git
+      version: rolling
+    release:
+      packages:
+      - rqml
+      - rqml_core
+      - rqml_default_plugins
+      - rqml_plugin_example
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqml-release.git
+      version: 3.26.41-1
     source:
       type: git
       url: https://github.com/StefanFabian/rqml.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqml` to `3.26.41-1`:

- upstream repository: https://github.com/StefanFabian/rqml
- release repository: https://github.com/ros2-gbp/rqml-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`

## rqml

```
* Initial release.
* Contributors: Aljoscha Schmidt, Stefan Fabian
```

## rqml_core

```
* destroy plugin on close
  Matches behavior observed when plugins are restored from a config and
  initialization happens in PluginManager::factoryFn instead of
  createPlugin
* Initial release.
* Contributors: Stefan Fabian, dzajac
```

## rqml_default_plugins

```
* Initial release.
* Contributors: Aljoscha Schmidt, Stefan Fabian
```

## rqml_plugin_example

```
* Initial release.
* Contributors: Stefan Fabian
```
