### PR TITLE
ros2_control: 4.45.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9077,7 +9077,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.45.0-1
+      version: 4.45.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.45.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `4.45.0-1`

## controller_interface

- No changes

## controller_manager

- No changes

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix C++20 behavior changes of std::from_chars (#3244 <https://github.com/ros-controls/ros2_control/issues/3244>) (#3247 <https://github.com/ros-controls/ros2_control/issues/3247>)
* Add missing charconv header (#3234 <https://github.com/ros-controls/ros2_control/issues/3234>) (#3236 <https://github.com/ros-controls/ros2_control/issues/3236>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

- No changes

## joint_limits

```
* Fix LNK2005 in joint*limiter (#3243 <https://github.com/ros-controls/ros2_control/issues/3243>) (#3245 <https://github.com/ros-controls/ros2_control/issues/3245>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
