### PR TITLE
iceoryx: 2.0.5-7 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3264,7 +3264,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/iceoryx-release.git
-      version: 2.0.5-6
+      version: 2.0.5-7
     source:
       type: git
       url: https://github.com/eclipse-iceoryx/iceoryx.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iceoryx` to `2.0.5-7`:

- upstream repository: https://github.com/eclipse-iceoryx/iceoryx.git
- release repository: https://github.com/ros2-gbp/iceoryx-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.0`
- previous version for package: `2.0.5-6`
