### PR TITLE
add libsocketcan

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7010,6 +7010,10 @@ libsndfile1-dev:
   openembedded: [libsndfile1@openembedded-core]
   rhel: [libsndfile-devel]
   ubuntu: [libsndfile1-dev]
+libsocketcan-dev:
+  debian: [libsocketcan-dev]
+  fedora: [libsocketcan-devel]
+  ubuntu: [libsocketcan-dev]
 libsodium-dev:
   alpine: [libsodium-dev]
   arch: [libsodium]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7013,6 +7013,7 @@ libsndfile1-dev:
 libsocketcan-dev:
   debian: [libsocketcan-dev]
   fedora: [libsocketcan-devel]
+  opensuse: [libsocketcan-dev]
   rhel:
     '*': null
     '8': [libsocketcan-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7013,7 +7013,10 @@ libsndfile1-dev:
 libsocketcan-dev:
   debian: [libsocketcan-dev]
   fedora: [libsocketcan-devel]
-  rhel: [libsocketcan-devel]
+  rhel:
+    '*': null
+    '8': [libsocketcan-devel]
+    '9': [libsocketcan-devel]
   ubuntu: [libsocketcan-dev]
 libsodium-dev:
   alpine: [libsodium-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7013,6 +7013,7 @@ libsndfile1-dev:
 libsocketcan-dev:
   debian: [libsocketcan-dev]
   fedora: [libsocketcan-devel]
+  rhel: [libsocketcan-devel]
   ubuntu: [libsocketcan-dev]
 libsodium-dev:
   alpine: [libsodium-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7013,7 +7013,7 @@ libsndfile1-dev:
 libsocketcan-dev:
   debian: [libsocketcan-dev]
   fedora: [libsocketcan-devel]
-  opensuse: [libsocketcan-dev]
+  opensuse: [libsocketcan-devel]
   rhel:
     '*': null
     '8': [libsocketcan-devel]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name: libsocketcan-dev

## Package Upstream Source:

https://github.com/linux-can/libsocketcan

## Purpose of using this:

Building ROS nodes and device drivers for devices using SocketCAN

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/de/sid/libsocketcan-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libsocketcan-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/libsocketcan/libsocketcan-devel/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - https://rhel.pkgs.org/9/epel-x86_64/libsocketcan-devel-0.0.12-3.el9.x86_64.rpm.html

