### PR TITLE
mola_sm_loop_closure: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5910,7 +5910,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_sm_loop_closure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_sm_loop_closure` to `1.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_sm_loop_closure.git
- release repository: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.0-1`

## mola_sm_loop_closure

```
* Merge pull request #10 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/10> from MOLAorg/refactor/lc-common-helpers
  refactor: extract lc_common helpers; port planar-world annealing + GNC to SM
* refactor: replace two-pass LM with single GNC pass in SimplemapLoopClosure
* refactor: extract lc_common helpers; port planar-world annealing + GNC to SM
* Merge pull request #9 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/9> from MOLAorg/feat/planar-world-in-f2f
  feat: optional f2f planar world soft-constraints
* feat: optional f2f planar world soft-constraints
* Merge pull request #8 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/8> from MOLAorg/feat/manual-lc
  Support for optional manual hints for LC
* Support for optional manual hints for LC
* Merge pull request #7 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/7> from MOLAorg/feat/more-flexible-icp-sigmas-and-logging
  Expose more env vars
* Expose more env vars
* f2f pipeline file: add env var MOLA_DESKEW_IGNORE_ACCELEROMETER
* Contributors: Jose Luis Blanco-Claraco
```
