### PR TITLE
Add rosidl_buffer_backends_tutorials source entry

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8142,6 +8142,13 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: lyrical
     status: maintained
+  rosidl_buffer_backends_tutorials:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_buffer_backends_tutorials.git
+      version: main
+    status: developed
   rosidl_core:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

lyrical

# The source is here:

https://github.com/ros2/rosidl_buffer_backends_tutorials.git

# Checks
- [x] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [x] This package is expected to build on the submitted rosdistro