### PR TITLE
mola_sm_loop_closure: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5963,7 +5963,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_sm_loop_closure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_sm_loop_closure` to `1.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_sm_loop_closure.git
- release repository: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.0-1`

## mola_sm_loop_closure

```
* f2f pipeline: switch to multi-objective as default strategy
* Merge pull request #15 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/15> from MOLAorg/simplify-ci
  CI: simplify clang-format helpers and use ros: docker images for stable builds
* fix: wrap find -iname predicates in parentheses to scope them to listed dirs
  Without grouping, the -o operators apply at top level and -print0 only
  attaches to the last alternative, so files outside the intended directories
  can be matched.
* CI: simplify clang-format helpers and use ros: docker images for stable builds
  - Replace complex Python-based clang_git_format with a simple scripts/formatter.sh supporting --check
  - Standardize formatter to scripts/formatter.sh (moved from root formatter.sh)
  - Simplify check-clang-format.yml to just apt-install clang-format-14 and run the script
  - Use ros:humble / ros:jazzy pre-built images for stable CI builds (faster, no setup-ros needed)
* fix:as libflann as build_depend as needed for kiss-matcher
* CI: sensible job names
* bump min req cmake version to 3.22
* feat: live gui, show GNSS data points
* update package.xml build deps
* Merge pull request #14 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/14> from MOLAorg/improve-lc-hypothesis-coverage
  Improve lc hypothesis coverage
* fix: deduplicate candidates by block-pair ID before selection in find_loop_candidates
  Multiple (i,j) frame pairs can round to the same (frameGroup_i, frameGroup_j)
  block and all pass the alreadyChecked filter (which only holds pairs from
  previous rounds). All of them survived into the scored candidate list, so
  max_lc_candidates were returned but the evaluation loop in process() silently
  skipped all but the first occurrence of each block pair -- causing far fewer
  ICP evaluations than expected.
  Fix: after scoring (step 1) and before selection (step 2), deduplicate each
  candidate container by block-pair ID, keeping only the highest-scored entry
  per block. This is applied to both the flat candidates vector (PROXIMITY_ONLY,
  MULTI_OBJECTIVE) and each distance bin (DISTANCE_STRATIFIED), so
  max_lc_candidates now matches the number of candidates that will actually
  be evaluated.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* fix: MULTI_OBJECTIVE coverage term now uses spatial midpoints instead of sin formula
  The old coverage score used abs(sin(pi * topologicalMidpoint / totalFrames)),
  which only rewards candidates near the center of the frame index range and
  ignores actual map geometry. This caused clustering in the same physical region
  on non-linear trajectories (U-shapes, figure-8s, long straights).
  New approach:
  - Add LoopCandidate::spatialMidpoint ((pose_i + pose_j) / 2, computed once
  per candidate in find_loop_candidates()).
  - Track selectedMidpoints alongside selectedDistances in the greedy selection
  loop.
  - Coverage score penalizes candidates whose spatial midpoint is within ~20 m
  of an already-selected midpoint, forcing the selected set to cover different
  map areas regardless of trajectory shape.
  - Refactor score_multi_objective() to accept a MultiObjectiveArgs struct
  instead of a long flat parameter list, making call sites self-documenting.
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
* fix: MULTI_OBJECTIVE diversity scoring is now actually applied during selection
  selectedDistances was declared but never populated, so score_multi_objective()
  always computed diversity against an empty set (score = 1.0 always). The fix
  replaces the simple sort+truncate step 2 path for MULTI_OBJECTIVE with a greedy
  selection loop: pick the best candidate, record its distance, re-score the rest
  with the updated selectedDistances, repeat. This makes the diversity term a
  real participant in selection instead of a no-op.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* fix: live preview GNC stats no longer reset to zero at each LC round start
  liveStats was zero-initialized at the top of every lcRound loop, causing
  the 3Dscene caption to show "0 inliers, 0 outliers" until the first GNC
  optimization ran in that round. Carry lastGncInliers / lastGncOutliers
  forward so the caption always reflects the most recent optimizer result.
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* feat: show better inliers/outliers stats
* feat: manual LC now has an optional bypass for inliers
* Merge pull request #13 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/13> from MOLAorg/feat/live-gui-3dscene-file
  feat: show 'live' progress via 3Dscene file updates
* feat: show 'live' progress via 3Dscene file updates
* add new mp2p_icp flags: force_final_pairings_for_quality
* Add Codecov badge to README
* Merge pull request #12 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/12> from MOLAorg/feat/f2f-integrate-kiss-matcher
  feat: Incorporate KISS-Matcher as optional seeder for initial ICP poses
* fix: CI code coverage
* chore: add more INFO traces
* Fixes: cmake gating, don't expose kiss-matcher headers, manual LC should be inlier
* feat: Incorporate KISS-Matcher as optional seeder for initial ICP poses
* FIX: crashes due to missing noise model and different gtsam symbols
* feat: add gnss filter by max uncertainty
* Merge pull request #11 <https://github.com/MOLAorg/mola_sm_loop_closure/issues/11> from MOLAorg/refactor-common-code
  refactor: unify common code between the two LC algorithms
* CI: Fix for new ROS2 rolling, add codecov upload
* refactor: unify common code between the two LC algorithms
* Contributors: Jose Luis Blanco-Claraco
```
