### PR TITLE
point_cloud_transport: 5.4.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6018,7 +6018,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.4.0-3
+      version: 5.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.4.1-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `5.4.0-3`

## point_cloud_transport

```
* Fix exit crash on aarch64 by using leaky singleton for global loader (#157 <https://github.com/ros-perception/point_cloud_transport/issues/157>)
* Contributors: Michael Carroll
```

## point_cloud_transport_py

- No changes
