### PR TITLE
sync_tooling_msgs: 0.2.9-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9616,7 +9616,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
-      version: 0.2.7-2
+      version: 0.2.9-1
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_tooling_msgs` to `0.2.9-1`:

- upstream repository: https://github.com/tier4/sync_tooling_msgs.git
- release repository: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.7-2`

## sync_tooling_msgs

```
* fix: make protobuf-dev an exported buildtool dependency
* Contributors: Max SCHMELLER
```
