### PR TITLE
ros2_canopen: 0.3.3-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9222,7 +9222,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.3.2-1
+      version: 0.3.3-2
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.3-2`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.2-1`

## canopen

```
* Merge pull request #385 <https://github.com/ros-industrial/ros2_canopen/issues/385>
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_402_driver

```
* fix(driver): fix lifecycle node deactive crash (#372 <https://github.com/ros-industrial/ros2_canopen/issues/372>)
* Merge pull request #409 <https://github.com/ros-industrial/ros2_canopen/issues/409>. Make get_effort optional.
* Merge pull request #404 <https://github.com/ros-industrial/ros2_canopen/issues/404>. Implement CiA 402-2 multi-channel support for multiple axes per CANopen node
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408> from nobleo/fix/deprecation-of-ament-target-dependencies
* canopen_402_driver: fixed typo in description (#341 <https://github.com/ros-industrial/ros2_canopen/issues/341>)
* Contributors: Benjamin Maidel, Jan Vermaete, Sven, Tim Clephas, Vishnuprasad Prachandabhanu, dodola
```

## canopen_base_driver

```
* Merge pull request #385 <https://github.com/ros-industrial/ros2_canopen/issues/385>
* Merge pull request #383 <https://github.com/ros-industrial/ros2_canopen/issues/383> Add REAL32 support
* Merge pull request #340 <https://github.com/ros-industrial/ros2_canopen/issues/340> Fix uninitialization issues
* Merge pull request #409 <https://github.com/ros-industrial/ros2_canopen/issues/409> Make get_effort optional.
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Fix issues found while implementing tests caused by improper uninitialization:
  - poll_timer_ not set when polling_ is disabled
  - DeviceContainer's shutdown() is not called anywhere
  - init_thread is already joined in the contructor. This thread should be removed in the future.
* Contributors: Krasimir Milchev, Sven, Sven Fabricius, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_core

```
* Merge pull request #385 <https://github.com/ros-industrial/ros2_canopen/issues/385>
* Merge pull request #374 <https://github.com/ros-industrial/ros2_canopen/issues/374>
* fix(driver): fix lifecycle node deactive crash (#372 <https://github.com/ros-industrial/ros2_canopen/issues/372>)
* fix: typo in device_container.cpp (#354 <https://github.com/ros-industrial/ros2_canopen/issues/354>)
* Add remappings to bus config (#352 <https://github.com/ros-industrial/ros2_canopen/issues/352>)
* Merge pull request #340 <https://github.com/ros-industrial/ros2_canopen/issues/340>
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408> from nobleo/fix/deprecation-of-ament-target-dependencies
* using 'template' keyword to treat 'as' as a dependent template name (#326 <https://github.com/ros-industrial/ros2_canopen/issues/326>)
* Contributors: Ewoodss, Gaël Écorchard, Krasimir Milchev, Max Kivits, Sven, Tim Clephas, Vishnuprasad Prachandabhanu, dodola, luis-camero
```

## canopen_fake_slaves

```
* Fix status word of fake device in profiled position mode. (#345 <https://github.com/ros-industrial/ros2_canopen/issues/345>)
* Merge pull request #384 <https://github.com/ros-industrial/ros2_canopen/issues/384>
* Merge pull request #410 <https://github.com/ros-industrial/ros2_canopen/issues/410> Fix fake slave accept new goal
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Contributors: Gerry Salinas, Sven, Sven Fabricius, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_interfaces

```
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_master_driver

```
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_proxy_driver

```
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_ros2_control

```
* Merge pull request #385 <https://github.com/ros-industrial/ros2_canopen/issues/385>
* Merge pull request #340 <https://github.com/ros-industrial/ros2_canopen/issues/340>
* Merge pull request #404 <https://github.com/ros-industrial/ros2_canopen/issues/404>
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Contributors: Benjamin Maidel, Krasimir Milchev, Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_ros2_controllers

```
* Merge pull request #408 <https://github.com/ros-industrial/ros2_canopen/issues/408>
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## canopen_tests

```
* Merge pull request #404 <https://github.com/ros-industrial/ros2_canopen/issues/404>. Implement CiA 402-2 multi-channel support for multiple axes per CANopen node
* Contributors: Benjamin Maidel, Sven, Tim Clephas, Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_utils

```
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```

## lely_core_libraries

```
* Merge branch 'master' into tutorial-fixes
* Merge branch 'master' into const_and_other
* Merge branch 'ros-industrial:master' into support-real32
* Merge branch 'ros-industrial:master' into named-can-register
* Contributors: Sven, Tim Clephas, Vishnuprasad Prachandabhanu
```
