### PR TITLE
Update ROS PMC managed repos with Lyrical branches

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -181,7 +181,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - ament_cmake
@@ -213,7 +213,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_cmake.git
-      version: rolling
+      version: lyrical
     status: developed
   ament_cmake_catch2:
     doc:
@@ -234,7 +234,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - ament_cmake_ros
@@ -250,7 +250,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ament_cmake_ros.git
-      version: rolling
+      version: lyrical
     status: maintained
   ament_download:
     doc:
@@ -271,7 +271,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_index.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - ament_index_cpp
@@ -284,13 +284,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_index.git
-      version: rolling
+      version: lyrical
     status: maintained
   ament_lint:
     doc:
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - ament_clang_format
@@ -332,7 +332,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_lint.git
-      version: rolling
+      version: lyrical
     status: developed
   ament_nodl:
     release:
@@ -349,7 +349,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/ament_package.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -359,7 +359,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/ament_package.git
-      version: rolling
+      version: lyrical
     status: developed
   ament_vitis:
     doc:
@@ -1117,7 +1117,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/class_loader.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -1127,7 +1127,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
-      version: rolling
+      version: lyrical
     status: maintained
   classic_bags:
     doc:
@@ -1282,7 +1282,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - common_interfaces
@@ -1305,7 +1305,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/common_interfaces.git
-      version: rolling
+      version: lyrical
     status: maintained
   compass:
     doc:
@@ -1332,7 +1332,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -1342,7 +1342,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/console_bridge_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   control_box_rst:
     doc:
@@ -1543,7 +1543,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/demos.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - action_tutorials_cpp
@@ -1574,7 +1574,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/demos.git
-      version: rolling
+      version: lyrical
     status: developed
   depthimage_to_laserscan:
     doc:
@@ -1869,7 +1869,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -1878,7 +1878,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/eigen3_cmake_module.git
-      version: rolling
+      version: lyrical
     status: maintained
   eigen_stl_containers:
     doc:
@@ -2020,7 +2020,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -2030,13 +2030,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/example_interfaces.git
-      version: rolling
+      version: lyrical
     status: maintained
   examples:
     doc:
       type: git
       url: https://github.com/ros2/examples.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - examples_rclcpp_async_client
@@ -2069,7 +2069,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/examples.git
-      version: rolling
+      version: lyrical
     status: maintained
   fastcdr:
     release:
@@ -2539,7 +2539,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - examples_tf2_py
@@ -2564,7 +2564,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/geometry2.git
-      version: rolling
+      version: lyrical
     status: maintained
   geometry_tutorials:
     doc:
@@ -2589,7 +2589,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -2599,7 +2599,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ament/google_benchmark_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   googletest:
     release:
@@ -2613,7 +2613,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/googletest.git
-      version: rolling
+      version: lyrical
     status: maintained
   gps_umd:
     doc:
@@ -3296,7 +3296,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - camera_calibration_parsers
@@ -3313,7 +3313,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_common.git
-      version: rolling
+      version: lyrical
     status: maintained
   image_pipeline:
     doc:
@@ -3423,7 +3423,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -3433,7 +3433,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/interactive_markers.git
-      version: rolling
+      version: lyrical
     status: maintained
   inverse_dynamics_solver:
     doc:
@@ -3553,7 +3553,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/kdl_parser.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -3563,7 +3563,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/kdl_parser.git
-      version: rolling
+      version: lyrical
     status: maintained
   kdl_parser_py:
     doc:
@@ -3728,7 +3728,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -3738,7 +3738,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/laser_geometry.git
-      version: rolling
+      version: lyrical
     status: maintained
   laser_proc:
     doc:
@@ -3775,7 +3775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - launch
@@ -3792,7 +3792,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch.git
-      version: rolling
+      version: lyrical
     status: developed
   launch_frontend_py:
     doc:
@@ -3843,7 +3843,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - launch_ros
@@ -3857,7 +3857,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch_ros.git
-      version: rolling
+      version: lyrical
     status: maintained
   ld08_driver:
     release:
