### PR TITLE
rclcpp: 32.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6719,7 +6719,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 31.0.3-3
+      version: 32.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `32.0.0-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `31.0.3-3`

## rclcpp

```
* Include EventsCBGExecutor (#3137 <https://github.com/ros2/rclcpp/issues/3137>)
* Fix topic statistics for IPC subscriptions (#3130 <https://github.com/ros2/rclcpp/issues/3130>)
* fix: Fixed MSVC compile errors (#3135 <https://github.com/ros2/rclcpp/issues/3135>)
* feat: Added callback group events executor (#3097 <https://github.com/ros2/rclcpp/issues/3097>)
* Fix wrong dependency (#3133 <https://github.com/ros2/rclcpp/issues/3133>)
* feat: Switch to c++20 and remove resulting compile warnings (#3124 <https://github.com/ros2/rclcpp/issues/3124>)
* fix: Compile fix for MSVC 2022 (#3131 <https://github.com/ros2/rclcpp/issues/3131>)
* Contributors: Janosch Machowinski, Maurice Alexander Purnawan, jay
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Refactor component containers + Add option for CBG Executor (#3134 <https://github.com/ros2/rclcpp/issues/3134>)
* Contributors: Skyler Medeiros
```

## rclcpp_lifecycle

- No changes
