### PR TITLE
Add qt base dev to python3-qt-bindings

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9596,10 +9596,10 @@ python3-qt-bindings:
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
   ubuntu:
-    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
+    '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     jammy: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
-    noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
+    noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
 python3-qt-material-pip:
   '*':
     pip:


### PR DESCRIPTION
This adds `qt6-base-dev` or `qtbase5-dev` to the `python3-qt-bindings` rosdep key for Ubuntu. The debian key already has these.


Fixes https://github.com/ros-visualization/python_qt_binding/pull/157#discussion_r3105770433

which is also happening on the build farm

https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__qt_gui_cpp__ubuntu_noble_amd64__binary/118/console
```
14:07:52 CMake Warning at /opt/ros/rolling/share/python_qt_binding/cmake/sip_helper.cmake:38 (message):
14:07:52   Could not determine PyQt6 bindings directory.
14:07:52 Call Stack (most recent call first):
14:07:52   /opt/ros/rolling/share/python_qt_binding/cmake/sip_helper.cmake:79 (__find_qt_sip_files)
14:07:52   src/qt_gui_cpp_sip/CMakeLists.txt:71 (include)
14:07:52 
14:07:52 
14:07:52 CMake Error at /opt/ros/rolling/share/python_qt_binding/cmake/sip_helper.cmake:81 (message):
14:07:52   PyQt6 SIP bindings are required but were not found.
14:07:52 Call Stack (most recent call first):
14:07:52   src/qt_gui_cpp_sip/CMakeLists.txt:71 (include)
```