### PR TITLE
fuse: 1.2.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2566,7 +2566,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.2.4-1
+      version: 1.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.2.5-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.4-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

- No changes

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

```
* Fix tf2_ros header order
* Contributors: Stephen Williams
```

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

```
* Fix tf2_ros header order
* Contributors: Stephen Williams
```

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

- No changes
