### PR TITLE
rqt: 1.10.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8519,7 +8519,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.10.3-1
+      version: 1.10.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.10.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.10.3-1`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

```
* Use qt-base-dev / libqtwidgets (#345 <https://github.com/ros-visualization/rqt/issues/345>)
* fix: include unistd.h for getpid (#341 <https://github.com/ros-visualization/rqt/issues/341>)
* Contributors: Daisuke Nishimatsu, Shane Loretz
```

## rqt_gui_py

- No changes

## rqt_py_common

```
* Use qt-base-dev / libqtwidgets (#345 <https://github.com/ros-visualization/rqt/issues/345>)
* Contributors: Shane Loretz
```
