### PR TITLE
linear_feedback_controller_msgs: 1.2.2-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5203,6 +5203,21 @@ repositories:
       url: https://github.com/david-dorf/lightning_rrt_interfaces.git
       version: jazzy
     status: maintained
+  linear_feedback_controller_msgs:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller-msgs.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
+      version: 1.2.2-2
+    source:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller-msgs.git
+      version: main
+    status: developed
   linux_isolate_process:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller_msgs` to `1.2.2-2`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller-msgs.git
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
