### PR TITLE
eiquadprog: 1.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1984,7 +1984,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/eiquadprog-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/eiquadprog.git


### PR DESCRIPTION
Increasing version of package(s) in repository `eiquadprog` to `1.3.2-1`:

- upstream repository: git@github.com:stack-of-tasks/eiquadprog.git
- release repository: https://github.com/ros2-gbp/eiquadprog-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.1-1`
