### PR TITLE
mola_input_ouster: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5777,6 +5777,21 @@ repositories:
       url: https://github.com/MOLAorg/mola_imu_preintegration.git
       version: develop
     status: developed
+  mola_input_ouster:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_ouster.git
+      version: develop
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_input_ouster-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_ouster.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_input_ouster` to `0.1.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_input_ouster.git
- release repository: https://github.com/ros2-gbp/mola_input_ouster-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mola_input_ouster

```
* Initial release: live Ouster sensor and PCAP replay support.
* Contributors: Jose Luis Blanco-Claraco
```
