### PR TITLE
qml6_ros2_plugin: 4.26.42-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6428,7 +6428,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
-      version: 4.26.40-1
+      version: 4.26.42-1
     source:
       type: git
       url: https://github.com/StefanFabian/qml6_ros2_plugin.git


### PR DESCRIPTION
Increasing version of package(s) in repository `qml6_ros2_plugin` to `4.26.42-1`:

- upstream repository: https://github.com/StefanFabian/qml6_ros2_plugin.git
- release repository: https://github.com/ros2-gbp/qml6_ros2_plugin-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.26.40-1`

## qml6_ros2_plugin

```
* Added bandwidth and frequency to Subscription. (#50 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/50>)
  * Added bandwidth and frequency to Subscription. Refactored logic for computation affecting TfBuffer as well.
* Ensure tf transform is always updated when target or source frame changes.
* Added TfBuffer element with namespaced tf support (#42 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/42>)
  * Added TfBuffer to be able to get transforms from namespaced tf and additional information such as frame info.
* Fix deprecation warnings during build due to interface changes in ament_index_cpp version 1.13.2.
* Subscription: Only reset message when topic or messageType is changed. (#53 <https://github.com/StefanFabian/qml6_ros2_plugin/issues/53>)
  Also improved locking behavior when processing messages to prevent a new possible deadlock if the topic is changed in the message changed callback.
* Contributors: Stefan Fabian
```
