### PR TITLE
rmw_connextdds: 1.2.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7279,7 +7279,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.4-2
+      version: 1.2.5-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.5-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.2.4-2`

## rmw_connextdds

```
* Remove default from switch with enum to enable compiler warnings (#216 <https://github.com/ros2/rmw_connextdds/issues/216>)
* Contributors: Tomoya Fujita
```

## rmw_connextdds_common

```
* Add variable ``RMW_CONNEXT_USER_TOPICS_PUBLISH_MODE`` and deprecate ``RMW_CONNEXT_USE_DEFAULT_PUBLISH_MODE`` (#224 <https://github.com/ros2/rmw_connextdds/issues/224>)
* Update Connext from 7.3.0 to 7.7.0, disable monitoring library by default, and use synchronous publishing mode (#219 <https://github.com/ros2/rmw_connextdds/issues/219>)
* Enable property ``dds.ros.demangle_topic_and_type_names`` to announce demangled topic name as topic alias (#221 <https://github.com/ros2/rmw_connextdds/issues/221>)
* Enable content filtering flag (#223 <https://github.com/ros2/rmw_connextdds/issues/223>)
* Remove deprecated security properties and use new ones (#217 <https://github.com/ros2/rmw_connextdds/issues/217>)
* Remove default from switch with enum to enable compiler warnings (#216 <https://github.com/ros2/rmw_connextdds/issues/216>)
* Replace ``DDS_ContentFilter_register_filter`` with ``DDS_DomainParticipant_register_contentfilterI`` (#215 <https://github.com/ros2/rmw_connextdds/issues/215>)
* Remove superfluous ``buildtool_export_depend`` (#210 <https://github.com/ros2/rmw_connextdds/issues/210>)
* Contributors: Barry Xu, Francisco Gallego Salido, Tomoya Fujita
```

## rti_connext_dds_cmake_module

```
* Update Connext from 7.3.0 to 7.7.0, disable monitoring library by default, and use synchronous publishing mode (#219 <https://github.com/ros2/rmw_connextdds/issues/219>)
* Contributors: Francisco Gallego Salido
```
