### PR TITLE
rclcpp: 33.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6773,7 +6773,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 33.0.0-1
+      version: 33.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `33.0.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `33.0.0-1`

## rclcpp

```
* add event_type_is_supported() for Publisher/Subscription. (#3132 <https://github.com/ros2/rclcpp//issues/3132>)
* chore: remove outdated TODO in GenericClient (#3146 <https://github.com/ros2/rclcpp//issues/3146>)
* chore: fix typo in test_time_source.cpp (#3145 <https://github.com/ros2/rclcpp//issues/3145>)
* Contributors: Pietro Gelmini, Tomoya Fujita
```

## rclcpp_action

- No changes

## rclcpp_components

- No changes

## rclcpp_lifecycle

- No changes
