### PR TITLE
swri_console: 2.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11327,7 +11327,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.1.2-2
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.1.3-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.2-2`

## swri_console

```
* Improve bag reading (#76 <https://github.com/swri-robotics/swri_console/issues/76>)
  * Opening bag from parent directory so that metadata can be found. Added .db3 as option so both mcap and sqlite3 supported.
  * Added some extra safe-guards around reading bags w/ no metadata
* Update README.md
* Harmonizing Builds Across ROS Distros
* Contributors: David Anthony, Robert Brothers
```
