### PR TITLE
tf_namespace_bridge: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11741,6 +11741,21 @@ repositories:
       url: https://github.com/RobotWebTools/tf2_web_republisher.git
       version: ros2
     status: maintained
+  tf_namespace_bridge:
+    doc:
+      type: git
+      url: https://github.com/husarion/tf_namespace_bridge.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/husarion/tf_namespace_bridge-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/husarion/tf_namespace_bridge.git
+      version: jazzy
+    status: maintained
   tf_transformations:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_namespace_bridge` to `0.1.0-1`:

- upstream repository: https://github.com/husarion/tf_namespace_bridge.git
- release repository: https://github.com/husarion/tf_namespace_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
