### PR TITLE
ur_description: 2.10.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13131,7 +13131,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.10.0-1
+      version: 2.10.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.10.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.10.0-1`

## ur_description

```
* Correct offsets of wrist3 meshes (backport #393 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/393>) (#394 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/394>)
* Contributors: mergify[bot]
```
