### PR TITLE
log_view: 0.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5325,7 +5325,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/hatchbed/log_view-release.git
-      version: 0.2.5-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.3.1-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/hatchbed/log_view-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.5-1`

## log_view

```
* Persist logs to disk in ``~/.local/share/log_view/`` with configurable rotation and max size.
* Load persisted logs on startup.
* Add preferences panel (CTRL-k) for persistence and filter settings.
* Show filtered log count in status bar (``logs: X of Y`` when a filter is active).
* Contributors: Marc Alban
```
