### PR TITLE
gz_dartsim_vendor: 0.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2870,7 +2870,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
-      version: 0.1.2-1
+      version: 0.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_dartsim_vendor` to `0.1.3-1`:

- upstream repository: https://github.com/gazebo-release/gz_dartsim_vendor.git
- release repository: https://github.com/ros2-gbp/gz_dartsim_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.2-1`

## gz_dartsim_vendor

```
* Merge pull request #9 <https://github.com/gazebo-release/gz_dartsim_vendor/issues/9> from gazebo-release/jrivero/bump_6_16
  Bump dart vendor in rolling to 6.16.6
* Bump DART version to 6.16.6
* Update patch
* Contributors: Jose Luis Rivero
```
