### PR TITLE
fusioncore: add doc/source entries and set status maintained for Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3444,6 +3444,10 @@ repositories:
       version: release
     status: developed
   fusioncore:
+    doc:
+      type: git
+      url: https://github.com/manankharwar/fusioncore.git
+      version: main
     release:
       packages:
       - compass_msgs
@@ -3455,6 +3459,10 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
       version: 0.2.2-1
+    source:
+      type: git
+      url: https://github.com/manankharwar/fusioncore.git
+      version: main
     status: maintained
   game_controller_spl:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3455,6 +3455,7 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
       version: 0.2.2-1
+    status: maintained
   game_controller_spl:
     doc:
       type: git


### PR DESCRIPTION
Two changes for the `fusioncore` repository entry in `humble/distribution.yaml`:

1. Add `doc:` and `source:` entries pointing to the main branch — enables API documentation generation at docs.ros.org and source browsing on index.ros.org
2. Set `status: maintained` — fixes index.ros.org incorrectly showing the package as UNMAINTAINED

Jazzy already has both of these set correctly; this brings Humble to parity.