### PR TITLE
rcl_interfaces: 2.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8288,7 +8288,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `2.0.4-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.3-1`

## action_msgs

- No changes

## builtin_interfaces

- No changes

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

- No changes

## rosgraph_msgs

```
* Actually build the new graph description messages (#192 <https://github.com/ros2/rcl_interfaces/issues/192>) (#194 <https://github.com/ros2/rcl_interfaces/issues/194>)
* Add Graph description messages to rosgraph_msgs (#188 <https://github.com/ros2/rcl_interfaces/issues/188>) (#190 <https://github.com/ros2/rcl_interfaces/issues/190>)
* Contributors: mergify[bot]
```

## service_msgs

- No changes

## statistics_msgs

- No changes

## test_msgs

- No changes

## type_description_interfaces

- No changes
