### PR TITLE
novatel_oem7_driver: 28.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5465,7 +5465,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
-      version: 4.3.0-2
+      version: 28.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_oem7_driver` to `28.0.0-1`:

- upstream repository: https://github.com/novatel/novatel_oem7_driver.git
- release repository: https://github.com/novatel-gbp/novatel_oem7_driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.3.0-2`

## novatel_oem7_driver

```
Formal support for Kilted
Modifications:
* Removed all remaining Boost header dependencies
```

## novatel_oem7_msgs

```
Formal support for Kilted
```
