### PR TITLE
leo_robot: 2.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4002,7 +4002,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.6.0-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.0-1`

## leo_bringup

```
* feat: Add heading controller (#42 <https://github.com/LeoRover/leo_robot-ros2/issues/42>)
* feat: New firmware parameter bridging and node parameter override mechanism (#43 <https://github.com/LeoRover/leo_robot-ros2/issues/43>)
* Contributors: Błażej Sowa, Jan Hernas
```

## leo_filters

```
* feat: Use EventsExecutor to reduce CPU consumption (#44 <https://github.com/LeoRover/leo_robot-ros2/issues/44>)
* Contributors: Błażej Sowa
```

## leo_fw

```
* feat: Use EventsExecutor to reduce CPU consumption (#44 <https://github.com/LeoRover/leo_robot-ros2/issues/44>)
* feat: New firmware parameter bridging and node parameter override mechanism (#43 <https://github.com/LeoRover/leo_robot-ros2/issues/43>)
* fix: Ensure firmware parameters are always updated (#41 <https://github.com/LeoRover/leo_robot-ros2/issues/41>)
* Contributors: Błażej Sowa, Jan Hernas
```

## leo_robot

- No changes
