### PR TITLE
image_common: 5.1.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4378,7 +4378,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 5.1.7-1
+      version: 5.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `5.1.8-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.1.7-1`

## camera_calibration_parsers

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#418 <https://github.com/ros-perception/image_common/issues/418>)
* Contributors: mergify[bot]
```

## camera_info_manager

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#418 <https://github.com/ros-perception/image_common/issues/418>)
* Contributors: mergify[bot]
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#418 <https://github.com/ros-perception/image_common/issues/418>)
* Contributors: mergify[bot]
```
