### PR TITLE
Add edac-utils rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -988,6 +988,9 @@ ed:
   ubuntu: [ed]
 edac-utils:
   debian: [edac-utils]
+  fedora: [edac-utils]
+  nixos: [edac-utils]
+  rhel: [edac-utils]
   ubuntu: [edac-utils]
 eigen:
   alpine: [eigen-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -986,6 +986,9 @@ ed:
   fedora: [ed]
   nixos: [ed]
   ubuntu: [ed]
+edac-utils:
+  debian: [edac-utils]
+  ubuntu: [edac-utils]
 eigen:
   alpine: [eigen-dev]
   arch: [eigen]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

edac-utils

## Package Upstream Source:

https://github.com/grondo/edac-utils

## Purpose of using this:

edac-utils reports kernel-detected PCI and ECC RAM errors. It's useful for ROS packages that need to monitor hardware health (memory errors, PCI bus errors) on robotic platforms — particularly long-running systems where silent memory corruption could affect safety-critical behavior.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/edac-utils
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jammy/edac-utils
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/edac-utils/edac-utils/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=25.11&query=edac-utils#show=edac-utils
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - https://pkgs.org/search/?q=edac-utils
