### PR TITLE
rqt_bag: 2.2.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8517,7 +8517,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.2.2-3
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.2.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.2-3`

## rqt_bag

```
* Fix Qt6 issues (backport #207 <https://github.com/ros-visualization/rqt_bag/issues/207>) (#208 <https://github.com/ros-visualization/rqt_bag/issues/208>)
* Contributors: mergify[bot]
```

## rqt_bag_plugins

- No changes
