### PR TITLE
rosbridge_suite: 4.2.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8133,7 +8133,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 4.1.0-3
+      version: 4.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `4.2.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.1.0-3`

## rosapi

```
* feat: Provide separate arguments for publish and subscribe topic globs (#1260 <https://github.com/RobotWebTools/rosbridge_suite/issues/1260>)
* fix: avoid rosapi crash on requesting typedefs for non-existent packages (#1239 <https://github.com/RobotWebTools/rosbridge_suite/issues/1239>)
* chore: Update cmake minimum version to 3.20 (#1232 <https://github.com/RobotWebTools/rosbridge_suite/issues/1232>)
* Contributors: Błażej Sowa, Harshdeep Singh, p7yong
```

## rosapi_msgs

```
* chore: Update cmake minimum version to 3.20 (#1232 <https://github.com/RobotWebTools/rosbridge_suite/issues/1232>)
* Contributors: Błażej Sowa
```

## rosbridge_library

```
* fix: Use Clock instead of deprecated ROSClock (#1273 <https://github.com/RobotWebTools/rosbridge_suite/issues/1273>)
* fix: prevent rclpy entity-lifecycle race in service and action capabilities (#1255 <https://github.com/RobotWebTools/rosbridge_suite/issues/1255>)
* feat: Provide separate arguments for publish and subscribe topic globs (#1260 <https://github.com/RobotWebTools/rosbridge_suite/issues/1260>)
* fix: mypy errors and flaky subscriber/publisher tests (#1258 <https://github.com/RobotWebTools/rosbridge_suite/issues/1258>)
* feat: Improve action unadvertising (#1248 <https://github.com/RobotWebTools/rosbridge_suite/issues/1248>)
* fix: Don't raise exception in service callback (#1247 <https://github.com/RobotWebTools/rosbridge_suite/issues/1247>)
* fix: Don't use MultiThreadedExecutor in tests (#1228 <https://github.com/RobotWebTools/rosbridge_suite/issues/1228>)
* chore: Update cmake minimum version to 3.20 (#1232 <https://github.com/RobotWebTools/rosbridge_suite/issues/1232>)
* chore: Remove unused experimental tests (#1231 <https://github.com/RobotWebTools/rosbridge_suite/issues/1231>)
* feat: Add QoS Profile support for advertise, publish and subscribe operations (#1150 <https://github.com/RobotWebTools/rosbridge_suite/issues/1150>)
* fix: Auto-populate header.stamp when header omitted (#1220 <https://github.com/RobotWebTools/rosbridge_suite/issues/1220>)
* Contributors: Błażej Sowa, Joshua Whitley, Roald Schaum, p7yong
```

## rosbridge_msgs

```
* chore: Update cmake minimum version to 3.20 (#1232 <https://github.com/RobotWebTools/rosbridge_suite/issues/1232>)
* Contributors: Błażej Sowa
```

## rosbridge_server

```
* feat: Provide separate arguments for publish and subscribe topic globs (#1260 <https://github.com/RobotWebTools/rosbridge_suite/issues/1260>)
* fix: mypy errors and flaky subscriber/publisher tests (#1258 <https://github.com/RobotWebTools/rosbridge_suite/issues/1258>)
* chore: Update cmake minimum version to 3.20 (#1232 <https://github.com/RobotWebTools/rosbridge_suite/issues/1232>)
* Contributors: Błażej Sowa, Joshua Whitley, p7yong
```

## rosbridge_suite

```
* chore: Update cmake minimum version to 3.20 (#1232 <https://github.com/RobotWebTools/rosbridge_suite/issues/1232>)
* Contributors: Błażej Sowa
```

## rosbridge_test_msgs

```
* chore: Update rosbridge_test_msgs cmake minimum version to 3.20 (#1271 <https://github.com/RobotWebTools/rosbridge_suite/issues/1271>)
* Contributors: Błażej Sowa
```
