### PR TITLE
async_web_server_cpp: 2.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -586,7 +586,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/async_web_server_cpp-release.git
-      version: 2.0.1-3
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/fkie/async_web_server_cpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `async_web_server_cpp` to `2.0.2-1`:

- upstream repository: https://github.com/fkie/async_web_server_cpp.git
- release repository: https://github.com/ros2-gbp/async_web_server_cpp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-3`

## async_web_server_cpp

```
* Fix compile errors with Boost >= 1.87 (#8 <https://github.com/fkie/async_web_server_cpp/issues/8>)
* Contributors: Michal Sojka
```
