### PR TITLE
color_util: 1.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1894,7 +1894,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/color_util-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `color_util` to `1.0.2-1`:

- upstream repository: https://github.com/MetroRobots/color_util.git
- release repository: https://github.com/ros2-gbp/color_util-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`
