### PR TITLE
Add zlib-devel to assimp-dev rule for Fedora

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -187,7 +187,7 @@ assimp-dev:
   alpine: [assimp-dev]
   arch: [assimp]
   debian: [libassimp-dev]
-  fedora: [assimp-devel]
+  fedora: [assimp-devel, zlib-devel]
   freebsd: [assimp]
   gentoo: [media-libs/assimp]
   nixos: [assimp]


### PR DESCRIPTION
There's a bug in the assimp package in Fedora right now, and the zlib-devel package needs to be explicitly installed.

https://packages.fedoraproject.org/pkgs/zlib-ng/zlib-ng-compat-devel/

```shell
$  dnf provides zlib-devel
zlib-ng-compat-devel-2.3.3-2.fc43.x86_64 : Development files for zlib-ng-compat
Repo         : @System
Matched From : 
Provide      : zlib-ng-compat-devel = 2.3.3-2.fc43
```

Upstream fix: https://src.fedoraproject.org/rpms/assimp/pull-request/15

This is needed to build `gz_common_vendor` on Fedora 43.