### PR TITLE
leo_robot: 2.6.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3926,7 +3926,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/leo_robot-release.git
-      version: 2.5.0-3
+      version: 2.6.1-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_robot-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_robot` to `2.6.1-1`:

- upstream repository: https://github.com/LeoRover/leo_robot-ros2.git
- release repository: https://github.com/ros2-gbp/leo_robot-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.0-3`

## leo_bringup

- No changes

## leo_filters

- No changes

## leo_fw

```
* feat: Update leocore firmware to version 2.1.0 (#48 <https://github.com/LeoRover/leo_robot-ros2/issues/48>)
* Contributors: Błażej Sowa
```

## leo_robot

- No changes
