### PR TITLE
rmw_fastrtps: 9.4.8-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7371,7 +7371,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 9.4.7-3
+      version: 9.4.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_fastrtps` to `9.4.8-1`:

- upstream repository: https://github.com/ros2/rmw_fastrtps.git
- release repository: https://github.com/ros2-gbp/rmw_fastrtps-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.4.7-3`

## rmw_fastrtps_cpp

```
* Clean up logs for the rosidl::Buffer path (#886 <https://github.com/ros2/rmw_fastrtps//issues/886>) (#887 <https://github.com/ros2/rmw_fastrtps//issues/887>)
* Change the buffer-aware BUFBE: -> bufbe. (backport #880 <https://github.com/ros2/rmw_fastrtps//issues/880>) (#884 <https://github.com/ros2/rmw_fastrtps//issues/884>)
* Fix UB in accessing the keys (#879 <https://github.com/ros2/rmw_fastrtps//issues/879>) (#882 <https://github.com/ros2/rmw_fastrtps//issues/882>)
* Contributors: mergify[bot]
```

## rmw_fastrtps_dynamic_cpp

```
* Fix UB in accessing the keys (#879 <https://github.com/ros2/rmw_fastrtps//issues/879>) (#882 <https://github.com/ros2/rmw_fastrtps//issues/882>)
* Contributors: mergify[bot]
```

## rmw_fastrtps_shared_cpp

```
* Change the buffer-aware BUFBE: -> bufbe. (backport #880 <https://github.com/ros2/rmw_fastrtps//issues/880>) (#884 <https://github.com/ros2/rmw_fastrtps//issues/884>)
* Contributors: mergify[bot]
```
