### PR TITLE
depthai-ros: 3.2.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1575,7 +1575,7 @@ repositories:
       - depthai_ros_msgs
       tags:
         release: release/kilted/{package}/{version}
-      url: git@github.com:luxonis/depthai-ros-release.git
+      url: https://github.com/luxonis/depthai-ros-release.git
       version: 3.2.1-1
     source:
       test_pull_requests: true

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1575,8 +1575,8 @@ repositories:
       - depthai_ros_msgs
       tags:
         release: release/kilted/{package}/{version}
-      url: https://github.com/luxonis/depthai-ros-release.git
-      version: 3.2.0-1
+      url: git@github.com:luxonis/depthai-ros-release.git
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.2.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: git@github.com:luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.2.0-1`

## depthai-ros

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_bridge

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_examples

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_ros_msgs

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```
