### PR TITLE
mp2p_icp: 2.10.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4876,7 +4876,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.9.1-1
+      version: 2.10.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.10.3-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.1-1`

## mp2p_icp

```
* Merge pull request #67 <https://github.com/MOLAorg/mp2p_icp/issues/67> from MOLAorg/fix/deskew-empty-trajectory
  FIX: robust against temporary lack of IMU in Deskew
* Merge pull request #66 <https://github.com/MOLAorg/mp2p_icp/issues/66> from MOLAorg/add-gicp-benchmark
  test: add new end-to-end gicp test as benchmark
* test: add new end-to-end gicp test as benchmark
* fix: icp-log-viewer bug in translations if view prior was enabled
* Contributors: Jose Luis Blanco-Claraco
```
