### PR TITLE
sros2: 0.16.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9489,7 +9489,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/sros2-release.git
-      version: 0.16.5-1
+      version: 0.16.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sros2` to `0.16.6-1`:

- upstream repository: https://github.com/ros2/sros2.git
- release repository: https://github.com/ros2-gbp/sros2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.16.5-1`

## sros2

```
* Fix load_file_into_BIO: File could not be found, opened or is empty error on Windows (#386 <https://github.com/ros2/sros2/issues/386>) (#387 <https://github.com/ros2/sros2/issues/387>)
* Contributors: mergify[bot]
```

## sros2_cmake

- No changes
