### PR TITLE
mrpt_ros_bridge: 3.5.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4961,7 +4961,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.5.1-1
+      version: 3.5.2-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.5.2-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.1-1`

## mrpt_libros_bridge

```
* Merge pull request #7 <https://github.com/MRPT/mrpt_ros_bridge/issues/7> from MRPT/fix/gps-nmea-regression
  Fix/gps nmea regression
* Add GPS unit tests
* FIX: Regression in populating GPS ROS2 messages for mrpt>=2.15.11
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

- No changes
