### PR TITLE
depthai_ros_v3: 3.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2153,7 +2153,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.1.1-2
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai_ros_v3` to `3.2.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-v3-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.1-2`

## depthai_bridge_v3

```
* Expose pipeline auto calibration mode through the ROS driver.
```

## depthai_examples_v3

```
* Expose pipeline auto calibration mode through the ROS driver.
```

## depthai_ros_msgs_v3

```
* Expose pipeline auto calibration mode through the ROS driver.
```

## depthai_ros_v3

```
* Expose pipeline auto calibration mode through the ROS driver.
```
