### PR TITLE
simulation_interfaces: 1.6.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9366,7 +9366,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/simulation_interfaces-release.git
-      version: 1.6.0-1
+      version: 1.6.1-1
     source:
       type: git
       url: https://github.com/ros-simulation/simulation_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `simulation_interfaces` to `1.6.1-1`:

- upstream repository: https://github.com/ros-simulation/simulation_interfaces.git
- release repository: https://github.com/ros2-gbp/simulation_interfaces-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.6.0-1`

## simulation_interfaces

```
Added missing INVALID_POSE error code (#27 <https://github.com/ros-simulation/simulation_interfaces/issues/27>)
* Contributors: Norbert Prokopiuk
```
