### PR TITLE
resource_retriever_service: 0.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6931,7 +6931,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever_service-release.git
-      version: 0.0.1-3
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever_service` to `0.0.2-1`:

- upstream repository: https://github.com/ros2/resource_retriever_service
- release repository: https://github.com/ros2-gbp/resource_retriever_service-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.0.1-3`

## resource_retriever_interfaces

```
* Update the plugin license (#17 <https://github.com/ros2/resource_retriever_service/issues/17>)
* Contributors: Stoyan Gaydarov
```

## resource_retriever_service

```
* Update the plugin license (#17 <https://github.com/ros2/resource_retriever_service/issues/17>)
* Contributors: Stoyan Gaydarov
```

## resource_retriever_service_plugin

```
* Update the plugin license (#17 <https://github.com/ros2/resource_retriever_service/issues/17>)
* Contributors: Stoyan Gaydarov
```
