### PR TITLE
persist_parameter_server: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7211,7 +7211,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/persist_parameter_server-release.git
-      version: 1.0.5-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `persist_parameter_server` to `2.0.0-1`:

- upstream repository: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
- release repository: https://github.com/ros2-gbp/persist_parameter_server-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.5-1`

## persist_parameter_server

```
* fix redundant and unexpected mergify configuration for barckports. (#87 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/87>) (#89 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/89>)
* Add save on update argument (#73 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/73>) (#86 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/86>)
* create downstream branches, apply corresponding changes to workflow. (#79 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/79>) (#81 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/81>)
* enable mergifyio and added appropriate labels. (#75 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/75>) (#77 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/77>)
* Upgrade github action/run-gemini-cli workflows. (#71 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/71>)
* doc,fix: link in readme pointing to valid URL (#68 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/68>)
  The URL to how to install ROS 2 has changed a while back.
* enable actions/stale to close issues and PRs. (#70 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/70>)
* Contributors: Simon Gene Gottlieb, Tomoya Fujita, mergify[bot]
```
