### PR TITLE
rmw_connextdds: 1.2.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7278,7 +7278,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.5-1
+      version: 1.2.6-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.6-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.2.5-1`

## rmw_connextdds

```
* fix: Fixed compilation on MSVC 2022 (#225 <https://github.com/ros2/rmw_connextdds/issues/225>)
* Contributors: Janosch Machowinski
```

## rmw_connextdds_common

```
* fix: Fixed compilation on MSVC 2022 (#225 <https://github.com/ros2/rmw_connextdds/issues/225>)
* Contributors: Janosch Machowinski
```

## rti_connext_dds_cmake_module

- No changes
