### PR TITLE
beluga: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1333,7 +1333,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/beluga-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `beluga` to `2.1.1-1`:

- upstream repository: https://github.com/Ekumen-OS/beluga.git
- release repository: https://github.com/ros2-gbp/beluga-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.1`
- previous version for package: `2.1.0-1`

## beluga

```
* Change default of the strict boundaries setting to true (#555 <https://github.com/Ekumen-OS/beluga/issues/555>)
* Add paranoid mode (#557 <https://github.com/Ekumen-OS/beluga/issues/557>)
* Add missing Eigen/Eigenvalues include for GCC 15 / Eigen5 compatibility (#553 <https://github.com/Ekumen-OS/beluga/issues/553>)
* Add new overload for reweight action that tracks likelihood (#530 <https://github.com/Ekumen-OS/beluga/issues/530>)
* Thick walls pre-processing feature added (#541 <https://github.com/Ekumen-OS/beluga/issues/541>)
* Add random probability term to landmark sensor model (#544 <https://github.com/Ekumen-OS/beluga/issues/544>)
* Drop ciabatta dependency (#542 <https://github.com/Ekumen-OS/beluga/issues/542>)
* Contributors: Andrés Brumovsky, Gerardo Puga, Jesús Silva, Michel Hidalgo, Nahuel Espinosa, Paul Verhoeckx, Tim Clephas
```

## beluga_amcl

```
* Change default of the strict boundaries setting to true (#555 <https://github.com/Ekumen-OS/beluga/issues/555>)
* Add paranoid mode (#557 <https://github.com/Ekumen-OS/beluga/issues/557>)
* Thick walls pre-processing feature added (#541 <https://github.com/Ekumen-OS/beluga/issues/541>)
* Contributors: Andrés Brumovsky, Gerardo Puga, Michel Hidalgo
```

## beluga_ros

```
* Change default of the strict boundaries setting to true (#555 <https://github.com/Ekumen-OS/beluga/issues/555>)
* Add paranoid mode (#557 <https://github.com/Ekumen-OS/beluga/issues/557>)
* Contributors: Gerardo Puga, Michel Hidalgo
```
