### PR TITLE
image_transport_plugins: 2.5.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4358,7 +4358,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 2.5.4-1
+      version: 2.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `2.5.5-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.5.4-1`

## compressed_depth_image_transport

```
* fix(compressed_depth): use push_back instead of index assignment (#222 <https://github.com/ros-perception/image_transport_plugins/issues/222>) (#225 <https://github.com/ros-perception/image_transport_plugins/issues/225>)
* Contributors: mergify[bot]
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes
