### PR TITLE
crocoddyl: 3.2.1-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2117,6 +2117,21 @@ repositories:
       url: https://github.com/AutonomyLab/create_robot.git
       version: humble
     status: maintained
+  crocoddyl:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/crocoddyl.git
+      version: devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/crocoddyl-release.git
+      version: 3.2.1-2
+    source:
+      type: git
+      url: https://github.com/loco-3d/crocoddyl.git
+      version: devel
+    status: developed
   crx_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `crocoddyl` to `3.2.1-2`:

- upstream repository: https://github.com/loco-3d/crocoddyl.git
- release repository: https://github.com/ros2-gbp/crocoddyl-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
