### PR TITLE
rqt_graph: 1.8.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8568,7 +8568,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.8.2-3
+      version: 1.8.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.8.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.2-3`

## rqt_graph

```
* Support Wheel event in qt6 (backport #116 <https://github.com/ros-visualization/rqt_graph/issues/116>) (#117 <https://github.com/ros-visualization/rqt_graph/issues/117>)
* Contributors: mergify[bot]
```
