### PR TITLE
Update ffmpeg and ffmpeg-dev for resolute and trixie

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1145,7 +1145,9 @@ ffmpeg:
 ffmpeg-dev:
   alpine: [ffmpeg-dev]
   arch: [ffmpeg]
-  debian: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
+  debian:
+    '*': [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libswresample-dev, libswscale-dev]
+    bookworm: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
   fedora: [ffmpeg-free-devel]
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
@@ -1157,7 +1159,11 @@ ffmpeg-dev:
     '*': [ffmpeg-free-devel]
     '8': null
   slackware: [ffmpeg]
-  ubuntu: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
+  ubuntu:
+    '*': [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libswresample-dev, libswscale-dev]
+    focal: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
+    jammy: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
+    noble: [libavcodec-dev, libavdevice-dev, libavfilter-dev, libavformat-dev, libavutil-dev, libpostproc-dev, libswresample-dev, libswscale-dev]
 ffmpeg2theora:
   arch: [ffmpeg2theora]
   debian: [ffmpeg2theora]


### PR DESCRIPTION
This PR updates the rosdep entries for ffmpeg and ffmpeg-dev to exclude libpostproc-dev on Ubuntu Resolute and Debian Trixie, where the package has been removed.