### PR TITLE
color_util: 1.2.0-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1266,7 +1266,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/color_util-release.git
-      version: 1.1.0-3
+      version: 1.2.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `color_util` to `1.2.0-2`:

- upstream repository: https://github.com/MetroRobots/color_util.git
- release repository: https://github.com/ros2-gbp/color_util-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.0-3`
