### PR TITLE
depthai_ros_v3: 3.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2317,8 +2317,8 @@ repositories:
   depthai_ros_v3:
     doc:
       type: git
-      url: https://github.com/luxonis/depthai-ros.git
-      version: v3_humble
+      url: https://github.com/luxonis/depthai-ros-v3-release.git
+      version: 3.2.1-1
     release:
       packages:
       - depthai_bridge_v3
@@ -2331,12 +2331,12 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.1.1-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/luxonis/depthai-ros.git
-      version: v3_humble
+      url: https://github.com/luxonis/depthai-ros-v3-release.git
+      version: 3.2.1-1
     status: developed
   depthai_v3:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2317,8 +2317,8 @@ repositories:
   depthai_ros_v3:
     doc:
       type: git
-      url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.2.1-1
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3_humble
     release:
       packages:
       - depthai_bridge_v3
@@ -2335,8 +2335,8 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.2.1-1
+      url: https://github.com/luxonis/depthai-ros.git
+      version: v3_humble
     status: developed
   depthai_v3:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai_ros_v3` to `3.2.1-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-v3-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`

## depthai_bridge_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_examples_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_ros_msgs_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```

## depthai_ros_v3

```
* Add support for RVC4 IMU magnetometer and rotation vector data.
```
