### PR TITLE
libcaer_driver: 1.5.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4979,7 +4979,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.5.2-1
+      version: 1.5.4-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.5.4-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.5.2-1`

## libcaer_driver

```
* fix rolling errors
* updated license string in package.xml
* warn of upgrade to firmware 1.0
* updated README and github workflow
* formatting fixes
* Cmake extension to support clang compiler and lsp
* fix doubled time in the imu (and frame) time_stamp
  Instead of passing current rostime to the frame and imu Callbacks,
  now correctly pass rosBaseTime_ (rostime at startup) to both.
  Then the sensor_time of the SDK_packet is added, resulting in the time visible
  in the msgs.
  note: the change to the frame callback is technically not tested, because
  the hardware accessible to me does not support frame capture.
  Signed-of-by: Erik Schlenzka
* Contributors: Bernd Pfrommer, EschronS
```
