### PR TITLE
coal: 3.0.3-5 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1815,12 +1815,12 @@ repositories:
     doc:
       type: git
       url: https://github.com/coal-library/coal.git
-      version: master
+      version: devel
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.2-1
+      version: 3.0.3-5
     source:
       type: git
       url: https://github.com/coal-library/coal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.3-5`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`
