### PR TITLE
Migrate gz_rendering_vendor to Rolling and Lyrical

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2974,6 +2974,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
+      version: 0.4.3-3
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2977,6 +2977,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_rendering_vendor-release.git
+      version: 0.4.3-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
This package is in the path to `desktop_full` and was missed during the initial migrations because its dependencies can't be resolved on Trixie.