### PR TITLE
rviz: 15.2.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9022,7 +9022,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.2.2-3
+      version: 15.2.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.3-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.2.2-3`

## rviz2

```
* Don't use windeployqt (#1738 <https://github.com/ros2/rviz/issues/1738>) (#1739 <https://github.com/ros2/rviz/issues/1739>)
* Contributors: mergify[bot]
```

## rviz_common

```
* Fixed Qcolor deprecation (#1725 <https://github.com/ros2/rviz/issues/1725>) (#1732 <https://github.com/ros2/rviz/issues/1732>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

- No changes

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
