### PR TITLE
topic_tools: 1.4.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9939,7 +9939,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.3-1
+      version: 1.4.4-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.4.4-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.4.3-1`

## topic_tools

```
* Fix race condition on shutdown in try_discover_source() (#143 <https://github.com/ros-tooling/topic_tools/issues/143>)
* Replace deprecated rclcpp::spin_some (#144 <https://github.com/ros-tooling/topic_tools/issues/144>)
* Enable QOS Overrides to All Publishers (#131 <https://github.com/ros-tooling/topic_tools/issues/131>)
* Contributors: Christoph Fröhlich, Marq Rasmussen, Zeerek Ahmad, Emerson Knapp
```

## topic_tools_interfaces

- No changes
