### PR TITLE
mola_academic_datasets: 3.0.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5909,6 +5909,29 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_academic_datasets:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_academic_datasets.git
+      version: develop
+    release:
+      packages:
+      - kitti_metrics_eval
+      - mola_academic_datasets
+      - mola_input_euroc_dataset
+      - mola_input_kitti360_dataset
+      - mola_input_kitti_dataset
+      - mola_input_mulran_dataset
+      - mola_input_paris_luco_dataset
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_academic_datasets-release.git
+      version: 3.0.0-2
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_academic_datasets.git
+      version: develop
+    status: developed
   mola_common:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_academic_datasets` to `3.0.0-2`:

- upstream repository: https://github.com/MOLAorg/mola_academic_datasets.git
- release repository: https://github.com/ros2-gbp/mola_academic_datasets-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## kitti_metrics_eval

```
* Merge pull request #143 <https://github.com/MOLAorg/mola_academic_datasets/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_academic_datasets

```
* Add mola_academic_datasets metapackage
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_euroc_dataset

```
* Merge pull request #143 <https://github.com/MOLAorg/mola_academic_datasets/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti360_dataset

```
* Merge pull request #143 <https://github.com/MOLAorg/mola_academic_datasets/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_kitti_dataset

```
* Merge pull request #143 <https://github.com/MOLAorg/mola_academic_datasets/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_mulran_dataset

```
* Merge pull request #143 <https://github.com/MOLAorg/mola_academic_datasets/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_paris_luco_dataset

```
* Merge pull request #143 <https://github.com/MOLAorg/mola_academic_datasets/issues/143> from MOLAorg/bump-cmake-version
  bump min req cmake version to 3.22
* bump min req cmake version to 3.22
* Contributors: Jose Luis Blanco-Claraco
```
