### PR TITLE
event_camera_tools: 3.1.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2025,7 +2025,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_tools-release.git
-      version: 3.1.2-1
+      version: 3.1.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `event_camera_tools` to `3.1.3-1`:

- upstream repository: https://github.com/ros-event-camera/event_camera_tools.git
- release repository: https://github.com/ros2-gbp/event_camera_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `3.1.2-1`

## event_camera_tools

```
* fix c++ standard 20 warnings
* added seqno gap detection to event_statistics
* store in mcap mode (also on humble)
* provide timestamps file to correlate frame numbers with time stamps
* add dependency on ament_cmake_test for humble builds
* Contributors: Bernd Pfrommer
```
