### PR TITLE
rcl: 10.5.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6657,7 +6657,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 10.5.0-1
+      version: 10.5.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `10.5.1-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `10.5.0-1`

## rcl

```
* add rcl_publisher/subscription_event_type_is_supported(). (#1317 <https://github.com/ros2/rcl/issues/1317>)
* Contributors: Tomoya Fujita
```

## rcl_action

- No changes

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
