### PR TITLE
message_filters: 7.4.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4350,7 +4350,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 7.3.9-1
+      version: 7.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `7.4.0-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.3.9-1`

## message_filters

```
* Cleanup headers and removed deadcode (#284 <https://github.com/ros2/message_filters/issues/284>) (#291 <https://github.com/ros2/message_filters/issues/291>)
* feat(python): add python implementation of InputAligner  (backport #283 <https://github.com/ros2/message_filters/issues/283>) (#286 <https://github.com/ros2/message_filters/issues/286>)
* Contributors: mergify[bot]
```
