### PR TITLE
point_cloud_transport: 4.0.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7514,7 +7514,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 4.0.7-1
+      version: 4.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `4.0.8-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.7-1`

## point_cloud_transport

```
* Added version.h (backport #163 <https://github.com/ros-perception/point_cloud_transport/issues/163>) (#171 <https://github.com/ros-perception/point_cloud_transport/issues/171>)
* Cleanups headers and avoid use std::cout (backport #158 <https://github.com/ros-perception/point_cloud_transport/issues/158>) (#166 <https://github.com/ros-perception/point_cloud_transport/issues/166>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* Cleanups headers and avoid use std::cout (backport #158 <https://github.com/ros-perception/point_cloud_transport/issues/158>) (#166 <https://github.com/ros-perception/point_cloud_transport/issues/166>)
* Contributors: mergify[bot]
```
