### PR TITLE
robotraconteur_companion: 0.4.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7557,7 +7557,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robotraconteur_companion-release.git
-      version: 0.4.2-3
+      version: 0.4.3-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur_companion.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robotraconteur_companion` to `0.4.3-1`:

- upstream repository: https://github.com/robotraconteur/robotraconteur_companion.git
- release repository: https://github.com/ros2-gbp/robotraconteur_companion-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.2-3`
