### PR TITLE
automatika_ros_sugar: 0.7.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -640,7 +640,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.6.1-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.7.0-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.6.1-1`

## automatika_ros_sugar

```
* (chore) Adds tests for base attrs
* (fix) Adds check for any type fields in base attrs
* (feature) Adds display of action server logs in the main logging card (#46 <https://github.com/automatika-robotics/sugarcoat/issues/46>)
* (fix) Changes sleep time between probe service response checks to 1/loop_rate instead of arbitrary constant
* (feature) Adds on_process_fail method to launcher that respawns processes
  - Adds lifecycle service calling methods in monitor to respawn processes and handle lifecylce transitions
  - Creates unified timer for watching process start for initial launch and failed process launch
  - Uses internal launch actions for emitting the action to launch all components at init
* (fix) Adds a param to base config for executor spin timeout to decouple it from loop rate
* (feature) Adds ui display for geometry types when no map element is present
* (fix) Specifies callback in tf listener timer (#43 <https://github.com/automatika-robotics/sugarcoat/issues/43>)
* (chore) Adds testing for execute action service
* (feature) Calling the execute method service for component actions now returns the method response
* (chore) Adds testing CI
* (chore) Adds test for safe restart
* (feature) Adds the safe restart context manager in base component
* Contributors: Maria Kabtoul, ahr, mkabtoul
```
