### PR TITLE
keyboard_handler: 0.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3595,7 +3595,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/keyboard_handler-release.git
-      version: 0.5.0-2
+      version: 0.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `keyboard_handler` to `0.5.1-1`:

- upstream repository: https://github.com/ros-tooling/keyboard_handler.git
- release repository: https://github.com/ros2-gbp/keyboard_handler-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.5.0-2`

## keyboard_handler

```
* fix cmake deprecation (#55 <https://github.com/ros-tooling/keyboard_handler/issues/55>)
* Contributors: mosfet80
```
