### PR TITLE
Align ffmpeg rules on Fedora and RHEL with Ubuntu

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1129,7 +1129,7 @@ ffmpeg:
   arch: [ffmpeg]
   debian:
     '*': [ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev, libswscale-dev]
-  fedora: [ffmpeg-free-devel]
+  fedora: [ffmpeg-free-devel, libavcodec-free-devel, libavformat-free-devel, libavutil-free-devel, libswscale-free-devel]
   freebsd: [ffmpeg]
   gentoo: [virtual/ffmpeg]
   macports: [ffmpeg]
@@ -1137,7 +1137,7 @@ ffmpeg:
   openembedded: [ffmpeg@openembedded-core]
   opensuse: [ffmpeg-4-libavcodec-devel, ffmpeg-4-libavdevice-devel, ffmpeg-4-libavfilter-devel, ffmpeg-4-libavformat-devel, ffmpeg-4-libavresample-devel, ffmpeg-4-libavutil-devel, ffmpeg-4-libpostproc-devel, ffmpeg-4-libswresample-devel, ffmpeg-4-libswscale-devel, ffmpeg-4-private-devel]
   rhel:
-    '*': [ffmpeg-free-devel]
+    '*': [ffmpeg-free-devel, libavcodec-free-devel, libavformat-free-devel, libavutil-free-devel, libswscale-free-devel]
     '8': null
   slackware: [ffmpeg]
   ubuntu:


### PR DESCRIPTION
Simply aligning the list of installed packages on Fedora and RHEL with what's listed for Ubuntu. Used by the `usb_cam` package in Lyrical.

https://packages.fedoraproject.org/pkgs/ffmpeg/libavcodec-free-devel/
https://packages.fedoraproject.org/pkgs/ffmpeg/libavformat-free-devel/
https://packages.fedoraproject.org/pkgs/ffmpeg/libavutil-free-devel/
https://packages.fedoraproject.org/pkgs/ffmpeg/libswscale-free-devel/