### PR TITLE
realsense2_camera: 4.58.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8534,7 +8534,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/realsense-ros-release.git
-      version: 4.57.7-1
+      version: 4.58.1-1
     source:
       test_pull_requests: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.58.1-1`:

- upstream repository: https://github.com/realsenseai/realsense-ros.git
- release repository: https://github.com/ros2-gbp/realsense-ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.57.7-1`
