### PR TITLE
ros_tutorials: 1.10.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7996,7 +7996,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.10.8-3
+      version: 1.10.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.10.9-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.10.8-3`

## turtlesim

```
* Add icon for Lyrical Luth (#196 <https://github.com/ros/ros_tutorials/issues/196>) (#197 <https://github.com/ros/ros_tutorials/issues/197>)
* Contributors: mergify[bot]
```

## turtlesim_msgs

- No changes
