### PR TITLE
mapviz: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4202,7 +4202,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.6.3-4
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `3.0.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.6.3-4`

## mapviz

```
* Refactor OpenGL Interface (#871 <https://github.com/swri-robotics/mapviz/issues/871>)
  * Refactoring to use Qt's OpenGL interfaces rather than raw GLEW and GLUT.
  ---------
  Co-authored-by: DangitBen <mailto:30333928+DangitBen@users.noreply.github.com>
* Contributors: David Anthony
```

## mapviz_interfaces

```
* Refactor OpenGL Interface (#871 <https://github.com/swri-robotics/mapviz/issues/871>)
  * Refactoring to use Qt's OpenGL interfaces rather than raw GLEW and GLUT.
  ---------
  Co-authored-by: DangitBen <mailto:30333928+DangitBen@users.noreply.github.com>
* Contributors: David Anthony
```

## mapviz_plugins

```
* Refactor OpenGL Interface (#871 <https://github.com/swri-robotics/mapviz/issues/871>)
  * Refactoring to use Qt's OpenGL interfaces rather than raw GLEW and GLUT.
  ---------
  Co-authored-by: DangitBen <mailto:30333928+DangitBen@users.noreply.github.com>
* Contributors: David Anthony
```

## multires_image

```
* Refactor OpenGL Interface (#871 <https://github.com/swri-robotics/mapviz/issues/871>)
  * Refactoring to use Qt's OpenGL interfaces rather than raw GLEW and GLUT.
  ---------
  Co-authored-by: DangitBen <mailto:30333928+DangitBen@users.noreply.github.com>
* Contributors: David Anthony
```

## tile_map

```
* Refactor OpenGL Interface (#871 <https://github.com/swri-robotics/mapviz/issues/871>)
  * Refactoring to use Qt's OpenGL interfaces rather than raw GLEW and GLUT.
  ---------
  Co-authored-by: DangitBen <mailto:30333928+DangitBen@users.noreply.github.com>
* Contributors: David Anthony
```
