### PR TITLE
Fix regression in migration script

### DIFF
--- a/migration-tools/migrate-rosdistro.py
+++ b/migration-tools/migrate-rosdistro.py
@@ -228,7 +228,6 @@ for repo_name in sorted(new_repositories + repositories_to_retry):
             del dest_track['release_tag_saved']
             write_tracks_file(tracks, f'Restore saved version and tag for {args.dest} track.')
         new_release_track_inc = str(int(tracks['tracks'][args.dest]['release_inc']))
-        release_spec.url = new_release_repo_url
 
         ver, _inc = release_spec.version.split('-')
         release_spec.version = '-'.join([ver, new_release_track_inc])


### PR DESCRIPTION
This isn't necessary now that the migration script doesn't duplicate release repositories that are outside of the target organization.

Fixes #45268