### PR TITLE
slider_publisher: 2.5.0-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9373,7 +9373,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/slider_publisher-release.git
-      version: 2.4.3-3
+      version: 2.5.0-2
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `slider_publisher` to `2.5.0-2`:

- upstream repository: https://github.com/oKermorgant/slider_publisher.git
- release repository: https://github.com/ros2-gbp/slider_publisher-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.3-3`

## slider_publisher

```
* adapt to Qt6
* Contributors: Olivier Kermorgant
```
