### PR TITLE
proto2ros: 1.0.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8113,16 +8113,16 @@ repositories:
   proto2ros:
     doc:
       type: git
-      url: https://github.com/bdaiinstitute/proto2ros.git
+      url: https://github.com/rai-opensource/proto2ros.git
       version: main
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/bdaiinstitute/proto2ros-release.git
-      version: 1.0.1-1
+      url: https://github.com/rai-opensource/proto2ros-release.git
+      version: 1.0.1-2
     source:
       type: git
-      url: https://github.com/bdaiinstitute/proto2ros.git
+      url: https://github.com/rai-opensource/proto2ros.git
       version: main
     status: developed
   proxsuite:


### PR DESCRIPTION
Increasing version of package(s) in repository `proto2ros` to `1.0.1-2`:

- upstream repository: https://github.com/rai-opensource/proto2ros.git
- release repository: https://github.com/rai-opensource/proto2ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.0.1-1`

## proto2ros

```
* Add Jazzy support (#13 <https://github.com/bdaiinstitute/proto2ros/issues/13>)
* Change to new RAI Institute copyright (#12 <https://github.com/bdaiinstitute/proto2ros/issues/12>)
* Fix proto2ros C++ conversions template (#11 <https://github.com/bdaiinstitute/proto2ros/issues/11>)
* Trim trailing whitespace (#10 <https://github.com/bdaiinstitute/proto2ros/issues/10>)
* Have proto2ros mypy checks follow imports silently (#8 <https://github.com/bdaiinstitute/proto2ros/issues/8>)
* Contributors: Ben Axelrod, Michel Hidalgo
```
