### PR TITLE
tsid: 1.10.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9954,7 +9954,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/tsid-release.git
-      version: 1.9.0-3
+      version: 1.10.0-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/tsid.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tsid` to `1.10.0-1`:

- upstream repository: https://github.com/stack-of-tasks/tsid
- release repository: https://github.com/ros2-gbp/tsid-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.9.0-3`
