### PR TITLE
mrpt_ros_bridge: 3.5.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6019,7 +6019,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.5.2-1
+      version: 3.5.3-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.5.3-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.5.2-1`

## mrpt_libros_bridge

```
* Merge pull request #8 <https://github.com/MRPT/mrpt_ros_bridge/issues/8> from MRPT/fix/potential-ub-reinterpret-cast
  FIX: Potential UB for reinterpret_cast
* FIX: Potential UB for reinterpret_cast
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

- No changes
