### PR TITLE
rosdep: drop legacy Python 2 keys - Stage 1 (20%)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -572,14 +572,6 @@ python-adafruit-bno055-pip:
   ubuntu:
     pip:
       packages: [adafruit_bno055]
-python-alembic:
-  debian:
-    buster: [python-alembic]
-    stretch: [python-alembic]
-  fedora: [python-alembic]
-  gentoo: [dev-python/alembic]
-  ubuntu:
-    '*': [python-alembic]
 python-amqp:
   debian:
     buster: [python-amqp]
@@ -612,17 +604,6 @@ python-anyjson:
   fedora: [python-anyjson]
   gentoo: [dev-python/anyjson]
   ubuntu: [python-anyjson]
-python-apparmor:
-  debian: [python-apparmor]
-  gentoo: ['sys-libs/libapparmor[python]']
-  ubuntu: [python-apparmor]
-python-argcomplete:
-  fedora: [python-argcomplete]
-  gentoo: [dev-python/argcomplete]
-  nixos: [pythonPackages.argcomplete]
-  openembedded: [python3-argcomplete@meta-python]
-  opensuse: [python2-argcomplete]
-  ubuntu: [python-argcomplete]
 python-argh:
   debian: [python-argh]
   fedora: [python-argh]
@@ -678,31 +659,10 @@ python-astrometry-pip: &migrate_eol_2025_04_30_python3_astrometry_pip
   ubuntu:
     pip:
       packages: [astrometry]
-python-attrs:
-  debian:
-    buster: [python-attr]
-  gentoo: [dev-python/attrs]
-  nixos: [pythonPackages.attrs]
-  ubuntu:
-    bionic: [python-attr]
-    focal: [python-attr]
 python-attrs-pip:
   '*':
     pip:
       packages: [attrs]
-python-autobahn:
-  debian: [python-autobahn]
-  fedora:
-    pip:
-      packages: [autobahn]
-  gentoo: [dev-python/autobahn]
-  nixos: [pythonPackages.autobahn]
-  openembedded: ['${PYTHON_PN}-autobahn@meta-python']
-  osx:
-    pip:
-      packages: [autobahn]
-  ubuntu:
-    '*': [python-autobahn]
 python-avahi:
   arch: [avahi]
   debian: [python-avahi]
@@ -711,30 +671,6 @@ python-avahi:
   nixos: [pythonPackages.avahi]
   opensuse: [python3-avahi]
   ubuntu: [python-avahi]
-python-babel:
-  debian: [python-babel]
-  fedora: [python-babel]
-  gentoo: [dev-python/Babel]
-  ubuntu: [python-babel]
-python-backoff-pip:
-  arch:
-    pip:
-      packages: [backoff]
-  debian:
-    pip:
-      packages: [backoff]
-  fedora:
-    pip:
-      packages: [backoff]
-  opensuse:
-    pip:
-      packages: [backoff]
-  osx:
-    pip:
-      packages: [backoff]
-  ubuntu:
-    pip:
-      packages: [backoff]
 python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
@@ -742,31 +678,11 @@ python-backports.ssl-match-hostname:
   openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
     bionic: [python-backports.ssl-match-hostname]
-python-bcrypt:
-  arch: [python2-bcrypt]
-  debian: [python-bcrypt]
-  fedora: [python-bcrypt]
-  gentoo: [dev-python/bcrypt]
-  nixos: [pythonPackages.bcrypt]
-  ubuntu: [python-bcrypt]
 python-beautifulsoup:
   arch: [python2-beautifulsoup3]
   debian: [python-beautifulsoup]
   gentoo: [dev-python/beautifulsoup]
   ubuntu: [python-beautifulsoup]
-python-bitarray:
-  debian: [python-bitarray]
-  fedora: [python-bitarray]
-  gentoo: [dev-python/bitarray]
-  ubuntu: [python-bitarray]
-python-bitstring:
-  debian:
-    buster: [python-bitstring]
-    stretch: [python-bitstring]
-  gentoo: [dev-python/bitstring]
-  nixos: [pythonPackages.bitstring]
-  ubuntu:
-    bionic: [python-bitstring]
 python-bitstring-pip:
   debian:
     pip:
@@ -785,26 +701,6 @@ python-blinker:
   fedora: [python-blinker]
   gentoo: [dev-python/blinker]
   ubuntu: [python-blinker]
-python-bloom:
-  debian: [python-bloom]
-  fedora: [python-bloom]
-  gentoo: [dev-python/bloom]
-  ubuntu:
-    '*': [python-bloom]
-python-bluez:
-  arch: [python2-pybluez]
-  debian: [python-bluez]
-  gentoo: [dev-python/pybluez]
-  nixos: [pythonPackages.pybluez]
-  openembedded: ['${PYTHON_PN}-pybluez@meta-python']
-  ubuntu: [python-bluez]
-python-bokeh-pip:
-  debian:
-    pip:
-      packages: [bokeh]
-  ubuntu:
-    pip:
-      packages: [bokeh]
 python-boltons:
   debian:
     '*': [python-boltons]
