### PR TITLE
agnocast: 2.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -242,7 +242,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/agnocast-release.git
-      version: 2.3.3-1
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/autowarefoundation/agnocast.git


### PR DESCRIPTION
Increasing version of package(s) in repository `agnocast` to `2.3.4-1`:

- upstream repository: https://github.com/tier4/agnocast.git
- release repository: https://github.com/ros2-gbp/agnocast-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.3.3-1`

## agnocast

- No changes

## agnocast_cie_config_msgs

```
* feat(cie_thread_configurator): add ~/reapply_config service for runtime YAML reload (#1303 <https://github.com/autowarefoundation/agnocast/issues/1303>)
* refactor(cie_thread_configurator): migrate non-ROS thread reporting from rclcpp pub/sub to abstract Unix domain socket (#1295 <https://github.com/autowarefoundation/agnocast/issues/1295>)
```

## agnocast_cie_thread_configurator

```
* fix: ubuntu24.04/jazzy compilation warnings (#1339 <https://github.com/autowarefoundation/agnocast/issues/1339>)
* fix(sample_application): add agnocast_ prefix to sample app and thread_configurator (#1319 <https://github.com/autowarefoundation/agnocast/issues/1319>)
* feat(cie_thread_configurator): add ~/reapply_config service for runtime YAML reload (#1303 <https://github.com/autowarefoundation/agnocast/issues/1303>)
* refactor(cie_thread_configurator): extract ThreadConfig and YAML parser into thread_config.hpp/cpp (#1304 <https://github.com/autowarefoundation/agnocast/issues/1304>)
* refactor(cie_thread_configurator): migrate non-ROS thread reporting from rclcpp pub/sub to abstract Unix domain socket (#1295 <https://github.com/autowarefoundation/agnocast/issues/1295>)
* refactor(cie_thread_configurator): split callback groups and atomicize shared state (#1288 <https://github.com/autowarefoundation/agnocast/issues/1288>)
* fix(cie_thread_configurator): address misc code quality issues (#1277 <https://github.com/autowarefoundation/agnocast/issues/1277>)
* fix(cie_thread_configurator): always re-apply configuration regardless of thread_id (#1262 <https://github.com/autowarefoundation/agnocast/issues/1262>)
* refactor(cie_thread_configurator): apply SCHED_DEADLINE immediately with RESET_ON_FORK (#1248 <https://github.com/autowarefoundation/agnocast/issues/1248>)
* fix: add missing export dependencies (#1254 <https://github.com/autowarefoundation/agnocast/issues/1254>)
* refactor(thread_configurator): split into separate executables and use ROS parameters (#1234 <https://github.com/autowarefoundation/agnocast/issues/1234>)
* fix(cie_thread_configurator): make spawn_non_ros2_thread node name unique using thread_name (#1243 <https://github.com/autowarefoundation/agnocast/issues/1243>)
* fix(cie_thread_configurator): align QoS settings between ThreadConfiguratorNode and PrerunNode (#1218 <https://github.com/autowarefoundation/agnocast/issues/1218>)
```

## agnocast_components

```
* fix(cie): fix cancel_executor race condition (#1278 <https://github.com/autowarefoundation/agnocast/issues/1278>)
* refactor(agnocast_components): use rclcpp_components_register_nodes for resource index registration (#1238 <https://github.com/autowarefoundation/agnocast/issues/1238>)
* fix(agnocast_components): allow agnocast_components_register_node to coexist with rclcpp_components_register_node (#1230 <https://github.com/autowarefoundation/agnocast/issues/1230>)
* refactor(e2e_test): move CIE component container test to agnocast_e2e_test (#1228 <https://github.com/autowarefoundation/agnocast/issues/1228>)
* fix(test): filter out bridge node from callback info count in CIE test (#1226 <https://github.com/autowarefoundation/agnocast/issues/1226>)
* refactor(test): replace assertSequentialStdout with direct proc_output access (#1225 <https://github.com/autowarefoundation/agnocast/issues/1225>)
```

## agnocast_e2e_test

