### PR TITLE
rclpy: 11.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6740,7 +6740,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 10.0.9-2
+      version: 11.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `11.0.0-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `10.0.9-2`

## rclpy

```
* Removed dead code (#1657 <https://github.com/ros2/rclpy/issues/1657>)
* Refactor warn_fini_failure (#1658 <https://github.com/ros2/rclpy/issues/1658>)
* Feature: async node (#1620 <https://github.com/ros2/rclpy/issues/1620>)
* Refactor: moved TypeDescriptionService, LoggingService, ParameterService to BaseNode (#1645 <https://github.com/ros2/rclpy/issues/1645>)
* Refactor: base node (#1637 <https://github.com/ros2/rclpy/issues/1637>)
* Bugfix: executor doesn't propagate exception from task that awaited a future (#1643 <https://github.com/ros2/rclpy/issues/1643>)
* Fix: disable flaky executor test (#1648 <https://github.com/ros2/rclpy/issues/1648>) (#1649 <https://github.com/ros2/rclpy/issues/1649>)
* Contributors: Alejandro Hernández Cordero, Nadav Elkabets
```
