### PR TITLE
ros_babel_fish: 4.26.43-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7917,7 +7917,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 4.26.42-1
+      version: 4.26.43-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_babel_fish` to `4.26.43-1`:

- upstream repository: https://github.com/LOEWE-emergenCITY/ros_babel_fish.git
- release repository: https://github.com/ros2-gbp/ros_babel_fish-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `4.26.42-1`

## ros_babel_fish

```
* C++20 compatibility.
* Contributors: Stefan Fabian
```

## ros_babel_fish_test_msgs

- No changes

## ros_babel_fish_tools

```
* C++20 compatibility.
* Contributors: Stefan Fabian
```
