### PR TITLE
image_common: 6.4.8-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3313,7 +3313,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.7-3
+      version: 6.4.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.8-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `6.4.7-3`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Removed clang warning (#399 <https://github.com/ros-perception/image_common/issues/399>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

- No changes
