### PR TITLE
ros_battery_monitoring: 1.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9637,7 +9637,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
-      version: 1.0.2-1
+      version: 1.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_battery_monitoring` to `1.2.0-1`:

- upstream repository: https://github.com/ipa320/ros_battery_monitoring.git
- release repository: https://github.com/ros2-gbp/ros_battery_monitoring-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.2-1`

## battery_state_broadcaster

```
* Fix compile error with latest realtime_tools #12 <https://github.com/ipa320/ros_battery_monitoring/issues/12>
* Contributors: Jonas Otto, Michal Sojka
```

## battery_state_rviz_overlay

```
* Fix battery percentage scale #11 <https://github.com/ipa320/ros_battery_monitoring/issues/11>
* Contributors: Jonas Otto, Ramon Wijnands
```
