### PR TITLE
fuse: 1.3.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2463,7 +2463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.3.1-2
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.3.2-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.1-2`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

```
* Workaround for a bug in Boost 1.90 any_range included in Ubuntu Resolute (#424 <https://github.com/locusrobotics/fuse/issues/424>)
  Boost versions 1.88 - 1.90 are missing a header include for any_range.hpp or any_iterator.hpp. The workaround is to include the missing header before including one of the affect headers.
* Contributors: Stephen Williams
```

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

- No changes

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

- No changes

## fuse_tutorials

- No changes

## fuse_variables

- No changes

## fuse_viz

- No changes
