### PR TITLE
log_view: 0.3.3-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4166,7 +4166,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/log_view-release.git
-      version: 0.3.2-1
+      version: 0.3.3-2
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.3.3-2`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/ros2-gbp/log_view-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.2-1`

## log_view

```
* Added support for UTF8 glyphs in log messages.
* Added support for ANSI color codes in log messages.
* Fixed display for terminals limited to 8 colors.
* Fixed session boundaries to not be treated as normal log entries.
* Fixed details panel to scroll vertically when insufficient space is available.
* Fixed help panel to scroll vertically when insufficient space is available.
* Fixed preference panel to scroll vertically when insufficient space is available.
* Updated node panel scrolling to make it consistent with other panels.
* Improved selection controls.
```