@@ -4083,7 +4083,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/libyaml_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   lidar_mirror_fov_reshaper:
     source:
@@ -4339,7 +4339,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -4349,7 +4349,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/message_filters.git
-      version: rolling
+      version: lyrical
     status: maintained
   message_tf_frame_transformer:
     doc:
@@ -4440,7 +4440,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -4449,7 +4449,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   mini_tof:
     source:
@@ -5772,7 +5772,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/performance_test_fixture.git
-      version: rolling
+      version: lyrical
     status: maintained
   persist_parameter_server:
     doc:
@@ -5969,7 +5969,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - pluginlib
@@ -5982,7 +5982,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/pluginlib.git
-      version: rolling
+      version: lyrical
     status: maintained
   point_cloud_msg_wrapper:
     doc:
@@ -6003,7 +6003,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - point_cloud_transport
@@ -6016,7 +6016,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git
-      version: rolling
+      version: lyrical
     status: maintained
   point_cloud_transport_plugins:
     doc:
@@ -6333,7 +6333,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -6343,7 +6343,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: rolling
+      version: lyrical
     status: maintained
   qml6_ros2_plugin:
     doc:
@@ -6390,7 +6390,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - qt_dotgraph
@@ -6407,7 +6407,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: rolling
+      version: lyrical
     status: maintained
   quaternion_operation:
     doc:
@@ -6586,7 +6586,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcl.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rcl
@@ -6601,13 +6601,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl.git
-      version: rolling
+      version: lyrical
     status: maintained
   rcl_interfaces:
     doc:
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - action_msgs
@@ -6628,13 +6628,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_interfaces.git
-      version: rolling
+      version: lyrical
     status: maintained
   rcl_logging:
     doc:
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rcl_logging_implementation
@@ -6649,7 +6649,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcl_logging.git
-      version: rolling
+      version: lyrical
     status: maintained
   rcl_logging_rcutils:
     doc:
@@ -6702,7 +6702,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rclcpp
@@ -6717,13 +6717,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclcpp.git
-      version: rolling
+      version: lyrical
     status: maintained
   rclpy:
     doc:
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -6733,13 +6733,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rclpy.git
-      version: rolling
+      version: lyrical
     status: maintained
   rcpputils:
     doc:
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -6749,7 +6749,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcpputils.git
-      version: rolling
+      version: lyrical
     status: developed
   rcss3d_agent:
     doc:
@@ -6790,7 +6790,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -6800,7 +6800,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rcutils.git
-      version: rolling
+      version: lyrical
     status: maintained
   reach:
     source:
@@ -6835,7 +6835,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rttest
@@ -6848,7 +6848,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/realtime_support.git
-      version: rolling
+      version: lyrical
     status: maintained
   realtime_tools:
     doc:
@@ -6899,7 +6899,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -6909,13 +6909,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/resource_retriever.git
-      version: rolling
+      version: lyrical
     status: maintained
   resource_retriever_service:
     doc:
       type: git
       url: https://github.com/ros2/resource_retriever_service.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - resource_retriever_interfaces
@@ -6929,7 +6929,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/resource_retriever_service.git
-      version: rolling
+      version: lyrical
     status: maintained
   rig_reconfigure:
     release:
@@ -7242,7 +7242,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rmw
@@ -7256,13 +7256,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw.git
-      version: rolling
+      version: lyrical
     status: maintained
   rmw_connextdds:
     doc:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rmw_connextdds
@@ -7275,13 +7275,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git
-      version: rolling
+      version: lyrical
     status: developed
   rmw_cyclonedds:
     doc:
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rmw_cyclonedds_cpp
@@ -7293,13 +7293,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_cyclonedds.git
-      version: rolling
+      version: lyrical
     status: developed
   rmw_dds_common:
     doc:
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -7309,7 +7309,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_dds_common.git
-      version: rolling
+      version: lyrical
     status: maintained
   rmw_desert:
     doc:
