### PR TITLE
adaptive_bridge: 0.1.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -82,6 +82,17 @@ repositories:
       url: https://github.com/rudislabs/actuator_msgs.git
       version: main
     status: maintained
+  adaptive_bridge:
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/KaushalrajPuwar/adaptive_bridge-release.git
+      version: 0.1.0-2
+    source:
+      type: git
+      url: https://github.com/KaushalrajPuwar/adaptive-bridge.git
+      version: main
+    status: maintained
   adaptive_component:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `adaptive_bridge` to `0.1.0-2`:

- upstream repository: https://github.com/KaushalrajPuwar/adaptive-bridge.git
- release repository: https://github.com/KaushalrajPuwar/adaptive_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
