### PR TITLE
image_pipeline: 6.0.12-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3417,7 +3417,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.11-1
+      version: 6.0.12-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.12-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.1`
- previous version for package: `6.0.11-1`

## camera_calibration

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## depth_image_proc

```
* heap-buffer-overflow write in PointCloudXyzNode / convertDepth<unsigned short>() with oversized depth Image dimensions (backport #1136 <https://github.com/ros-perception/image_pipeline/issues/1136>) (#1145 <https://github.com/ros-perception/image_pipeline/issues/1145>)
* ConvertMetricNode crashes on malformed Image with empty data (backport #1135 <https://github.com/ros-perception/image_pipeline/issues/1135>) (#1143 <https://github.com/ros-perception/image_pipeline/issues/1143>)
* Cleanup bsd 3 clause license usage (backport #1125 <https://github.com/ros-perception/image_pipeline/issues/1125>) (#1140 <https://github.com/ros-perception/image_pipeline/issues/1140>)
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## image_pipeline

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## image_proc

```
* Segmentation fault (Null Pointer Dereference) in CropNonZeroNode when processing all-black images (backport #1134 <https://github.com/ros-perception/image_pipeline/issues/1134>) (#1137 <https://github.com/ros-perception/image_pipeline/issues/1137>)
* Cleanup bsd 3 clause license usage (backport #1125 <https://github.com/ros-perception/image_pipeline/issues/1125>) (#1140 <https://github.com/ros-perception/image_pipeline/issues/1140>)
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## image_publisher

```
* Cleanup bsd 3 clause license usage (backport #1125 <https://github.com/ros-perception/image_pipeline/issues/1125>) (#1140 <https://github.com/ros-perception/image_pipeline/issues/1140>)
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## image_rotate

```
* Cleanup bsd 3 clause license usage (backport #1125 <https://github.com/ros-perception/image_pipeline/issues/1125>) (#1140 <https://github.com/ros-perception/image_pipeline/issues/1140>)
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## image_view

```
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## stereo_image_proc

```
* Cleanup bsd 3 clause license usage (backport #1125 <https://github.com/ros-perception/image_pipeline/issues/1125>) (#1140 <https://github.com/ros-perception/image_pipeline/issues/1140>)
* Update index.ros.org package website links (backport #1101 <https://github.com/ros-perception/image_pipeline/issues/1101>) (#1103 <https://github.com/ros-perception/image_pipeline/issues/1103>)
* Contributors: mergify[bot]
```

## tracetools_image_pipeline

- No changes
