### PR TITLE
ur_description: 2.11.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13131,7 +13131,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_description` to `2.11.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
- release repository: https://github.com/ros2-gbp/ur_description-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.10.0-1`

## ur_description

```
* Add Lyrical to README and ci_builds page (backport #401 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/401>) (#402 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/402>)
* Add Payload state interfaces (#399 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/399>)
* Contributors: Felix Exner, mergify[bot]
```