### PR TITLE
rosidl_typesupport_fastrtps: 3.10.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8347,7 +8347,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.10.0-1
+      version: 3.10.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.10.1-2`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.10.0-1`

## rosidl_typesupport_fastrtps_c

```
* Update rosidl typesupport to support rosidl::Buffer in nested uint8[] (#151 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/151>)
* Contributors: CY Chen
```

## rosidl_typesupport_fastrtps_cpp

```
* Clean up logs in buffer serialization functions (#153 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/153>)
* Update rosidl typesupport to support rosidl::Buffer in nested uint8[] (#151 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/151>)
* Contributors: CY Chen
```
