### PR TITLE
linear_feedback_controller_msgs: 1.2.2-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4143,6 +4143,21 @@ repositories:
       url: https://github.com/ioskn/lidar_mirror_fov_reshaper.git
       version: rolling
     status: maintained
+  linear_feedback_controller_msgs:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller-msgs.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
+      version: 1.2.2-2
+    source:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller-msgs.git
+      version: main
+    status: developed
   linux_isolate_process:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller_msgs` to `1.2.2-2`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller-msgs.git
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
