### PR TITLE
Update libboost-serialization for resolute and trixie

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3244,6 +3244,7 @@ libboost-serialization:
     bookworm: [libboost-serialization1.74.0]
     bullseye: [libboost-serialization1.74.0]
     buster: [libboost-serialization1.67.0]
+    trixie: [libboost-serialization1.83.0]
   fedora: [boost-serialization]
   gentoo: [dev-libs/boost]
   nixos: [boost]
@@ -3255,6 +3256,7 @@ libboost-serialization:
     focal: [libboost-serialization1.71.0]
     jammy: [libboost-serialization1.74.0]
     noble: [libboost-serialization1.83.0]
+    resolute: [libboost-serialization1.83.0]
 libboost-serialization-dev:
   arch: [boost]
   debian: [libboost-serialization-dev]


### PR DESCRIPTION
### Add `trixie` and `resolute` entries for `libboost-serialization`                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                
  `libboost-serialization` is the only key in the `libboost-*` runtime family that's missing `trixie` (Debian 13) and `resolute` (Ubuntu 26.04) — `libboost-program-options` and `libboost-system` both have them. The omission breaks any package that exec-depends on         
  `libboost-serialization` on those platforms; ROS Rolling devel jobs running on Ubuntu Resolute fail at rosdep resolution:                                                                                                                                                     
                                                                                                                                                                                                                                                                                
  rosdep2.lookup.ResolutionError: No definition of [libboost-serialization] for OS version [resolute]                                                                                                                                                                           
                                                                                                                                                                                                                                                                              
  Example failure: [`Rdev__ompl__ubuntu_resolute_amd64`](https://build.ros2.org/job/Rdev__ompl__ubuntu_resolute_amd64/) — OMPL recently switched its package.xml from `<depend>libboost-serialization-dev</depend>` to a build/exec-split that uses the bare                    
  `libboost-serialization` runtime key. The build dep resolves fine; the exec dep blocks the entire job.                                                                                                                                                                        
                                                                                                                                                                                                                                                                              
  This PR adds:                                                                                                                                                                                                                                                                 
  - `debian: trixie: [libboost-serialization1.83.0]`                                                                                                                                                                                                                          
  - `ubuntu: resolute: [libboost-serialization1.83.0]`                                                                                                                                                                                                                          
   
  Versions match what `libboost-program-options` and `libboost-system` already use for the same OS rows in this file (and what the corresponding `-dev` packages resolve to).