### PR TITLE
mola_common: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4554,7 +4554,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_common-release.git
-      version: 0.6.0-2
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_common` to `0.6.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_common.git
- release repository: https://github.com/ros2-gbp/mola_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.0-2`

## mola_common

```
* fix: remove stale wrong trace cmake message with each configured library
* Contributors: Jose Luis Blanco-Claraco
```
