### PR TITLE
zed-ros2-interfaces: 5.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12996,7 +12996,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
-      version: 5.2.1-1
+      version: 5.3.0-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-interfaces` to `5.3.0-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-interfaces.git
- release repository: https://github.com/ros2-gbp/zed-ros2-interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `5.2.1-1`

## zed_msgs

```
* Update PosTrackStatus to GEN_3
* Add "scene_illuminance" to health status message
* Contributors: Walter Lucetti
```