@@ -819,168 +715,9 @@ python-boltons:
       packages: [boltons]
   ubuntu:
     '*': [python-boltons]
-python-boto3:
-  arch: [python-boto3]
-  debian: [python-boto3]
-  gentoo: [dev-python/boto3]
-  nixos: [pythonPackages.boto3]
-  openembedded: ['${PYTHON_PN}-boto3@meta-ros-common']
-  opensuse: [python-boto3]
-  ubuntu:
-    '*': [python-boto3]
-python-bottle:
-  debian: [python-bottle]
-  fedora: [python-bottle]
-  gentoo: [dev-python/bottle]
-  ubuntu: [python-bottle]
 python-box2d:
   debian: [python-box2d]
   ubuntu: [python-box2d]
-python-breathe:
-  debian: [python-breathe]
-  fedora: [python-breathe]
-  ubuntu: [python-breathe]
-python-bs4:
-  debian: [python-bs4]
-  fedora: [python-beautifulsoup4]
-  gentoo: [=dev-python/beautifulsoup-4*]
-  nixos: [pythonPackages.beautifulsoup4]
-  ubuntu: [python-bs4]
-python-bson:
-  debian: [python-bson]
-  fedora: [python-bson]
-  gentoo: [dev-python/pymongo]
-  nixos: [pythonPackages.pymongo]
-  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
-  osx:
-    pip:
-      packages: [bson]
-  ubuntu: [python-bson]
-python-cairo:
-  arch: [python2-cairo]
-  debian: [python-cairo]
-  fedora: [pycairo]
-  freebsd: [py27-cairo]
-  gentoo: [dev-python/pycairo]
-  nixos: [pythonPackages.pycairo]
-  opensuse: [python2-cairo]
-  rhel:
-    '7': [pycairo]
-    '8': [python2-cairo]
-  slackware:
-    slackpkg:
-      packages: [pycairo]
-  ubuntu: [python-cairo]
-python-cairosvg:
-  arch: [python2-cairosvg]
-  debian: [python-cairosvg]
-  fedora: [python-cairosvg]
-  gentoo: [media-gfx/cairosvg]
-  nixos: [pythonPackages.cairosvg]
-  opensuse: [python3-CairoSVG]
-  ubuntu: [python-cairosvg]
-python-can:
-  alpine:
-    pip:
-      packages: [python-can]
-  arch:
-    pip:
-      packages: [python-can]
-  debian:
-    buster: [python-can]
-    stretch: [python-can]
-  fedora:
-    pip:
-      packages: [python-can]
-  osx:
-    pip:
-      packages: [python-can]
-  ubuntu:
-    bionic: [python-can]
-python-cantools-pip:
-  debian:
-    pip:
-      packages: [cantools]
-  ubuntu:
-    pip:
-      packages: [cantools]
-python-catkin-lint:
-  fedora: [python-catkin_lint]
-  openembedded: ['${PYTHON_PN}-catkin-lint@meta-ros-common']
-  ubuntu: [python-catkin-lint]
-python-catkin-pkg:
-  alpine:
-    pip:
-      packages: [catkin-pkg]
-  arch: [python2-catkin_pkg]
-  debian: [python-catkin-pkg]
-  fedora: [python-catkin_pkg]
-  freebsd:
-    pip:
-      packages: [catkin-pkg]
-  gentoo: [dev-python/catkin_pkg]
-  macports: [python-catkin-pkg]
-  nixos: [pythonPackages.catkin-pkg]
-  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
-  opensuse: [python-catkin_pkg]
-  osx:
-    pip:
-      packages: [catkin-pkg]
-  rhel:
-    '7': [python2-catkin_pkg]
-  slackware:
-    pip:
-      packages: [catkin-pkg]
-  ubuntu:
-    bionic: [python-catkin-pkg]
-python-catkin-pkg-modules:
-  alpine:
-    pip:
-      packages: [catkin-pkg]
-  arch: [python2-catkin_pkg]
-  debian: [python-catkin-pkg-modules]
-  fedora: [python-catkin_pkg]
-  freebsd:
-    pip:
-      packages: [catkin-pkg]
-  gentoo: [dev-python/catkin_pkg]
-  macports: [python-catkin-pkg]
-  nixos: [pythonPackages.catkin-pkg]
-  openembedded: ['${PYTHON_PN}-catkin-pkg@meta-ros-common']
-  opensuse: [python-catkin_pkg]
-  osx:
-    pip:
-      packages: [catkin-pkg]
-  slackware:
-    pip:
-      packages: [catkin-pkg]
-  ubuntu: [python-catkin-pkg-modules]
-python-catkin-sphinx:
-  arch:
-    pip:
-      packages: [catkin_sphinx]
-  debian:
-    pip:
-      packages: [catkin_sphinx]
-  fedora: [python-catkin-sphinx]
-  gentoo:
-    pip:
-      packages: [catkin_sphinx]
-  osx:
-    pip:
-      packages: [catkin_sphinx]
-  ubuntu:
-    '*': null
-    bionic: [python-catkin-sphinx]
-python-catkin-tools:
-  arch: [python2-catkin-tools]
-  debian: [python-catkin-tools]
-  fedora: [python-catkin_tools]
-  openembedded: ['${PYTHON_PN}-catkin-tools@meta-ros-common']
-  osx:
-    pip:
-      packages: [catkin_tools]
-  ubuntu: [python-catkin-tools]
 python-cbor:
   debian: [python-cbor]
   gentoo: [dev-python/cbor]
