### PR TITLE
depthai_ros_v3: 3.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2245,7 +2245,7 @@ repositories:
       - depthai_ros_v3
       tags:
         release: release/jazzy/{package}/{version}
-      url: git@github.com:luxonis/depthai-ros-v3-release.git
+      url: https://github.com/luxonis/depthai-ros-v3-release.git
       version: 3.2.1-1
     source:
       test_pull_requests: true

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2245,8 +2245,8 @@ repositories:
       - depthai_ros_v3
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.2.0-1
+      url: git@github.com:luxonis/depthai-ros-v3-release.git
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai_ros_v3` to `3.2.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: git@github.com:luxonis/depthai-ros-v3-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.2.0-1`

## depthai_bridge_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_examples_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_ros_msgs_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_ros_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```
