### PR TITLE
ros2_canopen: 0.3.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9222,7 +9222,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_canopen-release.git
-      version: 0.3.3-2
+      version: 0.3.4-1
     source:
       type: git
       url: https://github.com/ros-industrial/ros2_canopen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_canopen` to `0.3.4-1`:

- upstream repository: https://github.com/ros-industrial/ros2_canopen.git
- release repository: https://github.com/ros2-gbp/ros2_canopen-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.3-2`

## canopen

- No changes

## canopen_402_driver

```
* Reorder constructor member initializer list in DefaultHomingMode for consistency
* Refactor device name handling in LifecycleManager configuration loading
* Contributors: ipa-vsp
```

## canopen_base_driver

- No changes

## canopen_core

```
* Merge pull request #433 <https://github.com/ros-industrial/ros2_canopen/issues/433> from ros-industrial/432-lyrical-compatibility
* Fix Boost package requirement in ConfigExtras.cmake and improve logging format in LifecycleManager
* Improve error handling in load_from_config by checking for missing node_id and ensuring device_namespace ends with a '/'
* Format device_namespace assignment for improved readability in load_from_config
* Refactor device name handling in LifecycleManager configuration loading
* Contributors: Vishnuprasad Prachandabhanu, ipa-vsp
```

## canopen_fake_slaves

- No changes

## canopen_interfaces

- No changes

## canopen_master_driver

- No changes

## canopen_proxy_driver

- No changes

## canopen_ros2_control

- No changes

## canopen_ros2_controllers

- No changes

## canopen_tests

- No changes

## canopen_utils

- No changes

## lely_core_libraries

```
* Merge pull request #433 <https://github.com/ros-industrial/ros2_canopen/issues/433> from ros-industrial/432-lyrical-compatibility
* Update external project lely-core and apply patches for C23/GCC14 compatibility
* Contributors: Vishnuprasad Prachandabhanu, ipa-vsp
```
