### PR TITLE
Add qt-base-dev and libqtwidgets rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6230,21 +6230,6 @@ libqrencode-dev:
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [libqrencode-dev]
-libqtwidgets:
-  arch: [qt6-base]
-  debian: [libqt6widgets6]
-  fedora: [qt6-qtbase-gui]
-  nixos: [qt6.qtbase]
-  openembedded: [qtbase@meta-qt6]
-  rhel:
-    '*': [qt6-qtbase]
-    '8': null
-    '9': [qt5-qtbase]
-  ubuntu:
-    '*': [libqt6widgets6]
-    'focal': null
-    'jammy': null
-    'noble': [libqt5widgets5t64]
 libqt4:
   debian: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
   fedora: [qt]
@@ -6714,6 +6699,21 @@ libqtwebkit-dev:
   nixos: [qt5.qtwebkit]
   openembedded: [qtwebkit@meta-qt5]
   ubuntu: [libqtwebkit-dev]
+libqtwidgets:
+  arch: [qt6-base]
+  debian: [libqt6widgets6]
+  fedora: [qt6-qtbase-gui]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+    '9': [qt5-qtbase]
+  ubuntu:
+    '*': [libqt6widgets6]
+    'focal': null
+    'jammy': null
+    'noble': [libqt5widgets5t64]
 libqwt-qt5-dev:
   arch: [qwt]
   debian: [libqwt-qt5-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6230,6 +6230,21 @@ libqrencode-dev:
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [libqrencode-dev]
+libqtwidgets:
+  arch: [qt6-base]
+  debian: [libqt6widgets6]
+  fedora: [qt6-qtbase-gui]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+    '9': [qt5-qtbase]
+  ubuntu:
+    '*': [libqt6widgets6]
+    'focal': null
+    'jammy': null
+    'noble': [libqt5widgets5t64]
 libqt4:
   debian: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
   fedora: [qt]
@@ -9207,6 +9222,27 @@ qrencode:
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [qrencode]
+qt-base-dev:
+  alpine: [qt6-qtbase-dev]
+  arch: [qt6-base]
+  debian: [qt6-base-dev]
+  fedora: [qt6-qtbase-devel]
+  gentoo: ['dev-qt/qtcore:6', 'dev-qt/qtwidgets:6', 'dev-qt/qttest:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse:
+    '*': [libqt6-qtbase-devel]
+    '15.2': null
+  rhel:
+    '*': [qt6-qtbase-devel]
+    '8': null
+    '9': [qt5-qtbase-devel]
+  slackware: [qt6]
+  ubuntu:
+    '*': [qt6-base-dev]
+    'focal': null
+    'jammy': null
+    'noble': [qtbase5-dev]
 qt4-dev-tools:
   debian: [qt4-dev-tools]
   fedora: [qt-devel]


### PR DESCRIPTION
This PR adds two new rosdep keys `qt-base-dev` and `libqtwidgets`. The purpose of these keys is to select different versions of Qt on different platforms. This lets Rolling (and in the future Lyrical) use Qt5 on RHEL 9 / Ubuntu Noble, and Qt6 everywhere else.

I used gemini to combine the following existing rosdep keys: (and then reviewed it manually)

* qt6-base-dev
* qtbase5-dev
* libqt5-widgets
* libqt6widgets6t64