### PR TITLE
Align 'libturbojpeg' rule for Fedora with RHEL rule

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7308,7 +7308,7 @@ libturbojpeg:
   arch: [libjpeg-turbo]
   debian:
     '*': [libturbojpeg0-dev]
-  fedora: [turbojpeg-devel]
+  fedora: [libjpeg-turbo-devel, turbojpeg-devel]
   freebsd: [libjpeg-turbo]
   gentoo: [media-libs/libjpeg-turbo]
   nixos: [libjpeg_turbo]


### PR DESCRIPTION
Just aligning the Fedora rule with what we're listing for RHEL.

https://packages.fedoraproject.org/pkgs/libjpeg-turbo/libjpeg-turbo-devel/