### PR TITLE
foxglove-sdk: 3.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3344,7 +3344,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.2.6-1
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.3.0-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `3.2.6-1`

## foxglove_bridge

```
* Fix an issue where the bridge would stay subscribed to the graph even after clients disconnect
* Add support for remote access
* Publish process and system statistics (CPU, memory) on ``/foxglove_bridge/sysinfo`` by default
* Update Foxglove SDK version to 0.23.1
```

## foxglove_msgs

```
* Breaking: Remove Velocity3 schema; LocationFix.velocity now uses Vector3
* Add Odometry schema
```
