### PR TITLE
ur_client_library: 2.12.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12483,7 +12483,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.11.0-1
+      version: 2.12.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.12.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.11.0-1`

## ur_client_library

```
* [CI] Make circular motion in example more compatible (#508 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/508>)
* [CI], [bugfix] Added a test to check all robot model parametrizations (#505 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/505>)
* [CI]Add cppreference link to ignore list (#506 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/506>)
* [Instruction Executor], [wire-breaking] Allow joint and pose targets for all motion functions (#491 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/491>)
* Add parsing masterboard data (#492 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/492>)
* [Docs] Make default group tab point to PolyScope X (#502 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/502>)
* [Fix] primary_configuration_timeout as configurable field in UrDriverConfiguration (#489 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/489>)
* [CI] Add lyrical build and migrate rolling to resolute (#499 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/499>)
* Contributors: Felix Exner, Litzia Carla Vilchez
```