### PR TITLE
rosbot_mavlink_bridge: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9864,6 +9864,21 @@ repositories:
       url: https://github.com/fictionlab/rosbag2_to_video.git
       version: ros2
     status: maintained
+  rosbot_mavlink_bridge:
+    doc:
+      type: git
+      url: https://github.com/husarion/rosbot-firmware.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/husarion/rosbot_mavlink_bridge-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/husarion/rosbot-firmware.git
+      version: jazzy
+    status: maintained
   rosbot_ros:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbot_mavlink_bridge` to `2.0.1-1`:

- upstream repository: https://github.com/husarion/rosbot-firmware.git
- release repository: https://github.com/husarion/rosbot_mavlink_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
