### PR TITLE
image_transport_plugins: 6.2.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3355,7 +3355,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 6.2.4-3
+      version: 6.2.5-1
     source:
       test_pull_requests: true
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3344,7 +3344,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - compressed_depth_image_transport
@@ -3360,7 +3360,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
-      version: rolling
+      version: lyrical
     status: maintained
   imu_pipeline:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `6.2.5-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.2.4-3`

## compressed_depth_image_transport

```
* fix(compressed_depth): use push_back instead of index assignment (#222 <https://github.com/ros-perception/image_transport_plugins//issues/222>)
* Contributors: Nicolas Frick
```

## compressed_image_transport

- No changes

## image_transport_plugins

- No changes

## theora_image_transport

- No changes

## zstd_image_transport

- No changes
