### PR TITLE
Adding qt6-qmake

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9461,8 +9461,6 @@ qt6-qmake:
   gentoo: ['dev-qt/qtcore:6']
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
-  opensuse: [libqt6-qtbase-common-devel]
-  rhel: [qt6-qtbase-devel]
   slackware: [qt6]
   ubuntu: [qmake6]
 qt6-5compat-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9453,16 +9453,6 @@ qt5-qmake:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qt5-qmake]
-qt6-qmake:
-  alpine: [qt6-qtbase-dev]
-  arch: [qt6-base]
-  debian: [qmake6]
-  fedora: [qt6-qtbase-devel]
-  gentoo: ['dev-qt/qtcore:6']
-  nixos: [qt6.qtbase]
-  openembedded: [qtbase@meta-qt6]
-  slackware: [qt6]
-  ubuntu: [qmake6]
 qt6-5compat-dev:
   alpine: [qt6-qt5compat]
   arch: [qt6-5compat]
@@ -9562,6 +9552,16 @@ qt6-multimedia-dev:
   ubuntu:
     '*': [qt6-multimedia-dev]
     'focal': null
+qt6-qmake:
+  alpine: [qt6-qtbase-dev]
+  arch: [qt6-base]
+  debian: [qmake6]
+  fedora: [qt6-qtbase-devel]
+  gentoo: ['dev-qt/qtcore:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  slackware: [qt6]
+  ubuntu: [qmake6]
 qt6-scxml-dev:
   arch: [qt6-scxml]
   debian: [qt6-scxml-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9561,7 +9561,9 @@ qt6-qmake:
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
   slackware: [qt6]
-  ubuntu: [qmake6]
+  ubuntu:
+    '*': [qmake6]
+    'focal': null
 qt6-scxml-dev:
   arch: [qt6-scxml]
   debian: [qt6-scxml-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9453,6 +9453,18 @@ qt5-qmake:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [qt5-qmake]
+qt6-qmake:
+  alpine: [qt6-qtbase-dev]
+  arch: [qt6-base]
+  debian: [qmake6]
+  fedora: [qt6-qtbase-devel]
+  gentoo: ['dev-qt/qtcore:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libqt6-qtbase-common-devel]
+  rhel: [qt6-qtbase-devel]
+  slackware: [qt6]
+  ubuntu: [qmake6]
 qt6-5compat-dev:
   alpine: [qt6-qt5compat]
   arch: [qt6-5compat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9567,6 +9567,9 @@ qt6-qmake:
   gentoo: ['dev-qt/qtcore:6']
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase-devel]
+    '8': null
   slackware: [qt6]
   ubuntu:
     '*': [qmake6]


### PR DESCRIPTION
`mapviz` is currently failing because it cannot find qt6-qmake as dependency. Debian and Ubuntu renamed this to qmake6, where it used to be qt5-qmake. FreeBSD does not appear to have a Qt6 version of this package, so it was removed.

<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

qt6-qmake

## Package Upstream Source:

https://github.com/qt/qtbase

## Purpose of using this:

Previous ROS 2 distros included qt4-qmake and qt5-qmake. This adds qmake for Qt6 to support porting packages to new versions of ROS 2 and Ubuntu.

Distro packaging links:

## Links to Distribution Packages


- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/qmake6
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/resolute/qt6-base
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/qt6-qtbase/qt6-qtbase/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/qt6-base/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-qt/qtcore
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86_64/qt6-qtbase
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/libraries/qt-6/default.nix#L143

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Humble, Jazzy, Kilted, Rolling

# The source is here:

https://github.com/qt/qtbase

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
