### PR TITLE
topic_tools: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12543,7 +12543,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/topic_tools-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_tools` to `1.1.2-1`:

- upstream repository: https://github.com/ros-tooling/topic_tools.git
- release repository: https://github.com/ros2-gbp/topic_tools-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.1-1`

## topic_tools

```
* Fix race condition on shutdown in try_discover_source() (#143 <https://github.com/ros-tooling/topic_tools/issues/143>) (#152 <https://github.com/ros-tooling/topic_tools/issues/152>)
* Enable QOS Overrides to All Publishers (#131 <https://github.com/ros-tooling/topic_tools/issues/131>) (#134 <https://github.com/ros-tooling/topic_tools/issues/134>)
* Contributors: mergify[bot]
```

## topic_tools_interfaces

- No changes
