### PR TITLE
realtime_support: 0.20.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6850,7 +6850,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 0.20.0-3
+      version: 0.20.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `0.20.1-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.20.0-3`

## rttest

```
* cleanups and removed dead code (#141 <https://github.com/ros2/realtime_support/issues/141>) (#144 <https://github.com/ros2/realtime_support/issues/144>)
* Contributors: mergify[bot]
```

## tlsf_cpp

```
* cleanups and removed dead code (#141 <https://github.com/ros2/realtime_support/issues/141>) (#144 <https://github.com/ros2/realtime_support/issues/144>)
* fix: Removed AllocatorMemoryStrategy (backport #140 <https://github.com/ros2/realtime_support/issues/140>) (#142 <https://github.com/ros2/realtime_support/issues/142>)
* Contributors: mergify[bot]
```
