### PR TITLE
resource_retriever_service: 1.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6946,7 +6946,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever_service-release.git
-      version: 0.0.1-2
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever_service` to `1.0.0-1`:

- upstream repository: https://github.com/ros2/resource_retriever_service
- release repository: https://github.com/ros2-gbp/resource_retriever_service-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.1-2`

## resource_retriever_interfaces

```
* Update the plugin license (#17 <https://github.com/ros2/resource_retriever_service/issues/17>)
* Contributors: Stoyan Gaydarov
```

## resource_retriever_service

```
* Update the plugin license (#17 <https://github.com/ros2/resource_retriever_service/issues/17>)
* Contributors: Stoyan Gaydarov
```

## resource_retriever_service_plugin

```
* Update the plugin license (#17 <https://github.com/ros2/resource_retriever_service/issues/17>)
* Contributors: Stoyan Gaydarov
```
