### PR TITLE
qt_gui_core: 2.10.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6466,7 +6466,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.10.4-1
+      version: 2.10.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.10.5-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `2.10.4-1`

## qt_dotgraph

- No changes

## qt_gui

- No changes

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Use qt-base-dev / libqtwidgets (#330 <https://github.com/ros-visualization/qt_gui_core/issues/330>)
* Contributors: Shane Loretz
```

## qt_gui_py_common

- No changes
