### PR TITLE
topic_tools: 1.6.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9943,7 +9943,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.4-2
+      version: 1.6.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.6.0-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.4-2`

## topic_tools

- No changes

## topic_tools_interfaces

- No changes
