### PR TITLE
ur_client_library: 2.11.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12319,7 +12319,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.11.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.10.0-1`

## ur_client_library

```
* Remove programs.UR5 linking to /ursim/programs (#500 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/500>)
* Fix data race (#498 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/498>)
* Fix flaky reverse_interface test (#497 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/497>)
* Add getKinematicsInfo accessor to PrimaryClient (#496 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/496>)
* Make downloading and checking RTDE outputs from docs optional (#493 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/493>)
* Add helper function to get robot series (#488 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/488>)
* Make sure motion control returns to main thread before stopping (#490 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/490>)
* Fix broken links (#487 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/487>)
* Contributors: Felix Exner, Nick Franczak
```