### PR TITLE
mola: 2.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4487,16 +4487,10 @@ repositories:
       version: develop
     release:
       packages:
-      - kitti_metrics_eval
       - mola
       - mola_bridge_ros2
       - mola_demos
-      - mola_input_euroc_dataset
-      - mola_input_kitti360_dataset
-      - mola_input_kitti_dataset
       - mola_input_lidar_bin_dataset
-      - mola_input_mulran_dataset
-      - mola_input_paris_luco_dataset
       - mola_input_rawlog
       - mola_input_rosbag2
       - mola_input_video
@@ -4508,11 +4502,12 @@ repositories:
       - mola_relocalization
       - mola_traj_tools
       - mola_viz
+      - mola_viz_imgui
       - mola_yaml
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.8.0-1
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `2.9.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.0-1`

## mola

```
* mola metapackage no longer installs academic dataset modules
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_bridge_ros2

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Less verbose output: don't print covariance matrix for each geo-referenced solution
* Contributors: Jose Luis Blanco-Claraco
```

## mola_demos

```
* chore: clear leftover
* Merge pull request #112 <https://github.com/MOLAorg/mola/issues/112> from MOLAorg/feat/dear-imgui-viz
  Introduce Dear ImGui alternative viz module
* imgui windows: persistent state across sessions
* Introduce Dear ImGui alternative viz module
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* fix: pep257 docs
* demos: replace mock sensor publisher scripts with one centralized script
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rawlog

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_rosbag2

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_kernel

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Merge pull request #142 <https://github.com/MOLAorg/mola/issues/142> from MOLAorg/feat/add-keyframe-map-capable-api
  feat: Add keyframe map capable API
* feat: Add keyframe map capable API
* kernel: utils RegexCache made thread-safe
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* fix: KeyframePointCloudMap viz should honor pointSize
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Merge pull request #142 <https://github.com/MOLAorg/mola/issues/142> from MOLAorg/feat/add-keyframe-map-capable-api
  feat: Add keyframe map capable API
* feat: Add keyframe map capable API
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

```
* fix: rollback min cmake version for local builds in Humble with modern cmake
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_pose_list

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_relocalization

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_traj_tools

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz

```
* Merge pull request #112 <https://github.com/MOLAorg/mola/issues/112> from MOLAorg/feat/dear-imgui-viz
  Introduce Dear ImGui alternative viz module
* chore: misc improvements
* Introduce Dear ImGui alternative viz module
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_viz_imgui

```
* fix: Imgui background scene color was washed out
* Merge pull request #144 <https://github.com/MOLAorg/mola/issues/144> from MOLAorg/imgui-improvements
  fix: background scene doesn't respond to mouse
* fix: background scene doesn't respond to mouse
* Merge pull request #112 <https://github.com/MOLAorg/mola/issues/112> from MOLAorg/feat/dear-imgui-viz
  Introduce Dear ImGui alternative viz module
* Cleaner shutdown order
* Introduce Dear ImGui alternative viz module
* Contributors: Jose Luis Blanco-Claraco
```

## mola_yaml

```
* Merge pull request #143 <https://github.com/MOLAorg/mola/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```
