### PR TITLE
rqml: 3.26.42-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10082,7 +10082,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rqml-release.git
-      version: 3.26.41-1
+      version: 3.26.42-1
     source:
       type: git
       url: https://github.com/StefanFabian/rqml.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqml` to `3.26.42-1`:

- upstream repository: https://github.com/StefanFabian/rqml
- release repository: https://github.com/ros2-gbp/rqml-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `3.26.41-1`

## rqml

- No changes

## rqml_core

```
* Adding KDDockWidgets as third_party to the repo until better option is viable (e.g. vendor package).
* Contributors: Stefan Fabian
```

## rqml_default_plugins

- No changes

## rqml_plugin_example

- No changes
