### PR TITLE
topic_tools: 1.5.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9875,7 +9875,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.4-3
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.5.0-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.4-3`

## topic_tools

- No changes

## topic_tools_interfaces

- No changes
