### PR TITLE
autoware_lanelet2_extension: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -830,7 +830,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_lanelet2_extension` to `1.1.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
- release repository: https://github.com/ros2-gbp/autoware_lanelet2_extension-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## autoware_lanelet2_extension

```
* feat: add traffic rules to enable driving for areas (#104 <https://github.com/autowarefoundation/autoware_lanelet2_extension/issues/104>)
* Contributors: emmeyteja
```

## autoware_lanelet2_extension_python

- No changes
