### PR TITLE
ign_ros2_control: 0.7.20-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4292,7 +4292,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.19-1
+      version: 0.7.20-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ign_ros2_control` to `0.7.20-1`:

- upstream repository: https://github.com/ros-controls/gz_ros2_control
- release repository: https://github.com/ros2-gbp/ign_ros2_control-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.19-1`

## gz_ros2_control

- No changes

## gz_ros2_control_demos

```
* Add missing tests for pendulum and gripper (position and effort) (backport #814 <https://github.com/ros-controls/gz_ros2_control/issues/814>) (#842 <https://github.com/ros-controls/gz_ros2_control/issues/842>)
* Fix controller dependencies (backport #837 <https://github.com/ros-controls/gz_ros2_control/issues/837>) (#840 <https://github.com/ros-controls/gz_ros2_control/issues/840>)
* Contributors: José Luis Pérez Martín, mergify[bot]
```

## gz_ros2_control_tests

```
* Add missing tests for pendulum and gripper (position and effort) (backport #814 <https://github.com/ros-controls/gz_ros2_control/issues/814>) (#842 <https://github.com/ros-controls/gz_ros2_control/issues/842>)
* Contributors: José Luis Pérez Martín
```

## ign_ros2_control

- No changes

## ign_ros2_control_demos

```
* Add missing tests for pendulum and gripper (position and effort) (backport #814 <https://github.com/ros-controls/gz_ros2_control/issues/814>) (#842 <https://github.com/ros-controls/gz_ros2_control/issues/842>)
* Contributors: José Luis Pérez Martín
```
