### PR TITLE
synchros2: 1.0.4-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11919,16 +11919,16 @@ repositories:
   synchros2:
     doc:
       type: git
-      url: https://github.com/bdaiinstitute/synchros2.git
+      url: https://github.com/rai-opensource/synchros2.git
       version: main
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/bdaiinstitute/synchros2-release.git
-      version: 1.0.4-1
+      url: https://github.com/rai-opensource/synchros2-release.git
+      version: 1.0.4-2
     source:
       type: git
-      url: https://github.com/bdaiinstitute/synchros2.git
+      url: https://github.com/rai-opensource/synchros2.git
       version: main
     status: developed
   system_fingerprint:


### PR DESCRIPTION
Increasing version of package(s) in repository `synchros2` to `1.0.4-2`:

- upstream repository: https://github.com/rai-opensource/synchros2.git
- release repository: https://github.com/rai-opensource/synchros2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.0.4-1`

## synchros2

```
* [N/A] Add missing synchros2 test deps (#186 <https://github.com/bdaiinstitute/ros_utilities/issues/186>)
* [N/A] tf2_ros is tf2_ros_py for Python (#185 <https://github.com/bdaiinstitute/ros_utilities/issues/185>)
* Contributors: Michel Hidalgo
```
