### PR TITLE
ros2_control_cmake: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9102,7 +9102,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9097,7 +9097,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git
-      version: master
+      version: jazzy
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -9106,7 +9106,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git
-      version: master
+      version: jazzy
     status: developed
   ros2_controllers:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control_cmake` to `0.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control_cmake.git
- release repository: https://github.com/ros2-gbp/ros2_control_cmake-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.3.0-1`

## ros2_control_cmake

```
* Default to C++20 if available (#30 <https://github.com/ros-controls/ros2_control_cmake/issues/30>)
* Contributors: Christoph Fröhlich
```
