### PR TITLE
Add rosdep rules for Rolling on Resolute and Trixie

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2898,6 +2898,7 @@ libboost-atomic:
     bookworm: [libboost-atomic1.74.0]
     bullseye: [libboost-atomic1.74.0]
     buster: [libboost-atomic1.67.0]
+    trixie: [libboost-atomic1.83.0]
   fedora: [boost-atomic]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2909,6 +2910,7 @@ libboost-atomic:
     focal: [libboost-atomic1.71.0]
     jammy: [libboost-atomic1.74.0]
     noble: [libboost-atomic1.83.0]
+    resolute: [libboost-atomic1.83.0]
 libboost-atomic-dev:
   arch: [boost]
   debian: [libboost-atomic-dev]
@@ -2925,6 +2927,7 @@ libboost-chrono:
     bookworm: [libboost-chrono1.74.0]
     bullseye: [libboost-chrono1.74.0]
     buster: [libboost-chrono1.67.0]
+    trixie: [libboost-chrono1.83.0t64]
   fedora: [boost-chrono]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2936,6 +2939,7 @@ libboost-chrono:
     focal: [libboost-chrono1.71.0]
     jammy: [libboost-chrono1.74.0]
     noble: [libboost-chrono1.83.0t64]
+    resolute: [libboost-chrono1.83.0t64]
 libboost-chrono-dev:
   arch: [boost]
   debian: [libboost-chrono-dev]
@@ -2983,6 +2987,7 @@ libboost-date-time:
     bookworm: [libboost-date-time1.74.0]
     bullseye: [libboost-date-time1.74.0]
     buster: [libboost-date-time1.67.0]
+    trixie: [libboost-date-time1.83.0]
   fedora: [boost-date-time]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -2994,6 +2999,7 @@ libboost-date-time:
     focal: [libboost-date-time1.71.0]
     jammy: [libboost-date-time1.74.0]
     noble: [libboost-date-time1.83.0]
+    resolute: [libboost-date-time1.83.0]
 libboost-date-time-dev:
   arch: [boost]
   debian: [libboost-date-time-dev]
@@ -3020,6 +3026,7 @@ libboost-filesystem:
     bookworm: [libboost-filesystem1.74.0]
     bullseye: [libboost-filesystem1.74.0]
     buster: [libboost-filesystem1.67.0]
+    trixie: [libboost-filesystem1.83.0]
   fedora: [boost-filesystem]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -3031,6 +3038,7 @@ libboost-filesystem:
     focal: [libboost-filesystem1.71.0]
     jammy: [libboost-filesystem1.74.0]
     noble: [libboost-filesystem1.83.0]
+    resolute: [libboost-filesystem1.83.0]
 libboost-filesystem-dev:
   arch: [boost]
   debian: [libboost-filesystem-dev]
@@ -3108,6 +3116,7 @@ libboost-program-options:
     bookworm: [libboost-program-options1.74.0]
     bullseye: [libboost-program-options1.74.0]
     buster: [libboost-program-options1.67.0]
+    trixie: [libboost-program-options1.83.0]
   fedora: [boost-program-options]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -3119,6 +3128,7 @@ libboost-program-options:
     focal: [libboost-program-options1.71.0]
     jammy: [libboost-program-options1.74.0]
     noble: [libboost-program-options1.83.0]
+    resolute: [libboost-program-options1.83.0]
 libboost-program-options-dev:
   arch: [boost]
   debian: [libboost-program-options-dev]
@@ -3136,6 +3146,7 @@ libboost-python:
     bookworm: [libboost-python1.74.0]
     bullseye: [libboost-python1.74.0]
     buster: [libboost-python1.67.0]
+    trixie: [libboost-python1.83.0]
   fedora: [boost-python3]
   gentoo: ['dev-libs/boost[python]']
   nixos: [boost]
@@ -3149,6 +3160,7 @@ libboost-python:
     focal: [libboost-python1.71.0]
     jammy: [libboost-python1.74.0]
     noble: [libboost-python1.83.0]
