### PR TITLE
Add more Qt5/Qt6 selecting rosdep keys

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6747,7 +6747,7 @@ libqtopengl:
     '8': null
     '9': [qt5-qtbase]
   ubuntu:
-    '*': [libqt6opengl6t64]
+    '*': [libqt6opengl6]
     'focal': null
     'jammy': null
     'noble': [libqt5opengl5t64]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6665,7 +6665,7 @@ libqt6svg6:
   nixos: [qt6.qtsvg]
   openembedded: [qtsvg@meta-qt6]
   rhel:
-    '*': [qt6-qtsvg-devel]
+    '*': [qt6-qtsvg]
     '8': null
   ubuntu:
     '*': [libqt6svg6]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6707,6 +6707,26 @@ libqt6widgets6t64:
     'focal': null
     'jammy': [libqt6widgets6]
     'noble': [libqt6widgets6t64]
+libqtgui:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian: [libqt6gui6]
+  fedora: [qt6-qtbase-gui]
+  freebsd: [qt6-gui]
+  gentoo: ['dev-qt/qtgui:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libQt6Gui6]
+  rhel:
+    '*': [qt6-qtbase-gui]
+    '8': null
+    '9': [qt5-qtbase-gui]
+  slackware: [qt6]
+  ubuntu:
+    '*': [libqt6gui6]
+    'focal': null
+    'jammy': null
+    'noble': [libqt5gui5t64]
 libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6735,6 +6735,22 @@ libqtgui4:
   rhel:
     '7': [qt-x11]
   ubuntu: [libqtgui4]
+libqtopengl:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian: [libqt6opengl6]
+  fedora: [qt6-qtbase]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+    '9': [qt5-qtbase]
+  ubuntu:
+    '*': [libqt6opengl6
+    'focal': null
+    'jammy': null
+    'noble': [libqt5opengl5t64]
 libqtsvg:
   alpine: [qt6-qtsvg]
   arch: [qt6-svg]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6692,6 +6692,23 @@ libqtgui4:
   rhel:
     '7': [qt-x11]
   ubuntu: [libqtgui4]
+libqtsvg:
+  alpine: [qt6-qtsvg]
+  arch: [qt6-svg]
+  debian: [libqt6svg6]
+  fedora: [qt6-qtsvg]
+  gentoo: ['dev-qt/qtsvg:6']
+  nixos: [qt6.qtsvg]
+  openembedded: [qtsvg@meta-qt6]
+  rhel:
+    '*': [qt6-qtsvg-devel]
+    '8': null
+    '9': [qt5-qtsvg]
+  ubuntu:
+    '*': [libqt6svg6]
+    'focal': null
+    'jammy': null
+    'noble': [libqt5svg5]
 libqtwebkit-dev:
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]
@@ -9243,6 +9260,23 @@ qt-base-dev:
     'focal': null
     'jammy': null
     'noble': [qtbase5-dev]
+qt-svg-dev:
+  alpine: [qt6-qtsvg-dev]
+  arch: [qt6-svg]
+  debian: [qt6-svg-dev]
+  fedora: [qt6-qtsvg-devel]
+  gentoo: ['dev-qt/qtsvg:6']
+  nixos: [qt6.qtsvg]
+  openembedded: [qtsvg@meta-qt6]
+  rhel:
+    '*': [qt6-qtsvg-devel]
+    '8': null
+    '9': [qt5-qtsvg-devel]
+  ubuntu:
+    '*': [qt6-svg-dev]
+    'focal': null
+    'jammy': null
+    'noble': [libqt5svg5-dev]
 qt4-dev-tools:
   debian: [qt4-dev-tools]
   fedora: [qt-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6230,6 +6230,29 @@ libqrencode-dev:
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [libqrencode-dev]
+libqt-core:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian:
+    '*': [libqt6core6t64]
+    bookworm: [libqt6core6]
+  fedora: [qt6-qtbase]
+  gentoo: ['dev-qt/qtcore:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse:
+    '*': [libQt6Core6]
+    '15.2': null
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+    '9': [qt5-qtbase]
+  slackware: [qt6]
+  ubuntu:
+    '*': [libqt6core6t64]
+    focal: null
+    jammy: null
+    noble: [libqt5core5t64]
 libqt4:
   debian: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
   fedora: [qt]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6716,7 +6716,6 @@ libqtgui:
   gentoo: ['dev-qt/qtgui:6']
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
-  opensuse: [libQt6Gui6]
   rhel:
     '*': [qt6-qtbase-gui]
     '8': null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6747,7 +6747,7 @@ libqtopengl:
     '8': null
     '9': [qt5-qtbase]
   ubuntu:
-    '*': [libqt6opengl6
+    '*': [libqt6opengl6t64]
     'focal': null
     'jammy': null
     'noble': [libqt5opengl5t64]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6665,7 +6665,7 @@ libqt6svg6:
   nixos: [qt6.qtsvg]
   openembedded: [qtsvg@meta-qt6]
   rhel:
-    '*': [qt6-qtsvg]
+    '*': [qt6-qtsvg-devel]
     '8': null
   ubuntu:
     '*': [libqt6svg6]
@@ -6759,7 +6759,7 @@ libqtsvg:
   nixos: [qt6.qtsvg]
   openembedded: [qtsvg@meta-qt6]
   rhel:
-    '*': [qt6-qtsvg-devel]
+    '*': [qt6-qtsvg]
     '8': null
     '9': [qt5-qtsvg]
   ubuntu:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6230,29 +6230,6 @@ libqrencode-dev:
   gentoo: [media-gfx/qrencode]
   nixos: [qrencode]
   ubuntu: [libqrencode-dev]
-libqt-core:
-  alpine: [qt6-qtbase]
-  arch: [qt6-base]
-  debian:
-    '*': [libqt6core6t64]
-    bookworm: [libqt6core6]
-  fedora: [qt6-qtbase]
-  gentoo: ['dev-qt/qtcore:6']
-  nixos: [qt6.qtbase]
-  openembedded: [qtbase@meta-qt6]
-  opensuse:
-    '*': [libQt6Core6]
-    '15.2': null
-  rhel:
-    '*': [qt6-qtbase]
-    '8': null
-    '9': [qt5-qtbase]
-  slackware: [qt6]
-  ubuntu:
-    '*': [libqt6core6t64]
-    focal: null
-    jammy: null
-    noble: [libqt5core5t64]
 libqt4:
   debian: [libqt4-dbus, libqt4-network, libqt4-script, libqt4-test, libqt4-xml, libqtcore4]
   fedora: [qt]
@@ -6707,6 +6684,29 @@ libqt6widgets6t64:
     'focal': null
     'jammy': [libqt6widgets6]
     'noble': [libqt6widgets6t64]
+libqtcore:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian:
+    '*': [libqt6core6t64]
+    bookworm: [libqt6core6]
+  fedora: [qt6-qtbase]
+  gentoo: ['dev-qt/qtcore:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse:
+    '*': [libQt6Core6]
+    '15.2': null
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+    '9': [qt5-qtbase]
+  slackware: [qt6]
+  ubuntu:
+    '*': [libqt6core6t64]
+    focal: null
+    jammy: null
+    noble: [libqt5core5t64]
 libqtgui:
   alpine: [qt6-qtbase]
   arch: [qt6-base]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9594,7 +9594,7 @@ python3-qt-bindings:
   rhel:
     '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-Builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
-    '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel, PyQt-Builder]
+    '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel, PyQt-builder]
   ubuntu:
     '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9592,7 +9592,7 @@ python3-qt-bindings:
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
   rhel:
-    '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-Builder]
+    '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel, PyQt-builder]
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9594,7 +9594,7 @@ python3-qt-bindings:
   rhel:
     '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-Builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
-    '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel]
+    '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel, PyQt-Builder]
   ubuntu:
     '*': [libpyside6-dev, libshiboken6-dev, pyqt6-dev, python3-pyqt6, python3-pyqt6.qtsvg, python3-pyside6.qtsvg, qt6-base-dev, shiboken6, python3-sipbuild, python3-pyqtbuild, pyqt6-dev-tools]
     focal: [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9592,7 +9592,7 @@ python3-qt-bindings:
     'bullseye': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2, python3-sipbuild]
   fedora: [python3-pyqt6-devel, python3-pyqt6-sip, sip6]
   rhel:
-    '*': [python3-qt6-devel, python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-builder]
+    '*': [python3-pyqt6-devel, python3-pyqt6-sip, sip6, PyQt-builder]
     '8': ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
     '9': [python3-qt5-devel, python3-sip-devel, sip6, libXext-devel, PyQt-builder]
   ubuntu:


### PR DESCRIPTION
This pull request creates more keys that select qt5 on Ubuntu Noble and RHEL 9, and qt6 everywhere else

* qt-svg-dev and libqtsvg are combined from these rosdep keys: http://gist.github.com/sloretz/18e231ee122a89232a290ca874932cf4
* libqtcore rosdep key combined from these https://gist.github.com/sloretz/5bfe791fcc844f5629786671d04ff68b
* libqtgui rosdep key combined from these: https://gist.github.com/sloretz/6d28619f79f7b684a8926d5733766c5e
* libqtopengl rosdep key combined from these: https://gist.github.com/sloretz/7deb134fee9908033a0ec38e9710a2d1
* Fixed typo on RHEL - package name is is `PyQt-builder` (lowercase b)
* Removed non-existant package python3-qt6-devel from RHEL 10 entry on python3-qt-bindings