### PR TITLE
Add localization_msgs_tool repo

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5289,7 +5289,6 @@ repositories:
       type: git
       url: https://github.com/oKermorgant/localization_msgs_tools.git
       version: main
-    statuc: developed
   log_view:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5284,6 +5284,12 @@ repositories:
       url: https://github.com/clearpathrobotics/LMS1xx.git
       version: humble-devel
     status: maintained
+  localization_msgs_tools:
+    source:
+      type: git
+      url: https://github.com/oKermorgant/localization_msgs_tools.git
+      version: main
+    statuc: developed
   log_view:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

Jazzy

# The source is here:

https://github.com/oKermorgant/localization_msgs_tools.git

These two packages offer simple nodes to modify localization-related messages that probably many people reproduce on their side.
- `pose_to_tf`: Bridging pose messages to tf was proposed in ROS 1' s [`message_to_tf`](https://index.ros.org/p/message_to_tf) but has been discontinued since.
- `with_covariance`: Adding or changing covariance information is an often-raised question when using e.g. `robot_localization`.

This PR is to prepare a bloom release under all supported distros.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
