### PR TITLE
hatchbed_common: 0.1.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3982,7 +3982,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/hatchbed_common-release.git
-      version: 0.1.2-1
+      version: 0.1.6-1
     source:
       type: git
       url: https://github.com/hatchbed/hatchbed_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hatchbed_common` to `0.1.6-1`:

- upstream repository: https://github.com/hatchbed/hatchbed_common.git
- release repository: https://github.com/ros2-gbp/hatchbed_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.1.2-1`

## hatchbed_common

```
* ParamHandler now accepts rclcpp_lifecycle::LifecycleNode via a template constructor that
  stores ROS node interfaces internally, removing the hard dependency on rclcpp::Node::SharedPtr.
* Add unit tests for ParamHandler covering regular nodes, lifecycle nodes, dynamic parameter
  updates, static parameter rejection, and numeric range constraints.
* Add localization utilities: covariance rotation helpers and PoseBuffer with interpolation.
* Add point cloud utilities: field helpers, transform/deskew functions, and utility nodes.
* Add logging utilities with fmt support.
* Add helper for validating ROS parameter names.
* Add fmt support for SimpleProfiler.
* Contributors: Marc Alban
```
