### PR TITLE
autoware_core: 1.8.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -800,6 +800,88 @@ repositories:
       url: https://github.com/autowarefoundation/autoware_cmake.git
       version: main
     status: developed
+  autoware_core:
+    release:
+      packages:
+      - autoware_adapi_adaptors
+      - autoware_adapi_specs
+      - autoware_agnocast_wrapper
+      - autoware_awsim_sensor_kit_description
+      - autoware_behavior_velocity_planner
+      - autoware_behavior_velocity_planner_common
+      - autoware_behavior_velocity_stop_line_module
+      - autoware_component_interface_specs
+      - autoware_core
+      - autoware_core_api
+      - autoware_core_control
+      - autoware_core_localization
+      - autoware_core_map
+      - autoware_core_perception
+      - autoware_core_planning
+      - autoware_core_sensing
+      - autoware_core_vehicle
+      - autoware_crop_box_filter
+      - autoware_default_adapi
+      - autoware_downsample_filters
+      - autoware_ekf_localizer
+      - autoware_euclidean_cluster_object_detector
+      - autoware_geography_utils
+      - autoware_global_parameter_loader
+      - autoware_gnss_poser
+      - autoware_ground_filter
+      - autoware_gyro_odometer
+      - autoware_interpolation
+      - autoware_kalman_filter
+      - autoware_lanelet2_map_visualizer
+      - autoware_lanelet2_utils
+      - autoware_localization_util
+      - autoware_map_height_fitter
+      - autoware_map_loader
+      - autoware_map_projection_loader
+      - autoware_marker_utils
+      - autoware_mission_planner
+      - autoware_motion_utils
+      - autoware_motion_velocity_obstacle_stop_module
+      - autoware_motion_velocity_planner
+      - autoware_motion_velocity_planner_common
+      - autoware_ndt_scan_matcher
+      - autoware_node
+      - autoware_object_recognition_utils
+      - autoware_objects_of_interest_marker_interface
+      - autoware_osqp_interface
+      - autoware_path_generator
+      - autoware_perception_objects_converter
+      - autoware_planning_factor_interface
+      - autoware_planning_test_manager
+      - autoware_planning_topic_converter
+      - autoware_point_types
+      - autoware_pose_initializer
+      - autoware_pyplot
+      - autoware_qos_utils
+      - autoware_qp_interface
+      - autoware_route_handler
+      - autoware_sample_sensor_kit_description
+      - autoware_sample_vehicle_description
+      - autoware_signal_processing
+      - autoware_simple_pure_pursuit
+      - autoware_stop_filter
+      - autoware_test_node
+      - autoware_test_utils
+      - autoware_testing
+      - autoware_trajectory
+      - autoware_twist2accel
+      - autoware_vehicle_info_utils
+      - autoware_vehicle_velocity_converter
+      - autoware_velocity_smoother
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/autoware_core-release.git
+      version: 1.8.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_core.git
+      version: main
+    status: developed
   autoware_internal_msgs:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_core` to `1.8.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_core.git
- release repository: https://github.com/ros2-gbp/autoware_core-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

