### PR TITLE
qt_gui_core: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6415,7 +6415,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.10.7-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `3.0.0-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.10.7-2`

## qt_dotgraph

```
* More qt6 fixes (#334 <https://github.com/ros-visualization/qt_gui_core/issues/334>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui

```
* More qt6 fixes (#334 <https://github.com/ros-visualization/qt_gui_core/issues/334>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* More qt6 fixes (#334 <https://github.com/ros-visualization/qt_gui_core/issues/334>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_py_common

```
* More qt6 fixes (#334 <https://github.com/ros-visualization/qt_gui_core/issues/334>)
* Contributors: Alejandro Hernández Cordero
```
