### PR TITLE
mujoco_ros2_control: 0.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6077,7 +6077,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ros-controls/mujoco_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_ros2_control` to `0.0.3-1`:

- upstream repository: https://github.com/ros-controls/mujoco_ros2_control.git
- release repository: https://github.com/ros2-gbp/mujoco_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `0.0.2-1`

## mujoco_ros2_control

```
* Add more useful plugins for the mujoco_ros2_control (#165 <https://github.com/ros-controls/mujoco_ros2_control/issues/165>)
* Explicit scipy version for numpy >2.0 compatibility (#177 <https://github.com/ros-controls/mujoco_ros2_control/issues/177>)
* Use pkg install dir for requirements in conversion script (#170 <https://github.com/ros-controls/mujoco_ros2_control/issues/170>)
* Documentation on Generating MJCFs (#167 <https://github.com/ros-controls/mujoco_ros2_control/issues/167>)
* Use requirements.txt to install python dependencies (#151 <https://github.com/ros-controls/mujoco_ros2_control/issues/151>)
* Allow freejoint without name (#163 <https://github.com/ros-controls/mujoco_ros2_control/issues/163>)
* Replace stream logging with compiled log statements (#160 <https://github.com/ros-controls/mujoco_ros2_control/issues/160>)
* Increase timeout on sim being ready to 10s (#161 <https://github.com/ros-controls/mujoco_ros2_control/issues/161>)
* improve debug logs (#159 <https://github.com/ros-controls/mujoco_ros2_control/issues/159>)
* Search delimiter from back to support joint names with '/' (#158 <https://github.com/ros-controls/mujoco_ros2_control/issues/158>)
* Use right arrow key to advance the simulation instead of S key (#150 <https://github.com/ros-controls/mujoco_ros2_control/issues/150>)
* [Feature] Add ability to run the simulation progress by steps upon pause  (#139 <https://github.com/ros-controls/mujoco_ros2_control/issues/139>)
* disable site visuals by default in the visualizer and cameras (#149 <https://github.com/ros-controls/mujoco_ros2_control/issues/149>)
* Contributors: Christian Rauch, Emily Sheetz, Erik Holum, Nathan Dunkelberger, Sai Kishor Kothakota, Óscar Martínez Martínez, Mathias Lüdtke
```

## mujoco_ros2_control_demos

```
* Switch to forward_command_controller dependency (#173 <https://github.com/ros-controls/mujoco_ros2_control/issues/173>)
* Contributors: Christoph Fröhlich
```

## mujoco_ros2_control_msgs

```
* Add more useful plugins for the mujoco_ros2_control (#165 <https://github.com/ros-controls/mujoco_ros2_control/issues/165>)
* [Feature] Add ability to run the simulation progress by steps upon pause  (#139 <https://github.com/ros-controls/mujoco_ros2_control/issues/139>)
* Contributors: Sai Kishor Kothakota, Erik Holum
```

## mujoco_ros2_control_plugins

```
* Add macro check using realtime_tools_MAJOR_VERSION (#181 <https://github.com/ros-controls/mujoco_ros2_control/issues/181>)
* Add more useful plugins for the mujoco_ros2_control (#165 <https://github.com/ros-controls/mujoco_ros2_control/issues/165>)
* Contributors: Sai Kishor Kothakota, Erik Holum
```
