### PR TITLE
image_common: 7.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3318,7 +3318,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 7.0.0-1
+      version: 7.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `7.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.0.0-1`

## camera_calibration_parsers

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>)
* Contributors: Martin Pecka
```

## camera_info_manager

```
* Removed deprecated API (#413 <https://github.com/ros-perception/image_common/issues/413>)
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>)
* Contributors: Alejandro Hernández Cordero, Martin Pecka
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Removed deprecated API (#413 <https://github.com/ros-perception/image_common/issues/413>)
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>)
* Contributors: Alejandro Hernández Cordero, Martin Pecka
```

## image_transport_py

- No changes
