### PR TITLE
rtest: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10616,7 +10616,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rtest-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/Beam-and-Spyrosoft/rtest.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtest` to `0.2.2-1`:

- upstream repository: https://github.com/Beam-and-Spyrosoft/rtest.git
- release repository: https://github.com/ros2-gbp/rtest-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.2.1-1`

## rtest

```
* Bug Fix: Normalize Service Client/Provider Names by removing leading … (#115 <https://github.com/Beam-and-Spyrosoft/rtest/issues/115>)
  Co-authored-by: Thomas Parker <mailto:32755663+tparker48@users.noreply.github.com>
  Co-authored-by: MariuszSzczepanikSpyrosoft <mailto:118888269+MariuszSzczepanikSpyrosoft@users.noreply.github.com>
* Contributors: Sławomir Cielepak
```
