### PR TITLE
pybind11_json_vendor: 0.7.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6280,6 +6280,11 @@ repositories:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git
       version: main
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pybind11_json_vendor` to `0.7.0-1`:

- upstream repository: https://github.com/open-rmf/pybind11_json_vendor
- release repository: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## pybind11_json_vendor

```
* Un-archive repo for Lyrical (#18 <https://github.com/open-rmf/pybind11_json_vendor/issues/18>)
* Update README to reflect the reason for archiving (#17 <https://github.com/open-rmf/pybind11_json_vendor/issues/17>)
* Add triage github action (#15 <https://github.com/open-rmf/pybind11_json_vendor/issues/15>)
* Contributors: Grey, Luca Della Vedova
```
