### PR TITLE
geographic_info: 1.0.7-4 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2524,7 +2524,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geographic_info-release.git
-      version: 1.0.6-2
+      version: 1.0.7-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geographic_info` to `1.0.7-4`:

- upstream repository: https://github.com/ros-geographic-info/geographic_info.git
- release repository: https://github.com/ros2-gbp/geographic_info-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.6-2`

## geodesy

```
* Add ECEF support as well as WGS84 geodesics calculations. (#60 <https://github.com/ros-geographic-info/geographic_info/issues/60>)
  * Add ECEF support as well as WGS84 geodesics calculations.
  * Add documentation, tests and uncrustify
  * Fix ament_cpplint issues
* Fix targets (#59 <https://github.com/ros-geographic-info/geographic_info/issues/59>)
* [kilted] Update deprecated call to ament_target_dependencies (#58 <https://github.com/ros-geographic-info/geographic_info/issues/58>)
* Contributors: David V. Lu!!, Roland Arsenault
```

## geographic_info

- No changes

## geographic_msgs

- No changes
