### PR TITLE
Add datamodel-code-generator dependencies for Ubuntu

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -193,8 +193,9 @@ datamodel-code-generator:
         packages: [datamodel-code-generator]
     trixie: [python3-datamodel-code-generator]
   fedora:
-    pip:
-      packages: [datamodel-code-generator]
+    '*':
+      pip:
+        packages: [datamodel-code-generator]
   nixos: [python312Packages.datamodel-code-generator]
   opensuse:
     '*':

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -191,15 +191,12 @@ datamodel-code-generator:
   fedora:
     pip:
       packages: [datamodel-code-generator]
-  gentoo:
-    pip:
-      packages: [datamodel-code-generator]
   nixos: [python312Packages.datamodel-code-generator]
   opensuse: [python-datamodel-code-generator]
   ubuntu:
-    resolute: [python3-datamodel-code-generator]
     pip:
       packages: [datamodel-code-generator]
+    resolute: [python3-datamodel-code-generator]
 dpath-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -188,20 +188,23 @@ datamodel-code-generator:
     pip:
       packages: [datamodel-code-generator]
   debian:
-    pip:
-      packages: [datamodel-code-generator]
+    '*':
+      pip:
+        packages: [datamodel-code-generator]
     trixie: [python3-datamodel-code-generator]
   fedora:
     pip:
       packages: [datamodel-code-generator]
   nixos: [python312Packages.datamodel-code-generator]
   opensuse:
-    pip:
-      packages: [datamodel-code-generator]
+    '*':
+      pip:
+        packages: [datamodel-code-generator]
     tumbleweed: [python-datamodel-code-generator]
   ubuntu:
-    pip:
-      packages: [datamodel-code-generator]
+    '*':
+      pip:
+        packages: [datamodel-code-generator]
     resolute: [python3-datamodel-code-generator]
 dpath-pip:
   ubuntu:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -185,8 +185,9 @@ cython3:
   ubuntu: [cython3]
 datamodel-code-generator:
   arch:
-    pip:
-      packages: [datamodel-code-generator]
+    '*':
+      pip:
+        packages: [datamodel-code-generator]
   debian:
     '*':
       pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -198,6 +198,7 @@ datamodel-code-generator:
   opensuse:
     pip:
       packages: [datamodel-code-generator]
+    tumbleweed: [python-datamodel-code-generator]
   ubuntu:
     pip:
       packages: [datamodel-code-generator]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -184,7 +184,18 @@ cython3:
   nixos: [python3Packages.cython]
   ubuntu: [cython3]
 datamodel-code-generator:
+  arch:
+    pip:
+      packages: [datamodel-code-generator]
   debian: [python3-datamodel-code-generator]
+  fedora:
+    pip:
+      packages: [datamodel-code-generator]
+  gentoo:
+    pip:
+      packages: [datamodel-code-generator]
+  nixos: [python312Packages.datamodel-code-generator]
+  opensuse: [python-datamodel-code-generator]
   ubuntu:
     resolute: [python3-datamodel-code-generator]
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -187,12 +187,17 @@ datamodel-code-generator:
   arch:
     pip:
       packages: [datamodel-code-generator]
-  debian: [python3-datamodel-code-generator]
+  debian:
+    pip:
+      packages: [datamodel-code-generator]
+    trixie: [python3-datamodel-code-generator]
   fedora:
     pip:
       packages: [datamodel-code-generator]
   nixos: [python312Packages.datamodel-code-generator]
-  opensuse: [python-datamodel-code-generator]
+  opensuse:
+    pip:
+      packages: [datamodel-code-generator]
   ubuntu:
     pip:
       packages: [datamodel-code-generator]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -183,6 +183,12 @@ cython3:
   gentoo: [dev-python/cython]
   nixos: [python3Packages.cython]
   ubuntu: [cython3]
+datamodel-code-generator:
+  debian: [python3-datamodel-code-generator]
+  ubuntu:
+    resolute: [python3-datamodel-code-generator]
+    pip:
+      packages: [datamodel-code-generator]
 dpath-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
## Package name:

datamodel-code-generator 

## Package Upstream Source:

https://github.com/koxudaxi/datamodel-code-generator

## Purpose of using this:

[`rmf_api_msgs` ](https://github.com/open-rmf/rmf_api_msgs/tree/main) uses this for generating python models. So far we have been advising users to manually pip install this package, but since it ships with resolute, it'd be good to ship it directly as part of the package.xml.

Distro packaging links: 

## Links to Distribution Packages


- Debian: https://packages.debian.org/trixie/python3-datamodel-code-generator
- Ubuntu: https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=datamodel-code-generator
- Fedora: Not Available
- Arch: Not Available
- Gentoo: Not Available
- macOS: Not Available
- Alpine: Not Available
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=25.11&query=datamodel-code-generator#show=python312Packages.datamodel-code-generator
- openSUSE: https://software.opensuse.org/package/python-datamodel-code-generator
- rhel: Not Available


# The source is here:

https://github.com/koxudaxi/datamodel-code-generator

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
