### PR TITLE
google_benchmark_vendor: 0.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2601,7 +2601,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
-      version: 0.7.0-2
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `google_benchmark_vendor` to `0.8.0-1`:

- upstream repository: https://github.com/ament/google_benchmark_vendor.git
- release repository: https://github.com/ros2-gbp/google_benchmark_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.0-2`

## google_benchmark_vendor

- No changes
