### PR TITLE
diagnostics: 4.4.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1602,7 +1602,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/diagnostics-release.git
-      version: 4.4.6-3
+      version: 4.4.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `diagnostics` to `4.4.7-1`:

- upstream repository: https://github.com/ros/diagnostics.git
- release repository: https://github.com/ros2-gbp/diagnostics-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.4.6-3`

## diagnostic_aggregator

```
* Updating package.xml s (#616 <https://github.com/ros/diagnostics/issues/616>)
* Stop flooding the terminal by default with matches of aggregators (#364 <https://github.com/ros/diagnostics/issues/364>)
  Co-authored-by: Tim Clephas <mailto:tim.clephas@nobleo.nl>
* Some fixes that came apparent when building for lyrical / resolute (#609 <https://github.com/ros/diagnostics/issues/609>)
* Option publish_values to control whether aggregated state should contain values (#597 <https://github.com/ros/diagnostics/issues/597>)
  Co-authored-by: Denis Draca <mailto:denis.draca@greenroomrobotics.com>
  Co-authored-by: David Revay <mailto:daverevay@gmail.com>
  Co-authored-by: David Revay <mailto:MrBlenny@users.noreply.github.com>
* Aggregate to stale if one underlying is stale (#593 <https://github.com/ros/diagnostics/issues/593>)
  Co-authored-by: Ferry Schoenmakers <mailto:ferry.schoenmakers@nobleo.nl>
  Co-authored-by: Tim Clephas <mailto:tim.clephas@nobleo.nl>
* Implement onParametersSet for handling only analyzers node parameters (#551 <https://github.com/ros/diagnostics/issues/551>)
  Co-authored-by: Christian Henkel <mailto:christian.henkel2@de.bosch.com>
* Adding analyzer tests again (#555 <https://github.com/ros/diagnostics/issues/555>)
* Adding aggregator tests again (#467 <https://github.com/ros/diagnostics/issues/467>)
* Contributors: Christian Henkel, Ferry Schoenmakers, Noel Jiménez García
```

## diagnostic_common_diagnostics

```
* updating package.xml s (#616 <https://github.com/ros/diagnostics/issues/616>)
* CPU monitor fix (#618 <https://github.com/ros/diagnostics/issues/618>)
* Adding aggregator tests again (#467 <https://github.com/ros/diagnostics/issues/467>)
* All packages in one build job (#532 <https://github.com/ros/diagnostics/issues/532>)
* Correct porting status of diagnostic_common_diagnostics in README (#530 <https://github.com/ros/diagnostics/issues/530>)
* Fixing "AttributeError: 'RcutilsLogger' object has no attribute 'warn'" (#521 <https://github.com/ros/diagnostics/issues/521>)
* Contributors: Christian Henkel, Jasper van Brakel
```

## diagnostic_remote_logging

```
* updating package.xml s (#616 <https://github.com/ros/diagnostics/issues/616>)
* Change node name from influxdb to influxdb_connector (#547 <https://github.com/ros/diagnostics/issues/547>)
  Co-authored-by: Christian Henkel <mailto:christian.henkel2@de.bosch.com>
* Adding aggregator tests again (#467 <https://github.com/ros/diagnostics/issues/467>)
* Fix node name and port in diagnostic_remote_logging readme (#515 <https://github.com/ros/diagnostics/issues/515>)
* Remote name splitting (#525 <https://github.com/ros/diagnostics/issues/525>)
  Co-authored-by: Daan Wijffels <mailto:dwijffels@lely.com>
  Co-authored-by: Christian Henkel <mailto:christian.henkel2@de.bosch.com>
* Fix windows build of diagnostic_remote_logging (#527 <https://github.com/ros/diagnostics/issues/527>)
  Co-authored-by: Christoph Fröhlich
* Contributors: Christian Henkel, Christoph Fröhlich, Daan Wijffels
```

## diagnostic_updater

```
* updating package.xml s (#616 <https://github.com/ros/diagnostics/issues/616>)
* Some fixes that came apparent when building for lyrical / resolute (#609 <https://github.com/ros/diagnostics/issues/609>)
* Add starting_up_state parameter to Updater (#354 <https://github.com/ros/diagnostics/issues/354>)
  Co-authored-by: Noel Jiménez García <mailto:noel.jimenez.gar@gmail.com>
  Co-authored-by: Christian Henkel <mailto:christian.henkel2@de.bosch.com>
  Co-authored-by: Maurice Alexander Purnawan <mailto:mauricepurnawan@gmail.com>
* Get rid of deprecated rclcpp::spin_some() (#563 <https://github.com/ros/diagnostics/issues/563>)
* Remote name splitting (#525 <https://github.com/ros/diagnostics/issues/525>)
* Fixing "AttributeError: 'RcutilsLogger' object has no attribute 'warn'" (#521 <https://github.com/ros/diagnostics/issues/521>)
* Contributors: Christian Henkel, Daan Wijffels, Maurice Alexander Purnawan, Vince Reda
```

## diagnostics

```
* updating package.xml s (#616 <https://github.com/ros/diagnostics/issues/616>)
* Contributors: Christian Henkel
```

## self_test

```
* updating package.xml s (#616 <https://github.com/ros/diagnostics/issues/616>)
* Fix example relative path (#550 <https://github.com/ros/diagnostics/issues/550>)
* Contributors: Christian Henkel, Noel Jiménez García
```
