### PR TITLE
rqt: 2.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8469,7 +8469,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.10.4-2
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `2.0.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.10.4-2`

## rqt

- No changes

## rqt_gui

- No changes

## rqt_gui_cpp

```
* Cleanup headers (#347 <https://github.com/ros-visualization/rqt/issues/347>)
* Contributors: Alejandro Hernández Cordero
```

## rqt_gui_py

- No changes

## rqt_py_common

```
* Cleanup headers (#347 <https://github.com/ros-visualization/rqt/issues/347>)
* Contributors: Alejandro Hernández Cordero
```