@@ -990,14 +727,6 @@ python-celery:
   fedora: [python-celery]
   gentoo: [dev-python/celery]
   ubuntu: [python-celery]
-python-certifi:
-  debian:
-    buster: [python-certifi]
-    stretch: [python-certifi]
-  fedora: [python-certifi]
-  gentoo: [dev-python/certifi]
-  ubuntu:
-    bionic: [python-certifi]
 python-chainer-mask-rcnn-pip:
   debian:
     pip:
@@ -1068,18 +797,6 @@ python-clearsilver:
   rhel:
     '7': [python-clearsilver]
   ubuntu: [python-clearsilver]
-python-click:
-  debian:
-    buster: [python-click]
-    stretch: [python-click]
-  fedora: [python-click]
-  gentoo: [dev-python/click]
-  nixos: [pythonPackages.click]
-  osx:
-    pip:
-      packages: [click]
-  ubuntu:
-    bionic: [python-click]
 python-cobs-pip:
   debian:
     pip:
@@ -1090,19 +807,6 @@ python-cobs-pip:
   ubuntu:
     pip:
       packages: [cobs]
-python-collada:
-  debian: [python-collada]
-  ubuntu: [python-collada]
-python-colorama:
-  arch: [python2-colorama]
-  debian: [python-colorama]
-  fedora: [python-colorama]
-  gentoo: [dev-python/colorama]
-  nixos: [pythonPackages.colorama]
-  osx:
-    pip:
-      packages: [colorama]
-  ubuntu: [python-colorama]
 python-concurrent.futures:
   debian: [python-concurrent.futures]
   gentoo: [virtual/python-futures]
@@ -1112,13 +816,6 @@ python-configparser:
   debian: [python-configparser]
   gentoo: [dev-python/configparser]
   ubuntu: [python-configparser]
-python-construct:
-  arch: [python-construct]
-  debian: [python-construct]
-  gentoo: [dev-python/construct]
-  openembedded: [python3-construct@meta-ros2]
-  ubuntu:
-    bionic: [python-construct]
 python-construct-pip:
   debian:
     pip:
@@ -1133,18 +830,6 @@ python-control-pip:
   ubuntu:
     pip:
       packages: [control]
-python-cookiecutter:
-  debian:
-    buster: [python-cookiecutter]
-    stretch: [python-cookiecutter]
-  fedora:
-    pip:
-      packages: [cookiecutter]
-  gentoo: [dev-util/cookiecutter]
-  osx:
-    pip:
-      packages: [cookiecutter]
-  ubuntu: [python-cookiecutter]
 python-cookiecutter-pip:
   debian:
     pip:
@@ -1159,28 +844,6 @@ python-cookiecutter-pip:
   ubuntu:
     pip:
       packages: [cookiecutter]
-python-couchdb:
-  debian: [python-couchdb]
-  gentoo: [dev-python/couchdb-python]
-  ubuntu: [python-couchdb]
-python-coverage:
-  alpine: [py-coverage]
-  arch: [python2-coverage]
-  debian: [python-coverage]
-  fedora: [python-coverage]
-  freebsd: [py27-coverage]
-  gentoo: [dev-python/coverage]
-  nixos: [pythonPackages.coverage]
-  opensuse: [python2-coverage]
-  osx:
-    pip:
-      packages: [coverage]
-  rhel:
-    '7': [python-coverage]
-    '8': [python2-coverage]
-  slackware: [coverage]
-  ubuntu:
-    bionic: [python-coverage]
 python-cpplint:
   debian:
     pip:
@@ -1208,17 +871,6 @@ python-crccheck-pip:
   ubuntu:
     pip:
       packages: [crccheck]
