### PR TITLE
autoware_adapi_msgs: 1.9.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -697,7 +697,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
-      version: 1.9.0-3
+      version: 1.9.1-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_adapi_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_adapi_msgs` to `1.9.1-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_adapi_msgs.git
- release repository: https://github.com/ros2-gbp/autoware_adapi_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.9.0-3`

## autoware_adapi_v1_msgs

```
* feat(autoware_adapi_v1_msgs): add ROUNDABOUT support (#102 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/102>)
  feat(autoware_adapi_v1_msgs): add ROUNDABOUT constant to PlanningBehavior message
* Contributors: Sho Iwasawa
```

## autoware_adapi_version_msgs

- No changes
