### PR TITLE
mola: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5580,7 +5580,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.6.1-1
+      version: 2.7.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.7.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.6.1-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Merge pull request #131 <https://github.com/MOLAorg/mola/issues/131> from MOLAorg/feat/actions-custom-runner
  CI actions: build for arm64 too
* Merge branch 'Zeal-Robotics-fix/bridge-ros2-skip-empty-tf-on-rep105-failure' into develop
* Fix formatting and clarify function arguments
* fix(bridge_ros2): skip TF publish when REP-105 odom lookup fails
  In publishLocalizationTf, when publish_localization_following_rep105
  is enabled, the bridge needs to look up odom_frame -> base_link_frame
  to compose map -> odom. If that lookup fails (e.g. wheel odometry
  hasn't started publishing yet during system startup), the previous code
  logged the error but still fell through to tf_bc_->sendTransform(tf)
  with a default-constructed TransformStamped (empty frame_id and
  child_frame_id).
  This poisoned every subscriber's tf2 buffer at the localization rate,
  producing a continuous stream of TF_NO_FRAME_ID,
  TF_NO_CHILD_FRAME_ID, and TF_SELF_TRANSFORM errors across every
  node in the system until the odom TF became available.
  Fix: return early on lookup failure so no broadcast happens. While
  here, restructure the function with an early-return guard for
  publish_tf_from_slam to flatten the nesting, and include the actual
  frame names in the error message.
  Behavior unchanged in the success path.
* Merge pull request #129 <https://github.com/MOLAorg/mola/issues/129> from MOLAorg/feat/ros2-diagnostics
  Feature: ROS2 diagnostics
* feat(bridge_ros2): publish REP-107 /diagnostics DiagnosticArray
  Collect structured diagnostics from modules implementing the new
  mola::DiagnosticsProvider interface and publish them on the standard
  ROS 2 /diagnostics topic alongside the existing ad-hoc mola_diagnostics/
  topics. Adds the diagnostic_msgs dependency.
  Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
* Merge pull request #122 <https://github.com/MOLAorg/mola/issues/122> from MOLAorg/feat/ros2-bridge-multiple-odometries
  Add param 'odometry_as_robot_pose_observation' to switch OdometryMsg …
* Skip entries with empty topic name
* Add param 'odometry_as_robot_pose_observation' to switch OdometryMsg mapping to MRPT types
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_demos

```
* Merge pull request #122 <https://github.com/MOLAorg/mola/issues/122> from MOLAorg/feat/ros2-bridge-multiple-odometries
  Add param 'odometry_as_robot_pose_observation' to switch OdometryMsg …
* demo publishers: each odom starts at a random pose
* Add publisher scripts for state estimation demos
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

```
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

- No changes

## mola_input_lidar_bin_dataset

- No changes

## mola_input_mulran_dataset

```
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* Merge pull request #128 <https://github.com/MOLAorg/mola/issues/128> from MOLAorg/feat/docs-cookbook
  Feat/docs cookbook
* sanity checks; expand docs
* Docs: explain more odometry source cases
* rosbag2: Enable custom /tf names (e.g. for namespaces)
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

- No changes

## mola_kernel

```
* Merge pull request #129 <https://github.com/MOLAorg/mola/issues/129> from MOLAorg/feat/ros2-diagnostics
  Feature: ROS2 diagnostics
* feat(kernel): add DiagnosticsProvider interface for REP-107 diagnostics
  Introduce an opt-in mix-in interface for modules to publish structured,
  severity-tagged diagnostics, to be bridged to ROS 2 /diagnostics by
  mola_bridge_ros2 in a follow-up.
  Co-Authored-By: Claude Opus 4.7 <mailto:noreply@anthropic.com>
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Bump minimum required MRPT version to 2.15.0
* Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge pull request #122 <https://github.com/MOLAorg/mola/issues/122> from MOLAorg/feat/ros2-bridge-multiple-odometries
  Add param 'odometry_as_robot_pose_observation' to switch OdometryMsg …
* FIX: mola-cli should not destroy modules too early to avoid race conditions
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* Reorganize website
* Merge pull request #121 <https://github.com/MOLAorg/mola/issues/121> from MOLAorg/fix/clean-up-old-mrpt-version-checks
  Clean up: remove old mrpt version fallback code sections
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
