### PR TITLE
flexbe_behavior_engine: 4.1.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2277,7 +2277,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
-      version: 4.0.3-3
+      version: 4.1.4-1
     source:
       type: git
       url: https://github.com/flexbe/flexbe_behavior_engine.git


### PR DESCRIPTION
Increasing version of package(s) in repository `flexbe_behavior_engine` to `4.1.4-1`:

- upstream repository: https://github.com/FlexBE/flexbe_behavior_engine.git
- release repository: https://github.com/ros2-gbp/flexbe_behavior_engine-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.3-3`

## flexbe_behavior_engine

- No changes

## flexbe_core

```
* Updated expected FlexBE WebUI version
* Allow sub-statemachines to have infinite loop (no outcome)
```

## flexbe_input

- No changes

## flexbe_mirror

```
* Allow sub-statemachines to have infinite loop (no outcome)
```

## flexbe_msgs

- No changes

## flexbe_onboard

- No changes

## flexbe_states

```
* Remove __init__.py from test folder
```

## flexbe_testing

```
* Remove __init__.py from test folder
```

## flexbe_widget

- No changes
