### PR TITLE
rosidl: 5.1.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8196,7 +8196,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.1.4-2
+      version: 5.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.1.5-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.0`
- previous version for package: `5.1.4-2`

## rosidl_adapter

- No changes

## rosidl_buffer

- No changes

## rosidl_buffer_backend

```
* Clarify return of get_descriptor_type_support() (#958 <https://github.com/ros2/rosidl/issues/958>)
* Contributors: CY Chen
```

## rosidl_buffer_backend_registry

```
* Add missing ament_cmake_gtest dep (#960 <https://github.com/ros2/rosidl/issues/960>)
* Contributors: Scott K Logan
```

## rosidl_buffer_py

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

```
* Install interface files to same folder as idl (#935 <https://github.com/ros2/rosidl/issues/935>)
* Contributors: Tim Wendt
```

## rosidl_generator_c

- No changes

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

- No changes

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
