### PR TITLE
gz_launch_vendor: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2879,7 +2879,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
-      version: 0.3.1-2
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_launch_vendor` to `0.4.0-1`:

- upstream repository: https://github.com/gazebo-release/gz_launch_vendor.git
- release repository: https://github.com/ros2-gbp/gz_launch_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.1-2`

## gz_launch_vendor

- No changes
