### PR TITLE
pfs: 0.15.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5814,6 +5814,21 @@ repositories:
       url: https://github.com/fujitatomoya/ros2_persist_parameter_server.git
       version: rolling
     status: maintained
+  pfs:
+    doc:
+      type: git
+      url: https://github.com/dtrugman/pfs.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/pfs-release.git
+      version: 0.15.0-1
+    source:
+      type: git
+      url: https://github.com/dtrugman/pfs.git
+      version: main
+    status: maintained
   phidgets_drivers:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pfs` to `0.15.0-1`:

- upstream repository: https://github.com/dtrugman/pfs.git
- release repository: https://github.com/ros2-gbp/pfs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
