### PR TITLE
mrpt_sensors: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6371,10 +6371,11 @@ repositories:
       - mrpt_sensor_imu_taobotics
       - mrpt_sensorlib
       - mrpt_sensors
+      - novatel_oem6_msgs
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_sensors-release.git
-      version: 0.2.4-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/mrpt_sensors.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_sensors` to `0.3.0-1`:

- upstream repository: https://github.com/mrpt-ros-pkg/mrpt_sensors.git
- release repository: https://github.com/ros2-gbp/mrpt_sensors-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.4-1`

## mrpt_generic_sensor

- No changes

## mrpt_sensor_bumblebee_stereo

```
* remove obsolete dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_nmea

```
* FIX: Don't throw if an invalid stamp arrives from the sensor
* remove obsolete dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_gnss_novatel

```
* Publish oem6 ros2 messages too
* Add novatel_oem6_msgs package and service to send custom commands to Novatel
* Fix param type errors
* Fix obsolete tf headers
* Novatel SPAN node can now subscribe to an IMU and use its orientation to initialize the INS azimuth
* FIX: Don't throw if an invalid stamp arrives from the sensor
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensor_imu_taobotics

```
* remove obsolete dependencies
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensorlib

```
* feat(mrpt_sensorlib): retry on sensor exception instead of crashing
  When doProcess() throws (e.g. serial port unavailable at startup),
  catch the exception, report ERROR via /diagnostics, and retry after
  retry_on_error_delay seconds (default 5 s, tunable via ROS 2 param).
* feat(mrpt_sensorlib): add /diagnostics support to all sensor nodes
  Centralised in GenericSensorNode so every sensor package inherits it
  automatically without any per-package changes.
  State machine:
  - WARN "initialising" for the first diag_startup_timeout seconds (default 30 s)
  - ERROR if no observation received after that timeout
  - ERROR if time since last observation exceeds 3× the expected period (stale)
  - WARN if smoothed rate < 50% of expected rate
  - OK otherwise
  New ROS 2 parameters (both in mrpt_sensorlib):
  diag_startup_timeout  [s]  (default 30.0)
  diag_expected_rate    [Hz] (default 1.0)
* Novatel SPAN node can now subscribe to an IMU and use its orientation to initialize the INS azimuth
* FIX: Don't throw if an invalid stamp arrives from the sensor
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_sensors

- No changes

## novatel_oem6_msgs

```
* Publish oem6 ros2 messages too
* Add novatel_oem6_msgs package and service to send custom commands to Novatel
* Contributors: Jose Luis Blanco-Claraco
```