-python-crcmod:
-  debian: [python-crcmod]
-  fedora:
-    pip:
-      packages: [crcmod]
-  nixos: [pythonPackages.crcmod]
-  osx:
-    pip:
-      packages: [crcmod]
-  ubuntu:
-    bionic: [python-crcmod]
 python-crypto:
   alpine: [py-crypto]
   arch: [python2-crypto]
@@ -1234,23 +886,6 @@ python-crypto:
       packages: [pycrypto]
   ubuntu:
     bionic: [python-crypto]
-python-cryptography:
-  debian: [python-cryptography]
-  gentoo: [dev-python/cryptography]
-  rhel:
-    '7': [python2-cryptography]
-  ubuntu: [python-cryptography]
-python-cvxopt:
-  arch: [python-cvxopt]
-  debian:
-    '*': null
-    buster: [python-cvxopt]
-  fedora: [python-cvxopt]
-  macports: [py27-cvxopt]
-  nixos: [pythonPackages.cvxopt]
-  ubuntu:
-    '*': null
-    bionic: [python-cvxopt]
 python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   debian:
     pip:
@@ -1261,11 +896,6 @@ python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   ubuntu:
     pip:
       packages: [cvxpy]
-python-cwiid:
-  arch: [cwiid]
-  debian: [python-cwiid]
-  gentoo: ['app-misc/cwiid[python]']
-  ubuntu: [python-cwiid]
 python-cython-pip:
   arch:
     pip:
@@ -1279,20 +909,6 @@ python-cython-pip:
   ubuntu:
     pip:
       packages: [cython]
-python-datadog-pip:
-  ubuntu:
-    pip:
-      packages: [datadog]
-python-dateutil:
-  arch: [python2-dateutil]
-  debian: [python-dateutil]
-  fedora: [python-dateutil]
-  gentoo: [dev-python/python-dateutil]
-  nixos: [pythonPackages.dateutil]
-  osx:
-    pip:
-      packages: [python-dateutil]
-  ubuntu: [python-dateutil]
 python-deap-pip:
   debian:
     pip: [deap]
@@ -1304,13 +920,6 @@ python-debian:
   gentoo: [dev-python/python-debian]
   ubuntu:
     bionic: [python-debian]
-python-decorator:
-  debian: [python-decorator]
-  gentoo: [dev-python/decorator]
-  nixos: [pythonPackages.decorator]
-  osx:
-    pip: [decorator]
-  ubuntu: [python-decorator]
 python-deepdiff-pip:
   debian:
     pip: [deepdiff]
@@ -1322,25 +931,6 @@ python-defer-pip:
   ubuntu:
     pip:
       packages: [defer]
-python-defusedxml:
-  alpine: [py-defusedxml]
-  arch: [python2-defusedxml]
-  debian: [python-defusedxml]
-  fedora: [python-defusedxml]
-  freebsd: [py27-defusedxml]
-  gentoo: [dev-python/defusedxml]
-  nixos: [pythonPackages.defusedxml]
-  openembedded: ['${PYTHON_PN}-defusedxml@meta-ros-common']
-  opensuse: [python2-defusedxml]
-  osx:
-    pip:
-      packages: [defusedxml]
-  rhel:
-    '7': [python2-defusedxml]
-  slackware:
-    pip:
-      packages: [defusedxml]
-  ubuntu: [python-defusedxml]
 python-dialogflow-pip:
   arch:
     pip:
@@ -1354,56 +944,6 @@ python-dialogflow-pip:
   ubuntu:
     pip:
       packages: [dialogflow]
-python-django:
-  arch: [python2-django]
-  debian: [python-django]
-  fedora: [python-django]
-  gentoo: [dev-python/django]
-  ubuntu: [python-django]
-python-django-cors-headers:
-  debian: [python-django-cors-headers]
-  ubuntu: [python-django-cors-headers]
-python-django-extensions:
-  debian: [python-django-extensions]
-  ubuntu: [python-django-extensions]
-python-django-extra-views:
-  debian: [python-django-extra-views]
-  ubuntu: [python-django-extra-views]
-python-djangorestframework:
-  debian: [python-djangorestframework]
-  ubuntu: [python-djangorestframework]
-python-dlib:
-  debian:
-    pip: [dlib]
-  fedora:
-    pip: [dlib]
-  nixos: [pythonPackages.dlib]
-  osx:
-    pip:
-      packages: [dlib]
-  ubuntu:
-    pip: [dlib]
-python-docker:
-  arch: [python-docker]
-  debian: [python-docker]
-  fedora: [python-docker]
-  nixos: [pythonPackages.docker]
-  ubuntu: [python-docker]
-python-docopt:
-  debian: [python-docopt]
-  fedora: [python-docopt]
-  gentoo: [dev-python/docopt]
-  nixos: [pythonPackages.docopt]
-  ubuntu: [python-docopt]
-python-docutils:
-  arch: [python2-docutils]
-  debian: [python-docutils]
-  fedora: [python-docutils]
-  gentoo: [dev-python/docutils]
-  nixos: [pythonPackages.docutils]
-  opensuse: [python2-docutils]
-  ubuntu:
-    bionic: [python-docutils]
 python-docx:
   fedora: [python-docx]
   ubuntu:
