### PR TITLE
Start testing rosdep rules against Fedora 44

### DIFF
--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -74,6 +74,7 @@ supported_versions:
   fedora:
   - '42'
   - '43'
+  - '44'
   opensuse:
   - '15.2'
   openembedded:
@@ -111,6 +112,8 @@ name_replacements:
     '42':
       '%{__isa_name}': 'x86'
     '43':
+      '%{__isa_name}': 'x86'
+    '44':
       '%{__isa_name}': 'x86'
   openembedded:
     master:


### PR DESCRIPTION
Fedora 44 has been released: https://fedoramagazine.org/announcing-fedora-linux-44/

Fedora 42 will be EOL on May 13th