### PR TITLE
autoware_adapi_msgs: 1.9.0-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -697,7 +697,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
-      version: 1.9.0-2
+      version: 1.9.0-3
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_adapi_msgs` to `1.9.0-3`:

- upstream repository: https://github.com/autowarefoundation/autoware_adapi_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.0`
- previous version for package: `1.9.0-2`

## autoware_adapi_v1_msgs

```
* feat(autoware_adapi_v1_msgs): add parent field to diag leaf message (#97 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/97>)
* fix(autoware_adapi_v1_msgs): fix description response (#96 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/96>)
* feat(autoware_adapi_v1_msgs): update diag messages (#92 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/92>)
* feat(autoware_adapi_v1_msgs): add mrm description (#94 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/94>)
* feat(autoware_adapi_v1_msgs): rename mrm request sender (#91 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/91>)
* feat(autoware_adapi_v1_msgs): add mrm request messages (#83 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/83>)
* feat(autoware_adapi_v1_msgs): add vehicle spec message (#85 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/85>)
* feat(autoware_adapi_v1_msgs): add metrics message (#84 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/84>)
* feat(autoware_adapi_v1_msgs): update manual control messages (#86 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/86>)
* feat(autoware_adapi_v1_msgs): add RTI message (#47 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/47>)
* feat(autoware_adapi_v1_msgs): add manual control messages (#82 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/82>)
* Contributors: Takagi, Isamu
```

## autoware_adapi_version_msgs

- No changes