@@ -1429,32 +969,6 @@ python-easygui:
   debian: [python-easygui]
   fedora: [python-easygui]
   ubuntu: [python-easygui]
-python-elasticsearch:
-  debian:
-    buster: [python-elasticsearch]
-    stretch: [python-elasticsearch]
-  opensuse: [python-elasticsearch]
-  ubuntu:
-    bionic: [python-elasticsearch]
-python-empy:
-  arch: [python2-empy]
-  debian: [python-empy]
-  fedora: [python-empy]
-  freebsd: [py27-empy]
-  gentoo: [dev-python/empy]
-  macports: [py27-empy]
-  nixos: [pythonPackages.empy]
-  openembedded: ['${PYTHON_PN}-empy@meta-ros-common']
-  opensuse: [python2-empy]
-  osx:
-    pip:
-      packages: [empy]
-  rhel:
-    '7': [python2-empy]
-  slackware:
-    pip:
-      packages: [empy]
-  ubuntu: [python-empy]
 python-enum:
   debian:
     wheezy: [python-enum]
@@ -1472,17 +986,6 @@ python-enum34-pip:
   ubuntu:
     pip:
       packages: [enum34]
-python-espeak:
-  debian: [python-espeak]
-python-evdev:
-  gentoo: [dev-python/python-evdev]
-  ubuntu: [python-evdev]
-python-expiringdict:
-  debian: [python-expiringdict]
-  fedora:
-    pip:
-      packages: [expiringdict]
-  ubuntu: [python-expiringdict]
 python-face-alignment-pip:
   debian:
     pip:
@@ -1509,11 +1012,6 @@ python-face-recognition-pip:
   ubuntu:
     pip:
       packages: [face_recognition]
-python-falcon:
-  debian: [python-falcon]
-  fedora: [python-falcon]
-  gentoo: [dev-python/falcon]
-  ubuntu: [python-falcon]
 python-fastdtw-pip:
   debian:
     pip:
@@ -1555,42 +1053,11 @@ python-fcn-pip: &migrate_eol_2025_04_30_python3_fcn_pip
     pip:
       depends: [liblapack-dev]
       packages: [fcn]
-python-filterpy-pip:
-  debian:
-    pip:
-      packages: [filterpy]
-  fedora:
-    pip:
-      packages: [filterpy]
-  osx:
-    pip:
-      packages: [filterpy]
-  ubuntu:
-    pip:
-      packages: [filterpy]
 python-fixtures:
   debian: [python-fixtures]
   fedora: [python-fixtures]
   gentoo: [dev-python/fixtures]
   ubuntu: [python-fixtures]
-python-flake8:
-  debian:
-    buster: [python-flake8]
-    stretch: [python-flake8]
-  fedora: [python-flake8]
-  gentoo: [dev-python/flake8]
-  nixos: [python3Packages.flake8]
-  openembedded: ['${PYTHON_PN}-flake8@meta-ros-common']
-  ubuntu:
-    bionic: [python-flake8]
-python-flask:
-  arch: [python-flask]
-  debian: [python-flask]
-  fedora: [python-flask]
-  gentoo: [dev-python/flask]
-  nixos: [pythonPackages.flask]
-  ubuntu:
-    '*': [python-flask]
 python-flask-appbuilder-pip:
   debian:
     pip:
@@ -1641,29 +1108,6 @@ python-frozendict:
   debian: [python-frozendict]
   fedora: [python-frozendict]
   ubuntu: [python-frozendict]
-python-ftdi1:
-  debian: [python-ftdi1]
-  gentoo: [dev-embedded/libftdi]
-  ubuntu: [python-ftdi1]
-python-funcsigs:
-  debian: [python-funcsigs]
-  fedora: [python-funcsigs]
-  rhel:
-    '7': [python2-funcsigs]
-    '8': [python2-funcsigs]
-  ubuntu: [python-funcsigs]
-python-future:
-  debian: [python-future]
-  fedora: [python-future]
-  gentoo: [dev-python/future]
-  nixos: [pythonPackages.future]
-  openembedded: ['${PYTHON_PN}-future@meta-python']
-  opensuse: [python2-future]
-  osx:
-    pip:
-      packages: [future]
-  ubuntu:
-    bionic: [python-future]
 python-fuzzywuzzy-pip:
   debian:
     pip:
@@ -1701,13 +1145,6 @@ python-gcloud-pip:
   ubuntu:
     pip:
       packages: [gcloud]
