### PR TITLE
Use a custom User-Agent for rosdep_repo_check

### DIFF
--- a/test/rosdep_repo_check/__init__.py
+++ b/test/rosdep_repo_check/__init__.py
@@ -104,7 +104,9 @@ def open_compressed_url(url, retry=2, retry_period=1, timeout=10):
 
     :returns: file-like object for streaming file data.
     """
-    request = Request(url)
+    request = Request(url, headers={
+        'User-Agent': 'rosdep_repo_check/1.0',
+    })
     try:
         f = urlopen(request, timeout=timeout)
     except HTTPError as e:


### PR DESCRIPTION
It seems that archive.ubuntu.com is now blocking requests which use the default urllib User-Agent.

Should resolve issues like this: https://github.com/ros/rosdistro/actions/runs/25393469511/job/74637085237