### PR TITLE
apriltag_msgs: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -476,7 +476,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/apriltag_msgs-release.git
-      version: 2.0.1-5
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/christianrauch/apriltag_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `apriltag_msgs` to `2.0.2-1`:

- upstream repository: https://github.com/christianrauch/apriltag_msgs.git
- release repository: https://github.com/ros2-gbp/apriltag_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-5`
