### PR TITLE
[robotraconteur,robotraconteur-companion] Use system packages on resolute and forky

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9753,6 +9753,16 @@ robin-map-dev:
   ubuntu: [robin-map-dev]
 robotino-api2:
   ubuntu: [robotino-api2]
+robotraconteur:
+  ubuntu:
+    resolute: [python3-robotraconteur, librobotraconteur-dev]
+  debian:
+    forky: [python3-robotraconteur, librobotraconteur-dev]
+robotraconteur_companion:
+  ubuntu:
+    resolute: [librobotraconteur-companion-dev]
+  debian:
+    forky: [librobotraconteur-companion-dev]
 rsync:
   arch: [rsync]
   debian: [rsync]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9754,15 +9754,15 @@ robin-map-dev:
 robotino-api2:
   ubuntu: [robotino-api2]
 robotraconteur:
-  ubuntu:
-    resolute: [python3-robotraconteur, librobotraconteur-dev]
   debian:
     forky: [python3-robotraconteur, librobotraconteur-dev]
-robotraconteur_companion:
   ubuntu:
-    resolute: [librobotraconteur-companion-dev]
+    resolute: [python3-robotraconteur, librobotraconteur-dev]
+robotraconteur_companion:
   debian:
     forky: [librobotraconteur-companion-dev]
+  ubuntu:
+    resolute: [librobotraconteur-companion-dev]
 rsync:
   arch: [rsync]
   debian: [rsync]


### PR DESCRIPTION
`robotraconteur` and `robotraconteur_companion` have recently been added to the Ubuntu and Debian system repositories for Resolute and Forky. This PR updates `base.yml` to use the system packages when available.

I am not clear if rosdep will fall back to the ROS packages on Ubuntu Noble and the other Debian/Redhat operating systems that do not have system packages. 

Resolves #50609 
