### PR TITLE
Un-release repos in Rolling which can't be migrated

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -115,11 +115,6 @@ repositories:
       version: rolling
     status: maintained
   ads_vendor:
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/b-robotized/ads_vendor-release.git
-      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git
@@ -516,14 +511,6 @@ repositories:
       type: git
       url: https://github.com/namo-robotics/aruco_markers.git
       version: humble
-    release:
-      packages:
-      - aruco_markers
-      - aruco_markers_msgs
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/namo-robotics/aruco_markers-release.git
-      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/namo-robotics/aruco_markers.git
@@ -973,11 +960,6 @@ repositories:
       type: git
       url: https://github.com/bob-ros2/bob_llm.git
       version: main
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/bob-ros2/bob_llm-release.git
-      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/bob-ros2/bob_llm.git
@@ -1212,14 +1194,6 @@ repositories:
       type: git
       url: https://github.com/facontidavide/cloudini.git
       version: main
-    release:
-      packages:
-      - cloudini_lib
-      - cloudini_ros
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/facontidavide/cloudini-release.git
-      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/facontidavide/cloudini.git
@@ -2253,11 +2227,6 @@ repositories:
       type: git
       url: https://github.com/introlab/find-object.git
       version: rolling-devel
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/find_object_2d-release.git
-      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/introlab/find-object.git
@@ -8980,25 +8949,6 @@ repositories:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
       version: rolling-devel
-    release:
-      packages:
-      - rtabmap_conversions
-      - rtabmap_demos
-      - rtabmap_examples
-      - rtabmap_launch
-      - rtabmap_msgs
-      - rtabmap_odom
-      - rtabmap_python
-      - rtabmap_ros
-      - rtabmap_rviz_plugins
-      - rtabmap_slam
-      - rtabmap_sync
-      - rtabmap_util
-      - rtabmap_viz
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.22.1-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
@@ -9107,11 +9057,6 @@ repositories:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
       version: main
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/nobleo/rviz_satellite-release.git
-      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
@@ -9143,11 +9088,6 @@ repositories:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/SBG-Systems/sbg_ros2-release.git
-      version: 3.3.2-1
     source:
       test_pull_requests: true
       type: git
@@ -9611,11 +9551,6 @@ repositories:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git
       version: rolling
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/synapticon/synapticon_ros2_control-release.git
-      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/synapticon/synapticon_ros2_control.git


### PR DESCRIPTION
These package repositories host release repositories outside of the `ros2-gbp` organization and therefore can't participate in Rolling migrations. They must be disabled so that the rest of the distribution can migrate to Ubuntu Resolute.

Maintainers of these packages should request created of release repositories in the `ros2-gbp` organization and perform releases of their packages in Rolling and Lyrical once the rest of the distributions have finished the migration and the distributions are un-frozen.