### PR TITLE
coal: 3.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1213,7 +1213,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.2-2
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/coal-library/coal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.3-1`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-2`
