### PR TITLE
autoware_cmake: 1.2.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -726,7 +726,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.1.0-2
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.2.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.0-2`

## autoware_cmake

```
* feat(autoware_cmake): support USE_SCOPED_HEADER_INSTALL_DIR in autoware_ament_auto_package (#40 <https://github.com/autowarefoundation/autoware_cmake/issues/40>)
  * feat(autoware_cmake): support USE_SCOPED_HEADER_INSTALL_DIR in autoware_ament_auto_package
  * Removed the FILES_MATCHING patterns from both install calls
  Removed unnecessary FILES_MATCHING patterns from install commands.
  ---------
  Co-authored-by: github-actions <mailto:github-actions@github.com>
* Contributors: Vishal Chauhan
```

## autoware_lint_common

- No changes
