### PR TITLE
rclpy: 11.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6789,7 +6789,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 11.0.0-1
+      version: 11.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `11.0.1-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `11.0.0-1`

## rclpy

```
* add publisher/subscription_event_type_is_supported(). (#1647 <https://github.com/ros2/rclpy/issues/1647>)
* Fix a race in the executors. (#1662 <https://github.com/ros2/rclpy/issues/1662>)
* Fix rclpy async executor sleep. (#1661 <https://github.com/ros2/rclpy/issues/1661>)
* Contributors: Chris Lalancette, Tomoya Fujita
```
