### PR TITLE
rtest: 0.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9029,6 +9029,21 @@ repositories:
       url: https://github.com/tilk/rtcm_msgs.git
       version: master
     status: maintained
+  rtest:
+    doc:
+      type: git
+      url: https://github.com/Beam-and-Spyrosoft/rtest.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rtest-release.git
+      version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/Beam-and-Spyrosoft/rtest.git
+      version: kilted
+    status: developed
   rtsp_image_transport:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9033,7 +9033,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/Beam-and-Spyrosoft/rtest.git
-      version: main
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -9042,7 +9042,7 @@ repositories:
     source:
       type: git
       url: https://github.com/Beam-and-Spyrosoft/rtest.git
-      version: kilted
+      version: rolling
     status: developed
   rtsp_image_transport:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtest` to `0.2.2-1`:

- upstream repository: https://github.com/Beam-and-Spyrosoft/rtest.git
- release repository: https://github.com/ros2-gbp/rtest-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `null`

## rtest

```
* Bug Fix: Normalize Service Client/Provider Names by removing leading … (#115 <https://github.com/Beam-and-Spyrosoft/rtest/issues/115>)
  Co-authored-by: Thomas Parker <mailto:32755663+tparker48@users.noreply.github.com>
  Co-authored-by: MariuszSzczepanikSpyrosoft <mailto:118888269+MariuszSzczepanikSpyrosoft@users.noreply.github.com>
* Contributors: Sławomir Cielepak
```
