### PR TITLE
point_cloud_transport: 5.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6046,7 +6046,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.4.1-1
+      version: 5.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.4.2-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.4.1-1`

## point_cloud_transport

```
* Added version.h (#163 <https://github.com/ros-perception/point_cloud_transport/issues/163>) (#169 <https://github.com/ros-perception/point_cloud_transport/issues/169>)
* Cleanups headers and avoid use std::cout (#158 <https://github.com/ros-perception/point_cloud_transport/issues/158>) (#164 <https://github.com/ros-perception/point_cloud_transport/issues/164>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* Cleanups headers and avoid use std::cout (#158 <https://github.com/ros-perception/point_cloud_transport/issues/158>) (#164 <https://github.com/ros-perception/point_cloud_transport/issues/164>)
* Contributors: mergify[bot]
```
