### PR TITLE
mola_state_estimation: 2.3.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5963,7 +5963,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.3.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.3.0-1`

## mola_georeferencing

- No changes

## mola_gtsam_factors

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Merge pull request #28 <https://github.com/MOLAorg/mola_state_estimation/issues/28> from Zeal-Robotics/fix/simple-fuse-imu-preserve-linear-twist
  fix(state_estimation_simple): preserve linear twist across fuse_imu()
  Regression introduced in 15a1fce ("Add tests for simple estimator").
* Merge pull request #26 <https://github.com/MOLAorg/mola_state_estimation/issues/26> from MOLAorg/fix/smoother-issues
  Fix misc smoother issues
* Remove copies of RegexCache.h and use the shared version in mola_kernel
* Merge pull request #25 <https://github.com/MOLAorg/mola_state_estimation/issues/25> from MOLAorg/feat/simple-also-process-robot-pose-obs
  feat: Simple estimator now also processes CObservationsRobotPose
* add regex filtering
* feat: Simple estimator now also processes CObservationsRobotPose
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_state_estimation_smoother

```
* Merge pull request #27 <https://github.com/MOLAorg/mola_state_estimation/issues/27> from MOLAorg/feature/ros2-integration-tests
  Add ROS 2 launch-testing integration tests for StateEstimationSmoother
* fix missing test dep
* workaround for older mola_yaml
* Fix frames of reference for the test checker
* Progress fixing integration test
* mock test code clean up
* More debug traces in python mock integration test
* Add ROS 2 launch-testing integration tests for StateEstimationSmoother
  Two end-to-end test scenarios driven by a Python sensor mock node.
* Merge pull request #26 <https://github.com/MOLAorg/mola_state_estimation/issues/26> from MOLAorg/fix/smoother-issues
  Fix misc smoother issues
* Clarify docs and fix test noise thresholds
* Remove copies of RegexCache.h and use the shared version in mola_kernel
* fix: make RegexCache move-assignable after adding std::mutex
* fix: guard IMU quaternion path against NaN components in fuse_imu
* fix: make RegexCache::get_regex thread-safe
* fix: replace ASSERT_ with descriptive exception in get_latest_state_and_covariance
* fix: use monotonic counter for odometry frame IDs
* fix: check both link sets before inserting in add_kinematic_factor_between
* fix: make GNSS Huber threshold a configurable parameter
* fix: skip BetweenFactor on first fuse_odometry call
* feat: Print number of active factors in DEBUG log level
* Contributors: Jose Luis Blanco-Claraco
```
