### PR TITLE
joint_state_publisher: 2.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3494,7 +3494,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/joint_state_publisher-release.git
-      version: 2.4.1-3
+      version: 2.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `joint_state_publisher` to `2.4.2-1`:

- upstream repository: https://github.com/ros/joint_state_publisher.git
- release repository: https://github.com/ros2-gbp/joint_state_publisher-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.1-3`

## joint_state_publisher

- No changes

## joint_state_publisher_gui

```
* Support Qt6 (#121 <https://github.com/ros/joint_state_publisher/issues/121>)
* Contributors: Alejandro Hernández Cordero
```
