### PR TITLE
Set topic_tools Lyrical versions to 'lyrical'

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9867,7 +9867,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - topic_tools
@@ -9879,7 +9879,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: rolling
+      version: lyrical
     status: developed
   toppra:
     doc:


### PR DESCRIPTION
After forking from Rolling. I've already updated the release repo: https://github.com/ros2-gbp/topic_tools-release/blob/56cbd505c807abb2ab346c30014de299c43006dd/tracks.yaml#L149