### PR TITLE
Add pulseaudio-utils to rosdep base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8850,9 +8850,7 @@ pulseaudio-utils:
   gentoo: [libpulse]
   nixos: [libpulseaudio]
   opensuse: [pulseaudio]
-  rhel:
-    '*': [pulseaudio-utils]
-    '7': null
+  rhel: [pulseaudio-utils]
   ubuntu: [pulseaudio-utils]
 pybind11-dev:
   arch: [pybind11]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8848,6 +8848,7 @@ pulseaudio-utils:
   debian: [pulseaudio-utils]
   fedora: [pulseaudio-utils]
   gentoo: [libpulse]
+  nixos: [libpulseaudio]
   opensuse: [pulseaudio]
   rhel:
     '*': [pulseaudio-utils]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8842,6 +8842,17 @@ pugixml-dev:
   openembedded: [pugixml@meta-oe]
   rhel: [pugixml-devel]
   ubuntu: [libpugixml-dev]
+pulseaudio-utils:
+  alpine: [pulseaudio-utils]
+  arch: [libpulse]
+  debian: [pulseaudio-utils]
+  fedora: [pulseaudio-utils]
+  gentoo: [libpulse]
+  opensuse: [pulseaudio]
+  rhel:
+    '*': [pulseaudio-utils]
+    '7': null
+  ubuntu: [pulseaudio-utils]
 pybind11-dev:
   arch: [pybind11]
   debian: [pybind11-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

pulseaudio-utils

## Package Upstream Source:

https://www.freedesktop.org/wiki/Software/PulseAudio/

## Purpose of using this:

Play sound.

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/pulseaudio-utils
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/questing/pulseaudio-utils
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/pulseaudio/pulseaudio-utils/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/?sort=&q=libpulse&maintainer=&flagged=
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/media-libs/libpulse
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/pulseaudio-utils
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.11&include_modular_service_options=1&include_nixos_options=1&query=libpulse&show=libpulseaudio
- openSUSE: https://software.opensuse.org/package/
  - https://build.opensuse.org/package/show/openSUSE%3AFactory/pulseaudio
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=pulseaudio-utils
 