### PR TITLE
ros_tutorials: 1.11.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8006,7 +8006,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.11.0-1
+      version: 1.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.11.1-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.11.0-1`

## turtlesim

```
* Add icon for Lyrical Luth (#196 <https://github.com/ros/ros_tutorials/issues/196>)
* Contributors: Shane Loretz
```

## turtlesim_msgs

- No changes