+    resolute: [libboost-python1.83.0]
 libboost-python-dev:
   alpine: [boost-python2]
   arch: [boost]
@@ -3168,6 +3180,7 @@ libboost-random:
     bookworm: [libboost-random1.74.0]
     bullseye: [libboost-random1.74.0]
     buster: [libboost-random1.67.0]
+    trixie: [libboost-random1.83.0]
   fedora: [boost-random]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -3179,6 +3192,7 @@ libboost-random:
     focal: [libboost-random1.71.0]
     jammy: [libboost-random1.74.0]
     noble: [libboost-random1.83.0]
+    resolute: [libboost-random1.83.0]
 libboost-random-dev:
   arch: [boost]
   debian: [libboost-random-dev]
@@ -3195,6 +3209,7 @@ libboost-regex:
     bookworm: [libboost-regex1.74.0]
     bullseye: [libboost-regex1.74.0]
     buster: [libboost-regex1.67.0]
+    trixie: [libboost-regex1.83.0]
   fedora: [boost-regex]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -3206,6 +3221,7 @@ libboost-regex:
     focal: [libboost-regex1.71.0]
     jammy: [libboost-regex1.74.0]
     noble: [libboost-regex1.83.0]
+    resolute: [libboost-regex1.83.0]
 libboost-regex-dev:
   arch: [boost]
   debian: [libboost-regex-dev]
@@ -3249,6 +3265,7 @@ libboost-system:
     bookworm: [libboost-system1.74.0]
     bullseye: [libboost-system1.74.0]
     buster: [libboost-system1.67.0]
+    trixie: [libboost-system1.83.0]
   fedora: [boost-system]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -3260,6 +3277,7 @@ libboost-system:
     focal: [libboost-system1.71.0]
     jammy: [libboost-system1.74.0]
     noble: [libboost-system1.83.0]
+    resolute: [libboost-system1.83.0]
 libboost-system-dev:
   arch: [boost]
   debian: [libboost-system-dev]
@@ -3276,6 +3294,7 @@ libboost-thread:
     bookworm: [libboost-thread1.74.0]
     bullseye: [libboost-thread1.74.0]
     buster: [libboost-thread1.67.0]
+    trixie: [libboost-thread1.83.0]
   fedora: [boost-thread]
   gentoo: ['dev-libs/boost[threads]']
   nixos: [boost]
@@ -3287,6 +3306,7 @@ libboost-thread:
     focal: [libboost-thread1.71.0]
     jammy: [libboost-thread1.74.0]
     noble: [libboost-thread1.83.0]
+    resolute: [libboost-thread1.83.0]
 libboost-thread-dev:
   arch: [boost]
   debian: [libboost-thread-dev]
@@ -5221,6 +5241,7 @@ libogre-1.12-dev:
 libogre-dev:
   arch: [ogre]
   debian:
+    bullseye: [libogre-1.9-dev]
     buster: [libogre-1.9-dev]
     stretch: [libogre-1.9-dev]
     wheezy: [libogre-dev]
@@ -5648,6 +5669,7 @@ libpcl-common:
     bookworm: [libpcl-common1.13]
     bullseye: [libpcl-common1.11]
     buster: [libpcl-common1.9]
+    trixie: [libpcl-common1.15]
   fedora: [pcl]
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
@@ -5661,12 +5683,14 @@ libpcl-common:
     focal: [libpcl-common1.10]
     jammy: [libpcl-common1.12]
     noble: [libpcl-common1.14]
+    resolute: [libpcl-common1.15]
 libpcl-features:
   alpine: [pcl-libs]
   debian:
     bookworm: [libpcl-features1.13]
     bullseye: [libpcl-features1.11]
     buster: [libpcl-features1.9]
+    trixie: [libpcl-features1.15]
   fedora: [pcl]
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
@@ -5680,12 +5704,14 @@ libpcl-features:
     focal: [libpcl-features1.10]
     jammy: [libpcl-features1.12]
     noble: [libpcl-features1.14]
