### PR TITLE
flir_ptu: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3096,7 +3096,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros-drivers-gbp/flir_ptu-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_ptu.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_ptu` to `1.0.1-1`:

- upstream repository: https://github.com/ros-drivers/flir_ptu.git
- release repository: https://github.com/ros-drivers-gbp/flir_ptu-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.1`
- previous version for package: `1.0.0-1`

## flir_ptu_description

- No changes

## flir_ptu_driver

```
* Fixed compiling on ARM by changing to sign char.
* Contributors: Tony Baltovski
```

## flir_ptu_viz

- No changes
