### PR TITLE
rcutils: 7.1.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6869,7 +6869,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.0.9-1
+      version: 7.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.1.0-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `7.0.9-1`

## rcutils

```
* Remove ATOMIC_VAR_INIT (#556 <https://github.com/ros2/rcutils/issues/556>)
* Use ``ament_set_default_language_standards`` from ``ament_cmake_core`` (#548 <https://github.com/ros2/rcutils/issues/548>)
* Use uncommon variable name in macro to avoid being overwritten (#551 <https://github.com/ros2/rcutils/issues/551>)
* Contributors: Alejandro Hernández Cordero, Shane Loretz, Tomoya Fujita
```
