### PR TITLE
compass: 3.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1322,7 +1322,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.2-3
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `3.0.3-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `3.0.2-3`

## compass_conversions

```
* Fixed build on Rolling
* Docs: Added build status to repo readmes.
* Contributors: Martin Pecka
```

## compass_interfaces

```
* Fixed outdated references
* Docs: Added build status to repo readmes.
* Contributors: Martin Pecka
```

## magnetic_model

```
* Fixed build on Rolling
* Docs: Added build status to repo readmes.
* Contributors: Martin Pecka
```

## magnetometer_compass

```
* Fixed build on Rolling
* Docs: Added build status to repo readmes.
* Contributors: Martin Pecka
```

## magnetometer_pipeline

```
* Fixed build on Rolling
* Docs: Added build status to repo readmes.
* Contributors: Martin Pecka
```
