### PR TITLE
generate_parameter_library: 1.0.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2493,11 +2493,10 @@ repositories:
       packages:
       - generate_parameter_library
       - generate_parameter_library_py
-      - parameter_traits
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.8.0-3
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `1.0.1-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.8.0-3`

## generate_parameter_library

```
* Silence deprecation warning for tl_expected (#350 <https://github.com/PickNikRobotics/generate_parameter_library/issues/350>)
* Contributors: Christoph Fröhlich
```

## generate_parameter_library_py

- No changes
