### PR TITLE
Skip azure-iot-sdk-c at least until cmake >=3.5 is supported

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -863,11 +863,6 @@ repositories:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
       version: main
-    release:
-      tags:
-        release: release/lyrical/{package}/{version}
-      url: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
-      version: 1.14.0-6
     source:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -868,11 +868,6 @@ repositories:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git
       version: main
-    release:
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/azure_iot_sdk_c-release.git
-      version: 1.14.0-5
     source:
       type: git
       url: https://github.com/Azure/azure-iot-sdk-c.git


### PR DESCRIPTION
https://github.com/Azure/azure-iot-sdk-c/issues/2719

Let's ease the buildfarm a bit until all issues are resolved upstream.
I can do a new release after that.