### PR TITLE
zed-ros2-description: 0.1.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10890,7 +10890,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/zed-ros2-description-release.git
-      version: 0.1.3-3
+      version: 0.1.5-1
     source:
       type: git
       url: https://github.com/stereolabs/zed-ros2-description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `zed-ros2-description` to `0.1.5-1`:

- upstream repository: https://github.com/stereolabs/zed-ros2-description.git
- release repository: https://github.com/ros2-gbp/zed-ros2-description-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.3-3`

## zed_description

```
* Fix material issue
  Apply againg PR https://github.com/stereolabs/zed-ros2-wrapper/pull/405 to fix the issue https://github.com/stereolabs/zed-ros2-description/issues/2
* Contributors: Walter Lucetti
```
