### PR TITLE
rmw_connextdds: 1.2.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7291,7 +7291,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.2.6-1
+      version: 1.2.7-1
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.2.7-1`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.6-1`

## rmw_connextdds

- No changes

## rmw_connextdds_common

```
* Fix content filtering on Windows with modern Connext DDS (#226 <https://github.com/ros2/rmw_connextdds/issues/226>) (#230 <https://github.com/ros2/rmw_connextdds/issues/230>)
* Contributors: mergify[bot]
```

## rti_connext_dds_cmake_module

- No changes
