### PR TITLE
fusioncore: 0.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3423,6 +3423,18 @@ repositories:
       url: https://github.com/ros-event-camera/frequency_cam.git
       version: release
     status: developed
+  fusioncore:
+    release:
+      packages:
+      - compass_msgs
+      - fusioncore_core
+      - fusioncore_datasets
+      - fusioncore_gazebo
+      - fusioncore_ros
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/manankharwar/fusioncore-release.git
+      version: 0.2.1-1
   game_controller_spl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fusioncore` to `0.2.1-1`:

- upstream repository: https://github.com/manankharwar/fusioncore
- release repository: https://github.com/manankharwar/fusioncore-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `null`
