### PR TITLE
cloudini: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1536,7 +1536,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/facontidavide/cloudini-release.git
-      version: 1.0.4-1
+      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cloudini` to `1.1.0-1`:

- upstream repository: https://github.com/facontidavide/cloudini.git
- release repository: https://github.com/facontidavide/cloudini-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.4-1`

## cloudini_lib

```
* feat(gorilla): Gorilla bit-packed XOR for FLOAT64 lossless (backward compatible) (#93 <https://github.com/facontidavide/cloudini/issues/93>)
* Contributors: Davide Faconti
```

## cloudini_ros

```
* feat(gorilla): Gorilla bit-packed XOR for FLOAT64 lossless (backward compatible) (#93 <https://github.com/facontidavide/cloudini/issues/93>)
* Contributors: Davide Faconti
```
