### PR TITLE
kinematics_interface: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3613,7 +3613,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `2.4.2-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.1-1`

## kinematics_interface

```
* Add missing dependency on rclcpp (#289 <https://github.com/ros-controls/kinematics_interface/issues/289>)
* Contributors: Scott K Logan
```

## kinematics_interface_kdl

- No changes

## kinematics_interface_pinocchio

- No changes
