### PR TITLE
Add cascadio to rosdep keys for python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5327,6 +5327,16 @@ python3-cantools-pip:
   ubuntu:
     pip:
       packages: [cantools]
+python3-cascadio:
+  debian:
+    pip:
+      packages: [cascadio]
+  fedora:
+    pip:
+      packages: [cascadio]
+  ubuntu:
+    pip:
+      packages: [cascadio]
 python3-catkin-lint:
   debian:
     '*': [catkin-lint]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-cascadio

## Package Upstream Source:

https://github.com/Oryx-Embedded/cascadio

## Purpose of using this:

This dependency provides Python bindings and tooling for converting STEP CAD models into GLB assets using OpenCASCADE. 

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - not available
- Ubuntu: https://packages.ubuntu.com/
  - not available
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-cascadio/python3-cascadio/
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available