### PR TITLE
robotraconteur_companion: 0.4.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9783,7 +9783,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robotraconteur_companion-release.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur_companion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur_companion` to `0.4.3-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur_companion.git
- release repository: https://github.com/ros2-gbp/robotraconteur_companion-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.2-1`
