### PR TITLE
Fix depthai_ros_v3 Jazzy source branch

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2233,7 +2233,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: v3-jazzy
+      version: v3_jazzy
     release:
       packages:
       - depthai_bridge_v3
@@ -2251,7 +2251,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: v3-jazzy
+      version: v3_jazzy
     status: developed
   depthai_v3:
     release:


### PR DESCRIPTION
This fixes the `depthai_ros_v3` Jazzy rosdistro metadata to point `doc.version` and `source.version` at the correct source branch, `v3_jazzy`.

The entry previously used `v3-jazzy`, but that branch name was a mistake. The v3 source branches use underscores, matching the existing `v3_humble` branch naming, and the Jazzy release work was done from `v3_jazzy`.

The release entry is unchanged and remains at `3.2.1-1`.
