### PR TITLE
moveit_task_constructor: 0.1.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5853,7 +5853,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_task_constructor-release.git
-      version: 0.1.4-3
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5841,7 +5841,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git
-      version: jazzy
+      version: ros2
     release:
       packages:
       - moveit_task_constructor_capabilities
@@ -5857,7 +5857,7 @@ repositories:
     source:
       type: git
       url: https://github.com/moveit/moveit_task_constructor.git
-      version: jazzy
+      version: ros2
     status: maintained
   moveit_visual_tools:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_task_constructor` to `0.1.5-1`:

- upstream repository: https://github.com/moveit/moveit_task_constructor.git
- release repository: https://github.com/ros2-gbp/moveit_task_constructor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.1.4-3`

## moveit_task_constructor_capabilities

```
* Add missing package dependency: controller_manager
* Contributors: Robert Haschke
```

## moveit_task_constructor_core

```
* Replace deprecated rclcpp::spin_some()
* Fix #737 <https://github.com/moveit/moveit_task_constructor/issues/737> (pruning in fallback stages with a connect stage) (#742 <https://github.com/moveit/moveit_task_constructor/issues/742>)
* Directly lift solutions of SerialContainer (#730 <https://github.com/moveit/moveit_task_constructor/issues/730>)
* Mention InitStageException's type in its what() method (#738 <https://github.com/moveit/moveit_task_constructor/issues/738>)
* Remove unused setup.py
* Add link rotation cost (#726 <https://github.com/moveit/moveit_task_constructor/issues/726>)
* Support for optimising IK solvers (#724 <https://github.com/moveit/moveit_task_constructor/issues/724>)
* Contributors: Demonmasterlqx, Michael Görner, Robert Haschke, joseph-moore-CO
```

## moveit_task_constructor_demo

```
* Fix demo/README.md
* Add link rotation cost (#726 <https://github.com/moveit/moveit_task_constructor/issues/726>)
* Add missing package dependency: controller_manager
* Contributors: Robert Haschke
```

## moveit_task_constructor_msgs

- No changes

## moveit_task_constructor_visualization

- No changes

## rviz_marker_tools

- No changes
