### PR TITLE
geometry2: 0.46.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2565,7 +2565,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.45.7-2
+      version: 0.46.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.46.0-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.45.7-2`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

- No changes

## tf2_bullet

- No changes

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Improve tf2_ros::MessageFilter test reliability (#929 <https://github.com/ros2/geometry2/issues/929>)
* Contributors: Michael Carroll
```

## tf2_ros_py

```
* tf2_ros_py: Make node parameter optional in TransformListener (#935 <https://github.com/ros2/geometry2/issues/935>)
* tf2_ros_py: Ignore ExternalShutdownException in background thread (#930 <https://github.com/ros2/geometry2/issues/930>)
* Contributors: Martin Pecka
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
