### PR TITLE
autoware_msgs: 1.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1102,13 +1102,14 @@ repositories:
       - autoware_perception_msgs
       - autoware_planning_msgs
       - autoware_sensing_msgs
+      - autoware_simulation_msgs
       - autoware_system_msgs
       - autoware_v2x_msgs
       - autoware_vehicle_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_msgs-release.git
-      version: 1.11.0-1
+      version: 1.12.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_msgs` to `1.12.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.11.0-1`

## autoware_common_msgs

- No changes

## autoware_control_msgs

- No changes

## autoware_localization_msgs

- No changes

## autoware_map_msgs

```
* docs: add documentation to remaining msg/srv fields (#156 <https://github.com/autowarefoundation/autoware_msgs/issues/156>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * add comments
  * style(pre-commit): autofix
  * Apply suggestions from code review
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_system_msgs/srv/ChangeOperationMode.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_vehicle_msgs/srv/ControlModeCommand.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_planning_msgs/srv/SetWaypointRoute.srv
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
* Contributors: Yutaka Kondo
```

## autoware_msgs

```
* chore(autoware_simulation_msgs): ported from tier4_autoware_msgs (#162 <https://github.com/autowarefoundation/autoware_msgs/issues/162>)
* Contributors: Junya Sasaki
```

## autoware_perception_msgs

```
* docs: add documentation to remaining msg/srv fields (#156 <https://github.com/autowarefoundation/autoware_msgs/issues/156>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * add comments
  * style(pre-commit): autofix
  * Apply suggestions from code review
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_system_msgs/srv/ChangeOperationMode.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_vehicle_msgs/srv/ControlModeCommand.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_planning_msgs/srv/SetWaypointRoute.srv
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
* docs: add unit and range documentation to message fields (#155 <https://github.com/autowarefoundation/autoware_msgs/issues/155>)
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
* Contributors: Yutaka Kondo
```

## autoware_planning_msgs

```
* docs: add documentation to remaining msg/srv fields (#156 <https://github.com/autowarefoundation/autoware_msgs/issues/156>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * add comments
  * style(pre-commit): autofix
  * Apply suggestions from code review
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_system_msgs/srv/ChangeOperationMode.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_vehicle_msgs/srv/ControlModeCommand.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_planning_msgs/srv/SetWaypointRoute.srv
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
* Contributors: Yutaka Kondo
```

## autoware_sensing_msgs

- No changes

## autoware_simulation_msgs

```
* chore(autoware_simulation_msgs): ported from tier4_autoware_msgs (#162 <https://github.com/autowarefoundation/autoware_msgs/issues/162>)
* Contributors: Junya Sasaki
* chore(autoware_simulation_msgs): ported from tier4_autoware_msgs (#162 <https://github.com/autowarefoundation/autoware_msgs/issues/162>)
* Contributors: Junya Sasaki
```

## autoware_system_msgs

```
* docs: add documentation to remaining msg/srv fields (#156 <https://github.com/autowarefoundation/autoware_msgs/issues/156>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * add comments
  * style(pre-commit): autofix
  * Apply suggestions from code review
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_system_msgs/srv/ChangeOperationMode.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_vehicle_msgs/srv/ControlModeCommand.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_planning_msgs/srv/SetWaypointRoute.srv
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
* Contributors: Yutaka Kondo
```

## autoware_v2x_msgs

- No changes

## autoware_vehicle_msgs

```
* docs: add documentation to remaining msg/srv fields (#156 <https://github.com/autowarefoundation/autoware_msgs/issues/156>)
  * docs: add unit and range documentation to message fields
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
  * add comments
  * style(pre-commit): autofix
  * Apply suggestions from code review
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_system_msgs/srv/ChangeOperationMode.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_vehicle_msgs/srv/ControlModeCommand.srv
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
  * Update autoware_planning_msgs/srv/SetWaypointRoute.srv
  ---------
  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
  Co-authored-by: Mete Fatih Cırıt <mailto:mfc@autoware.org>
* docs: add unit and range documentation to message fields (#155 <https://github.com/autowarefoundation/autoware_msgs/issues/155>)
  Add inline comments to clarify units and valid ranges for:
  - TrafficLightElement.msg: confidence range (0.0-1.0)
  - ObjectClassification.msg: probability range (0.0-1.0)
  - SteeringReport.msg: steering_tire_angle unit [rad]
  - VelocityReport.msg: velocity units [m/s], heading_rate [rad/s]
  Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106
* Contributors: Yutaka Kondo
```
