### PR TITLE
Adding libqt6-opengl and libqt6-opengl-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6635,21 +6635,23 @@ libqt6-opengl:
   fedora: [qt6-qtbase]
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
-  opensuse: [libQt6OpenGL6]
-  rhel: [qt6-qtbase]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
   ubuntu:
-    '*': [libqt6opengl6]
+    '*': [libqt6opengl6t64]
     'focal': null
 libqt6-opengl-dev:
   arch: [qt6-base]
-  debian: [libqt6opengl6-dev]
+  debian: [qt6-base-dev]
   fedora: [qt6-qtbase-devel]
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
-  opensuse: [libQt6OpenGL-devel]
-  rhel: [qt6-qtbase-devel]
+  rhel:
+    '*': [qt6-qtbase-devel]
+    '8': null
   ubuntu:
-    '*': [libqt6opengl6-dev]
+    '*': [qt6-base-dev]
     'focal': null
 libqt6-qml:
   arch: [qt6-declarative]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6639,10 +6639,9 @@ libqt6-opengl:
     '*': [qt6-qtbase]
     '8': null
   ubuntu:
-    '*': [libqt6opengl6t64]
+    '*': [libqt6opengl6]
     'focal': null
-    'jammy': [libqt6opengl6]
-    'resolute': [libqt6opengl6]
+    'noble': [libqt6opengl6t64]
 libqt6-opengl-dev:
   arch: [qt6-base]
   debian: [qt6-base-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6460,29 +6460,6 @@ libqt5-opengl-dev:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [libqt5opengl5-dev]
-libqt6-opengl:
-  alpine: [qt6-qtbase]
-  arch: [qt6-base]
-  debian: [libqt6opengl6]
-  fedora: [qt6-qtbase]
-  nixos: [qt6.qtbase]
-  openembedded: [qtbase@meta-qt6]
-  opensuse: [libQt6OpenGL6]
-  rhel: [qt6-qtbase]
-  ubuntu:
-    '*': [libqt6opengl6]
-    'focal': null
-libqt6-opengl-dev:
-  arch: [qt6-base]
-  debian: [libqt6opengl6-dev]
-  fedora: [qt6-qtbase-devel]
-  nixos: [qt6.qtbase]
-  openembedded: [qtbase@meta-qt6]
-  opensuse: [libQt6OpenGL-devel]
-  rhel: [qt6-qtbase-devel]
-  ubuntu:
-    '*': [libqt6opengl6-dev]
-    'focal': null
 libqt5-printsupport:
   arch: [qt5-base]
   debian:
@@ -6650,6 +6627,29 @@ libqt6-multimedia:
     '8': null
   ubuntu:
     '*': [libqt6multimedia6]
+    'focal': null
+libqt6-opengl:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian: [libqt6opengl6]
+  fedora: [qt6-qtbase]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libQt6OpenGL6]
+  rhel: [qt6-qtbase]
+  ubuntu:
+    '*': [libqt6opengl6]
+    'focal': null
+libqt6-opengl-dev:
+  arch: [qt6-base]
+  debian: [libqt6opengl6-dev]
+  fedora: [qt6-qtbase-devel]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libQt6OpenGL-devel]
+  rhel: [qt6-qtbase-devel]
+  ubuntu:
+    '*': [libqt6opengl6-dev]
     'focal': null
 libqt6-qml:
   arch: [qt6-declarative]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6434,7 +6434,7 @@ libqt5-opengl:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]
   debian:
-    '*': [libqt5opengl5t64]
+    '*': [libqt5opengl5]
     bookworm: [libqt5opengl5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-opengl]
@@ -6445,9 +6445,21 @@ libqt5-opengl:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu:
-    '*': [libqt5opengl5t64]
+    '*': [libqt5opengl5]
     focal: [libqt5opengl5]
     jammy: [libqt5opengl5]
+libqt6-opengl:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian: [libqt6opengl6]
+  fedora: [qt6-qtbase]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libQt6OpenGL6]
+  rhel: [qt6-qtbase]
+  ubuntu:
+    '*': [libqt6opengl6]
+    'focal': null
 libqt5-opengl-dev:
   arch: [qt5-base]
   debian: [libqt5opengl5-dev]
