### PR TITLE
autoware_core: 1.8.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -971,6 +971,7 @@ repositories:
       packages:
       - autoware_adapi_adaptors
       - autoware_adapi_specs
+      - autoware_agnocast_wrapper
       - autoware_awsim_sensor_kit_description
       - autoware_behavior_velocity_planner
       - autoware_behavior_velocity_planner_common
@@ -1041,7 +1042,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_core-release.git
-      version: 1.7.0-2
+      version: 1.8.0-3
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_core` to `1.8.0-3`:

- upstream repository: https://github.com/autowarefoundation/autoware_core.git
- release repository: https://github.com/ros2-gbp/autoware_core-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.0-2`
