### PR TITLE
depthai-ros: 3.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1566,7 +1566,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.2.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.0-1`

## depthai-ros

```
* Expose pipeline auto calibration mode through the ROS driver.
```

## depthai_bridge

```
* Expose pipeline auto calibration mode through the ROS driver.
```

## depthai_examples

```
* Expose pipeline auto calibration mode through the ROS driver.
```

## depthai_ros_msgs

```
* Expose pipeline auto calibration mode through the ROS driver.
```
