### PR TITLE
frequency_cam: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2430,7 +2430,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/frequency_cam-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/frequency_cam.git


### PR DESCRIPTION
Increasing version of package(s) in repository `frequency_cam` to `3.1.2-1`:

- upstream repository: https://github.com/ros-event-camera/frequency_cam.git
- release repository: https://github.com/ros2-gbp/frequency_cam-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.1-1`
