### PR TITLE
gz_ros2_control: 3.0.8-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2990,7 +2990,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 3.0.7-3
+      version: 3.0.8-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `3.0.8-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.7-3`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Fix controller dependencies (#837 <https://github.com/ros-controls/gz_ros2_control/issues/837>)
* Contributors: Christoph Fröhlich
```
