### PR TITLE
plotjuggler: 3.17.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6055,7 +6055,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.15.0-1
+      version: 3.17.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git


### PR DESCRIPTION
Increasing version of package(s) in repository `plotjuggler` to `3.17.2-1`:

- upstream repository: https://github.com/facontidavide/PlotJuggler.git
- release repository: https://github.com/ros2-gbp/plotjuggler-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.15.0-1`

## plotjuggler

```
* Rework Foxglove and PlotJuggler websocket bridge plugins to accept arbitrary websocket URLs (#1361 <https://github.com/facontidavide/PlotJuggler/issues/1361>)
* Fix crash when saving empty/zero-byte layout XML files (#1362 <https://github.com/facontidavide/PlotJuggler/issues/1362>)
* Add alert for plotjuggler.com phishing site
```
