### PR TITLE
flexbe_behavior_engine: 4.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2403,7 +2403,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
-      version: 4.0.2-1
+      version: 4.1.3-1
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_behavior_engine` to `4.1.3-1`:

- upstream repository: https://github.com/FlexBE/flexbe_behavior_engine.git
- release repository: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `4.0.2-1`

## flexbe_behavior_engine

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```

## flexbe_core

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```

## flexbe_input

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```

## flexbe_mirror

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```

## flexbe_msgs

- No changes

## flexbe_onboard

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```

## flexbe_states

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
* Fix selection_state.on_enter to use dict-style userdata['items'] access
```

## flexbe_testing

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```

## flexbe_widget

```
* Use ROS 2 standard flake8 settings; use test folder as standard name
```
