### PR TITLE
Add PyQt-builder to Fedora rule for python3-qt-bindings

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9590,7 +9590,7 @@ python3-qt-bindings:
     '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     'bookworm': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
-  fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
+  fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-builder]
   rhel:
     '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-Builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]


### PR DESCRIPTION
https://packages.fedoraproject.org/pkgs/PyQt-builder/PyQt-builder/

Already listed for RHEL 10 for this key.