### PR TITLE
Set topic_tools Kilted versions to 'kilted'

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10005,7 +10005,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: rolling
+      version: kilted
     release:
       packages:
       - topic_tools
@@ -10017,7 +10017,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-tooling/topic_tools.git
-      version: rolling
+      version: kilted
     status: developed
   toppra:
     doc:


### PR DESCRIPTION
This was missing after forking from Rolling. I've already updated the release repo: https://github.com/ros2-gbp/topic_tools-release/blob/56cbd505c807abb2ab346c30014de299c43006dd/tracks.yaml#L121