### PR TITLE
crocoddyl: 3.2.1-2 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1446,6 +1446,21 @@ repositories:
       url: https://github.com/ctu-vras/ros-utils.git
       version: ros2
     status: developed
+  crocoddyl:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/crocoddyl.git
+      version: devel
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/crocoddyl-release.git
+      version: 3.2.1-2
+    source:
+      type: git
+      url: https://github.com/loco-3d/crocoddyl.git
+      version: devel
+    status: developed
   crx_kinematics:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `crocoddyl` to `3.2.1-2`:

- upstream repository: https://github.com/loco-3d/crocoddyl.git
- release repository: https://github.com/ros2-gbp/crocoddyl-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
