### PR TITLE
Align 'libccd-dev' rule for Fedora with RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3419,7 +3419,7 @@ libcap2-bin:
   ubuntu: [libcap2-bin]
 libccd-dev:
   debian: [libccd-dev]
-  fedora: [libccd]
+  fedora: [libccd-devel]
   gentoo: [sci-libs/libccd]
   nixos: [libccd]
   openembedded: [libccd@meta-ros-common]


### PR DESCRIPTION
https://packages.fedoraproject.org/pkgs/libccd/libccd-devel/