### PR TITLE
Add pip keys for lerobot, lerobot[all] and lerobot with motor extras

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7248,6 +7248,30 @@ python3-lensfun:
     '*': [python3-lensfun]
     '8': null
   ubuntu: [python3-lensfun]
+python3-lerobot-all-pip:
+  '*':
+    pip:
+      packages: ["lerobot[all]"]
+python3-lerobot-damiao-pip:
+  '*':
+    pip:
+      packages: ["lerobot[damiao]"]
+python3-lerobot-dynamixel-pip:
+  '*':
+    pip:
+      packages: ["lerobot[dynamixel]"]
+python3-lerobot-feetech-pip:
+  '*':
+    pip:
+      packages: ["lerobot[feetech]"]
+python3-lerobot-pip:
+  '*':
+    pip:
+      packages: [lerobot]
+python3-lerobot-robstride-pip:
+  '*':
+    pip:
+      packages: ["lerobot[robstride]"]
 python3-lgpio:
   alpine:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

`lerobot` (python3-lerobot-pip)
`lerobot[all]` (python3-lerobot-all-pip)
`lerobot[feetech]` (python3-lerobot-feetech-pip)
`lerobot[dynamixel]` (python3-lerobot-dynamixel-pip)
`lerobot[damiao]` (python3-lerobot-damiao-pip)
`lerobot[robstride]` (python3-lerobot-robstride-pip)

Similarly to #44305, lerobot pip offers some pip-extras for different policies, robots and simulators.
This PR only contains the pip-keys for the standalone `lerobot`, the all-included `lerobot[all]` and the four individual "motor"-extras as defined [here](https://github.com/huggingface/lerobot/blob/main/pyproject.toml#L158).
The motor-extras are required when controlling LeRobot compatible arms with the LeRobot python API. The `lerobot` and `lerobot[all]` variants are included to cover the whole dependency range. I suggest to not including all other extras for now, but future PRs can add them if required.

Unlike in #44305, I was able to directly specify the extras (i.e. extra all with `lerobot[all]`) in the python rosdep pip-keys by placing the pip-package name in quotes like this:
```yaml
python3-lerobot-all-pip
  '*':
    pip:
      packages: ["lerobot[all]"]
``` 

## Package Upstream Source:
https://github.com/huggingface/lerobot 

## Purpose of using this:
From [lerobot webpage](https://huggingface.co/docs/lerobot/index):
> State-of-the-art machine learning for real-world robotics
>
>🤗 LeRobot aims to provide models, datasets, and tools for real-world robotics in PyTorch. The goal is to lower the barrier for entry to robotics so that everyone can contribute and benefit from sharing datasets and pretrained models.
>
>🤗 LeRobot contains state-of-the-art approaches that have been shown to transfer to the real-world with a focus on imitation learning and reinforcement learning.
>
>🤗 LeRobot already provides a set of pretrained models, datasets with human collected demonstrations, and simulated environments so that everyone can get started.
>
>🤗 LeRobot hosts pretrained models and datasets on the LeRobot HuggingFace page.

Example usecase for the rosdep key(s): The LeRobot python package provides an API for the [SO-101](https://huggingface.co/docs/lerobot/so101) robot arm that I want to use with ROS 2.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- pip: https://pypi.org/project/lerobot/

