### PR TITLE
ros2_tracing: 9.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7755,7 +7755,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.10.2-1
+      version: 9.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `9.0.0-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `8.10.2-1`

## lttngpy

- No changes

## ros2trace

- No changes

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
