### PR TITLE
image_transport_plugins: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3360,7 +3360,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 6.2.4-2
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `7.0.0-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.2.4-2`

## compressed_depth_image_transport

```
* fix(compressed_depth): use push_back instead of index assignment (#222 <https://github.com/ros-perception/image_transport_plugins//issues/222>)
* Contributors: Nicolas Frick
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes

## zstd_image_transport

- No changes
