### PR TITLE
frequency_cam: 3.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3240,7 +3240,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/frequency_cam-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/frequency_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frequency_cam` to `3.1.1-1`:

- upstream repository: https://github.com/ros-event-camera/frequency_cam.git
- release repository: https://github.com/ros2-gbp/frequency_cam-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `3.1.0-1`

## frequency_cam

```
* get rid of ament_auto stuff
* rely on event_camera_msgs and codecs packages
* fix c++ standard 20 warnings
* Contributors: Bernd Pfrommer
```
