### PR TITLE
libstatistics_collector: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4073,7 +4073,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 2.1.1-2
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libstatistics_collector` to `2.1.2-1`:

- upstream repository: https://github.com/ros-tooling/libstatistics_collector.git
- release repository: https://github.com/ros2-gbp/libstatistics_collector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `2.1.1-2`

## libstatistics_collector

```
* Use new aggregate rosidl target instead of _TARGETS (#222 <https://github.com/ros-tooling/libstatistics_collector/issues/222>)
* Contributors: Alexis Tsogias, dependabot[bot]
```
