### PR TITLE
mola_state_estimation: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5931,7 +5931,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.3.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.2.0-1`

## mola_georeferencing

```
* FIX: Filter out invalid geodetic coordinates (0,0,0)
* Merge pull request #20 <https://github.com/MOLAorg/mola_state_estimation/issues/20> from MOLAorg/fix/wrong-enu-map-transform
  FIX: Wrong transformation applied to ENU-MAP
* FIX: Wrong transformation applied to ENU-MAP
* Merge pull request #19 <https://github.com/MOLAorg/mola_state_estimation/issues/19> from MOLAorg/feat/georef-output-yaml
  mola-sm-georeferencing: support yaml output format
* mola-sm-georeferencing: support yaml output format
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Merge pull request #24 <https://github.com/MOLAorg/mola_state_estimation/issues/24> from MOLAorg/fix/bugs-in-simple-estimator-cov
  Fix: Avoid double covariance increment
* fix: don't use twist cov in propagating pose uncertainty in this simple mode
* Fix: Avoid double covariance increment
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* Merge pull request #23 <https://github.com/MOLAorg/mola_state_estimation/issues/23> from MOLAorg/feat/fuse-ros2-demos
  Add ros2 launch demo files to fuse 2 odometries
* mola cli launch file: made generic for multiple odometry sources
* harden frame name usage
* Odometry sources: use CObservationRobotPose::sensorLabel as 'tf' frame name
* Add ros2 launch demo files to fuse 2 odometries
* Merge pull request #22 <https://github.com/MOLAorg/mola_state_estimation/issues/22> from MOLAorg/feat/refactor-mutexes
  Feat/refactor mutexes
* Refactor to use regular mutex instead of recursive_mutex
* Merge pull request #21 <https://github.com/MOLAorg/mola_state_estimation/issues/21> from MOLAorg/fix-misc
  Fixes for 2D motion
* FIX: Planar constraints didn't constraint roll / pitch, only tz
* FIX: 2D probabilistic model used wrong XY uncertainty
* Contributors: Jose Luis Blanco-Claraco
```