-python-gdal:
-  debian:
-    buster: [python-gdal]
-    stretch: [python-gdal]
-  gentoo: ['sci-libs/gdal[python]']
-  ubuntu:
-    bionic: [python-gdal]
 python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
   debian:
     pip:
@@ -1733,36 +1170,11 @@ python-geocoder-pip:
   ubuntu:
     pip:
       packages: [geocoder]
-python-geographiclib:
-  debian: [python-geographiclib]
-  fedora: [python-GeographicLib]
-  nixos: [pythonPackages.geographiclib]
-  ubuntu: [python-geographiclib]
-python-geopy:
-  debian: [python-geopy]
-  gentoo: [dev-python/geopy]
-  ubuntu: [python-geopy]
 python-gevent:
   debian: [python-gevent]
   fedora: [python-gevent]
   gentoo: [dev-python/gevent]
   ubuntu: [python-gevent]
-python-gi:
-  arch: [python2-gobject]
-  debian: [python-gi]
-  gentoo: [dev-python/pygobject]
-  nixos: [pythonPackages.pygobject3]
-  ubuntu: [python-gi]
-python-gi-cairo:
-  debian: [python-gi-cairo]
-  gentoo: [dev-python/pygobject]
-  nixos: [pythonPackages.pygobject3]
-  ubuntu: [python-gi-cairo]
-python-git:
-  arch: [python2-gitpython]
-  debian: [python-git]
-  gentoo: [dev-python/git-python]
-  ubuntu: [python-git]
 python-github-pip:
   osx:
     pip:
@@ -1770,12 +1182,6 @@ python-github-pip:
   ubuntu:
     pip:
       packages: [PyGithub]
-python-gitlab:
-  debian:
-    buster: [python-gitlab]
-    stretch: [python-gitlab]
-  ubuntu:
-    bionic: [python-gitlab]
 python-gitpython-pip:
   ubuntu:
     pip:
@@ -1790,21 +1196,6 @@ python-glpk-pip: &migrate_eol_2025_04_30_python3_glpk_pip
   ubuntu:
     pip:
       packages: [glpk]
-python-gnupg:
-  alpine:
-    pip:
-      packages: [python-gnupg]
-  arch: [python2-gnupg]
-  debian: [python-gnupg]
-  fedora: [python-gnupg]
-  freebsd: [py27-python-gnupg]
-  gentoo: [dev-python/python-gnupg]
-  nixos: [pythonPackages.python-gnupg]
-  openembedded: ['${PYTHON_PN}-gnupg@meta-ros-common']
-  opensuse: [python2-python-gnupg]
-  rhel:
-    '7': [python2-gnupg]
-  ubuntu: [python-gnupg]
 python-gobject:
   arch: [python2-gobject]
   debian:
@@ -1865,16 +1256,6 @@ python-google-cloud-vision-pip:
   ubuntu:
     pip:
       packages: [google-cloud-vision]
-python-googleapi:
-  debian: [python-googleapi]
-  gentoo: [dev-python/google-api-python-client]
-  ubuntu:
-    bionic: [python-googleapi]
-python-gpiozero:
-  debian:
-    buster: [python-gpiozero]
-  ubuntu:
-    bionic: [python-gpiozero]
 python-gputil-pip:
   debian:
     pip:
@@ -1888,13 +1269,6 @@ python-gputil-pip:
   ubuntu:
     pip:
       packages: [gputil]
-python-gpxpy:
-  debian:
-    buster: [python-gpxpy]
-    stretch: [python-gpxpy]
-  gentoo: [sci-geosciences/gpxpy]
-  ubuntu:
-    bionic: [python-gpxpy]
 python-graphitesend-pip:
   debian:
     pip:
@@ -1915,25 +1289,6 @@ python-graphviz-pip:
 python-gridfs:
   debian: [python-gridfs]
   fedora: [python-pymongo-gridfs]
-python-grpc-tools:
-  debian:
-    '*': [python-grpc-tools]
-    stretch:
-      pip: [grpcio-tools]
-  nixos: [pythonPackages.grpcio-tools]
-  ubuntu:
-    '*': [python-grpc-tools]
-    bionic:
-      pip: [grpcio-tools]
-python-grpcio:
-  debian:
-    '*': [python-grpcio]
-    stretch:
-      pip: [grpcio]
-  ubuntu:
-    '*': [python-grpcio]
-    bionic:
-      pip: [grpcio]
 python-gst:
   arch: [gstreamer0.10-python]
   debian:
@@ -1946,26 +1301,6 @@ python-gst-1.0:
   gentoo: ['dev-python/gst-python:1.0']
   openembedded: [gstreamer1.0-python@openembedded-core]
   ubuntu: [python-gst-1.0]
