### PR TITLE
rosidlcpp: 0.6.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8394,7 +8394,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rosidlcpp-release.git
-      version: 0.5.0-3
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/Tonywelte/rosidlcpp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidlcpp` to `0.6.0-1`:

- upstream repository: https://github.com/TonyWelte/rosidlcpp.git
- release repository: https://github.com/ros2-gbp/rosidlcpp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.0-3`

## rosidlcpp

- No changes

## rosidlcpp_generator_c

- No changes

## rosidlcpp_generator_core

```
* Fix json formatting with fmt version 10 (#22 <https://github.com/TonyWelte/rosidlcpp/issues/22>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_cpp

- No changes

## rosidlcpp_generator_py

```
* Fix json formatting with fmt version 10 (#22 <https://github.com/TonyWelte/rosidlcpp/issues/22>)
* Contributors: Anthony Welte
```

## rosidlcpp_generator_type_description

- No changes

## rosidlcpp_parser

```
* Fix rosidlcpp_parser build failures for Lyrical (#21 <https://github.com/TonyWelte/rosidlcpp/issues/21>)
* Contributors: Michael Carroll
```

## rosidlcpp_typesupport_c

- No changes

## rosidlcpp_typesupport_cpp

- No changes

## rosidlcpp_typesupport_fastrtps_c

- No changes

## rosidlcpp_typesupport_fastrtps_cpp

- No changes

## rosidlcpp_typesupport_introspection_c

- No changes

## rosidlcpp_typesupport_introspection_cpp

- No changes
