### PR TITLE
Align 'libqt5-websockets-dev' rule on Fedora with RHEL

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6520,7 +6520,7 @@ libqt5-svg-dev:
 libqt5-websockets-dev:
   arch: [qt5-websockets]
   debian: [libqt5websockets5-dev]
-  fedora: [qt5-qtwebsockets]
+  fedora: [qt5-qtwebsockets-devel]
   gentoo: ['dev-qt/qtwebsockets:5']
   nixos: [qt5.qtwebsockets]
   openembedded: [qtwebsockets@meta-qt5]


### PR DESCRIPTION
https://packages.fedoraproject.org/pkgs/qt5-qtwebsockets/qt5-qtwebsockets-devel/