### PR TITLE
rviz: 15.2.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9077,7 +9077,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.2.0-1
+      version: 15.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `15.2.0-1`

## rviz2

```
* Use rosdep keys that select Qt5 or Qt6 by platform (#1720 <https://github.com/ros2/rviz/issues/1720>)
* Contributors: Shane Loretz
```

## rviz_common

```
* Use rosdep keys that select Qt5 or Qt6 by platform (#1720 <https://github.com/ros2/rviz/issues/1720>)
* Contributors: Shane Loretz
```

## rviz_default_plugins

```
* Use rosdep keys that select Qt5 or Qt6 by platform (#1720 <https://github.com/ros2/rviz/issues/1720>)
* Contributors: Shane Loretz
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Use rosdep keys that select Qt5 or Qt6 by platform (#1720 <https://github.com/ros2/rviz/issues/1720>)
* Contributors: Shane Loretz
```

## rviz_rendering_tests

```
* Use rosdep keys that select Qt5 or Qt6 by platform (#1720 <https://github.com/ros2/rviz/issues/1720>)
* Contributors: Shane Loretz
```

## rviz_visual_testing_framework

```
* Use rosdep keys that select Qt5 or Qt6 by platform (#1720 <https://github.com/ros2/rviz/issues/1720>)
* Contributors: Shane Loretz
```
