### PR TITLE
ur_robot_driver: 6.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10381,7 +10381,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 5.0.0-3
+      version: 6.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `6.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.0.0-3`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Check payload state in gpio_controller (#1770 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1770>)
* BREAKING: Remove scaled joint trajectory controller (#1769 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1769>)
* Contributors: Felix Exner
```

## ur_dashboard_msgs

- No changes

## ur_moveit_config

```
* BREAKING: Remove scaled joint trajectory controller (#1769 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1769>)
* [Doc moveit_config] Add a note about joint_limits.yaml (#1764 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1764>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* [driver] Remove deprecated packages from package.xml (#1785 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1785>)
* Verify the robot type on startup (#1771 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1771>)
* Check payload state in gpio_controller (#1770 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1770>)
* BREAKING: Remove scaled joint trajectory controller (#1769 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1769>)
* Contributors: Felix Exner
```
