### PR TITLE
flir_camera_driver: 3.0.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3164,7 +3164,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/flir_camera_driver-release.git
-      version: 3.0.4-1
+      version: 3.0.5-1
     source:
       type: git
       url: https://github.com/ros-drivers/flir_camera_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flir_camera_driver` to `3.0.5-1`:

- upstream repository: https://github.com/ros-drivers/flir_camera_driver.git
- release repository: https://github.com/ros2-gbp/flir_camera_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.4-1`

## flir_camera_description

```
* modifications to compile on Ubuntu 26.04
* Contributors: Bernd Pfrommer
```

## flir_camera_msgs

```
* modifications to compile on Ubuntu 26.04
* Contributors: Bernd Pfrommer
```

## spinnaker_camera_driver

```
* modifications to compile on Ubuntu 26.04
* Add configuration file for FLIR Firefly FFy U3162C camera
* Contributors: Bernd Pfrommer, Jacopo Vivaldi
```

## spinnaker_synchronized_camera_driver

```
* guard against min_exposure_time = max_exposure_time
* Contributors: Bernd Pfrommer
```
