### PR TITLE
ros2_control: 4.45.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9184,7 +9184,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.45.1-1
+      version: 4.45.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.45.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.45.1-1`

## controller_interface

```
* Fix the out of bound access of the std::vector in ChainableController (backport #3287 <https://github.com/ros-controls/ros2_control/issues/3287>) (#3288 <https://github.com/ros-controls/ros2_control/issues/3288>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Fix size assertion in test_chainable_controller (#3284 <https://github.com/ros-controls/ros2_control/issues/3284>) (#3303 <https://github.com/ros-controls/ros2_control/issues/3303>)
* Fix the out of bound access of the std::vector in ChainableController (backport #3287 <https://github.com/ros-controls/ros2_control/issues/3287>) (#3288 <https://github.com/ros-controls/ros2_control/issues/3288>)
* [doc] Add dedicated documentation page for running controllers asynchronously (backport #3195 <https://github.com/ros-controls/ros2_control/issues/3195>) (#3254 <https://github.com/ros-controls/ros2_control/issues/3254>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* fix(generic_system): Fix loop bound of states (#3282 <https://github.com/ros-controls/ros2_control/issues/3282>) (#3285 <https://github.com/ros-controls/ros2_control/issues/3285>)
* Fix pre-commit of ament_cppcheck on rolling Resolute Raccoon (#3276 <https://github.com/ros-controls/ros2_control/issues/3276>) (#3277 <https://github.com/ros-controls/ros2_control/issues/3277>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix pre-commit of ament_cppcheck on rolling Resolute Raccoon (#3276 <https://github.com/ros-controls/ros2_control/issues/3276>) (#3277 <https://github.com/ros-controls/ros2_control/issues/3277>)
* Add tests for duplicate prevention (fixes #2952 <https://github.com/ros-controls/ros2_control/issues/2952>) (#3189 <https://github.com/ros-controls/ros2_control/issues/3189>) (#3262 <https://github.com/ros-controls/ros2_control/issues/3262>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Fix std::clamp regression on Ubuntu 26.04 (#3275 <https://github.com/ros-controls/ros2_control/issues/3275>) (#3280 <https://github.com/ros-controls/ros2_control/issues/3280>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
