### PR TITLE
Index mola_input_ouster for doc and source (humble)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5908,6 +5908,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_imu_preintegration.git
       version: develop
     status: developed
+  mola_input_ouster:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_ouster.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_ouster.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/MOLAorg/mola_input_ouster

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
