### PR TITLE
rosbag2: 0.33.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8036,7 +8036,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.33.1-3
+      version: 0.33.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.33.2-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.33.1-3`

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

```
* Removed clang warning (#2404 <https://github.com/ros2/rosbag2/issues/2404>)
* Contributors: Alejandro Hernández Cordero
```

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

```
* Reduce flakiness in rosbag2 recorder end-to-end tests (#2370 <https://github.com/ros2/rosbag2/issues/2370>)
* Contributors: Michael Orlov
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* fix: Fixed compile errors in rosbag2_transport for MSVC 2022 and C++20 (#2407 <https://github.com/ros2/rosbag2/issues/2407>)
* Fix QoS overrides ignored when topic name has no leading slash (#2394 <https://github.com/ros2/rosbag2/issues/2394>)
* Contributors: Janosch Machowinski, Sahil Lakhmani
```
