### PR TITLE
Add some late-breaking Lyrical migrations

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2385,6 +2385,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
+      version: 3.2.6-3
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git
@@ -2477,6 +2478,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/game_controller_spl-release.git
+      version: 5.0.0-4
     source:
       type: git
       url: https://github.com/ros-sports/game_controller_spl.git
@@ -2495,6 +2497,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
+      version: 0.8.0-3
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git
@@ -2992,6 +2995,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
+      version: 3.0.7-3
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git
@@ -4003,6 +4007,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
+      version: 0.7.0-4
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git
@@ -4952,6 +4957,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
+      version: 0.2.4-3
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
These repositories were missed in the initial migration of Lyrical, but appear to have migrated successfully now.