### PR TITLE
openeb_vendor: 2.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5619,7 +5619,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/openeb_vendor-release.git
-      version: 2.0.2-2
+      version: 2.0.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/openeb_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openeb_vendor` to `2.0.3-1`:

- upstream repository: https://github.com/ros-event-camera/openeb_vendor.git
- release repository: https://github.com/ros2-gbp/openeb_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.2-2`

## openeb_vendor

```
* switch to different workflow
* use openeb v5.2
* Contributors: Bernd Pfrommer
```
