### PR TITLE
ros2_tracing: 8.10.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7745,7 +7745,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.10.1-3
+      version: 8.10.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.10.2-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `8.10.1-3`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

```
* Work around segfault when reading trace with babeltrace1 Python API (#246 <https://github.com/ros2/ros2_tracing/issues/246>)
* Contributors: Christophe Bedard
```

## tracetools_test

- No changes

## tracetools_trace

- No changes
