### PR TITLE
fuse: 1.3.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2463,7 +2463,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fuse-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fuse` to `1.3.3-1`:

- upstream repository: https://github.com/locusrobotics/fuse.git
- release repository: https://github.com/ros2-gbp/fuse-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.2-1`

## fuse

- No changes

## fuse_constraints

- No changes

## fuse_core

```
* fuse_core: Don't fail with boost >= 1.86 (#423 <https://github.com/locusrobotics/fuse/issues/423>)
  Boost >= 1.86 provides std::hash<boost::uuids::uuid> itself; guard against redefinition since fuse_core::UUID is an alias for boost::uuids::uuid.
  See https://www.boost.org/doc/libs/latest/libs/uuid/doc/html/uuid.html#changes_changes_in_boost_1_86_0_major_update
* Fix edge condition on Boost fix versions. (#425 <https://github.com/locusrobotics/fuse/issues/425>)
  Boost Version 1.90 is affected by the any_range bug. Make sure that version is included in the fix.
* Contributors: Michal Sojka, Stephen Williams
```

## fuse_doc

- No changes

## fuse_graphs

- No changes

## fuse_loss

- No changes

## fuse_models

- No changes

## fuse_msgs

- No changes

## fuse_optimizers

- No changes

## fuse_publishers

- No changes

## fuse_tutorials

- No changes

## fuse_variables

```
* Starting with Boost 1.86, the boost::uuids::uuid class requires double braces for aggregate initialization from a list of bytes. Double-brace initialization works fine on older Boost versions as well.
* Contributors: Stephen Williams
```

## fuse_viz

- No changes
