### PR TITLE
mapviz: 2.6.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4202,7 +4202,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.6.3-4
+      version: 2.6.4-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.6.4-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.6.3-4`

## mapviz

```
* Added duplicate option (#872 <https://github.com/swri-robotics/mapviz/issues/872>)
  * Added duplicate option to plugin right-click and ctrl+d hotkey for duplicating selected plugins
* Contributors: Robert Brothers
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

- No changes
