### PR TITLE
mola_state_estimation: 2.4.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4602,7 +4602,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.2.0-3
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.4.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.0-3`

## mola_georeferencing

```
* Merge pull request #30 <https://github.com/MOLAorg/mola_state_estimation/issues/30> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

```
* Merge pull request #30 <https://github.com/MOLAorg/mola_state_estimation/issues/30> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation

```
* Merge pull request #30 <https://github.com/MOLAorg/mola_state_estimation/issues/30> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_simple

```
* Merge pull request #30 <https://github.com/MOLAorg/mola_state_estimation/issues/30> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Merge pull request #29 <https://github.com/MOLAorg/mola_state_estimation/issues/29> from MOLAorg/fix/odometry-fuse-pose-twist-corruption
  fix(state_estimation_simple): correct twist and initial-guess corruption when wheel odometry is active
* Add more unit test cases
* fix: odom twist does not overwrite IMU wx/wy
* fix(state_estimation_simple): correct twist and initial-guess corruption when wheel odometry is active
  Three inter-related bugs caused the LiDAR adaptive threshold sigma to grow
  toward maximum_sigma whenever wheel odometry was fused:
  1. Wrong twist from fuse_pose() when odometry is active.
  fuse_pose() computed incrPose = new_ICP - last_pose, but last_pose had
  been modified by fuse_odometry() / fuse_odometry_3d_pose() between scans.
  The result was the odometry residual / dt instead of the true robot velocity,
  corrupting de-skewing and the rot_error term in the adaptive threshold.
  Fix: per-source SourceState in State tracks each source's own last absolute
  pose and timestamp. fuse_pose() now computes incrPose = new_ICP - src.last_pose,
  which is always the true ICP-to-ICP motion regardless of intervening odom updates.
  2. CObservationRobotPose (3D odom path) overwrote last_pose_obs_tim.
  When BridgeROS2 forwards wheel odometry as CObservationRobotPose
  (odometry_as_robot_pose_observation=true), onNewObservation() routed it
  to fuse_pose(), which updated last_pose_obs_tim to the odom timestamp.
  If the next LiDAR ICP fuse_pose() arrived with a slightly earlier timestamp,
  dt < 0 and the call was silently rejected. last_pose was then the absolute
  wheel odometry pose (in the odom frame), producing ~90-degree initial-guess
  errors for ICP (confirmed by debug traces showing motionModelError with
  yaw ~ -1.56 rad and pitch ~ 0.51 rad on a stationary ground robot).
  Fix: route CObservationRobotPose matching do_process_odometry_labels_re to a
  new fuse_odometry_3d_pose() method that applies an incremental delta to
  last_pose (keeping it in the SLAM frame) and never touches last_pose_obs_tim.
  3. fuse_odometry() ignored the velocity carried in CObservationOdometry.
  BridgeROS2 always populates hasVelocities / velocityLocal from the ROS
  /odom twist. Those values were discarded, leaving last_twist stale.
  Fix: when hasVelocities is true, update last_twist from velocityLocal.
  IMU angular rates (fuse_imu) still override wx/wy/wz when available.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* chore: reduce fuse_pose() backwards in time warning rate
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

```
* FIX: reset() should reinitialize gtsam
* FIX: don't let gtsam exceptions to crash the node
* fix: support building in ROS2 humble with newer cmake
* Merge pull request #30 <https://github.com/MOLAorg/mola_state_estimation/issues/30> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```
