### PR TITLE
ament_cmake_ros: 0.16.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -245,7 +245,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_ros-release.git
-      version: 0.15.7-2
+      version: 0.16.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_cmake_ros` to `0.16.0-1`:

- upstream repository: https://github.com/ros2/ament_cmake_ros.git
- release repository: https://github.com/ros2-gbp/ament_cmake_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.15.7-2`

## ament_cmake_ros

- No changes

## ament_cmake_ros_core

- No changes

## domain_coordinator

- No changes

## rmw_test_fixture

- No changes

## rmw_test_fixture_implementation

```
* Block signals during Python environment reload in rmw_test_fixture_implementation (#64 <https://github.com/ros2/ament_cmake_ros/issues/64>)
* Contributors: Michael Carroll
```
