### PR TITLE
persist_parameter_server: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5800,7 +5800,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/persist_parameter_server-release.git
-      version: 1.0.5-2
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git


### PR DESCRIPTION
Increasing version of package(s) in repository `persist_parameter_server` to `4.0.0-1`:

- upstream repository: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
- release repository: https://github.com/ros2-gbp/persist_parameter_server-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.0.5-2`

## persist_parameter_server

- No changes
