### PR TITLE
Migrate tracik from bitbucket to github

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11885,7 +11885,7 @@ repositories:
   trac_ik:
     doc:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: jazzy
     release:
       packages:
@@ -11898,7 +11898,7 @@ repositories:
       version: 2.0.2-1
     source:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: jazzy
     status: developed
   tracetools_acceleration:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10048,7 +10048,7 @@ repositories:
   trac_ik:
     doc:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: kilted
     release:
       packages:
@@ -10061,7 +10061,7 @@ repositories:
       version: 2.1.1-2
     source:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: kilted
     status: developed
   tracetools_acceleration:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9947,7 +9947,7 @@ repositories:
   trac_ik:
     doc:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: rolling
     release:
       packages:
@@ -9960,7 +9960,7 @@ repositories:
       version: 2.2.0-3
     source:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: rolling
     status: developed
   tracetools_acceleration:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9971,7 +9971,7 @@ repositories:
   trac_ik:
     doc:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: rolling
     release:
       packages:
@@ -9984,7 +9984,7 @@ repositories:
       version: 2.2.0-2
     source:
       type: git
-      url: https://bitbucket.org/traclabs/trac_ik.git
+      url: https://github.com/traclabs/trac_ik.git
       version: rolling
     status: developed
   tracetools_acceleration:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please update the following dependency in the rosdep database.

## Package name:

trac_ik

## Package Upstream Source:

https://github.com/traclabs/trac_ik

## Purpose of using this:

The package provides an IK solver - it's been around for a while. The repositroy has been migrated from bitbucket to github. All branches and tags have been ported from bitbucket to github.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
