### PR TITLE
rosidl_buffer_backends_tutorials: 0.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8161,6 +8161,17 @@ repositories:
       version: main
     status: developed
   rosidl_buffer_backends_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros2/rosidl_buffer_backends_tutorials.git
+      version: main
+    release:
+      packages:
+      - robot_arm_demo
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/rosidl_buffer_backends_tutorials-release.git
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_buffer_backends_tutorials` to `0.1.0-1`:

- upstream repository: https://github.com/ros2/rosidl_buffer_backends_tutorials.git
- release repository: https://github.com/ros2-gbp/rosidl_buffer_backends_tutorials-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## robot_arm_demo

```
* Merge pull request #1 <https://github.com/ros2/rosidl_buffer_backends_tutorials/issues/1> from yuanknv/native_buffer_demo
  Add robot arm demo using torch_buffer_backend
* Contributors: Yuankun Zhu, yuanknv
```
