### PR TITLE
rmw_fastrtps: 9.5.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7363,7 +7363,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.7-2
+      version: 9.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.5.0-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.4.7-2`

## rmw_fastrtps_cpp

```
* Fix rmw_take_serialized. (#881 <https://github.com/ros2/rmw_fastrtps/issues/881>)
* Fix UB in accessing the keys (#879 <https://github.com/ros2/rmw_fastrtps/issues/879>)
* Contributors: Chris Lalancette
```

## rmw_fastrtps_dynamic_cpp

```
* Fix UB in accessing the keys (#879 <https://github.com/ros2/rmw_fastrtps/issues/879>)
* Contributors: Chris Lalancette
```

## rmw_fastrtps_shared_cpp

```
* Change the buffer-aware BUFBE: -> bufbe. (#880 <https://github.com/ros2/rmw_fastrtps/issues/880>)
* Contributors: Chris Lalancette
```
