### PR TITLE
rosbag2: 0.33.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8046,7 +8046,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.33.2-1
+      version: 0.33.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.33.3-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.33.2-1`

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

- No changes

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

- No changes

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* Apply /bigobj to all MSVC builds in rosbag2_transport (#2424 <https://github.com/ros2/rosbag2/issues/2424>) (#2428 <https://github.com/ros2/rosbag2/issues/2428>)
* Contributors: mergify[bot]
```
