### PR TITLE
rviz: 15.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9077,7 +9077,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.2.0-1
+      version: 15.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.1`
- previous version for package: `15.2.0-1`

## rviz2

- No changes

## rviz_common

```
* Compressed Image Display (#1288 <https://github.com/ros2/rviz//issues/1288>)
* fix: Fixed compilation on MSVC 2022 (#1706 <https://github.com/ros2/rviz//issues/1706>)
* Contributors: Janosch Machowinski, Matthew Foran
```

## rviz_default_plugins

```
* Compressed Image Display (#1288 <https://github.com/ros2/rviz//issues/1288>)
* Contributors: Matthew Foran
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
