### PR TITLE
rqt_service_caller: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8779,7 +8779,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.5.2-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.5.2-2`

## rqt_service_caller

- No changes
