### PR TITLE
mola: 2.8.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5825,7 +5825,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.7.0-1
+      version: 2.8.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.8.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-1`

## kitti_metrics_eval

- No changes

## mola

- No changes

## mola_bridge_ros2

```
* Merge pull request #140 <https://github.com/MOLAorg/mola/issues/140> from MOLAorg/feat/bridge-ros2-qos
  feat: BridgeROS2 now have configurable QoS
* fix: harden parameter parsing
* feat: BridgeROS2 now have configurable QoS
* Merge pull request #135 <https://github.com/MOLAorg/mola/issues/135> from MOLAorg/pr-132
  feat(bridge_ros2): align REP-105 TF with Nav2 conventions without regressing direct-publish mode
* feat(bridge_ros2): align REP-105 TF publishing with Nav2 conventions
  This brings the localization /tf publisher in line with the convention
  used by AMCL, slam_toolbox, RTAB-Map and Cartographer, addressing three
  issues observed when MOLA is consumed by Nav2-style downstream nodes:
  1. REP-105 composition bug (fix). The inner factor of
  map -> odom = (map -> base)(t_scan) * (base -> odom)(t)
  was sampled at "latest" via waitForTransform(), which only supports
  tf2::TimePoint{}. The two factors must be sampled at the same
  instant or the published correction is biased by the odom-frame
  motion accumulated during the localizer's processing latency. Switch
  to tf_buffer_->lookupTransform(..., scan_tp). On lookup failure the
  publish is skipped (an empty default-constructed TransformStamped
  would inject TF_NO_FRAME_ID into every consumer's tf2 buffer).
  2. transform_tolerance (new param, default 0.1s). The published stamp
  is now node->now() + transform_tolerance so consumers can do
  lookupTransform(map, base_link, now()) without
  ExtrapolationException. Mirrors AMCL's transform_tolerance and
  RTAB-Map's tf_tolerance. Uses the ROS clock so use_sim_time is
  honored automatically.
  3. transform_publish_period (new param, default 0.05s = 20 Hz). A
  wall timer re-broadcasts the cached map -> odom independent of
  localization update rate, keeping the TF buffer continuously fresh
  even when the localizer runs slower than the consumer query rate.
  Set to 0 to disable. Mirrors slam_toolbox's transform_publish_period
  and RTAB-Map's tf_delay.
  Backwards compat: to exactly preserve the prior (post-bugfix) stamping
  behavior set transform_tolerance: 0 and transform_publish_period: 0.
  publish_in_sim_time retains its meaning for all other publishers
  (sensor TFs, odom messages, etc.); only the localization /tf stamp
  source changed.
* Merge branch 'develop' into perf/keyframe-prewarm-global-submap
* Merge pull request #133 <https://github.com/MOLAorg/mola/issues/133> from Zeal-Robotics/fix/bridge-ros2-throttle-tf-lookup-errors
  fix(bridge_ros2): throttle TF lookup error logging
* fix(bridge_ros2): throttle TF lookup error logging
  Failed sensor TF lookups (e.g. missing static URDF transforms during
  bring-up) flooded the console with two unthrottled ERROR lines per
  observation. With a Livox IMU at ~100 Hz this produced ~200 lines/s
  per affected topic, drowning out other diagnostics.
  - Throttle (5 s) every per-observation "Could not forward ROS2
  observation to MOLA due to timeout..." in the PointCloud2,
  LaserScan, Imu, NavSatFix and gps_msgs paths, plus the
  "Could not get /tf" path that uses lookupSensorPose, and the
  REP-105 odom->base_link recompute warning in publishLocalizationTf.
  - Drop the redundant printErrors plumbing from waitForTransform: the
  inner MRPT_LOG_ERROR(ex.what()) duplicated what callers already
  print with more context (frames + timestamp). The raw tf2 reason
  is still emitted at DEBUG for deep diagnostics.
  Per-callsite throttle state means independent sensors still surface
  "this stream stopped" promptly; we just stop spamming the same one.
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_demos

- No changes

## mola_input_euroc_dataset

- No changes

## mola_input_kitti360_dataset

- No changes

## mola_input_kitti_dataset

- No changes

## mola_input_lidar_bin_dataset

- No changes

## mola_input_mulran_dataset

- No changes

## mola_input_paris_luco_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

- No changes

## mola_input_video

- No changes

## mola_kernel

```
* Merge branch 'Zeal-Robotics-fix/map-source-latched-replay' into develop
* chore: transient callbacks done with a copy of last updates
* fix(mola_kernel): replay latched MapUpdates to late subscribers
  MapSourceBase::subscribeToMapUpdates() now caches the most recent
  MapUpdate per map_name whenever it was advertised with
  keep_last_one_only=true, and replays it once into any callback
  registered later. This mirrors ROS' transient_local durability at
  the MOLA-callback layer.
  Without this, a producer that advertises its initial map before a
  consumer has had a chance to subscribe (e.g. mola_lidar_odometry
  publishing the loaded .mm on its first scan, before
  mola_bridge_ros2::doLookForNewMolaSubs() has run for the first
  time) would silently lose that update. The race is more likely with
  small maps, where odometry initialization is fast enough to beat the
  bridge's first sub-discovery poll. With this change the late
  subscriber receives the cached update on registration, and the ROS
  publisher created by the bridge then carries the map onward via its
  existing transient_local QoS.
  Updates flagged with keep_last_one_only=false (e.g. deskewed
  scans) are intentionally not cached, matching their fire-and-forget
  semantics.
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_launcher

- No changes

## mola_metric_maps

```
* Merge pull request #139 <https://github.com/MOLAorg/mola/issues/139> from MOLAorg/fix/monothonic-kf-ids
  Fix: ensure monothonic KF ids
* Fix: ensure monothonic KF ids
* Merge pull request #138 <https://github.com/MOLAorg/mola/issues/138> from MOLAorg/fix/kf-map
  fix: robustify edge cases from last API changes
* fix: robustify edge cases from last API changes
* Merge pull request #137 <https://github.com/MOLAorg/mola/issues/137> from MOLAorg/feat/metric-map-changes-for-lo-grav-align
  mola_metric_maps: per-KF pose plumbing for online gravity rebake
* feat(mola_metric_maps): per-KF pose plumbing for online gravity rebake
  Add the KeyframePointCloudMap APIs needed by mola_lidar_odometry's
  online gravity-rebake feature:
  - cloneKFPoses: snapshot of all KF poses keyed by id
  - setKeyframePose: per-KF pose overwrite with cache invalidation
  - lastInsertedKeyFrameID / nextFreeKeyFrameID_public: id introspection
  - drainEvictedKeyFrameIDs: pull-then-clear list of KFs dropped during
  remove_frames_farther_than-driven evictions inside insertObservation
  Also exports the MOLA_METRIC_MAPS_HAS_KFM_POSE_PLUMBING feature macro
  so downstream packages in separate repos (mola_lidar_odometry) can
  guard usage with __has_include + this macro and stay buildable
  against older mola_metric_maps checkouts.
  Adds unit-test coverage for the new APIs in
  test-mola_metric_maps_keyframemap.
  Co-Authored-By: Claude Opus 4.7 <mailto:noreply@anthropic.com>
* Merge pull request #134 <https://github.com/MOLAorg/mola/issues/134> from Zeal-Robotics/perf/keyframe-prewarm-global-submap
  perf(mola_metric_maps): pre-warm global-frame submap data in icp_get_prepared_as_global
* perf(mola_metric_maps): pre-warm global-frame submap data in icp_get_prepared_as_global
  icp_get_prepared_as_global() was building, on the search submap, only the
  local-frame KD-tree and per-point covariances (via KeyFrame::buildCache):
  - bbox
  - kdTreeEnsureIndexBuilt3D() on pointcloud_     (local frame)
  - computeCovariancesAndDensity()                 (local frame)
  The very first call to nn_search_cov2cov() then lazily materialized the
  global-frame counterparts on the caller thread:
  - pointcloud_global()      (deep copy of pointcloud_ rotated by pose())
  - kdTreeEnsureIndexBuilt3D() on the global cloud
  - covariancesGlobal()      (rotated covariances)
  For a non-trivial preloaded local map this stalled the first ICP align()
  by several seconds (e.g. ~6 s on a typical localization map), defeating
  the purpose of having a separate "prepare global" hook. Front-ends that
  explicitly pre-warm via icp_get_prepared_as_global() at startup were
  hit hardest, since the remaining lazy work then showed up on the very
  first scan instead of being amortized across startup.
  Pre-trigger the same three calls at the end of
  icp_get_prepared_as_global() so the search submap is fully ready by the
  time ICP::align() / nn_search_cov2cov() runs.
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_msgs

- No changes

## mola_pose_list

```
* Merge pull request #141 <https://github.com/MOLAorg/mola/issues/141> from MOLAorg/feat/pose-list-multiple
  feat: pose lists now support multiple nearby poses (Useful for non-repetitive scanners)
* feat: pose lists now support multiple nearby poses (Useful for Livox scanners)
* Merge pull request #138 <https://github.com/MOLAorg/mola/issues/138> from MOLAorg/fix/kf-map
  fix: robustify edge cases from last API changes
* fix: robustify edge cases from last API changes
* Merge pull request #137 <https://github.com/MOLAorg/mola/issues/137> from MOLAorg/feat/metric-map-changes-for-lo-grav-align
  mola_metric_maps: per-KF pose plumbing for online gravity rebake
* fix(mola_pose_list): cap k at cloud size in SearchablePoseList::check
  nn_multiple_search resizes its output vectors to the requested k
  regardless of how many neighbours actually exist, leaving trailing
  entries uninitialized when the cloud has fewer than k points. The
  best-match selection in check() then iterated over those garbage
  distances and indices, producing a wrong nearest-pose result whenever
  the list held fewer than 20 entries.
  Cap k to the actual cloud size before calling nn_multiple_search.
  Adds a regression test (test_check_with_few_kfs) that previously failed
  with the stale code: 3 KFs along x, query at (4.9, 0, 0) used to snap
  to the (0, 0, 0) entry instead of the correct (5, 0, 0).
  Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
* feat(mola_pose_list): id-keyed SearchablePoseList for online gravity rebake
  Add an optional KFID tag to SearchablePoseList entries plus an in-place
  pose updater. This lets the LIO online gravity-rebake update its
  distance-checkers when per-KF poses are corrected, without rebuilding
  the whole list.
  New API:
  - insert(pose, id) overload
  - setPoseById(id, new_pose): updates the stored pose and the kd-tree
  point in place; no-op for unknown ids or in from_last_only mode
  removeAllFartherThan now also maintains the id->index map for surviving
  entries.
  Exports MOLA_POSE_LIST_HAS_ID_KEYED_API so downstream packages in
  separate repos (mola_lidar_odometry) can guard usage with __has_include
  + this macro and stay buildable against older mola_pose_list checkouts.
  Adds unit tests for the new id-keyed API in test-searchable-pose-list
  (also fills in the previously-empty test fixture).
  Co-Authored-By: Claude Opus 4.7 <mailto:noreply@anthropic.com>
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

- No changes

## mola_yaml

- No changes