+    resolute: [libpcl-features1.15]
 libpcl-filters:
   alpine: [pcl-libs]
   debian:
     bookworm: [libpcl-filters1.13]
     bullseye: [libpcl-filters1.11]
     buster: [libpcl-filters1.9]
+    trixie: [libpcl-filters1.15]
   fedora: [pcl]
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
@@ -5699,12 +5725,14 @@ libpcl-filters:
     focal: [libpcl-filters1.10]
     jammy: [libpcl-filters1.12]
     noble: [libpcl-filters1.14]
+    resolute: [libpcl-filters1.15]
 libpcl-io:
   alpine: [pcl-libs]
   debian:
     bookworm: [libpcl-io1.13]
     bullseye: [libpcl-io1.11]
     buster: [libpcl-io1.9]
+    trixie: [libpcl-io1.15]
   fedora: [pcl]
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
@@ -5718,6 +5746,7 @@ libpcl-io:
     focal: [libpcl-io1.10]
     jammy: [libpcl-io1.12]
     noble: [libpcl-io1.14]
+    resolute: [libpcl-io1.15]
 libpcl-kdtree:
   alpine: [pcl-libs]
   debian:
@@ -5904,6 +5933,7 @@ libpcl-segmentation:
     bookworm: [libpcl-segmentation1.13]
     bullseye: [libpcl-segmentation1.11]
     buster: [libpcl-segmentation1.9]
+    trixie: [libpcl-segmentation1.15]
   fedora: [pcl]
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
@@ -5917,6 +5947,7 @@ libpcl-segmentation:
     focal: [libpcl-segmentation1.10]
     jammy: [libpcl-segmentation1.12]
     noble: [libpcl-segmentation1.14]
+    resolute: [libpcl-segmentation1.15]
 libpcl-stereo:
   alpine: [pcl-libs]
   debian:
@@ -5941,6 +5972,7 @@ libpcl-surface:
     bookworm: [libpcl-surface1.13]
     bullseye: [libpcl-surface1.11]
     buster: [libpcl-surface1.9]
+    trixie: [libpcl-surface1.15]
   fedora: [pcl]
   freebsd: [libpcl]
   gentoo: [sci-libs/pcl]
@@ -5954,6 +5986,7 @@ libpcl-surface:
     focal: [libpcl-surface1.10]
     jammy: [libpcl-surface1.12]
     noble: [libpcl-surface1.14]
+    resolute: [libpcl-surface1.15]
 libpcl-tracking:
   alpine: [pcl-libs]
   debian:
@@ -8854,6 +8887,7 @@ protobuf:
     bookworm: [libprotobuf32]
     bullseye: [libprotobuf23]
     buster: [libprotobuf17]
+    trixie: [libprotobuf32t64]
   fedora: [protobuf]
   freebsd: [protobuf]
   gentoo: [dev-libs/protobuf]
@@ -8868,6 +8902,7 @@ protobuf:
     focal: [libprotobuf17]
     jammy: [libprotobuf23]
     noble: [libprotobuf32t64]
+    resolute: [libprotobuf32t64]
 protobuf-compiler-grpc:
   arch: [grpc]
   debian: [protobuf-compiler-grpc]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -628,6 +628,7 @@ python-argparse:
   alpine: [py-argparse]
   arch: [python2]
   debian:
+    bullseye: [libpython2.7-stdlib]
     buster: [libpython2.7-stdlib]
     squeeze: [python-argparse]
     stretch: [libpython2.7-stdlib]
@@ -10907,8 +10908,10 @@ python3-transformers-pip:
       packages: [transformers]
 python3-transforms3d:
   debian:
-    pip:
-      packages: [transforms3d]
+    '*': [python3-transforms3d]
+    bullseye:
+      pip:
+        packages: [transforms3d]
   fedora: [python3-transforms3d]
   nixos: [python3Packages.transforms3d]
   ubuntu:


### PR DESCRIPTION
No new keys, only adding missing Rolling rules.

Only Debian and Ubuntu rules, which are verified by automation.