### PR TITLE
gz_ros2_control: 2.0.16-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3133,7 +3133,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 2.0.15-1
+      version: 2.0.16-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `2.0.16-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.15-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Add missing tests for pendulum and gripper (position and effort) (backport #814 <https://github.com/ros-controls/gz_ros2_control/issues/814>) (#844 <https://github.com/ros-controls/gz_ros2_control/issues/844>)
* Fix controller dependencies (#837 <https://github.com/ros-controls/gz_ros2_control/issues/837>) (#838 <https://github.com/ros-controls/gz_ros2_control/issues/838>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```
