### PR TITLE
log_view: 0.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5293,7 +5293,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/log_view-release.git
-      version: 0.3.3-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/hatchbed/log_view.git


### PR DESCRIPTION
Increasing version of package(s) in repository `log_view` to `0.4.0-1`:

- upstream repository: https://github.com/hatchbed/log_view.git
- release repository: https://github.com/ros2-gbp/log_view-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.3-1`

## log_view

```
* Added subscription to /clock to display sim time on status bar.
* Updated stamp format selection to preview the stamp format change.
* Improved formatting of nodes, preferences, and details panels.
* Improved search navigation.
* Fixed exit to only require a single ctrl-c press.
* Fixed message counts for nodes when loading messages from previous sessions.
```
