### PR TITLE
persist_parameter_server: 3.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5893,7 +5893,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/persist_parameter_server-release.git
-      version: 1.0.5-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `persist_parameter_server` to `3.0.0-1`:

- upstream repository: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
- release repository: https://github.com/ros2-gbp/persist_parameter_server-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.5-1`

## persist_parameter_server

```
* fix redundant and unexpected mergify configuration for barckports. (#87 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/87>) (#88 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/88>)
* Add save on update argument (#73 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/73>) (#83 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/83>)
* create downstream branches, apply corresponding changes to workflow. (#79 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/79>) (#80 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/80>)
* enable mergifyio and added appropriate labels. (#75 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/75>) (#76 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/76>)
* Upgrade github action/run-gemini-cli workflows. (#71 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/71>)
* doc,fix: link in readme pointing to valid URL (#68 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/68>)
  The URL to how to install ROS 2 has changed a while back.
* enable actions/stale to close issues and PRs. (#70 <https://github.com/fujitatomoya/ros2_persist_parameter_server/issues/70>)
* Contributors: Barry Xu, Simon Gene Gottlieb, Tomoya Fujita, mergify[bot]
```
