### PR TITLE
Roll Rolling to RHEL 10

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6,7 +6,7 @@ release_platforms:
   debian:
   - bookworm
   rhel:
-  - '9'
+  - '10'
   ubuntu:
   - noble
 repositories:


### PR DESCRIPTION
The dynamic RPM metadata for RHEL 10 does not require traditional migration and can be performed immediately.

Connected to ros2/ci#872
Connected to ros2/ros_buildfarm_config#365