### PR TITLE
ros2_snapshot: 0.0.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7777,7 +7777,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_snapshot-release.git
-      version: 0.0.2-1
+      version: 0.0.7-1
     source:
       type: git
       url: https://github.com/cnurobotics/ros2_snapshot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_snapshot` to `0.0.7-1`:

- upstream repository: https://github.com/cnurobotics/ros2_snapshot.git
- release repository: https://github.com/ros2-gbp/ros2_snapshot-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.0.2-1`

## ros2_snapshot

```
* Update prerelease metadata and citation
* Harden snapshot remote metadata and logging
* Add distributed snapshot remote collection
* Improve snapshot compatibility and matching
```
