### PR TITLE
Rosdep: Nixos: Fixed outdated capitals in python packages

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6621,7 +6621,7 @@ python3-github:
   debian: [python3-github]
   fedora: [python3-github]
   gentoo: [dev-python/PyGithub]
-  nixos: [python3Packages.PyGithub]
+  nixos: [python3Packages.pygithub]
   rhel: ['python%{python3_pkgversion}-pygithub']
   ubuntu: [python3-github]
 python3-gitlab:
@@ -10007,7 +10007,7 @@ python3-rtree:
   debian: [python3-rtree]
   fedora: [python3-rtree]
   gentoo: [sci-libs/rtree]
-  nixos: [python3Packages.Rtree]
+  nixos: [python3Packages.rtree]
   openembedded: [python3-rtree@meta-ros2]
   rhel:
     '*': [python3-rtree]


### PR DESCRIPTION
## Package names:

- python3-rtree
- python3-github

## Package Upstream Source:

https://github.com/NixOS/nixpkgs

## Purpose of using this:

These dependencies have been renamed since https://github.com/NixOS/nixpkgs/pull/217217. This PR updates their names to the newer format. 

## Method

The packages were identified using `grep -E 'nixos: \[python3Packages\.[A-Z]' rosdep/python.yaml`, resulting in the following output:
```
  nixos: [python3Packages.PyGithub]
  nixos: [python3Packages.Rtree]
```
Each of these were then checked against the [nixpkgs search](https://search.nixos.org/packages?channel=25.11) and renamed to the correct values.