### PR TITLE
Add libg2o-dev to rosdep

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4118,6 +4118,10 @@ libg2o-dev:
     '*': [libg2o-dev]
     bookworm: null
     bullseye: null
+  nixos: [g2o]
+  osx:
+    homebrew:
+      packages: [g2o]
   ubuntu:
     '*': [libg2o-dev]
     jammy: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4124,6 +4124,7 @@ libg2o-dev:
       packages: [g2o]
   ubuntu:
     '*': [libg2o-dev]
+    focal: null
     jammy: null
 libgazebo-dev:
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4113,6 +4113,14 @@ libfyaml-dev:
   ubuntu:
     '*': [libfyaml-dev]
     focal: null
+libg2o-dev:
+  debian:
+    '*': [libg2o-dev]
+    bookworm: null
+    bullseye: null
+  ubuntu:
+    '*': [libg2o-dev]
+    jammy: null
 libgazebo-dev:
   debian:
     bullseye: [libgazebo-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libg2o-dev

## Package Upstream Source:

https://github.com/RainerKuemmerle/g2o

## Purpose of using this:

g2o is a graph optimization library, useful as an alternative backend to Ceres and GTSAM for SLAM packages.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?keywords=libg2o-dev
- Ubuntu: https://packages.ubuntu.com/search?keywords=libg2o-dev
- macOS: https://formulae.brew.sh/formula/g2o#default
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.11&query=g2o&show=g2o

Unavailable on Fedora, Arch, Gentoo, Alpine, openSUSE