### PR TITLE
robotraconteur_companion: 0.4.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7512,7 +7512,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/robotraconteur_companion-release.git
-      version: 0.4.2-4
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur_companion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur_companion` to `0.4.3-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur_companion.git
- release repository: https://github.com/ros2-gbp/robotraconteur_companion-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.2-4`
