### PR TITLE
Add python3-pyqtbuild to python3-qt-bindings  on Noble

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9599,7 +9599,7 @@ python3-qt-bindings:
     '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
     jammy: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2, python3-sipbuild]
-    noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
+    noble: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild, python3-pyqtbuild]
 python3-qt-material-pip:
   '*':
     pip:


### PR DESCRIPTION
This adds `python3-pyqtbuild` to the `python3-qt-bindings` key on Ubuntu Noble. This is required to build ROS Rolling on Ubuntu Noble using Qt5.

https://packages.ubuntu.com/noble/python3-pyqtbuild