### PR TITLE
launch_ros: 0.30.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3860,7 +3860,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.7-2
+      version: 0.30.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.30.0-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.29.7-2`

## launch_ros

- No changes

## launch_testing_ros

```
* Fix launch_testing_ros so it works with pytest 7. (#543 <https://github.com/ros2/launch_ros/issues/543>)
* Fix Pytest 8/9 compatibility in launch_testing_ros hooks (#540 <https://github.com/ros2/launch_ros/issues/540>)
* Contributors: Chris Lalancette, Michael Carroll
```

## ros2launch

- No changes
