### PR TITLE
Make python-argparse entry for NixOS empty

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -641,7 +641,7 @@ python-argparse:
   freebsd: [py27-argparse]
   gentoo: [dev-lang/python]
   macports: [py27-argparse]
-  nixos: [python]
+  nixos: []
   openembedded: []
   opensuse: [python]
   osx:


### PR DESCRIPTION
This is the same what some other distros like Ubuntu do. This dependency corresponds to the argparse module for Python 2.7, which is no longer present in current Nixpkgs/NixOS.
