### PR TITLE
ros2_control_cmake: 0.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7637,7 +7637,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git
-      version: master
+      version: jazzy
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -7646,7 +7646,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git
-      version: master
+      version: jazzy
     status: developed
   ros2_controllers:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7642,7 +7642,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
-      version: 0.3.0-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control_cmake` to `0.4.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control_cmake.git
- release repository: https://github.com/ros2-gbp/ros2_control_cmake-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.3.0-1`

## ros2_control_cmake

```
* Default to C++20 if available (#30 <https://github.com/ros-controls/ros2_control_cmake/issues/30>)
* Contributors: Christoph Fröhlich
```
