### PR TITLE
ros2_controllers: 5.15.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7702,7 +7702,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.15.0-1
+      version: 5.15.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.15.1-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.15.0-1`

## ackermann_steering_controller

- No changes

## admittance_controller

```
* Suppress cppcheck errors from macros from version.h (backport #2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>) (#2348 <https://github.com/ros-controls/ros2_controllers/issues/2348>)
* fix: correct ASSERT_EQ to ASSERT_NE in admittance controller load test (backport #2264 <https://github.com/ros-controls/ros2_controllers/issues/2264>) (#2339 <https://github.com/ros-controls/ros2_controllers/issues/2339>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

- No changes

## chained_filter_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Suppress cppcheck errors from macros from version.h (backport #2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>) (#2348 <https://github.com/ros-controls/ros2_controllers/issues/2348>)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gps_sensor_broadcaster

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

```
* Suppress cppcheck errors from macros from version.h (backport #2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>) (#2348 <https://github.com/ros-controls/ros2_controllers/issues/2348>)
* fix(joint_state_broadcaster): suppress confusing warning for standard interfaces (backport #2276 <https://github.com/ros-controls/ros2_controllers/issues/2276>) (#2334 <https://github.com/ros-controls/ros2_controllers/issues/2334>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Suppress cppcheck errors from macros from version.h (backport #2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>) (#2348 <https://github.com/ros-controls/ros2_controllers/issues/2348>)
* fix JTC userdoc YAML indentation and stray quote (backport #2327 <https://github.com/ros-controls/ros2_controllers/issues/2327>) (#2330 <https://github.com/ros-controls/ros2_controllers/issues/2330>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

- No changes

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

- No changes

## parallel_gripper_controller

- No changes

## pid_controller

```
* Add lyrical workflows, update README, and fix gcc-15 issues (backport #2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>) (#2353 <https://github.com/ros-controls/ros2_controllers/issues/2353>)
* Contributors: mergify[bot]
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Add lyrical workflows, update README, and fix gcc-15 issues (backport #2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>) (#2353 <https://github.com/ros-controls/ros2_controllers/issues/2353>)
* Contributors: mergify[bot]
```

## rqt_joint_trajectory_controller

```
* Add lyrical workflows, update README, and fix gcc-15 issues (backport #2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>) (#2353 <https://github.com/ros-controls/ros2_controllers/issues/2353>)
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

- No changes

## steering_controllers_library

- No changes

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
