### PR TITLE
python_mrpt_ros marked as EOL

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8450,7 +8450,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, use mrpt3 instead
   python_qt_binding:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7873,7 +7873,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, use mrpt3 instead
   python_qt_binding:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6469,7 +6469,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, use mrpt3 instead
   python_qt_binding:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6348,7 +6348,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, use mrpt3 instead
   python_qt_binding:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6378,7 +6378,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/python_mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, use mrpt3 instead
   python_qt_binding:
     doc:
       type: git


### PR DESCRIPTION
This applies to all active distributions.
This package is now obsolete and will be replaced by the upcoming `mrpt3` (already indexed but not released), which provides finer-grained modular python packages per library instead of this big monolithic monster. 

Was about time...
