### PR TITLE
Revert adding hatchbed_localization source distribution.

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3149,16 +3149,6 @@ repositories:
       url: https://github.com/hatchbed/hatchbed_common.git
       version: main
     status: developed
-  hatchbed_localization:
-    doc:
-      type: git
-      url: https://github.com/hatchbed/hatchbed_localization.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/hatchbed/hatchbed_localization.git
-      version: main
-    status: developed
   heaphook:
     doc:
       type: git


### PR DESCRIPTION
Please revert adding hatchbed_localization source package, which just got merged recently.  There have been no releases for this package yet.  This package is getting merged into hatchbed_common instead.

# rosdistro.

rolling

# The source is here:

https://github.com/hatchbed/hatchbed_localization

