### PR TITLE
point_cloud_transport: 1.0.22-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8107,7 +8107,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 1.0.21-1
+      version: 1.0.22-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.22-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.21-1`

## point_cloud_transport

```
* Cleanups headers and avoid use std::cout (backport #158 <https://github.com/ros-perception/point_cloud_transport/issues/158>) (#167 <https://github.com/ros-perception/point_cloud_transport/issues/167>)
* Added version.h (backport #163 <https://github.com/ros-perception/point_cloud_transport/issues/163>) (#172 <https://github.com/ros-perception/point_cloud_transport/issues/172>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* Cleanups headers and avoid use std::cout (backport #158 <https://github.com/ros-perception/point_cloud_transport/issues/158>) (#167 <https://github.com/ros-perception/point_cloud_transport/issues/167>)
* Contributors: mergify[bot]
```
