### PR TITLE
rosbot_ros: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9711,7 +9711,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbot_ros-release.git
-      version: 0.18.6-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/husarion/rosbot_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbot_ros` to `1.0.0-1`:

- upstream repository: https://github.com/husarion/rosbot_ros.git
- release repository: https://github.com/ros2-gbp/rosbot_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.1`
- previous version for package: `0.18.6-1`

## rosbot

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Rename mecanum pkg dependency
* Open manipulator use all apt depndencies; Make flash_firmware executable
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_bringup

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki
```

## rosbot_controller

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Rename mecanum pkg dependency
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_description

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki
```

## rosbot_gazebo

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki
```

## rosbot_hardware_interfaces

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki
```

## rosbot_joy

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Fix rosbot_moveit dependencies
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_localization

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki
```

## rosbot_moveit

```
* Fix rosbot_moveit dependencies
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_utils

```
* New firmware with microros namespace pre-communication support (#168 <https://github.com/husarion/rosbot_ros/issues/168>)
  - **New firmware** (v1.0.0-jazzy) for ROSbot 3 and ROSbot XL enabling namespace
  configuration via serial pre-communication before microros agent starts
  - **`configure_robot` script** — serial pre-communication node: sends namespace to MCU
  over FTDI/UART, verifies firmware version, waits for ACK
  - **Separated bringup** — bringup.yaml dispatches to rosbot.yaml / rosbot_xl.yaml;
  ROSbot XL gets dedicated nodes: battery_alert, led_strip_car_wave
  - **`tf_namespace_bridge`** — bridges namespaced /tf to global /tf and /tf_static
  - **`microros_mode` arg** — allows overriding default communication mode (serial/udp)
  - Controller tuning: updated ICR, wheel params and acceleration limits for both robots
  - Renamed FirmwareFlasherUSB/UART → McuManagerFTDI/UART with added reset_mcu()
  - battery_alert: switched from aplay to paplay with configurable audio_device
  ROS parameter (snap-friendly via audio-playback interface);
  pulseaudio-utils dep commented pending [ros/rosdistro#50811 <https://github.com/ros/rosdistro/issues/50811>](https://github.com/ros/rosdistro/pull/50811)
  - Fixed: argparse required=True ignoring os.getenv() default in configure_robot
  and flash_firmware
  - Fixed: namespace validation before serial write in configure_robot
  - Fixed: missing hasattr(e, "stderr") guard in mcu_manager_uart
  - Fixed: deprecated on_init(HardwareInfo&) → on_init(HardwareComponentInterfaceParams&)
  in rosbot_hardware_interfaces
* Open manipulator use all apt depndencies; Make flash_firmware executable
* Fix Docker build and unify composes
* Add missing changelog descriptions for past releases (#167 <https://github.com/husarion/rosbot_ros/issues/167>)
  * Remove automatic bump
  * Add missing changelog descriptions for past releases
* Contributors: Rafal Gorecki, rafal-gorecki
```
