### PR TITLE
Add documentation section for robot_localization

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7457,6 +7457,10 @@ repositories:
       version: ros2
     status: developed
   robot_localization:
+    doc:
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: rolling-devel
     release:
       tags:
         release: release/rolling/{package}/{version}


### PR DESCRIPTION
The `robot_localization` package did not have a `doc` job, but we just [fixed](https://github.com/cra-ros-pkg/robot_localization/pull/970) the rosdoc2 config, so we should be good to add it now.
