### PR TITLE
mp2p_icp: 2.10.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6165,7 +6165,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.10.0-1
+      version: 2.10.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.10.1-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `2.10.0-1`

## mp2p_icp

```
* FIX: sm2mm pipeline for keyframe maps need valid KF poses
* FIX: copy/paste error in guard against missing layer
* mm-viewer: UI now has an easier near/far clipping plane tool
* chore: map contents as string made less verbose (hide full covariance)
* Merge pull request #63 <https://github.com/MOLAorg/mp2p_icp/issues/63> from MOLAorg/feat/optional-final-run-quality-matchers
  feat: optional last run of matchers with final ICP_ITERATION for adaptive thresholds to see final thresholds
* feat: optional last run of matchers with final ICP_ITERATION for adaptive thresholds to see final thresholds
* fix: wrong decimation applied in sm2mm filters
* Merge pull request #62 <https://github.com/MOLAorg/mp2p_icp/issues/62> from MOLAorg/feat/prior-weight-mitigations
  feat: Implement Birge-ratio auto-balance for cov2cov and prior weighting
* feat: Implement Birge-ratio auto-balance for cov2cov and prior weighting
* fix: icp-log-viewer didn't show the prior covariance at its correct location
* Contributors: Jose Luis Blanco-Claraco
```
