### PR TITLE
topic_tools: 1.3.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11845,7 +11845,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.3.3-1
+      version: 1.3.4-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.3.4-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.3-1`

## topic_tools

```
* Fix race condition on shutdown in try_discover_source() (#143 <https://github.com/ros-tooling/topic_tools/issues/143>) (#151 <https://github.com/ros-tooling/topic_tools/issues/151>)
* Enable QOS Overrides to All Publishers (#131 <https://github.com/ros-tooling/topic_tools/issues/131>) (#132 <https://github.com/ros-tooling/topic_tools/issues/132>)
* Contributors: mergify[bot]
```

## topic_tools_interfaces

- No changes
