### PR TITLE
rtsp_image_transport: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9061,7 +9061,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rtsp_image_transport-release.git
-      version: 2.0.1-2
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/fkie/rtsp_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtsp_image_transport` to `2.0.2-1`:

- upstream repository: https://github.com/fkie/rtsp_image_transport.git
- release repository: https://github.com/ros2-gbp/rtsp_image_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-2`

## rtsp_image_transport

```
* Drop obsolete display_picture_number
* Add ROS Lyrical to CI workflow
* Drop obsolete reordered_opaque
  The variable was set but never used anyway
* Contributors: Timo Röhling
```
