### PR TITLE
realtime_support: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6856,7 +6856,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.20.0-2
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.20.0-2`

## rttest

```
* cleanups and removed dead code (#141 <https://github.com/ros2/realtime_support/issues/141>)
* Contributors: Alejandro Hernández Cordero
```

## tlsf_cpp

```
* cleanups and removed dead code (#141 <https://github.com/ros2/realtime_support/issues/141>)
* fix: remove newly added overloads of AllocatorMemoryStrategy (#143 <https://github.com/ros2/realtime_support/issues/143>)
* fix: Removed AllocatorMemoryStrategy (#140 <https://github.com/ros2/realtime_support/issues/140>)
* Contributors: Alejandro Hernández Cordero, Janosch Machowinski
```
