### PR TITLE
launch: 3.10.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3795,7 +3795,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.7-2
+      version: 3.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.10.0-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.9.7-2`

## launch

```
* Robust pytest_ignore_collect for multi-version Pytest compatibility (#974 <https://github.com/ros2/launch/issues/974>)
* Fix Pytest 8/9 compatibility and coroutine leaks in launch_pytest (#972 <https://github.com/ros2/launch/issues/972>)
* Contributors: Michael Carroll
```

## launch_pytest

```
* Fix Pytest 8/9 compatibility and coroutine leaks in launch_pytest (#972 <https://github.com/ros2/launch/issues/972>)
* Contributors: Michael Carroll
```

## launch_testing

```
* Robust pytest_ignore_collect for multi-version Pytest compatibility (#974 <https://github.com/ros2/launch/issues/974>)
* Fix Pytest 8/9 compatibility and coroutine leaks in launch_pytest (#972 <https://github.com/ros2/launch/issues/972>)
* Contributors: Michael Carroll
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
