### PR TITLE
mrpt_ros_bridge: 3.5.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4929,7 +4929,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
-      version: 3.5.2-3
+      version: 3.5.3-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros_bridge.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros_bridge` to `3.5.3-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros_bridge.git
- release repository: https://github.com/ros2-gbp/mrpt_ros_bridge-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.5.2-3`

## mrpt_libros_bridge

```
* Merge pull request #8 <https://github.com/MRPT/mrpt_ros_bridge/issues/8> from MRPT/fix/potential-ub-reinterpret-cast
  FIX: Potential UB for reinterpret_cast
* FIX: Potential UB for reinterpret_cast
* Contributors: Jose Luis Blanco-Claraco
```

## rosbag2rawlog

- No changes