```
* fix: e2e stress workaround (#1340 <https://github.com/autowarefoundation/agnocast/issues/1340>)
* fix(sample_application): add agnocast_ prefix to sample app and thread_configurator (#1319 <https://github.com/autowarefoundation/agnocast/issues/1319>)
* feat(cie_thread_configurator): add ~/reapply_config service for runtime YAML reload (#1303 <https://github.com/autowarefoundation/agnocast/issues/1303>)
* refactor(cie_thread_configurator): migrate non-ROS thread reporting from rclcpp pub/sub to abstract Unix domain socket (#1295 <https://github.com/autowarefoundation/agnocast/issues/1295>)
* chore: remove @veqcc from maintainers (#1296 <https://github.com/autowarefoundation/agnocast/issues/1296>)
* fix(cie_thread_configurator): always re-apply configuration regardless of thread_id (#1262 <https://github.com/autowarefoundation/agnocast/issues/1262>)
* refactor(thread_configurator): split into separate executables and use ROS parameters (#1234 <https://github.com/autowarefoundation/agnocast/issues/1234>)
* refactor(e2e_test): move CIE tests from agnocastlib to agnocast_e2e_test (#1229 <https://github.com/autowarefoundation/agnocast/issues/1229>)
* test(e2e_test): add multi_domain_cie_talker integration test (#1221 <https://github.com/autowarefoundation/agnocast/issues/1221>)
* fix(agnocast_components): allow agnocast_components_register_node to coexist with rclcpp_components_register_node (#1230 <https://github.com/autowarefoundation/agnocast/issues/1230>)
* refactor(e2e_test): move CIE component container test to agnocast_e2e_test (#1228 <https://github.com/autowarefoundation/agnocast/issues/1228>)
* refactor(test): replace assertSequentialStdout with direct proc_output access (#1225 <https://github.com/autowarefoundation/agnocast/issues/1225>)
```

## agnocast_ioctl_wrapper

```
* refactor(ros2agnocast): typo, memory handle (#1305 <https://github.com/autowarefoundation/agnocast/issues/1305>)
* refactor(ros2agnocast): use context manager for ctypes topic arrays (#1293 <https://github.com/autowarefoundation/agnocast/issues/1293>)
* chore: remove @veqcc from maintainers (#1296 <https://github.com/autowarefoundation/agnocast/issues/1296>)
* feat:add version check command (#1224 <https://github.com/autowarefoundation/agnocast/issues/1224>)
```

## agnocast_sample_application

```
* fix(sample_application): add agnocast_ prefix to sample app and thread_configurator (#1319 <https://github.com/autowarefoundation/agnocast/issues/1319>)
* chore: remove @veqcc from maintainers (#1296 <https://github.com/autowarefoundation/agnocast/issues/1296>)
* fix(sample_application): use dedicated callback groups (#1273 <https://github.com/autowarefoundation/agnocast/issues/1273>)
* fix(doc): refer to autowarefoundation.github.io (#1261 <https://github.com/autowarefoundation/agnocast/issues/1261>)
* fix(sample_application): rename multi_domain_cie_tailer to talker (#1220 <https://github.com/autowarefoundation/agnocast/issues/1220>)
* refactor(agnocastlib): hide message types used in service/client communication (#862 <https://github.com/autowarefoundation/agnocast/issues/862>)
```

## agnocast_sample_interfaces

```
* chore: remove @veqcc from maintainers (#1296 <https://github.com/autowarefoundation/agnocast/issues/1296>)
```

## agnocastlib

