### PR TITLE
ur_description: 4.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10394,7 +10394,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 4.3.0-1
+      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `4.3.1-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.3.0-1`

## ur_description

```
* Correct offsets of wrist3 meshes (#393 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/393>)
* Use XML launchfile instead of Python (#382 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/382>)
* Contributors: Felix Exner
```