### PR TITLE
gz_ogre_next_vendor: 0.2.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2929,7 +2929,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
-      version: 0.2.0-3
+      version: 0.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ogre_next_vendor` to `0.2.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_ogre_next_vendor.git
- release repository: https://github.com/ros2-gbp/gz_ogre_next_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.2.0-3`

## gz_ogre_next_vendor

```
* Apply cxx20-constexpr patch for Resolute  (#13 <https://github.com/gazebo-release/gz_ogre_next_vendor/issues/13>)
  Co-authored-by: Jose Luis Rivero <mailto:jrivero@honurobitcs.com>
* Contributors: Addisu Z. Taddese
```