```
* fix(AgnocastOnlyExecutor): add cancel_requested_ to separate the state (#1346 <https://github.com/autowarefoundation/agnocast/issues/1346>)
* fix(agnocastlib): pass use_global_arguments to NodeParameters (#1345 <https://github.com/autowarefoundation/agnocast/issues/1345>)
* fix(agnocastlib): pass use_clock_thread to Node constructor (#1343 <https://github.com/autowarefoundation/agnocast/issues/1343>)
* fix: ubuntu24.04/jazzy compilation warnings (#1339 <https://github.com/autowarefoundation/agnocast/issues/1339>)
* refactor(bridge-plugins): consolidate .so and enable unity/lld build (#1336 <https://github.com/autowarefoundation/agnocast/issues/1336>)
* feat(timer): support set_period API (#1331 <https://github.com/autowarefoundation/agnocast/issues/1331>)
* feat(bridge): introduce shadow node to Agnocast bridge (#1300 <https://github.com/autowarefoundation/agnocast/issues/1300>)
* fix(cie): disable unnecessary options for cie client node (#1333 <https://github.com/autowarefoundation/agnocast/issues/1333>)
* refactor(timer): refactor timer unit tests (#1329 <https://github.com/autowarefoundation/agnocast/issues/1329>)
* Implement unsupported API for agnocast Timer (#1298 <https://github.com/autowarefoundation/agnocast/issues/1298>)
* docs: clarify service callback signature and defaults (#1287 <https://github.com/autowarefoundation/agnocast/issues/1287>)
* fix(service): move warning from Constructor to user API function (#1318 <https://github.com/autowarefoundation/agnocast/issues/1318>)
* feat: introduce diagnostic_updater for agnocast::Node (#1306 <https://github.com/autowarefoundation/agnocast/issues/1306>)
* fix(agnocastlib): fix infinite recursion (segfault) when calling dlopen() in performance bridge process (#1325 <https://github.com/autowarefoundation/agnocast/issues/1325>)
* feat: introduce tf2 for agnocast::Node (#1281 <https://github.com/autowarefoundation/agnocast/issues/1281>)
* test(timer): add unit tests for timer internals (#1307 <https://github.com/autowarefoundation/agnocast/issues/1307>)
* feat(agnocastlib, test): add --disable-stdout-logs support with test (#1173 <https://github.com/autowarefoundation/agnocast/issues/1173>)
* feat(bridge): add standard-mode R2A service bridge support (#1289 <https://github.com/autowarefoundation/agnocast/issues/1289>)
* test(agnocastlib): add unit tests for node base (#1001 <https://github.com/autowarefoundation/agnocast/issues/1001>)
* refactor(agnocastlib): remove event-specific logic from agnocast_epoll.cpp and .hpp (#1275 <https://github.com/autowarefoundation/agnocast/issues/1275>)
* feat(agnocastlib): add arg --log-level full support (#1174 <https://github.com/autowarefoundation/agnocast/issues/1174>)
* feat(agnocastlib): add support for agnocast::ok() and agnocast::shutdown() (#1297 <https://github.com/autowarefoundation/agnocast/issues/1297>)
* fix(agnocastlib): initialize parameter services in Node constructor body (#1286 <https://github.com/autowarefoundation/agnocast/issues/1286>)
* chore: remove @veqcc from maintainers (#1296 <https://github.com/autowarefoundation/agnocast/issues/1296>)
* refactor(agnocastlib): move signal handling to a dedicated thread (#1283 <https://github.com/autowarefoundation/agnocast/issues/1283>)
* feat: introduce tf2 broadcaster (#1282 <https://github.com/autowarefoundation/agnocast/issues/1282>)
* feat(bridge): add e2e support for R2A service bridges in performance mode (#1274 <https://github.com/autowarefoundation/agnocast/issues/1274>)
* fix(agnocastlib): add warning for reliability, qos_depth==0, and avoid_ros_namespace_connventions (#1285 <https://github.com/autowarefoundation/agnocast/issues/1285>)
* refactor(agnocastlib): use member initializer list for Node construction (#1279 <https://github.com/autowarefoundation/agnocast/issues/1279>)
* refactor(bridge): reduce standard bridge manager's memory usage (#1276 <https://github.com/autowarefoundation/agnocast/issues/1276>)
* feat(agnocastlib): instantiate ParameterService during node construction (#1256 <https://github.com/autowarefoundation/agnocast/issues/1256>)
* refactor(agnocastlib): remove the global variable need_epoll_updates (#1271 <https://github.com/autowarefoundation/agnocast/issues/1271>)
* feat(agnocastlib): add R2A service bridge request policy for performance mode (#1231 <https://github.com/autowarefoundation/agnocast/issues/1231>)
* feat(agnocastlib): warn when ROS 2 and Agnocast callbacks share a callback group (#1266 <https://github.com/autowarefoundation/agnocast/issues/1266>)
* refactor(agnocastlib): defer managed bridge table cleanup to check_managed_bridges (#1232 <https://github.com/autowarefoundation/agnocast/issues/1232>)
* fix(agnocastlib): override durability to Volatile in service/client (#1255 <https://github.com/autowarefoundation/agnocast/issues/1255>)
* feat:add version check command (#1224 <https://github.com/autowarefoundation/agnocast/issues/1224>)
* refactor(e2e_test): move CIE tests from agnocastlib to agnocast_e2e_test (#1229 <https://github.com/autowarefoundation/agnocast/issues/1229>)
* test: use ctest label exclude instead of name regex for test filtering (#1222 <https://github.com/autowarefoundation/agnocast/issues/1222>)
* refactor(e2e_test): move CIE component container test to agnocast_e2e_test (#1228 <https://github.com/autowarefoundation/agnocast/issues/1228>)
* feat(ros2agnocast): add R2A service plugin template (#1144 <https://github.com/autowarefoundation/agnocast/issues/1144>)
* refactor(agnocastlib): refine bridge cleanup (#1207 <https://github.com/autowarefoundation/agnocast/issues/1207>)
* refactor(agnocastlib): hide message types used in service/client communication (#862 <https://github.com/autowarefoundation/agnocast/issues/862>)
* fix(cie_thread_configurator): align QoS settings between ThreadConfiguratorNode and PrerunNode (#1218 <https://github.com/autowarefoundation/agnocast/issues/1218>)
```

