### PR TITLE
demos: 0.38.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1573,7 +1573,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.37.8-2
+      version: 0.38.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.38.0-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.37.8-2`

## action_tutorials_cpp

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Removed AllocatorMemoryStrategy (#784 <https://github.com/ros2/demos/issues/784>)
* Contributors: Janosch Machowinski
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Update showimage.cpp removing extra std::cerr outputs (#785 <https://github.com/ros2/demos/issues/785>)
* Contributors: jmackay2
```

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

```
* Removed AllocatorMemoryStrategy (#784 <https://github.com/ros2/demos/issues/784>)
* Contributors: Janosch Machowinski
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

```
* Fixed topic monitor demos (#791 <https://github.com/ros2/demos/issues/791>)
* Contributors: Alejandro Hernández Cordero
```

## topic_statistics_demo

- No changes
