### PR TITLE
Update orbbec_camera_v2 release repository URL

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7340,7 +7340,7 @@ repositories:
       - orbbec_description
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/orbbec/orbbec_camera_v2-release.git
+      url: https://github.com/ros2-gbp/orbbec_camera_v2-release.git
       version: 2.7.6-1
     source:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7018,7 +7018,7 @@ repositories:
       - orbbec_description
       tags:
         release: release/jazzy/{package}/{version}
-      url: https://github.com/orbbec/orbbec_camera_v2-release.git
+      url: https://github.com/ros2-gbp/orbbec_camera_v2-release.git
       version: 2.7.6-1
     source:
       type: git


### PR DESCRIPTION
This PR updates the `orbbec_camera_v2` release repository URL for Humble and Jazzy from:

https://github.com/orbbec/orbbec_camera_v2-release.git

to:

https://github.com/ros2-gbp/orbbec_camera_v2-release.git

The ros2-gbp release repository has been synchronized with the existing release repository. This PR does not change the released version; both distributions remain at `2.7.6-1`.