### PR TITLE
Update branch names of some repositories and unrelease hpp_fcl

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3175,21 +3175,6 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
       version: rolling-devel
     status: developed
-  hpp-fcl:
-    doc:
-      type: git
-      url: https://github.com/humanoid-path-planner/hpp-fcl.git
-      version: devel
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/hpp_fcl-release.git
-      version: 2.4.5-1
-    source:
-      type: git
-      url: https://github.com/humanoid-path-planner/hpp-fcl.git
-      version: devel
-    status: developed
   hri:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1203,7 +1203,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/coal-library/coal.git
-      version: master
+      version: devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1212,7 +1212,7 @@ repositories:
     source:
       type: git
       url: https://github.com/coal-library/coal.git
-      version: master
+      version: devel
     status: developed
   cob_common:
     doc:
@@ -1904,7 +1904,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git
-      version: master
+      version: devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -3179,7 +3179,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
-      version: master
+      version: devel
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -5257,7 +5257,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      version: main
     release:
       packages:
       - nodl_python
@@ -5269,7 +5269,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ubuntu-robotics/nodl.git
-      version: master
+      version: main
     status: developed
   nodl_to_policy:
     doc:


### PR DESCRIPTION
Fixing issies noticed in https://github.com/ros/rosdistro/pull/50955


* Coal has been released from `devel`: https://github.com/ros2-gbp/coal-release/blob/6f69fdfd1a97843be1fd5bdf8739786bad56551b/tracks.yaml#L100
* eigenpy has been released from `devel`: https://github.com/ros2-gbp/eigenpy-release/blob/abc09925f4bc177ca273a266c68471de1e5ed603/tracks.yaml#L154
* hpp_fcl redirects to coal, so I removed it https://github.com/humanoid-path-planner/hpp-fcl.git
* nodl now has a main branch: https://github.com/ros-tooling/nodl