### PR TITLE
image_common: 6.4.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3306,7 +3306,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.8-1
+      version: 6.4.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.9-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.4.8-1`

## camera_calibration_parsers

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#416 <https://github.com/ros-perception/image_common/issues/416>)
* Contributors: mergify[bot]
```

## camera_info_manager

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#416 <https://github.com/ros-perception/image_common/issues/416>)
* Fix camera_info_manager flakiness and Windows crashes (#405 <https://github.com/ros-perception/image_common/issues/405>) (#408 <https://github.com/ros-perception/image_common/issues/408>)
* Contributors: mergify[bot]
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#416 <https://github.com/ros-perception/image_common/issues/416>)
* Contributors: mergify[bot]
```

## image_transport_py

- No changes
