### PR TITLE
urdfdom_headers: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10570,7 +10570,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 2.1.1-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `3.0.0-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.1.1-1`

## urdfdom_headers

```
* Update lower, upper, effort, and velocity default joint limits (`#95 <https://github.com/ros/urdfdom_headers/issues/95>`_)
* Clean up declaration of ModelInterface's SharedPtrs (`#99 <https://github.com/ros/urdfdom_headers/issues/99>`_)
* Extend ``JointLimits`` class to include acceleration, deceleration and jerk limits (`#83 <https://github.com/ros/urdfdom_headers/issues/83>`_)

* Contributors: Aarav Gupta, Alejandro Hernández Cordero, Robert Haschke, Sai Kishor
```
