### PR TITLE
rosidl_buffer_backends: 0.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8154,6 +8154,22 @@ repositories:
       version: lyrical
     status: maintained
   rosidl_buffer_backends:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_buffer_backends.git
+      version: main
+    release:
+      packages:
+      - cuda_buffer
+      - cuda_buffer_backend
+      - cuda_buffer_backend_msgs
+      - libtorch_vendor
+      - tensor_msgs
+      - torch_conversions
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_buffer_backends-release.git
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_buffer_backends` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_buffer_backends.git
- release repository: https://github.com/ros2-gbp/rosidl_buffer_backends-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