-python-gtk2:
-  arch: [pygtk]
-  debian:
-    '*': null
-    buster: [python-gtk2]
-  fedora: [pygtk2]
-  freebsd: [py-gtk2]
-  gentoo: [=dev-python/pygtk-2*]
-  macports: [py27-gtk]
-  nixos: [pythonPackages.pygtk]
-  opensuse: [python-gtk]
-  osx:
-    pip:
-      packages: []
-  rhel:
-    '7': [pygtk2]
-    '8': [pygtk2]
-  ubuntu:
-    '*': null
-    bionic: [python-gtk2]
 python-gurobipy-pip: &migrate_eol_2025_04_30_python3_gurobipy_pip
   debian:
     pip:
@@ -1976,39 +1311,6 @@ python-gurobipy-pip: &migrate_eol_2025_04_30_python3_gurobipy_pip
   ubuntu:
     pip:
       packages: [gurobipy]
-python-h5py:
-  debian: [python-h5py]
-  gentoo: [dev-python/h5py]
-  nixos: [pythonPackages.h5py]
-  opensuse: [python2-h5py]
-  ubuntu:
-    '*': [python-h5py]
-python-httplib2:
-  debian: [python-httplib2]
-  fedora: [python-httplib2]
-  gentoo: [dev-python/httplib2]
-  ubuntu:
-    '*': [python-httplib2]
-python-hypothesis:
-  debian: [python-hypothesis]
-  fedora: [python-hypothesis]
-  gentoo: [dev-python/hypothesis]
-  ubuntu:
-    '*': [python-hypothesis]
-python-imageio:
-  debian:
-    buster: [python-imageio]
-    stretch:
-      pip:
-        packages: [imageio]
-  fedora:
-    pip:
-      packages: [imageio]
-  gentoo: [dev-python/imageio]
-  nixos: [pythonPackages.imageio]
-  opensuse: [python2-imageio]
-  ubuntu:
-    bionic: [python-imageio]
 python-imaging:
   alpine: [py-imaging]
   arch: [python2-pillow]
@@ -2040,12 +1342,6 @@ python-impacket:
   fedora: [python-impacket]
   nixos: [pythonPackages.impacket]
   ubuntu: [python-impacket]
-python-influxdb:
-  debian:
-    buster: [python-influxdb]
-  nixos: [pythonPackages.influxdb]
-  ubuntu:
-    bionic: [python-influxdb]
 python-inject-pip: &migrate_eol_2025_04_30_python3_inject_pip
   ubuntu:
     pip:
@@ -2118,36 +1414,10 @@ python-jetson-stats-pip:
   ubuntu:
     pip:
       packages: [jetson-stats]
-python-jinja2:
-  debian: [python-jinja2]
-  fedora: [python-jinja2]
-  gentoo: [dev-python/jinja]
-  nixos: [pythonPackages.jinja2]
-  ubuntu: [python-jinja2]
 python-jira-pip:
   ubuntu:
     pip:
       packages: [jira]
-python-jmespath:
-  debian: [python-jmespath]
-  osx:
-    pip:
-      packages: [jmespath]
-  ubuntu: [python-jmespath]
-python-joblib:
-  arch: [python2-joblib]
-  debian: [python-joblib]
-  fedora: [python-joblib]
-  gentoo: [dev-python/joblib]
-  nixos: [pythonPackages.joblib]
-  opensuse: [python2-joblib]
-  ubuntu: [python-joblib]
-python-jsonpickle:
-  arch: [python-jsonpickle]
-  debian: [python-jsonpickle]
-  fedora: [python-jsonpickle]
-  gentoo: [dev-python/jsonpickle]
-  ubuntu: [python-jsonpickle]
 python-jsonpyes-pip:
   debian:
     pip:
@@ -2159,20 +1429,10 @@ python-jsonref-pip:
   ubuntu:
     pip:
       packages: [jsonref]
-python-jsonschema:
-  debian: [python-jsonschema]
-  fedora: [python-jsonschema]
-  gentoo: [dev-python/jsonschema]
-  ubuntu: [python-jsonschema]
 python-jsonschema-pip:
   ubuntu:
     pip:
       packages: [jsonschema]
-python-jwt:
-  debian: [python-jwt]
-  fedora: [python-jwt]
-  gentoo: [dev-python/python-jwt]
-  ubuntu: [python-jwt]
 python-kdtree:
   debian:
     buster: [python-kdtree]
@@ -2206,16 +1466,6 @@ python-keras-rl-pip:
   ubuntu:
     pip:
       packages: [keras-rl]
-python-kitchen:
-  arch: [python2-kitchen]
-  debian: [python-kitchen]
-  fedora: [python-kitchen]
-  gentoo: [dev-python/kitchen]
-  nixos: [pythonPackages.kitchen]
-  osx:
-    pip:
-      packages: [kitchen]
-  ubuntu: [python-kitchen]
 python-kml:
   debian: [python-kml]
   ubuntu: [python-kml]