## ros2agnocast

```
* fix(bridge): suppress bridge plugin compilation warning (#1347 <https://github.com/autowarefoundation/agnocast/issues/1347>)
* fix: ubuntu24.04/jazzy compilation warnings (#1339 <https://github.com/autowarefoundation/agnocast/issues/1339>)
* perf(bridge-plugins): make bridge nodes use generic publisher and subscriber (#1337 <https://github.com/autowarefoundation/agnocast/issues/1337>)
* refactor(bridge-plugins): consolidate .so and enable unity/lld build (#1336 <https://github.com/autowarefoundation/agnocast/issues/1336>)
* feat(bridge): introduce shadow node to Agnocast bridge (#1300 <https://github.com/autowarefoundation/agnocast/issues/1300>)
* enhance(ros2agnocas): use get_agnocast_node_topics in node info_agnocast (#1237 <https://github.com/autowarefoundation/agnocast/issues/1237>)
* feat(bridge): add standard-mode R2A service bridge support (#1289 <https://github.com/autowarefoundation/agnocast/issues/1289>)
* enhance(ros2agnocast): avoid unnecessary get_topic_names_and_types in topic info_agnocast (#1236 <https://github.com/autowarefoundation/agnocast/issues/1236>)
* refactor(ros2agnocast): typo, memory handle (#1305 <https://github.com/autowarefoundation/agnocast/issues/1305>)
* refactor(ros2agnocast): use context manager for ctypes topic arrays (#1293 <https://github.com/autowarefoundation/agnocast/issues/1293>)
* feat(bridge): add e2e support for R2A service bridges in performance mode (#1274 <https://github.com/autowarefoundation/agnocast/issues/1274>)
* enhance(ros2agnocast): avoid unnecessary get_publishers/subscriptions_info_by_topic calls in topic list_agnocast (#1235 <https://github.com/autowarefoundation/agnocast/issues/1235>)
* fix(bridge): inherit version of ros2agnocast for agnocast bridge plugins (#1219 <https://github.com/autowarefoundation/agnocast/issues/1219>)
* feat:add version check command (#1224 <https://github.com/autowarefoundation/agnocast/issues/1224>)
* feat(ros2agnocast): add R2A service plugin template (#1144 <https://github.com/autowarefoundation/agnocast/issues/1144>)
```
