### PR TITLE
Add rosbag_timing_inspector to distribution.yaml

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10440,6 +10440,15 @@ repositories:
       url: https://github.com/fictionlab/rosbag2_to_video.git
       version: ros2
     status: maintained
+  rosbag_timing_inspector:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/rosbag_timing_inspector.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/rosbag_timing_inspector.git
+      version: develop
   rosbot_ros:
     source:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

[rosbag_timing_inspector](https://github.com/MOLAorg/rosbag_timing_inspector.git)

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
