### PR TITLE
rqt_topic: 2.1.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8853,7 +8853,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_topic-release.git
-      version: 2.1.0-3
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_topic` to `2.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_topic.git
- release repository: https://github.com/ros2-gbp/rqt_topic-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.0-3`

## rqt_topic

```
* Fixed messages are not displayed (backport #69 <https://github.com/ros-visualization/rqt_topic/issues/69>) (#70 <https://github.com/ros-visualization/rqt_topic/issues/70>)
* Contributors: mergify[bot]
```
