### PR TITLE
gz_common_vendor: 0.3.5-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2817,7 +2817,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.3.5-2
+      version: 0.3.5-3
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.3.5-3`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.0`
- previous version for package: `0.3.5-2`

## gz_common_vendor

```
* Bump version to 7.1.1 (#25 <https://github.com/gazebo-release/gz_common_vendor/issues/25>)
* Contributors: Addisu Z. Taddese
```
