### PR TITLE
rosdep: libxxhash-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7889,6 +7889,10 @@ libxxhash-dev:
     macports: [xxhash]
   nixos: [xxHash]
   opensuse: [xxhash]
+  rhel:
+    '*': [xxhash-devel]
+    '8': null
+    '9': null
   ubuntu: [libxxhash-dev]
 libyaml:
   alpine: [yaml]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7885,7 +7885,8 @@ libxxhash-dev:
   fedora: [xxhash-devel]
   freebsd: [xxhash]
   gentoo: [dev-libs/xxhash]
-  macports: [xxhash]
+  osx:
+    macports: [xxhash]
   nixos: [xxHash]
   opensuse: [xxhash]
   ubuntu: [libxxhash-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7878,6 +7878,17 @@ libxxf86vm:
   opensuse: [xorg-x11-devel]
   rhel: [libXxf86vm-devel]
   ubuntu: [libxxf86vm-dev]
+libxxhash-dev:
+  alpine: [xxhash-dev]
+  arch: [xxhash]
+  debian: [libxxhash-dev]
+  fedora: [xxhash-devel]
+  freebsd: [xxhash]
+  gentoo: [dev-libs/xxhash]
+  macports: [xxhash]
+  nixos: [xxHash]
+  opensuse: [xxhash]
+  ubuntu: [libxxhash-dev]
 libyaml:
   alpine: [yaml]
   arch: [libyaml]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7885,10 +7885,10 @@ libxxhash-dev:
   fedora: [xxhash-devel]
   freebsd: [xxhash]
   gentoo: [dev-libs/xxhash]
-  osx:
-    macports: [xxhash]
   nixos: [xxHash]
   opensuse: [xxhash]
+  osx:
+    macports: [xxhash]
   rhel:
     '*': [xxhash-devel]
     '8': null


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

### Package name:

`libxxhash-dev`

### Package Upstream Source:

https://github.com/Cyan4973/xxHash

### Purpose of using this:

xxHash is an extremely fast non-cryptographic hash algorithm. This dependency is being added to the rosdep database to allow ROS packages that require fast hashing (e.g., for checksums, data deduplication, or cache keys) to declare `libxxhash-dev` as a system dependency and have it resolved correctly across platforms.

---

### Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/search?keywords=libxxhash-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/search?keywords=libxxhash-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/xxhash/xxhash-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/xxhash/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-libs/xxhash
- macOS: https://formulae.brew.sh/
  - not available (macports: https://ports.macports.org/port/xxhash/)
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/packages?name=xxhash-dev
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?query=xxHash
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/xxhash
- FreeBSD: https://freshports.org
  - https://www.freshports.org/devel/xxhash/