### PR TITLE
rcl_interfaces: 1.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8845,7 +8845,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_interfaces-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl_interfaces` to `1.2.3-1`:

- upstream repository: https://github.com/ros2/rcl_interfaces.git
- release repository: https://github.com/ros2-gbp/rcl_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.2-1`

## action_msgs

- No changes

## builtin_interfaces

- No changes

## composition_interfaces

- No changes

## lifecycle_msgs

- No changes

## rcl_interfaces

- No changes

## rosgraph_msgs

```
* Actually build the new graph description messages (#192 <https://github.com/ros2/rcl_interfaces/issues/192>) (#195 <https://github.com/ros2/rcl_interfaces/issues/195>)
* Add Graph description messages to rosgraph_msgs (#188 <https://github.com/ros2/rcl_interfaces/issues/188>) (#189 <https://github.com/ros2/rcl_interfaces/issues/189>)
* Contributors: mergify[bot]
```

## statistics_msgs

- No changes

## test_msgs

- No changes
