### PR TITLE
sick_safevisionary_ros2: 1.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9213,7 +9213,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
-      version: 1.0.3-3
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/SICKAG/sick_safevisionary_ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sick_safevisionary_ros2` to `1.0.5-1`:

- upstream repository: https://github.com/SICKAG/sick_safevisionary_ros2.git
- release repository: https://github.com/ros2-gbp/sick_safevisionary_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.3-3`

## sick_safevisionary_driver

```
* Replace ament_target_libraries with target_link_libraries
* Contributors: Alejandro Hernandez Cordero, Christian Eichmann
```

## sick_safevisionary_interfaces

- No changes

## sick_safevisionary_tests

- No changes
