### PR TITLE
update jig branching strategy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4527,7 +4527,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nineyards-robotics/jig.git
-      version: humble
+      version: main
     status: maintained
   joint_state_publisher:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4455,7 +4455,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nineyards-robotics/jig.git
-      version: jazzy
+      version: main
     status: maintained
   joint_state_publisher:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3544,7 +3544,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nineyards-robotics/jig.git
-      version: kilted
+      version: main
     status: maintained
   joint_state_publisher:
     doc:


### PR DESCRIPTION
# Please Update Jig packages branching strategy

I have switched the repo from a branch per distro to "all distros work on main".

# The source is here:

https://github.com/nineyards-robotics/jig

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
