### PR TITLE
Add pip entries for oxrdflib, pyoxigraph, and reasonable

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8219,6 +8219,10 @@ python3-owslib:
   nixos: [python3Packages.owslib]
   rhel: [python3-OWSLib]
   ubuntu: [python3-owslib]
+python3-oxrdflib-pip:
+  '*':
+    pip:
+      packages: [oxrdflib]
 python3-packaging:
   alpine: [py3-packaging]
   arch: [python-packaging]
@@ -8965,6 +8969,10 @@ python3-pyotp:
     '*': [python3-pyotp]
     '8': null
   ubuntu: [python3-pyotp]
+python3-pyoxigraph-pip:
+  '*':
+    pip:
+      packages: [pyoxigraph]
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]
@@ -9757,6 +9765,10 @@ python3-rdflib:
   rhel:
     '8': ['python%{python3_pkgversion}-rdflib']
   ubuntu: [python3-rdflib]
+python3-reasonable-pip:
+  '*':
+    pip:
+      packages: [reasonable]
 python3-redis:
   debian: [python3-redis]
   fedora: [python3-redis]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

oxrdflib
pyoxigraph
reasonable

## Package Upstream Source:

https://github.com/oxigraph/oxigraph/tree/main/python
https://github.com/gtfierro/reasonable/tree/master/python
https://github.com/oxigraph/oxrdflib

## Purpose of using this:

The pyoxigraph dependency contains the oxigraph triplestore for rdf data. This is useful for developing knowledge storage and querying applications. The oxrdflib package allows inter-operation between the popular rdflib package and oxigraph. The reasonable package contains a reasoner that can be used to reason over RDF graphs to infer new information.

These packages are only available on pypi at
- https://pypi.org/project/pyoxigraph/
- https://pypi.org/project/reasonable/
- https://pypi.org/project/oxrdflib/

## Links to Distribution Packages

- Debian:
  - https://packages.debian.org/search?keywords=oxrdflib
  - https://packages.debian.org/search?keywords=pyoxigraph
  - https://packages.debian.org/search?keywords=reasonable

- Ubuntu:
  - https://packages.ubuntu.com/search?keywords=oxrdflib
  - https://packages.ubuntu.com/search?keywords=pyoxigraph
  - https://packages.ubuntu.com/search?keywords=reasonable

- Fedora: https://packages.fedoraproject.org/
  - not available
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available