### PR TITLE
image_common: 3.1.13-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4389,7 +4389,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 3.1.12-1
+      version: 3.1.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `3.1.13-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.12-1`

## camera_calibration_parsers

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#419 <https://github.com/ros-perception/image_common/issues/419>)
* Contributors: mergify[bot]
```

## camera_info_manager

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#419 <https://github.com/ros-perception/image_common/issues/419>)
* Contributors: mergify[bot]
```

## camera_info_manager_py

- No changes

## image_common

- No changes

## image_transport

```
* Added version.h (#415 <https://github.com/ros-perception/image_common/issues/415>) (#419 <https://github.com/ros-perception/image_common/issues/419>)
* Contributors: mergify[bot]
```
