### PR TITLE
unique_identifier_msgs: 2.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10299,7 +10299,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.8.1-2
+      version: 2.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.9.0-1`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.1-2`

## unique_identifier_msgs

- No changes
