### PR TITLE
image_common: 6.1.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3416,7 +3416,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.1.3-1
+      version: 6.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.1.4-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.1.3-1`

## camera_calibration_parsers

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#417 <https://github.com/ros-perception/image_common/issues/417>)
  (cherry picked from commit 2301484c02081398b70ba5b35c1f0d57669ca14f)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## camera_info_manager

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#417 <https://github.com/ros-perception/image_common/issues/417>)
  (cherry picked from commit 2301484c02081398b70ba5b35c1f0d57669ca14f)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#417 <https://github.com/ros-perception/image_common/issues/417>)
  (cherry picked from commit 2301484c02081398b70ba5b35c1f0d57669ca14f)
  Co-authored-by: Martin Pecka <mailto:peci1@seznam.cz>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## image_transport_py

- No changes