@@ -7342,7 +7342,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rmw_fastrtps_cpp
@@ -7356,7 +7356,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_fastrtps.git
-      version: rolling
+      version: lyrical
     status: developed
   rmw_gurumdds:
     doc:
@@ -7379,7 +7379,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -7389,13 +7389,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rmw_implementation.git
-      version: rolling
+      version: lyrical
     status: developed
   rmw_zenoh:
     doc:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rmw_zenoh_cpp
@@ -7408,7 +7408,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git
-      version: rolling
+      version: lyrical
     status: developed
   roboplan:
     doc:
@@ -7464,7 +7464,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -7474,7 +7474,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/robot_state_publisher.git
-      version: rolling
+      version: lyrical
     status: maintained
   robotraconteur:
     release:
@@ -7725,7 +7725,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2_tracing.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - lttngpy
@@ -7743,7 +7743,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2_tracing.git
-      version: rolling
+      version: lyrical
     status: developed
   ros2acceleration:
     doc:
@@ -7775,7 +7775,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - ros2action
@@ -7801,13 +7801,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros2cli.git
-      version: rolling
+      version: lyrical
     status: maintained
   ros2cli_common_extensions:
     doc:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -7816,7 +7816,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros2/ros2cli_common_extensions.git
-      version: rolling
+      version: lyrical
     status: maintained
   ros2launch_security:
     doc:
@@ -7892,7 +7892,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/ros_environment.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -7902,7 +7902,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_environment.git
-      version: rolling
+      version: lyrical
     status: maintained
   ros_gz:
     doc:
@@ -7952,7 +7952,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - ros2test
@@ -7965,13 +7965,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/ros_testing.git
-      version: rolling
+      version: lyrical
     status: maintained
   ros_tutorials:
     doc:
       type: git
       url: https://github.com/ros/ros_tutorials.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - turtlesim
@@ -7984,7 +7984,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_tutorials.git
-      version: rolling
+      version: lyrical
     status: maintained
   ros_workspace:
     release:
@@ -8001,7 +8001,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - lz4_cmake_module
@@ -8034,7 +8034,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosbag2.git
-      version: rolling
+      version: lyrical
     status: developed
   rosbag2_bag_v2:
     source:
@@ -8106,7 +8106,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_adapter
@@ -8134,13 +8134,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_core:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_core.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_core_generators
@@ -8153,13 +8153,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_core.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_dds:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_generator_dds_idl
@@ -8171,13 +8171,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dds.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_defaults:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_default_generators
@@ -8190,13 +8190,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_defaults.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_dynamic_typesupport:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8206,13 +8206,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_dynamic_typesupport_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8222,13 +8222,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_python:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_generator_py
@@ -8240,13 +8240,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_python.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_runtime_py:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8256,7 +8256,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_runtime_py.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_rust:
     doc:
@@ -8279,7 +8279,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_typesupport_c
@@ -8292,13 +8292,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport.git
-      version: rolling
+      version: lyrical
     status: maintained
   rosidl_typesupport_fastrtps:
     doc:
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rosidl_typesupport_fastrtps_c
@@ -8311,7 +8311,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-      version: rolling
+      version: lyrical
     status: developed
   rosidlcpp:
     doc:
@@ -8405,7 +8405,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8415,7 +8415,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rpyutils.git
-      version: rolling
+      version: lyrical
     status: developed
   rqml:
     doc:
@@ -8441,7 +8441,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rqt
@@ -8457,13 +8457,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_action:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8472,13 +8472,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_action.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_bag:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rqt_bag
@@ -8490,7 +8490,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_common_plugins:
     doc:
@@ -8511,7 +8511,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8520,7 +8520,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_dotgraph:
     doc:
@@ -8556,7 +8556,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8566,7 +8566,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_graph.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_image_overlay:
     doc:
@@ -8621,7 +8621,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8630,13 +8630,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_plot:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8645,13 +8645,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_publisher:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8660,13 +8660,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_py_console:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8675,13 +8675,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_reconfigure:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8691,7 +8691,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_reconfigure.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_robot_dashboard:
     doc:
