### PR TITLE
rtsp_image_transport: 2.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9036,7 +9036,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rtsp_image_transport-release.git
-      version: 2.0.1-3
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/fkie/rtsp_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsp_image_transport` to `2.0.2-1`:

- upstream repository: https://github.com/fkie/rtsp_image_transport.git
- release repository: https://github.com/ros2-gbp/rtsp_image_transport-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-3`

## rtsp_image_transport

```
* Drop obsolete display_picture_number
* Add ROS Lyrical to CI workflow
* Drop obsolete reordered_opaque
  The variable was set but never used anyway
* Contributors: Timo Röhling
```
