### PR TITLE
geographic_info: 1.0.7-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2510,7 +2510,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
-      version: 1.0.6-3
+      version: 1.0.7-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `1.0.7-2`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros2-gbp/geographic_info-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.2`
- previous version for package: `1.0.6-3`
