### PR TITLE
mp2p_icp: 2.10.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5986,7 +5986,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.10.1-1
+      version: 2.10.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.10.2-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.10.1-1`

## mp2p_icp

```
* Merge pull request #65 <https://github.com/MOLAorg/mp2p_icp/issues/65> from MOLAorg/simplify-ci
  CI: simplify CI scripts and docker install
* chore: don't use anymore map classes deprecated and to be removed in mrpt 3.0.0
* fix: maps creating multiple CPointsCloud won't have all with pointSize honored
* Merge pull request #64 <https://github.com/MOLAorg/mp2p_icp/issues/64> from MOLAorg/bump-cmake
  bump min req cmake version to 3.22
* CI: Use sensible names for jobs matrix
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```
