### PR TITLE
rcl: 10.4.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6603,7 +6603,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.4.3-3
+      version: 10.4.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.4.4-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `10.4.3-3`

## rcl

```
* feat: Added check for double usage of entities in rcl_waitset (#1206 <https://github.com/ros2/rcl/issues/1206>)
* Contributors: Janosch Machowinski
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
