### PR TITLE
ament_index: 1.8.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -334,7 +334,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ament_index-release.git
-      version: 1.8.3-1
+      version: 1.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_index` to `1.8.4-1`:

- upstream repository: https://github.com/ament/ament_index.git
- release repository: https://github.com/ros2-gbp/ament_index-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.3-1`

## ament_index_cpp

```
* Use get_package_share_path just as python (backport #112 <https://github.com/ament/ament_index/issues/112>) (#118 <https://github.com/ament/ament_index/issues/118>)
* Contributors: mergify[bot]
```

## ament_index_python

- No changes
