### PR TITLE
mrpt_navigation: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6254,7 +6254,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_navigation-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_navigation` to `2.5.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_navigation.git
- release repository: https://github.com/ros2-gbp/mrpt_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.0-1`

## mrpt_map_server

```
* Remove support for deprecated mrpt::maps classes
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_msgs_bridge

```
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav_interfaces

```
* fix: rollback min cmake version for local builds in Humble with modern cmake
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_navigation

```
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pf_localization

```
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_pointcloud_pipeline

```
* Merge pull request #161 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/161> from mrpt-ros-pkg/fix-threads
  Fix threads
* fix: safer multithreading access
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_reactivenav2d

```
* Merge pull request #161 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/161> from mrpt-ros-pkg/fix-threads
  Fix threads
* fix: destructor shutdown hang and broken thread-reap predicate in mrpt_reactivenav2d
  Call rnavEngine_.cancel() in the destructor (after cancelling the timer,
  before joining action threads) so any active navigation is aborted and
  action threads can observe a terminal nav state instead of always sleeping
  a full period before rclcpp::ok() lets them exit.
  Remove the erase/remove_if reap in handle_accepted and handle_accepted_wp:
  the predicate !t.joinable() never matched real threads because a finished
  but unjoined std::thread is still joinable; the cleanup loop was always a
  no-op. The destructor join loop already handles all cleanup correctly.
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
* fix: parameter declaration
* fix: various multithreading issues
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tps_astar_planner

```
* Merge pull request #161 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/161> from mrpt-ros-pkg/fix-threads
  Fix threads
* fix: safer multithreading access
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* fix: remove deadcode on debug 3D window
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tutorials

```
* Merge pull request #159 <https://github.com/mrpt-ros-pkg/mrpt_navigation/issues/159> from mrpt-ros-pkg/bump-cmake
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```
