### PR TITLE
autoware_lanelet2_extension: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -819,6 +819,10 @@ repositories:
       version: main
     status: developed
   autoware_lanelet2_extension:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
+      version: 1.0.0
     release:
       packages:
       - autoware_lanelet2_extension
@@ -826,7 +830,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 0.7.2-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `1.0.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.2-1`

## autoware_lanelet2_extension

```
* chore: cleanup ported functions (#107 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/107>)
* feat(lanelet2_extension): deprecate lanelet2_extension utilities functions (final)  (#103 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/103>)
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* feat(lanelet2_extension): deprecate toGeomMsgPt/toLaneltPoint (#102 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/102>)
  * feat(lanelet2_extension): deprecate toGeomMsgPt/toLaneltPoint
  * fix build error
  * fix build error 2
  * fix build error 3
  * fix build error 4
  * fix build error 5
  ---------
* feat(lanelet2_extension): deprecate remaining functions in utilities  (#95 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/95>)
* feat(lanelet2_extension): deprecate getClosestLanelet and others (#97 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/97>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* Contributors: Mamoru Sobue, Sarun MUKDAPITAK
```

## autoware_lanelet2_extension_python

```
* feat(lanelet2_extension): deprecate lanelet2_extension utilities functions (final)  (#103 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/103>)
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
* feat(lanelet2_extension): deprecate toGeomMsgPt/toLaneltPoint (#102 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/102>)
  * feat(lanelet2_extension): deprecate toGeomMsgPt/toLaneltPoint
  * fix build error
  * fix build error 2
  * fix build error 3
  * fix build error 4
  * fix build error 5
  ---------
* feat(lanelet2_extension): deprecate remaining functions in utilities  (#95 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/95>)
* feat(lanelet2_extension): deprecate getClosestLanelet and others (#97 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/97>)
  Co-authored-by: Junya Sasaki <mailto:j2sasaki1990@gmail.com>
* Contributors: Mamoru Sobue, Sarun MUKDAPITAK
```
