### PR TITLE
ros2_control: 6.7.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7552,7 +7552,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.7.0-3
+      version: 6.7.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.7.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.7.0-3`

## controller_interface

```
* Fix the out of bound access of std::vector in ChainableController and others (#3287 <https://github.com/ros-controls/ros2_control/issues/3287>)
* Bump C++ version to C++20 (#3253 <https://github.com/ros-controls/ros2_control/issues/3253>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## controller_manager

```
* Fix size assertion in test_chainable_controller (#3284 <https://github.com/ros-controls/ros2_control/issues/3284>)
* Fix the out of bound access of std::vector in ChainableController and others (#3287 <https://github.com/ros-controls/ros2_control/issues/3287>)
* [doc] Add dedicated documentation page for running controllers asynchronously (#3195 <https://github.com/ros-controls/ros2_control/issues/3195>)
* Bump C++ version to C++20 (#3253 <https://github.com/ros-controls/ros2_control/issues/3253>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota, Shahazad Abdulla
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* fix(generic_system): Fix loop bound of states (#3282 <https://github.com/ros-controls/ros2_control/issues/3282>)
* Fix pre-commit of ament_cppcheck on rolling Resolute Raccoon (#3276 <https://github.com/ros-controls/ros2_control/issues/3276>)
* Bump C++ version to C++20 (#3253 <https://github.com/ros-controls/ros2_control/issues/3253>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## hardware_interface_testing

```
* Fix pre-commit of ament_cppcheck on rolling Resolute Raccoon (#3276 <https://github.com/ros-controls/ros2_control/issues/3276>)
* Add tests for duplicate prevention (fixes #2952 <https://github.com/ros-controls/ros2_control/issues/2952>) (#3189 <https://github.com/ros-controls/ros2_control/issues/3189>)
* Contributors: Sai Kishor Kothakota, kamal2730
```

## joint_limits

```
* Fix std::clamp regression on Ubuntu 26.04 (#3275 <https://github.com/ros-controls/ros2_control/issues/3275>)
* Bump C++ version to C++20 (#3253 <https://github.com/ros-controls/ros2_control/issues/3253>)
* Contributors: Christoph Fröhlich, Sai Kishor Kothakota
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Bump C++ version to C++20 (#3253 <https://github.com/ros-controls/ros2_control/issues/3253>)
* Contributors: Christoph Fröhlich
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
