### PR TITLE
ros2_controllers: 6.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7692,7 +7692,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.5.0-1
+      version: 6.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.6.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `6.5.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Update admittance_controller to use shared 6D robot description (#2173 <https://github.com/ros-controls/ros2_controllers/issues/2173>)
* Contributors: Naitik
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Update controller tests to use configure/activate instead of on_configure/on_activate  (#1682 <https://github.com/ros-controls/ros2_controllers/issues/1682>)
* RateLimiter: Don't update parameters before input checks (#2074 <https://github.com/ros-controls/ros2_controllers/issues/2074>)
* Added test for open-loop odometry with clamped input (#2280 <https://github.com/ros-controls/ros2_controllers/issues/2280>)
* Contributors: Devdoot Chatterjee, JiaHui Huang, Junius Santoso
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

```
* Update controller tests to use configure/activate instead of on_configure/on_activate  (#1682 <https://github.com/ros-controls/ros2_controllers/issues/1682>)
* Contributors: Junius Santoso
```

## gps_sensor_broadcaster

```
* Update controller tests to use configure/activate instead of on_configure/on_activate  (#1682 <https://github.com/ros-controls/ros2_controllers/issues/1682>)
* Contributors: Junius Santoso
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Fix segfault in jtc if joint name not in urdf (#2321 <https://github.com/ros-controls/ros2_controllers/issues/2321>)
* Contributors: Iñigo Moreno
```

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

```
* fix(parallel_gripper): rename variables for consistency (#2314 <https://github.com/ros-controls/ros2_controllers/issues/2314>)
* Contributors: Akshay Arjun
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* [RQT_JTC] add unit tests for parse_joint_limits (#2281 <https://github.com/ros-controls/ros2_controllers/issues/2281>)
* Contributors: Sahil Lakhmani
```

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
