### PR TITLE
kinematics_interface: 1.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4672,7 +4672,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/kinematics_interface-release.git
-      version: 1.7.0-1
+      version: 1.7.1-1
     source:
       type: git
       url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kinematics_interface` to `1.7.1-1`:

- upstream repository: https://github.com/ros-controls/kinematics_interface.git
- release repository: https://github.com/ros2-gbp/kinematics_interface-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.0-1`

## kinematics_interface

```
* Add missing dependency on rclcpp (backport #289 <https://github.com/ros-controls/kinematics_interface/issues/289>) (#296 <https://github.com/ros-controls/kinematics_interface/issues/296>)
* Contributors: mergify[bot]
```

## kinematics_interface_kdl

- No changes

## kinematics_interface_pinocchio

```
* Fix deprecated frame member of pinocchio (backport #280 <https://github.com/ros-controls/kinematics_interface/issues/280>) (#288 <https://github.com/ros-controls/kinematics_interface/issues/288>)
* Contributors: mergify[bot]
```
