### PR TITLE
log_view: 0.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4166,7 +4166,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/log_view-release.git
-      version: 0.3.0-2
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.3.2-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/ros2-gbp/log_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.3.0-2`

## log_view

```
* Scope log and preference storage to the active ROS 2 workspace via ``COLCON_PREFIX_PATH`` (stored under ``<workspace>/.log_view/``).
* Show file paths in preferences panel; display a warning when persistence is unavailable.
* Contributors: Marc Alban
```
