### PR TITLE
kinematics_interface: 2.4.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3609,7 +3609,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.4.0-4
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.4.1-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.0-4`

## kinematics_interface

```
* Bump C++ version to C++20 (#259 <https://github.com/ros-controls/kinematics_interface/issues/259>)
* Contributors: Christoph Fröhlich
```

## kinematics_interface_kdl

```
* Bump C++ version to C++20 (#259 <https://github.com/ros-controls/kinematics_interface/issues/259>)
* Contributors: Christoph Fröhlich
```

## kinematics_interface_pinocchio

```
* Fix deprecated frame member of pinocchio (#280 <https://github.com/ros-controls/kinematics_interface/issues/280>)
* Bump C++ version to C++20 (#259 <https://github.com/ros-controls/kinematics_interface/issues/259>)
* Contributors: Christoph Fröhlich
```
