### PR TITLE
ros2_controllers: 6.7.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7585,7 +7585,6 @@ repositories:
       - bicycle_steering_controller
       - chained_filter_controller
       - diff_drive_controller
-      - effort_controllers
       - force_torque_sensor_broadcaster
       - forward_command_controller
       - gpio_controllers
@@ -7599,7 +7598,6 @@ repositories:
       - parallel_gripper_controller
       - pid_controller
       - pose_broadcaster
-      - position_controllers
       - range_sensor_broadcaster
       - ros2_controllers
       - ros2_controllers_test_nodes
@@ -7608,11 +7606,10 @@ repositories:
       - steering_controllers_library
       - tricycle_controller
       - tricycle_steering_controller
-      - velocity_controllers
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.6.0-3
+      version: 6.7.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.7.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.6.0-3`

## ackermann_steering_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## admittance_controller

```
* Suppress cppcheck errors from macros from version.h (#2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>)
* fix: correct ASSERT_EQ to ASSERT_NE in admittance controller load test (#2264 <https://github.com/ros-controls/ros2_controllers/issues/2264>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich, Souri Rishik
```

## bicycle_steering_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## chained_filter_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## diff_drive_controller

```
* Remove deprecated publish_rate from diff_drive_controller (#2259 <https://github.com/ros-controls/ros2_controllers/issues/2259>)
* Remove deprecated odometry reset methods (#2252 <https://github.com/ros-controls/ros2_controllers/issues/2252>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* diff_drive: set parameters as read_only or dynamically update them (#2293 <https://github.com/ros-controls/ros2_controllers/issues/2293>)
* Contributors: Bhavin Umatiya, Christoph Fröhlich, Ege Kural, kamal2730
```

## force_torque_sensor_broadcaster

```
* Suppress cppcheck errors from macros from version.h (#2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## forward_command_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## gpio_controllers

- No changes

## gps_sensor_broadcaster

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## imu_sensor_broadcaster

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## joint_state_broadcaster

```
* Suppress cppcheck errors from macros from version.h (#2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>)
* added warning messages when unable to remap the interface properly in Joint State Broadcaster.  (#2082 <https://github.com/ros-controls/ros2_controllers/issues/2082>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* fix(joint_state_broadcaster): suppress confusing warning for standard interfaces (#2276 <https://github.com/ros-controls/ros2_controllers/issues/2276>)
* Contributors: Christoph Fröhlich, Maksim Sviridov, Mithun Chakladar
```

## joint_trajectory_controller

```
* Suppress cppcheck errors from macros from version.h (#2346 <https://github.com/ros-controls/ros2_controllers/issues/2346>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* fix JTC userdoc YAML indentation and stray quote (#2327 <https://github.com/ros-controls/ros2_controllers/issues/2327>)
* Contributors: Christoph Fröhlich, ahmedbilal9
```

## mecanum_drive_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## motion_primitives_controllers

- No changes

## omni_wheel_drive_controller

```
* Remove deprecated odometry reset methods (#2252 <https://github.com/ros-controls/ros2_controllers/issues/2252>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich, Ege Kural
```

## parallel_gripper_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## pid_controller

```
* Add lyrical workflows, update README, and fix gcc-15 issues (#2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## pose_broadcaster

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## range_sensor_broadcaster

- No changes

## ros2_controllers

```
* Remove deprecated controller specializations (#2016 <https://github.com/ros-controls/ros2_controllers/issues/2016>)
* Contributors: Christoph Fröhlich
```

## ros2_controllers_test_nodes

```
* Add lyrical workflows, update README, and fix gcc-15 issues (#2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>)
* Contributors: Christoph Fröhlich
```

## rqt_joint_trajectory_controller

```
* Add lyrical workflows, update README, and fix gcc-15 issues (#2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>)
* [rqt_jtc] Use urdf_parser_py (#2254 <https://github.com/ros-controls/ros2_controllers/issues/2254>)
* Contributors: Christoph Fröhlich, Sahil Lakhmani
```

## state_interfaces_broadcaster

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## steering_controllers_library

```
* Add lyrical workflows, update README, and fix gcc-15 issues (#2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>)
* Remove deprecated odometry reset methods (#2252 <https://github.com/ros-controls/ros2_controllers/issues/2252>)
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich, Ege Kural
```

## tricycle_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```

## tricycle_steering_controller

```
* Bump C++ version to C++20 (#2331 <https://github.com/ros-controls/ros2_controllers/issues/2331>)
* Contributors: Christoph Fröhlich
```
