### PR TITLE
ros2_control_cmake: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7606,7 +7606,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
-      version: 0.3.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control_cmake` to `1.0.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control_cmake.git
- release repository: https://github.com/ros2-gbp/ros2_control_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.3.0-1`

## ros2_control_cmake

```
* Set CMAKE_CXX_STANDARD to 20 (#28 <https://github.com/ros-controls/ros2_control_cmake/issues/28>)
* Contributors: Christoph Fröhlich
```