@@ -2234,10 +1484,6 @@ python-levenshtein:
   fedora: [python-Levenshtein]
   gentoo: [dev-python/python-levenshtein]
   ubuntu: [python-levenshtein]
-python-libpcap:
-  debian: [python-libpcap]
-  gentoo: [dev-python/pylibpcap]
-  ubuntu: [python-libpcap]
 python-libpgm-pip:
   debian:
     pip:
@@ -2298,24 +1544,6 @@ python-luis-pip:
   ubuntu:
     pip:
       packages: [luis]
-python-lxml:
-  arch: [python2-lxml]
-  debian:
-    buster: [python-lxml]
-  fedora: [python-lxml]
-  freebsd: [py27-lxml]
-  gentoo: [dev-python/lxml]
-  nixos: [pythonPackages.lxml]
-  opensuse: [python2-lxml]
-  osx:
-    pip:
-      packages: [lxml]
-  rhel:
-    '7': [python-lxml]
-    '8': [python2-lxml]
-  ubuntu:
-    bionic: [python-lxml]
-    focal: [python-lxml]
 python-lzf-pip:
   debian:
     pip:
@@ -2327,89 +1555,10 @@ python-mahotas:
   ubuntu:
     pip:
       packages: [mahotas]
-python-mako:
-  debian: [python-mako]
-  fedora: [python-mako]
-  gentoo: [dev-python/mako]
-  ubuntu: [python-mako]
-python-mapnik:
-  debian: [python-mapnik]
-  ubuntu: [python-mapnik]
-python-marisa:
-  debian:
-    '*': null
-    buster: [python-marisa]
-    stretch: [python-marisa]
-  ubuntu:
-    '*': null
-    bionic: [python-marisa]
-python-markdown:
-  debian: [python-markdown]
-  fedora: [python-markdown]
-  gentoo: [dev-python/markdown]
-  ubuntu: [python-markdown]
-python-marshmallow:
-  fedora: [python-marshmallow]
-  ubuntu:
-    pip:
-      packages: [marshmallow]
 python-math3d-pip:
   ubuntu:
     pip:
       packages: [math3d]
-python-matplotlib:
-  arch: [python2-matplotlib]
-  debian: [python-matplotlib]
-  fedora: [python-matplotlib]
-  freebsd: [py27-matplotlib]
-  gentoo: [dev-python/matplotlib]
-  macports: [py27-matplotlib]
-  nixos: [pythonPackages.matplotlib]
-  openembedded: ['${PYTHON_PN}-matplotlib@meta-python']
-  opensuse: [python2-matplotlib]
-  osx:
-    pip:
-      depends: [pkg-config, freetype, libpng12-dev]
-      packages: [matplotlib]
-  rhel:
-    '7': [python-matplotlib]
-  slackware: [matplotlib]
-  ubuntu:
-    bionic: [python-matplotlib]
-python-mechanize:
-  arch: [python2-mechanize]
-  debian: [python-mechanize]
-  fedora: [python-mechanize]
-  gentoo: [dev-python/mechanize]
-  nixos: [pythonPackages.mechanize]
-  ubuntu: [python-mechanize]
-python-mistune:
-  debian:
-    '*': null
-    buster: [python-mistune]
-  opensuse: [python2-mistune]
-  ubuntu:
-    '*': null
-    bionic: [python-mistune]
-python-mock:
-  alpine: [py-mock]
-  arch: [python2-mock]
-  debian: [python-mock]
-  fedora: [python-mock]
-  freebsd: [py27-mock]
-  gentoo: [dev-python/mock]
-  nixos: [pythonPackages.mock]
-  openembedded: ['${PYTHON_PN}-mock@meta-python']
-  opensuse: [python2-mock]
-  osx:
-    pip:
-      packages: [mock]
-  rhel:
-    '7': [python2-mock]
-    '8': [python2-mock]
-  slackware: [mock]
-  ubuntu:
-    bionic: [python-mock]
 python-monotonic:
   arch: [python-monotonic]
   debian: [python-monotonic]
@@ -2417,12 +1566,6 @@ python-monotonic:
   nixos: [pythonPackages.monotonic]
   opensuse: [python2-monotonic]
   ubuntu: [python-monotonic]
-python-more-itertools:
-  arch: [python-more-itertools]
-  debian: [python-more-itertools]
-  fedora: [python-more-itertools]
-  ubuntu:
-    '*': [python-more-itertools]
 python-msgpack:
   arch: [python2-msgpack]
   debian: [python-msgpack]


### PR DESCRIPTION
Part of Python 2 drop. Links to https://github.com/ros/rosdistro/issues/51715