### PR TITLE
ros2_controllers: 5.15.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7687,7 +7687,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.14.0-1
+      version: 5.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `5.14.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Update admittance_controller to use shared 6D robot description (backport #2173 <https://github.com/ros-controls/ros2_controllers/issues/2173>) (#2311 <https://github.com/ros-controls/ros2_controllers/issues/2311>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

```
* Update controller tests to use configure/activate instead of on_configure/on_activate  (backport #1682 <https://github.com/ros-controls/ros2_controllers/issues/1682>) (#2301 <https://github.com/ros-controls/ros2_controllers/issues/2301>)
* RateLimiter: Don't update parameters before input checks (backport #2074 <https://github.com/ros-controls/ros2_controllers/issues/2074>) (#2292 <https://github.com/ros-controls/ros2_controllers/issues/2292>)
* Added test for open-loop odometry with clamped input (backport #2280 <https://github.com/ros-controls/ros2_controllers/issues/2280>) (#2285 <https://github.com/ros-controls/ros2_controllers/issues/2285>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

```
* Update controller tests to use configure/activate instead of on_configure/on_activate  (backport #1682 <https://github.com/ros-controls/ros2_controllers/issues/1682>) (#2301 <https://github.com/ros-controls/ros2_controllers/issues/2301>)
* Contributors: mergify[bot]
```

## gps_sensor_broadcaster

```
* Update controller tests to use configure/activate instead of on_configure/on_activate  (backport #1682 <https://github.com/ros-controls/ros2_controllers/issues/1682>) (#2301 <https://github.com/ros-controls/ros2_controllers/issues/2301>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* Fix segfault in jtc if joint name not in urdf (backport #2321 <https://github.com/ros-controls/ros2_controllers/issues/2321>) (#2324 <https://github.com/ros-controls/ros2_controllers/issues/2324>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

```
* fix(parallel_gripper): rename variables for consistency (backport #2314 <https://github.com/ros-controls/ros2_controllers/issues/2314>) (#2316 <https://github.com/ros-controls/ros2_controllers/issues/2316>)
* Contributors: mergify[bot]
```

## pid_controller

- No changes

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

- No changes

## rqt_joint_trajectory_controller

```
* [RQT_JTC] add unit tests for parse_joint_limits (backport #2281 <https://github.com/ros-controls/ros2_controllers/issues/2281>) (#2289 <https://github.com/ros-controls/ros2_controllers/issues/2289>)
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
