### PR TITLE
Add rosidl_buffer_backends source entry to Rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8163,6 +8163,13 @@ repositories:
       url: https://github.com/ros2/rosidl.git
       version: rolling
     status: maintained
+  rosidl_buffer_backends:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros2/rosidl_buffer_backends.git
+      version: main
+    status: developed
   rosidl_core:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/ros2/rosidl_buffer_backends.git

# Checks
- [x] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [x] This package is expected to build on the submitted rosdistro