### PR TITLE
rcl_interfaces: 2.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6635,7 +6635,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 2.4.4-2
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `2.5.0-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.4-2`

## action_msgs

- No changes

## builtin_interfaces

- No changes

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

- No changes

## rosgraph_msgs

```
* Actually build the new graph description messages (#192 <https://github.com/ros2/rcl_interfaces/issues/192>)
* Contributors: Emerson Knapp
```

## service_msgs

- No changes

## statistics_msgs

- No changes

## test_msgs

- No changes

## type_description_interfaces

- No changes
