### PR TITLE
rosbridge_suite: 2.7.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9907,7 +9907,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbridge_suite-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite` to `2.7.0-1`:

- upstream repository: https://github.com/RobotWebTools/rosbridge_suite.git
- release repository: https://github.com/ros2-gbp/rosbridge_suite-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.6.0-1`

## rosapi

```
* feat: Provide separate arguments for publish and subscribe topic globs (backport #1260 <https://github.com/RobotWebTools/rosbridge_suite/issues/1260>) (#1267 <https://github.com/RobotWebTools/rosbridge_suite/issues/1267>)
* fix: avoid rosapi crash on requesting typedefs for non-existent packages (#1239 <https://github.com/RobotWebTools/rosbridge_suite/issues/1239>) (#1241 <https://github.com/RobotWebTools/rosbridge_suite/issues/1241>)
* Contributors: Błażej Sowa, Harshdeep Singh, p7yong
```

## rosapi_msgs

- No changes

## rosbridge_library

```
* fix: Use Clock instead of deprecated ROSClock (backport #1273 <https://github.com/RobotWebTools/rosbridge_suite/issues/1273>) (#1275 <https://github.com/RobotWebTools/rosbridge_suite/issues/1275>)
* fix: Prevent client destruction race in services.call_service (backport #1255 <https://github.com/RobotWebTools/rosbridge_suite/issues/1255>) (#1270 <https://github.com/RobotWebTools/rosbridge_suite/issues/1270>)
* feat: Provide separate arguments for publish and subscribe topic globs (backport #1260 <https://github.com/RobotWebTools/rosbridge_suite/issues/1260>) (#1267 <https://github.com/RobotWebTools/rosbridge_suite/issues/1267>)
* feat: Improve action unadvertising (backport #1248 <https://github.com/RobotWebTools/rosbridge_suite/issues/1248>) (#1264 <https://github.com/RobotWebTools/rosbridge_suite/issues/1264>)
* fix: mypy errors and flaky subscriber/publisher tests (backport #1258 <https://github.com/RobotWebTools/rosbridge_suite/issues/1258>) (#1261 <https://github.com/RobotWebTools/rosbridge_suite/issues/1261>) (#1262 <https://github.com/RobotWebTools/rosbridge_suite/issues/1262>)
* fix: Don't raise exception in service callback (#1247 <https://github.com/RobotWebTools/rosbridge_suite/issues/1247>) (#1250 <https://github.com/RobotWebTools/rosbridge_suite/issues/1250>)
* fix: Don't use MultiThreadedExecutor in tests (#1228 <https://github.com/RobotWebTools/rosbridge_suite/issues/1228>) (#1245 <https://github.com/RobotWebTools/rosbridge_suite/issues/1245>)
* chore: Remove unused experimental tests (#1231 <https://github.com/RobotWebTools/rosbridge_suite/issues/1231>) (#1234 <https://github.com/RobotWebTools/rosbridge_suite/issues/1234>)
* feat: Add QoS Profile support for advertise, publish and subscribe operations (backport #1150 <https://github.com/RobotWebTools/rosbridge_suite/issues/1150>) (#1226 <https://github.com/RobotWebTools/rosbridge_suite/issues/1226>)
* fix: Auto-populate header.stamp when header omitted (#1220 <https://github.com/RobotWebTools/rosbridge_suite/issues/1220>) (#1222 <https://github.com/RobotWebTools/rosbridge_suite/issues/1222>)
* Contributors: Błażej Sowa, Roald Schaum, Joshua Whitley, p7yong
```

## rosbridge_msgs

- No changes

## rosbridge_server

```
* feat: Provide separate arguments for publish and subscribe topic globs (backport #1260 <https://github.com/RobotWebTools/rosbridge_suite/issues/1260>) (#1267 <https://github.com/RobotWebTools/rosbridge_suite/issues/1267>)
* fix: mypy errors and flaky subscriber/publisher tests (backport #1258 <https://github.com/RobotWebTools/rosbridge_suite/issues/1258>) (#1261 <https://github.com/RobotWebTools/rosbridge_suite/issues/1261>) (#1262 <https://github.com/RobotWebTools/rosbridge_suite/issues/1262>)
* feat: Add an option to use EventsExecutor (backport #1157 <https://github.com/RobotWebTools/rosbridge_suite/issues/1157>) (#1158 <https://github.com/RobotWebTools/rosbridge_suite/issues/1158>)
* Contributors: Błażej Sowa, Joshua Whitley, p7yong
```

## rosbridge_suite

- No changes

## rosbridge_test_msgs

- No changes
