### PR TITLE
aruco_opencv: 6.1.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -528,7 +528,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.1.1-3
+      version: 6.1.2-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `6.1.2-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.1.1-3`

## aruco_opencv

```
* Add support for camera with bgra8 encoding (#64 <https://github.com/fictionlab/ros_aruco_opencv/issues/64>)
* Contributors: Hubert, Błażej Sowa
```

## aruco_opencv_msgs

- No changes
