### PR TITLE
toppra: 0.6.8-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12475,7 +12475,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/toppra-release.git
-      version: 0.6.7-1
+      version: 0.6.8-1
     source:
       type: git
       url: https://github.com/hungpham2511/toppra.git


### PR DESCRIPTION
Increasing version of package(s) in repository `toppra` to `0.6.8-1`:

- upstream repository: https://github.com/hungpham2511/toppra.git
- release repository: https://github.com/ros2-gbp/toppra-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.7-1`

## toppra

```
* [cpp] Fix missing cassert includes in headers (#288 <https://github.com/hungpham2511/toppra/issues/288>)
* [cpp] Fix gtest target_link_libraries usage when fetching from source (#286 <https://github.com/hungpham2511/toppra/issues/286>)
* [cpp] fix pinocchio 4 compatibility (#287 <https://github.com/hungpham2511/toppra/issues/287>)
* Contributors: Guilhem Saurel, Sebastian Castro
```
