### PR TITLE
rclpy: 10.0.10-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6735,7 +6735,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.9-3
+      version: 10.0.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `10.0.10-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `10.0.9-3`

## rclpy

```
* Feature: async node (#1620 <https://github.com/ros2/rclpy/issues/1620>)
* Refactor: moved TypeDescriptionService, LoggingService, ParameterService to BaseNode (#1645 <https://github.com/ros2/rclpy/issues/1645>)
* Refactor: base node (#1637 <https://github.com/ros2/rclpy/issues/1637>)
* Bugfix: executor doesn't propagate exception from task that awaited a future (#1643 <https://github.com/ros2/rclpy/issues/1643>)
* Fix: disable flaky executor test (#1648 <https://github.com/ros2/rclpy/issues/1648>) (#1649 <https://github.com/ros2/rclpy/issues/1649>)
* Contributors: Nadav Elkabets
```
