### PR TITLE
mrpt_navigation: 2.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6181,7 +6181,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.4.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## mrpt_map_server

- No changes

## mrpt_msgs_bridge

- No changes

## mrpt_nav_interfaces

- No changes

## mrpt_navigation

- No changes

## mrpt_pf_localization

```
* Merge pull request #158 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/158> from mrpt-ros-pkg/feat/parallel-planner
  Implement parallel A* planner; misc bug and style fixes
* fix(pf_localization): guard OnProcessExit handler with UnlessCondition(use_composable)
  When use_composable:=true, pf_localization_node is never launched (it has
  UnlessCondition), so the OnProcessExit handler was targeting a process that
  never exists. While this did not crash at launch time, it left a dangling
  handler and silently skipped the managed shutdown in composable mode.
  Guard the RegisterEventHandler with the same condition so it is only
  registered when the standalone node is actually running.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* fix(pf_localization): declare use_composable launch arg with default 'false'
  localization.launch.py consumed LaunchConfiguration('use_composable') without
  ever declaring it. Launching the file directly (not via a parent that supplies
  the argument) caused InvalidConditionExpressionError at runtime because
  IfCondition/UnlessCondition received an unresolved empty string.
  Also added a description to container_name arg clarifying it is required when
  use_composable:=true.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* clang-format
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

```
* Merge pull request #158 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/158> from mrpt-ros-pkg/feat/parallel-planner
  Implement parallel A* planner; misc bug and style fixes
* fix(pointcloud_pipeline): declare use_composable launch arg with default 'false'
  pointcloud_pipeline.launch.py consumed LaunchConfiguration('use_composable')
  without declaring it, causing InvalidConditionExpressionError when launched
  directly. Same bug as the one fixed in mrpt_pf_localization.
  Also added a description to container_name arg.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* clang-format
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

- No changes

## mrpt_tps_astar_planner

```
* Merge pull request #158 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/158> from mrpt-ros-pkg/feat/parallel-planner
  Implement parallel A* planner; misc bug and style fixes
* Fix QoS type usage
* astar planner: made reentrant for serving multiple service calls in multithread
* Improve readme
* fix(tps_astar_planner): fix crashes, null deref, and minor log bugs
  - Replace ASSERT_(robot_pose_ok) with graceful error+return in both
  callback_goal and srv_make_plan_to, so a temporary TF outage does not
  abort the node or throw inside a service callback.
  - Add null guards before using e.grid_obstacles / e.obstacle_points in
  do_path_plan() and init_3d_debug() — both can be nullptr if the
  respective topic callback has not fired yet.
  - Call init_3d_debug() from do_path_plan() when gui_mrpt_ is true, so
  the 3D window is actually opened (was dead code).
  - Protect pub_costmaps_ resize and lazy publisher creation with
  pub_costmaps_cs_ mutex.
  - Fix copy-paste error: srv_make_plan_from_to catch block logged wrong
  function name.
  - Fix log format string: "topic_wp_seq_pub%s" -> "topic_wp_seq_pub: %s".
  - Launch file: lowercase 'false' for problem_world_bbox_ignore_obstacles
  and astar_skip_refine boolean args (was Python-cased 'False').
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

```
* Merge pull request #158 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/158> from mrpt-ros-pkg/feat/parallel-planner
  Implement parallel A* planner; misc bug and style fixes
* style(tutorials): normalize use_composable value to lowercase 'false'
  Three tutorial launch files passed 'False' (Python-cased) for use_composable.
  While this works at the launch level (ROS2 evaluates it case-insensitively),
  it is inconsistent with every other boolean launch argument in the repo and
  with demo_composable_nodes.launch.py which already uses 'false'.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* Contributors: Jose Luis Blanco-Claraco
```
