### PR TITLE
osrf_testing_tools_cpp: 2.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5622,7 +5622,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
-      version: 2.3.0-2
+      version: 2.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `osrf_testing_tools_cpp` to `2.3.1-1`:

- upstream repository: https://github.com/osrf/osrf_testing_tools_cpp.git
- release repository: https://github.com/ros2-gbp/osrf_testing_tools_cpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `2.3.0-2`

## osrf_testing_tools_cpp

```
* fix cmake min version (#96 <https://github.com/osrf/osrf_testing_tools_cpp/issues/96>)
* fix cmake deprecation  (#94 <https://github.com/osrf/osrf_testing_tools_cpp/issues/94>)
* Contributors: mosfet80
```
