### PR TITLE
sick_safetyscanners2_interfaces: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11354,7 +11354,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/SICKAG/sick_safetyscanners2_interfaces-release.git
-      version: 1.0.0-2
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safetyscanners2_interfaces` to `1.0.1-1`:

- upstream repository: https://github.com/SICKAG/sick_safetyscanners2_interfaces.git
- release repository: https://github.com/SICKAG/sick_safetyscanners2_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-2`

## sick_safetyscanners2_interfaces

```
* Updated maintainer and author information in package.xml
* Resolve cmakelists, package and licence issues
* Added StatusOverview Service
* Contributors: Andrej Pangercic, Christian Eichmann
```
