### PR TITLE
topic_tools: 1.4.5-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10013,7 +10013,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.4.2-2
+      version: 1.4.5-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.4.5-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.2-2`

## topic_tools

```
* Fix race condition on shutdown in try_discover_source() (#143 <https://github.com/ros-tooling/topic_tools/issues/143>) (#150 <https://github.com/ros-tooling/topic_tools/issues/150>)
* Enable QOS Overrides to All Publishers (#131 <https://github.com/ros-tooling/topic_tools/issues/131>) (#133 <https://github.com/ros-tooling/topic_tools/issues/133>)
* Contributors: mergify[bot]
```

## topic_tools_interfaces

- No changes
