### PR TITLE
image_common: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3317,7 +3317,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.7-2
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `7.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.4.7-2`

## camera_calibration_parsers

- No changes

## camera_info_manager

```
* Fix camera_info_manager flakiness and Windows crashes (#405 <https://github.com/ros-perception/image_common/issues/405>)
* Contributors: Michael Carroll
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Removed clang warning (#399 <https://github.com/ros-perception/image_common/issues/399>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

- No changes
