### PR TITLE
Add tf_namespace_bridge to jazzy (source entry)

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11741,6 +11741,12 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: ros2
     status: maintained
+  tf_namespace_bridge:
+    source:
+      type: git
+      url: https://github.com/husarion/tf_namespace_bridge.git
+      version: jazzy
+    status: developed
   tf_transformations:
     doc:
       type: git


### PR DESCRIPTION
Adds a source entry for `tf_namespace_bridge` to `jazzy/distribution.yaml`.

### Package

- **Name:** `tf_namespace_bridge`
- **Repository:** https://github.com/husarion/tf_namespace_bridge
- **Branch:** `jazzy`
- **License:** Apache 2.0
- **Maintainer:** Rafał Górecki <rafal.gorecki@husarion.com>

### What the package does

ROS 2 (Jazzy, C++17) package that bridges TF from per-robot namespaces (`/<ns>/tf`, `/<ns>/tf_static`) into the global `/tf` / `/tf_static` topics with prefixed frame names — needed for multi-robot setups where each robot publishes TF inside its own namespace but tools like RViz / Nav2 expect a single global TF tree.

Provides two executables:

- `tf_namespace_bridge` — single-robot, prefix derived from the node namespace.
- `multi_tf_namespace_bridge` — list of namespaces, runtime-updatable via a `namespaces` parameter.

Both executables support a `frame_filters` glob whitelist with automatic parent-frame inclusion.
