### PR TITLE
urdfdom: 6.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10554,7 +10554,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 5.1.1-1
+      version: 6.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom` to `6.0.0-1`:

- upstream repository: https://github.com/ros/urdfdom.git
- release repository: https://github.com/ros2-gbp/urdfdom-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.1.1-1`

## urdfdom

```
* Support for URDF Specification 1.2
    * Extend parsing of acceleration, deceleration and jerk limits from ``limit`` tag (`#212 <https://github.com/ros/urdfdom/issues/212>`_)
    * Update default limits for the joint limits and safety limits (`#249 <https://github.com/ros/urdfdom/issues/249>`_)
    * Add invalid data checks to the Geometry data (`#242 <https://github.com/ros/urdfdom/issues/242>`_)
    * Require urdfdom_headers 3.0.0 (`#257 <https://github.com/ros/urdfdom/issues/257>`_)
* Use URDF_MAJOR_VERSION for SOVERSION (`#248 <https://github.com/ros/urdfdom/issues/248>`_)
* Contributors: Jose Luis Rivero, Sai Kishor Kothakota, Steve Peters
```