@@ -8757,7 +8757,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8766,13 +8766,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_shell:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8781,13 +8781,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_srv:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8796,7 +8796,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_srv.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_tf_tree:
     doc:
@@ -8817,7 +8817,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8827,7 +8827,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
-      version: rolling
+      version: lyrical
     status: maintained
   rsl:
     doc:
@@ -8978,7 +8978,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/rviz.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - rviz2
@@ -8996,7 +8996,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rviz.git
-      version: rolling
+      version: lyrical
     status: maintained
   rviz_2d_overlay_plugins:
     doc:
@@ -9429,7 +9429,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/spdlog_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   srdfdom:
     doc:
@@ -9450,7 +9450,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/sros2.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - sros2
@@ -9463,7 +9463,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/sros2.git
-      version: rolling
+      version: lyrical
     status: developed
   steering_functions:
     doc:
@@ -9577,7 +9577,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/system_tests.git
-      version: rolling
+      version: lyrical
     status: developed
   system_webview:
     doc:
@@ -9603,7 +9603,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/tango_icons_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   teleop_tools:
     doc:
@@ -9677,7 +9677,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -9687,7 +9687,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/test_interface_files.git
-      version: rolling
+      version: lyrical
     status: maintained
   tf2_2d:
     doc:
@@ -9802,7 +9802,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -9812,7 +9812,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/tlsf.git
-      version: rolling
+      version: lyrical
     status: maintained
   topic_based_hardware_interfaces:
     doc:
@@ -10271,13 +10271,13 @@ repositories:
     source:
       type: git
       url: https://github.com/ament/uncrustify_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   unique_identifier_msgs:
     doc:
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -10287,7 +10287,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/unique_identifier_msgs.git
-      version: rolling
+      version: lyrical
     status: maintained
   ur_client_library:
     doc:
@@ -10374,7 +10374,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros2/urdf.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - urdf
@@ -10387,7 +10387,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/urdf.git
-      version: rolling
+      version: lyrical
     status: maintained
   urdf_launch:
     doc:
@@ -10825,7 +10825,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/yaml_cpp_vendor.git
-      version: rolling
+      version: lyrical
     status: maintained
   yasmin:
     doc:


### PR DESCRIPTION
This updates all repos in ros2.repos (that I have write access to, or are managed by the ROS PMC) to point to `lyrical` branches instead of `rolling` branches.

I did not create `lyrical` branches on these repos (output from a vibe-coded script)

```
Not this one: https://github.com/eProsima/Fast-CDR.git NO WRITE ACCESS
Not this one: https://github.com/eProsima/Fast-DDS.git NO WRITE ACCESS
Not this one: https://github.com/eProsima/foonathan_memory_vendor.git NO WRITE ACCESS
Not this one: https://github.com/eclipse-cyclonedds/cyclonedds.git NO WRITE ACCESS
Not this one: https://github.com/eclipse-iceoryx/iceoryx.git NO WRITE ACCESS
Not this one: https://github.com/gazebo-release/gz_cmake_vendor.git NO WRITE ACCESS
Not this one: https://github.com/gazebo-release/gz_math_vendor.git NO WRITE ACCESS
Not this one: https://github.com/gazebo-release/gz_utils_vendor.git NO WRITE ACCESS
Not this one: https://github.com/osrf/osrf_testing_tools_cpp.git NO WRITE ACCESS
Not this one: https://github.com/ros-planning/navigation_msgs.git NO WRITE ACCESS
Not this one: https://github.com/ros-tooling/keyboard_handler.git NO WRITE ACCESS
Not this one: https://github.com/ros-tooling/libstatistics_collector.git NO WRITE ACCESS
Not this one: https://github.com/ros/urdfdom.git ROS_CONTROLS PMC
Not this one: https://github.com/ros/urdfdom_headers.git ROS_CONTROLS PMC
Not this one: https://github.com/ros2-rust/rosidl_rust.git NO WRITE ACCESS
```