@@ -6460,6 +6472,17 @@ libqt5-opengl-dev:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [libqt5opengl5-dev]
+libqt6-opengl-dev:
+  arch: [qt6-base]
+  debian: [libqt6opengl6-dev]
+  fedora: [qt6-qtbase-devel
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libQt6OpenGL-devel]
+  rhel: [qt6-qtbase-devel]
+  ubuntu:
+    '*': [libqt6opengl6-dev]
+    'focal': null
 libqt5-printsupport:
   arch: [qt5-base]
   debian:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6641,6 +6641,8 @@ libqt6-opengl:
   ubuntu:
     '*': [libqt6opengl6t64]
     'focal': null
+    'jammy': [libqt6opengl6]
+    'resolute': [libqt6opengl6]
 libqt6-opengl-dev:
   arch: [qt6-base]
   debian: [qt6-base-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6475,7 +6475,7 @@ libqt5-opengl-dev:
 libqt6-opengl-dev:
   arch: [qt6-base]
   debian: [libqt6opengl6-dev]
-  fedora: [qt6-qtbase-devel
+  fedora: [qt6-qtbase-devel]
   nixos: [qt6.qtbase]
   openembedded: [qtbase@meta-qt6]
   opensuse: [libQt6OpenGL-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6434,7 +6434,7 @@ libqt5-opengl:
   alpine: [qt5-qtbase-dev]
   arch: [qt5-base]
   debian:
-    '*': [libqt5opengl5]
+    '*': [libqt5opengl5t64]
     bookworm: [libqt5opengl5]
   fedora: [qt5-qtbase]
   freebsd: [qt5-opengl]
@@ -6445,21 +6445,9 @@ libqt5-opengl:
   rhel: [qt5-qtbase]
   slackware: [qt5]
   ubuntu:
-    '*': [libqt5opengl5]
+    '*': [libqt5opengl5t64]
     focal: [libqt5opengl5]
     jammy: [libqt5opengl5]
-libqt6-opengl:
-  alpine: [qt6-qtbase]
-  arch: [qt6-base]
-  debian: [libqt6opengl6]
-  fedora: [qt6-qtbase]
-  nixos: [qt6.qtbase]
-  openembedded: [qtbase@meta-qt6]
-  opensuse: [libQt6OpenGL6]
-  rhel: [qt6-qtbase]
-  ubuntu:
-    '*': [libqt6opengl6]
-    'focal': null
 libqt5-opengl-dev:
   arch: [qt5-base]
   debian: [libqt5opengl5-dev]
@@ -6472,6 +6460,18 @@ libqt5-opengl-dev:
   rhel: [qt5-qtbase-devel]
   slackware: [qt5]
   ubuntu: [libqt5opengl5-dev]
+libqt6-opengl:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian: [libqt6opengl6]
+  fedora: [qt6-qtbase]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  opensuse: [libQt6OpenGL6]
+  rhel: [qt6-qtbase]
+  ubuntu:
+    '*': [libqt6opengl6]
+    'focal': null
 libqt6-opengl-dev:
   arch: [qt6-base]
   debian: [libqt6opengl6-dev]


### PR DESCRIPTION
Adding keys for Qt6 versions of libqt6-opengl and libqt6-opengl-dev since Qt5 is not supported in newer versions of Ubuntu.

Please add the following dependency to the rosdep database.

## Package name:

libqt6-opengl and libqt6-opengl-dev

## Package Upstream Source:

https://github.com/qt/qtbase

## Purpose of using this:

We have packages that currently reference the Qt5 version of this package and we need Qt6 for newer Linux distros.

Distro packaging links:

## Links to Distribution Packages

I kept the same distro support as the Qt5 versions, except for distros that do not have Qt6 support.

# Please Add This Package to be indexed in the rosdistro.

All current ROS 2 distros.

# The source is here:

https://github.com/qt/qtbase

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
