### PR TITLE
coal: 3.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1194,16 +1194,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/coal-library/coal.git
-      version: master
+      version: devel
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/coal-library/coal.git
-      version: master
+      version: devel
     status: developed
   cob_common:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.3-1`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`
