### PR TITLE
zed-ros2-description: 0.1.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13890,7 +13890,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-description-release.git
-      version: 0.1.4-1
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-description` to `0.1.5-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-description.git
- release repository: https://github.com/ros2-gbp/zed-ros2-description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `0.1.4-1`

## zed_description

```
* Fix material issue
  Apply againg PR https://github.com/stereolabs/zed-ros2-wrapper/pull/405 to fix the issue https://github.com/stereolabs/zed-ros2-description/issues/2
* Contributors: Walter Lucetti
```
