### PR TITLE
gz_ros2_control: 1.2.19-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3959,7 +3959,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.18-1
+      version: 1.2.19-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_ros2_control` to `1.2.19-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.18-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Add missing tests for pendulum and gripper (position and effort) (backport #814 <https://github.com/ros-controls/gz_ros2_control/issues/814>) (#841 <https://github.com/ros-controls/gz_ros2_control/issues/841>)
* Fix controller dependencies (#837 <https://github.com/ros-controls/gz_ros2_control/issues/837>) (#839 <https://github.com/ros-controls/gz_ros2_control/issues/839>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```
