### PR TITLE
Add ih2 azzurra packages to Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13902,5 +13902,17 @@ repositories:
       url: https://github.com/autowarefoundation/zmqpp_vendor.git
       version: main
     status: developed
+  ih2_azzurra_hand_driver:
+    source:
+      type: git
+      url: https://github.com/af-a/ih2_azzurra_hand_driver.git
+      version: humble
+    status: maintained
+  ih2_azzurra_hand_driver_interfaces:
+    source:
+      type: git
+      url: https://github.com/af-a/ih2_azzurra_hand_driver_interfaces.git
+      version: main
+    status: maintained
 type: distribution
 version: 2

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4318,6 +4318,18 @@ repositories:
       url: https://github.com/ignition-release/ignition_math6_vendor.git
       version: humble
     status: maintained
+  ih2_azzurra_hand_driver:
+    source:
+      type: git
+      url: https://github.com/af-a/ih2_azzurra_hand_driver.git
+      version: humble
+    status: maintained
+  ih2_azzurra_hand_driver_interfaces:
+    source:
+      type: git
+      url: https://github.com/af-a/ih2_azzurra_hand_driver_interfaces.git
+      version: main
+    status: maintained
   image_common:
     doc:
       type: git
@@ -13902,17 +13914,5 @@ repositories:
       url: https://github.com/autowarefoundation/zmqpp_vendor.git
       version: main
     status: developed
-  ih2_azzurra_hand_driver:
-    source:
-      type: git
-      url: https://github.com/af-a/ih2_azzurra_hand_driver.git
-      version: humble
-    status: maintained
-  ih2_azzurra_hand_driver_interfaces:
-    source:
-      type: git
-      url: https://github.com/af-a/ih2_azzurra_hand_driver_interfaces.git
-      version: main
-    status: maintained
 type: distribution
 version: 2


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

* https://github.com/af-a/ih2_azzurra_hand_driver
* https://github.com/af-a/ih2_azzurra_hand_driver_interfaces

<b>Note on purpose:</b> [ih2_azzurra_hand_driver](https://github.com/af-a/ih2_azzurra_hand_driver) enables controlling and tracking the state of a [Prensilia IH2 Azzurra hand](https://www.prensilia.com/ih2-azzurra-hand/) through ROS actions, topics, and an `rqt_reconfigure` plugin.
[ih2_azzurra_hand_driver_interfaces](https://github.com/af-a/ih2_azzurra_hand_driver_interfaces)  implements the necessary custom ROS messages and actions.

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
