### PR TITLE
Add and fix Fedora and RHEL rosdep rules for Lyrical

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4986,6 +4986,7 @@ libmodbus-dev:
   fedora: [libmodbus-devel]
   nixos: [libmodbus]
   openembedded: [libmodbus@meta-oe]
+  rhel: [libmodbus-devel]
   ubuntu: [libmodbus-dev]
 libmodbus5:
   debian: [libmodbus5]
@@ -5592,6 +5593,7 @@ libpaho-mqttpp:
   debian:
     '*': [libpaho-mqttpp3-1]
     bullseye: null
+  fedora: [paho-cpp]
   nixos: [paho-mqtt-cpp]
   openembedded: [paho-mqtt-cpp@meta-oe]
   rhel: [paho-cpp]
@@ -5603,6 +5605,7 @@ libpaho-mqttpp-dev:
   debian:
     '*': [libpaho-mqttpp-dev]
     bullseye: null
+  fedora: [paho-cpp-devel]
   nixos: [paho-mqtt-cpp]
   openembedded: [paho-mqtt-cpp@meta-oe]
   rhel: [paho-cpp-devel]
@@ -6603,6 +6606,7 @@ libqt6-multimedia:
 libqt6-qml:
   arch: [qt6-declarative]
   debian: [libqt6qml6]
+  fedora: [qt6-qtdeclarative]
   gentoo: ['dev-qt/qtdeclarative:6']
   nixos: [qt6.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt6]
@@ -6615,6 +6619,7 @@ libqt6-qml:
 libqt6-quick:
   arch: [qt6-declarative]
   debian: [libqt6quick6]
+  fedora: [qt6-qtdeclarative]
   gentoo: ['dev-qt/qtdeclarative:6']
   nixos: [qt6.qtdeclarative]
   openembedded: [qtdeclarative@meta-qt6]
@@ -7621,6 +7626,7 @@ libx11:
   nixos: [xorg.libX11]
   openembedded: [libx11@openembedded-core]
   opensuse: [libX11-6]
+  rhel: [libX11]
   ubuntu: [libx11-dev]
 libx11-dev:
   alpine: [libx11-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -282,6 +282,10 @@ jupyter-notebook:
     '*': [jupyter-notebook]
   fedora: [python3-notebook]
   nixos: [python3Packages.notebook]
+  rhel:
+    '*': [python3-notebook]
+    '8': null
+    '9': null
   ubuntu:
     '*': [jupyter-notebook]
 libgv-python:
@@ -6035,9 +6039,13 @@ python3-fastapi:
     buster:
       pip:
         packages: [fastapi]
-  fedora: [python-fastapi]
+  fedora: [python3-fastapi]
   nixos: [python3Packages.fastapi]
   openembedded: [python3-fastapi@meta-python]
+  rhel:
+    '*': [python3-fastapi]
+    '8': null
+    '9': null
   ubuntu:
     '*': [python3-fastapi]
     bionic:
@@ -7133,6 +7141,9 @@ python3-junitparser:
   debian:
     '*': [python3-junitparser]
     stretch: null
+  fedora:
+    '*': [python3-junitparser]
+    '42': null
   ubuntu:
     '*': [python3-junitparser]
     bionic: null
@@ -10720,6 +10731,7 @@ python3-termcolor:
   nixos: [python3Packages.termcolor]
   openembedded: [python3-termcolor@meta-python]
   opensuse: [python3-termcolor]
+  rhel: [python3-termcolor]
   ubuntu: [python3-termcolor]
 python3-texttable:
   debian: [python3-texttable]
@@ -11164,8 +11176,12 @@ python3-utm:
 python3-uvicorn:
   alpine: [uvicorn]
   debian: [python3-uvicorn]
-  fedora: [python-uvicorn]
+  fedora: [python3-uvicorn]
   nixos: [python3Packages.uvicorn]
+  rhel:
+    '*': [python3-uvicorn]
+    '8': null
+    '9': null
   ubuntu:
     '*': [python3-uvicorn]
     bionic:


### PR DESCRIPTION
All of these keys are referenced somewhere in Lyrical and have broken rules for Fedora and/or RHEL.

RHEL and Fedora are both verified by `rosdep_repo_check`.