### PR TITLE
libstatistics_collector: 2.1.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4068,7 +4068,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -4077,7 +4077,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git
-      version: rolling
+      version: lyrical
     status: developed
   libyaml_vendor:
     release:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4073,7 +4073,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 2.1.1-3
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `2.1.2-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `2.1.1-3`

## libstatistics_collector

```
* Use new aggregate rosidl target instead of _TARGETS (#222 <https://github.com/ros-tooling/libstatistics_collector/issues/222>)
* Contributors: Alexis Tsogias, dependabot[bot]
```
