### PR TITLE
Add ros2_gst_video_bridge to Humble distribution

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9959,6 +9959,12 @@ repositories:
       url: https://github.com/selfpatch/ros2_medkit.git
       version: main
     status: developed
+  ros2_gst_video_bridge:
+    source:
+      type: git
+      url: https://github.com/mkassimi98/ros2_gst_video_bridge.git
+      version: v1.0.0
+    status: developed
   ros2_ouster_drivers:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9963,7 +9963,7 @@ repositories:
     source:
       type: git
       url: https://github.com/mkassimi98/ros2_gst_video_bridge.git
-      version: v1.0.0
+      version: main
     status: developed
   ros2_ouster_drivers:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9907,6 +9907,12 @@ repositories:
       url: https://github.com/nobleo/ros2_fmt_logger.git
       version: main
     status: developed
+  ros2_gst_video_bridge:
+    source:
+      type: git
+      url: https://github.com/mkassimi98/ros2_gst_video_bridge.git
+      version: main
+    status: developed
   ros2_kortex:
     doc:
       type: git
@@ -9957,12 +9963,6 @@ repositories:
     source:
       type: git
       url: https://github.com/selfpatch/ros2_medkit.git
-      version: main
-    status: developed
-  ros2_gst_video_bridge:
-    source:
-      type: git
-      url: https://github.com/mkassimi98/ros2_gst_video_bridge.git
       version: main
     status: developed
   ros2_ouster_drivers:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/mkassimi98/ros2_gst_video_bridge

ros2_gst_video_bridge is a ROS 2 node that subscribes to raw image streams and forwards frames through configurable GStreamer pipelines. It supports multiple output targets such as SRT, RTSP, RTP/UDP and file recording, with codec selection and resilience-oriented runtime behavior.

# Checks

- [x] All packages have a declared license in the package.xml
- [x] This repository has a LICENSE file
- [x] This package is expected to build on the submitted rosdistro