### PR TITLE
Update rule for graphicsmagick

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1755,7 +1755,10 @@ graphicsmagick:
   nixos: [graphicsmagick]
   openembedded: [graphicsmagick@meta-ros2]
   rhel: [GraphicsMagick-c++-devel]
-  ubuntu: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
+  ubuntu:
+    '*': [libgraphicsmagick++1-dev]
+    jammy: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
+    noble: [libgraphicsmagick++1-dev, graphicsmagick-libmagick-dev-compat]
 graphviz:
   alpine: [graphviz]
   arch: [graphviz]


### PR DESCRIPTION
This PR updates the rule for graphicsmagick, specifically, graphicsmagick-libmagick-dev-compat is not available in Ubuntu Resolute, thus removing it.

https://packages.ubuntu.com/search?keywords=magick&searchon=sourcenames&suite=all&section=all

No AI involved