### PR TITLE
mola_imu_preintegration: 1.16.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4593,7 +4593,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.15.0-1
+      version: 1.16.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.16.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.15.0-1`

## mola_imu_preintegration

```
* Merge pull request #2 <https://github.com/MOLAorg/mola_imu_preintegration/issues/2> from MOLAorg/feat/implement-low-pass-filters
  Implement low-pass filtering for acc/omega (more stable transformed IMU vectors)
* Add formal CLA
* Contributors: Jose Luis Blanco-Claraco
```
