### PR TITLE
topic_based_hardware_interfaces: 1.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9963,7 +9963,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/topic_based_hardware-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-controls/topic_based_hardware_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_based_hardware_interfaces` to `1.1.0-1`:

- upstream repository: https://github.com/ros-controls/topic_based_hardware_interfaces.git
- release repository: https://github.com/ros2-gbp/topic_based_hardware-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## cm_topic_hardware_component

```
* Bump C++ version to C++20 (#119 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/119>)
* Bump version of pre-commit hooks (#98 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/98>)
* Contributors: Christoph Fröhlich, github-actions[bot]
```

## joint_state_topic_hardware_interface

```
* Publish JointState commands for velocity-only and effort-only interfaces (#118 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/118>)
* Bump C++ version to C++20 (#119 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/119>)
* Bump version of pre-commit hooks (#98 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/98>)
* Add alias for old topic_based_ros2_control plugin name (#87 <https://github.com/ros-controls/topic_based_hardware_interfaces/issues/87>)
* Contributors: Christoph Fröhlich, Ted Vanderfeen, github-actions[bot]
```
