### PR TITLE
rosdep: drop legacy Python 2 keys - Stage 2 (40%)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1566,15 +1566,6 @@ python-monotonic:
   nixos: [pythonPackages.monotonic]
   opensuse: [python2-monotonic]
   ubuntu: [python-monotonic]
-python-msgpack:
-  arch: [python2-msgpack]
-  debian: [python-msgpack]
-  fedora: [python-msgpack]
-  gentoo: [dev-python/msgpack]
-  nixos: [pythonPackages.msgpack]
-  openembedded: ['${PYTHON_PN}-msgpack@meta-python2']
-  opensuse: [python2-msgpack]
-  ubuntu: [python-msgpack]
 python-multicast:
   fedora:
     pip: [py-multicast]
@@ -1593,11 +1584,6 @@ python-multiprocess-pip:
   ubuntu:
     pip:
       packages: [multiprocess]
-python-mysqldb:
-  debian: [python-mysqldb]
-  fedora: [python-mysql]
-  gentoo: [dev-python/mysqlclient]
-  ubuntu: [python-mysqldb]
 python-namedlist-pip:
   debian:
     pip:
@@ -1611,16 +1597,6 @@ python-namedlist-pip:
   ubuntu:
     pip:
       packages: [namedlist]
-python-nclib-pip:
-  arch:
-    pip:
-      packages: [nclib]
-  debian:
-    pip:
-      packages: [nclib]
-  ubuntu:
-    pip:
-      packages: [nclib]
 python-netaddr:
   debian:
     buster: [python-netaddr]
@@ -1634,70 +1610,6 @@ python-netaddr:
       packages: [netaddr]
   ubuntu:
     bionic: [python-netaddr]
-python-netcdf4:
-  arch: [python-netcdf4]
-  debian: [python-netcdf4]
-  fedora: [netcdf4-python]
-  freebsd: [py27-netCDF4]
-  gentoo: [dev-python/netcdf4-python]
-  macports: [py27-netcdf4]
-  nixos: [pythonPackages.netcdf4]
-  ubuntu: [python-netcdf4]
-python-netifaces:
-  alpine: [py-netifaces]
-  arch: [python2-netifaces]
-  debian: [python-netifaces]
-  fedora: [python-netifaces]
-  freebsd: [py27-netifaces]
-  gentoo: [dev-python/netifaces]
-  macports: [p27-netifaces]
-  nixos: [pythonPackages.netifaces]
-  openembedded: ['${PYTHON_PN}-netifaces@meta-ros-common']
-  opensuse: [python2-netifaces]
-  osx:
-    pip:
-      packages: [netifaces]
-  rhel:
-    '7': [python-netifaces]
-  slackware: [netifaces]
-  ubuntu:
-    bionic: [python-netifaces]
-python-networkmanager:
-  debian:
-    buster: [python-networkmanager]
-    stretch: [python-networkmanager]
-  ubuntu: [python-networkmanager]
-python-networkx:
-  arch: [python2-networkx]
-  debian: [python-networkx]
-  fedora: [python-networkx]
-  gentoo: [dev-python/networkx]
-  ubuntu:
-    '*': [python-networkx]
-python-nose:
-  alpine: [py-nose]
-  arch: [python2-nose]
-  debian: [python-nose]
-  fedora: [python-nose]
-  freebsd: [py27-nose]
-  gentoo: [dev-python/nose]
-  macports: [py27-nose]
-  nixos: [pythonPackages.nose]
-  opensuse: [python2-nose]
-  osx:
-    pip:
-      packages: [nose]
-  rhel:
-    '7': [python2-nose]
-    '8': [python2-nose]
-  slackware: [nose]
-  ubuntu:
-    '*': [python-nose]
-python-ntplib:
-  debian: [python-ntplib]
-  fedora: [python-ntplib]
-  gentoo: [dev-python/ntplib]
-  ubuntu: [python-ntplib]
 python-numpy:
   arch: [python2-numpy]
   debian:
@@ -1751,42 +1663,10 @@ python-oauth2:
     wheezy: [python-oauth2]
   fedora: [python-oauth2]
   gentoo: [dev-python/oauth2]
-python-oauth2client:
-  debian: [python-oauth2client]
-  fedora: [python-oauth2client]
-  gentoo: [dev-python/oauth2client]
-  ubuntu: [python-oauth2client]
 python-objectpath-pip:
   ubuntu:
     pip:
       packages: [objectpath]
-python-omniorb:
-  fedora: [python-omniORB, omniORB-devel]
-  gentoo: ['net-misc/omniORB[python]']
-  ubuntu:
-    focal: [python-omniorb, python-omniorb-omg, omniidl-python]
-python-open3d-pip:
-  debian:
-    pip:
-      packages: [open3d-python]
-  fedora:
-    pip:
-      packages: [open3d-python]
-  ubuntu:
-    pip:
-      packages: [open3d-python]
-python-opencv:
-  arch: [opencv, python2-numpy]
-  debian: [python-opencv]
-  freebsd: [py27-opencv]
-  gentoo: ['media-libs/opencv[python]']
-  nixos: [pythonPackages.opencv4]
-  openembedded: [opencv@meta-oe]
-  opensuse: [python2-opencv]
-  rhel:
-    '7': [opencv-python]
-  slackware: [opencv]
-  ubuntu: [python-opencv]
 python-opencv-contrib-pip:
   debian:
     pip:
@@ -1797,26 +1677,6 @@ python-opencv-contrib-pip:
   ubuntu:
     pip:
       packages: [opencv-contrib-python]
-python-opengl:
-  arch: [python2-opengl]
-  debian: [python-opengl]
-  freebsd: [py27-PyOpenGL]
-  gentoo: [dev-python/pyopengl]
-  macports: [py27-opengl]
-  nixos: [pythonPackages.pyopengl]
-  opensuse: [python2-opengl]
-  osx:
-    pip:
-      packages: [PyOpenGL]
-  rhel:
-    '7': [PyOpenGL]
-  slackware: [PyOpenGL]
-  ubuntu:
-    bionic: [python-opengl]
-python-openssl:
-  debian: [python-openssl]
-  gentoo: [dev-python/pyopenssl]
-  ubuntu: [python-openssl]
 python-oyaml-pip:
   debian:
     pip:
@@ -1824,16 +1684,6 @@ python-oyaml-pip:
   ubuntu:
     pip:
       packages: [oyaml]
-python-packaging:
-  debian: [python-packaging]
-  fedora: [python-packaging]
-  nixos: [pythonPackages.packaging]
-  ubuntu: [python-packaging]
-python-paho-mqtt:
-  debian:
-    buster: [python-paho-mqtt]
-  ubuntu:
-    bionic: [python-paho-mqtt]
 python-paho-mqtt-pip:
   ubuntu:
     pip:
@@ -1845,46 +1695,6 @@ python-pandacan-pip:
   ubuntu:
     pip:
       packages: [pandacan]
-python-pandas:
-  arch: [python2-pandas]
-  debian: [python-pandas]
-  fedora: [python-pandas]
-  gentoo: [dev-python/pandas]
-  nixos: [pythonPackages.pandas]
-  ubuntu: [python-pandas]
-python-parameterized:
-  debian:
-    '*': [python-parameterized]
-    stretch:
-      pip:
-        packages: [parameterized]
-  fedora: [python-parameterized]
-  osx:
-    pip:
-      packages: [parameterized]
-  ubuntu:
-    bionic: [python-parameterized]
-python-paramiko:
-  alpine: [py-paramiko]
-  arch: [python2-paramiko]
-  debian: [python-paramiko]
-  fedora: [python-paramiko]
-  freebsd: [py27-paramiko]
-  gentoo: [dev-python/paramiko]
-  macports: [py27-paramiko]
-  nixos: [pythonPackages.paramiko]
-  openembedded: ['${PYTHON_PN}-paramiko@meta-ros-common']
-  opensuse: [python2-paramiko]
-  osx:
-    pip:
-      packages: [paramiko]
-  rhel:
-    '7': [python-paramiko]
-  slackware: [paramiko]
-  ubuntu: [python-paramiko]
-python-parse:
-  debian: [python-parse]
-  ubuntu: [python-parse]
 python-parso:
   debian:
     buster: [python-parso]
@@ -1946,25 +1756,6 @@ python-pcapy:
   debian: [python-pcapy]
   gentoo: [dev-python/pcapy]
   ubuntu: [python-pcapy]
-python-pcg-gazebo-pip:
-  debian:
-    pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
-      packages: [pcg-gazebo]
-  ubuntu:
-    pip:
-      depends: [libspatialindex-dev, geos, pybind11-dev]
-      packages: [pcg-gazebo]
-python-pep8:
-  arch: [python2-pep8]
-  debian: [pep8]
-  gentoo: [dev-python/pep8]
-  nixos: [pythonPackages.pep8]
-  osx:
-    pip:
-      packages: [pep8]
-  ubuntu:
-    '*': [python-pep8]
 python-percol:
   debian:
     pip:
@@ -2005,11 +1796,6 @@ python-persist-queue-pip:
   ubuntu:
     pip:
       packages: [persist-queue]
-python-pexpect:
-  arch: [python2-pexpect]
-  debian: [python-pexpect]
-  gentoo: [dev-python/pexpect]
-  ubuntu: [python-pexpect]
 python-photutils-pip: &migrate_eol_2025_04_30_python3_photutils_pip
   debian:
     pip:
@@ -2039,10 +1825,6 @@ python-pixel-ring-pip:
   ubuntu:
     pip:
       packages: [pixel-ring]
-python-pkg-resources:
-  debian: [python-pkg-resources]
-  nixos: [pythonPackages.setuptools]
-  ubuntu: [python-pkg-resources]
 python-planar-pip:
   ubuntu:
     pip:
@@ -2067,33 +1849,6 @@ python-plyfile-pip:
 python-poster:
   debian: [python-poster]
   ubuntu: [python-poster]
-python-pqdict-pip:
-  debian:
-    pip:
-      packages: [pqdict]
-  fedora:
-    pip:
-      packages: [pqdict]
-  osx:
-    pip:
-      packages: [pqdict]
-  ubuntu:
-    pip:
-      packages: [pqdict]
-python-prettytable:
-  debian: [python-prettytable]
-  fedora: [python-prettytable]
-  gentoo: [dev-python/prettytable]
-  ubuntu: [python-prettytable]
-python-progressbar:
-  debian: [python-progressbar]
-  gentoo: [dev-python/progressbar]
-  nixos: [pythonPackages.progressbar]
-  osx:
-    pip:
-      packages: [progressbar]
-  ubuntu:
-    bionic: [python-progressbar]
 python-progressbar2-pip:
   debian:
     pip:
@@ -2104,32 +1859,6 @@ python-progressbar2-pip:
   ubuntu:
     pip:
       packages: [progressbar2]
-python-protobuf:
-  debian: [python-protobuf]
-  gentoo: [dev-python/protobuf-python]
-  ubuntu: [python-protobuf]
-python-psutil:
-  arch: [python2-psutil]
-  debian: [python-psutil]
-  fedora: [python-psutil]
-  freebsd: [py27-psutil]
-  gentoo: [dev-python/psutil]
-  macports: [py27-psutil]
-  nixos: [pythonPackages.psutil]
-  opensuse: [python2-psutil]
-  osx:
-    pip:
-      packages: [psutil]
-  rhel:
-    '7': [python2-psutil]
-    '8': [python2-psutil]
-  slackware: [psutil]
-  ubuntu:
-    '*': [python-psutil]
-python-psycopg2:
-  debian: [python-psycopg2]
-  fedora: [python-psycopg2]
-  gentoo: [=dev-python/psycopg-2*]
 python-pulsectl-pip:
   debian:
     pip:
@@ -2140,38 +1869,6 @@ python-pulsectl-pip:
   ubuntu:
     pip:
       packages: [pulsectl]
-python-pyassimp:
-  arch: [python2-pyassimp]
-  debian: [python-pyassimp]
-  gentoo: [media-libs/assimp]
-  openembedded: [python-pyassimp@meta-ros-python2]
-  osx:
-    lion:
-      homebrew:
-        packages: [pyassimp]
-  ubuntu:
-    bionic: [python-pyassimp]
-python-pyaudio:
-  debian: [python-pyaudio]
-  gentoo: [dev-python/pyaudio]
-  nixos: [pythonPackages.pyaudio]
-  openembedded: ['${PYTHON_PN}-pyalsaaudio@meta-python']
-  ubuntu: [python-pyaudio]
-python-pycodestyle:
-  arch: [python2-pycodestyle]
-  debian:
-    '*': null
-    buster: [python-pycodestyle]
-    stretch: [python-pycodestyle]
-  fedora: [python-pycodestyle]
-  gentoo: [dev-python/pycodestyle]
-  nixos: [pythonPackages.pycodestyle]
-  rhel:
-    '7': [python2-pycodestyle]
-    '8': [python2-pycodestyle]
-  ubuntu:
-    '*': null
-    bionic: [python-pycodestyle]
 python-pycpd-pip:
   debian:
     pip:
@@ -2182,57 +1879,12 @@ python-pycpd-pip:
   ubuntu:
     pip:
       packages: [pycpd]
-python-pycryptodome:
-  arch: [python2-pycryptodome]
-  debian: [python-pycryptodome]
-  fedora: [python-pycryptodomex]
-  gentoo: [dev-python/pycryptodome]
-  nixos: [pythonPackages.pycryptodomex]
-  openembedded: ['${PYTHON_PN}-pycryptodomex@openembedded-core']
-  opensuse: [python2-pycryptodomex]
-  osx:
-    pip:
-      packages: [pycryptodome]
-  rhel:
-    '7': [python2-pycryptodomex]
-    '8': [python2-pycryptodomex]
-  ubuntu: [python-pycryptodome]
 python-pycurl:
   debian: [python-pycurl]
   ubuntu: [python-pycurl]
-python-pydbus:
-  ubuntu:
-    bionic: [python-pydbus]
-python-pydot:
-  arch: [python2-pydot]
-  debian: [python-pydot]
-  fedora: [pydot]
-  freebsd: [py27-pydot]
-  gentoo: [dev-python/pydot]
-  macports: [py27-pydot]
-  nixos: [pythonPackages.pydot]
-  opensuse: [python2-pydot]
-  osx:
-    pip:
-      packages: [pydot]
-  rhel:
-    '7': [python2-pydot]
-  slackware: [pydot]
-  ubuntu: [python-pydot]
 python-pyexiv2:
   debian: [python-pyexiv2]
   ubuntu: [python-pyexiv2]
-python-pyftpdlib:
-  debian: [python-pyftpdlib]
-  gentoo: [dev-python/pyftpdlib]
-  ubuntu: [python-pyftpdlib]
-python-pygame:
-  arch: [python2-pygame]
-  debian: [python-pygame]
-  fedora: [pygame-devel]
-  gentoo: [dev-python/pygame]
-  nixos: [pythonPackages.pygame]
-  ubuntu: [python-pygame]
 python-pygithub3:
   debian:
     pip:
@@ -2259,25 +1911,6 @@ python-pygps-pip:
 python-pygraph:
   debian: [python-pygraph]
   ubuntu: [python-pygraph]
-python-pygraphviz:
-  arch: [python2-pygraphviz]
-  debian: [python-pygraphviz]
-  freebsd: [py27-pygraphviz]
-  gentoo: [dev-python/pygraphviz]
-  nixos: [pythonPackages.pygraphviz]
-  opensuse: [python2-pygraphviz]
-  osx:
-    pip:
-      packages: [pygraphviz]
-  rhel:
-    '7': [python2-pygraphviz]
-  slackware: [pygraphviz]
-  ubuntu: [python-pygraphviz]
-python-pyinotify:
-  debian: [python-pyinotify]
-  fedora: [python-inotify]
-  gentoo: [dev-python/pyinotify]
-  ubuntu: [python-pyinotify]
 python-pykalman:
   debian:
     pip:
@@ -2325,10 +1958,6 @@ python-pymavlink:
   ubuntu:
     pip:
       packages: [pymavlink]
-python-pymodbus:
-  debian: [python-pymodbus]
-  ubuntu:
-    bionic: [python-pymodbus]
 python-pymodbus-pip: &migrate_eol_2027_04_30_python3_pymodbus_pip
   debian:
     pip:
@@ -2336,19 +1965,6 @@ python-pymodbus-pip: &migrate_eol_2027_04_30_python3_pymodbus_pip
   ubuntu:
     pip:
       packages: [pymodbus]
-python-pymongo:
-  arch: [python2-pymongo]
-  debian: [python-pymongo]
-  fedora: [python-pymongo]
-  gentoo: [dev-python/pymongo]
-  nixos: [pythonPackages.pymongo]
-  openembedded: ['${PYTHON_PN}-pymongo@meta-python']
-  opensuse: [python2-pymongo]
-  osx:
-    pip:
-      packages: [pymongo]
-  ubuntu:
-    '*': [python-pymongo]
 python-pymouse:
   debian:
     pip:
@@ -2365,60 +1981,14 @@ python-pymouse:
 python-pynfft:
   debian: [python-pynfft]
   ubuntu: [python-pynfft]
-python-pynmea2:
-  ubuntu:
-    pip:
-      packages: [pynmea2]
 python-pypcd-pip:
   ubuntu:
     pip:
       packages: [pypcd]
-python-pypng:
-  arch:
-    pip:
-      packages: [pypng]
-  debian:
-    buster: [python-png]
-    stretch:
-      pip:
-        packages: [pypng]
-  fedora: [python-pypng]
-  gentoo: [dev-python/pypng]
-  ubuntu:
-    bionic: [python-png]
 python-pypozyx-pip:
   ubuntu:
     pip:
       packages: [pypozyx]
-python-pyproj:
-  arch: [python2-pyproj]
-  debian: [python-pyproj]
-  gentoo: [dev-python/pyproj]
-  nixos: [pythonPackages.pyproj]
-  osx:
-    pip:
-      packages: [pyproj]
-  rhel:
-    '7': [pyproj]
-  ubuntu: [python-pyproj]
-python-pyqrcode:
-  arch: [python2-qrcode]
-  debian:
-    buster: [python-pyqrcode]
-    stretch:
-      pip:
-        packages: [PyQRCode]
-  gentoo: [dev-python/pyqrcode]
-  ubuntu:
-    bionic: [python-pyqrcode]
-python-pyqtgraph:
-  debian: [python-pyqtgraph]
-  fedora:
-    pip:
-      packages: [pyqtgraph]
-  nixos: [pythonPackages.pyqtgraph]
-  ubuntu:
-    bionic: [python-pyqtgraph]
 python-pyquery:
   debian: [python-pyquery]
   fedora: [python-pyquery]
@@ -2459,10 +2029,6 @@ python-pysimplegui27-pip:
   ubuntu:
     pip:
       packages: [pysimplegui27]
-python-pysnmp:
-  debian: [python-pysnmp4]
-  gentoo: [dev-python/pysnmp]
-  ubuntu: [python-pysnmp4]
 python-pytesseract-pip:
   debian:
     pip:
@@ -2476,22 +2042,6 @@ python-pytesseract-pip:
   ubuntu:
     pip:
       packages: [pytesseract]
-python-pytest:
-  arch: [python2-pytest]
-  debian: [python-pytest]
-  fedora: [python-pytest]
-  gentoo: [dev-python/pytest]
-  nixos: [pythonPackages.pytest]
-  openembedded: ['${PYTHON_PN}-pytest@openembedded-core']
-  ubuntu: [python-pytest]
-python-pytest-cov:
-  arch: [python2-pytest-cov]
-  debian: [python-pytest-cov]
-  fedora: [python-pytest-cov]
-  gentoo: [dev-python/pytest-cov]
-  nixos: [pythonPackages.pytestcov]
-  openembedded: ['${PYTHON_PN}-pytest-cov@meta-ros-common']
-  ubuntu: [python-pytest-cov]
 python-pytest-dependency-pip:
   debian:
     pip:
@@ -2502,12 +2052,6 @@ python-pytest-dependency-pip:
   ubuntu:
     pip:
       packages: [pytest-dependency]
-python-pytest-mock:
-  arch: [python2-pytest-mock]
-  debian: [python-pytest-mock]
-  fedora: [python-pytest-mock]
-  gentoo: [dev-python/pytest-mock]
-  ubuntu: [python-pytest-mock]
 python-pytest-qt-pip:
   debian:
     pip:
@@ -2539,13 +2083,6 @@ python-pytz-pip:
   ubuntu:
     pip:
       packages: [pytz]
-python-pyudev:
-  debian: [python-pyudev]
-  fedora: [python-pyudev]
-  gentoo: [dev-python/pyudev]
-  nixos: [pythonPackages.pyudev]
-  ubuntu:
-    '*': [python-pyudev]
 python-pyusb-pip:
   debian:
     pip: [pyusb]
@@ -2585,24 +2122,6 @@ python-pyzbar-pip:
   ubuntu:
     pip:
       packages: [pyzbar]
-python-qrencode:
-  debian: [python-qrencode]
-  gentoo: [media-gfx/qrencode-python]
-  ubuntu: [python-qrencode]
-python-qt-bindings:
-  arch: [python2-pyqt4]
-  debian:
-    buster: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-    squeeze: [python-qt4, python-qt4-dev, python-sip-dev]
-    stretch: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-    wheezy: [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
-  gentoo: [dev-python/pyside, dev-python/PyQt4]
-  macports: [p27-pyqt4]
-  opensuse: [python-qt4-devel]
-  rhel:
-    '7': [PyQt4, PyQt4-devel, sip-devel]
-  ubuntu:
-    '*': [python-pyside, libpyside-dev, libshiboken-dev, shiboken, python-qt4, python-qt4-dev, python-sip-dev]
 python-qt-bindings-gl:
   arch: [python2-pyqt4]
   debian: [python-qt4-gl]
@@ -2623,94 +2142,25 @@ python-qt4-gl:
   debian: [python-qt4-gl]
   gentoo: ['dev-python/pyside[opengl]', 'dev-python/PyQt4[opengl]']
   ubuntu: [python-qt4-gl]
-python-qt5-bindings:
-  arch: [python2-pyqt5]
-  debian:
-    buster: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
-    stretch: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev, qtbase5-dev]
-  fedora: [python-qt5-devel, sip]
-  freebsd: [py27-qt5]
-  gentoo: ['dev-python/PyQt5[gui,widgets]']
-  nixos: [pythonPackages.pyqt5]
-  opensuse: [python2-qt5-devel, python2-sip-devel]
-  slackware: [PyQt5]
-  ubuntu:
-    bionic: [pyqt5-dev, python-pyqt5, python-pyqt5.qtsvg, python-sip-dev]
-python-qt5-bindings-gl:
-  arch: [python2-pyqt5]
-  debian:
-    buster: [python-pyqt5.qtopengl]
-    stretch: [python-pyqt5.qtopengl]
-  fedora: [python-qt5]
-  freebsd: [py27-qt5-opengl]
-  gentoo: ['dev-python/PyQt5[opengl]']
-  nixos: [pythonPackages.pyqt5]
-  opensuse: [python2-qt5]
-  slackware: [PyQt5]
-  ubuntu:
-    bionic: [python-pyqt5.qtopengl]
 python-qt5-bindings-qsci:
   debian: [python-pyqt5.qsci]
   ubuntu: [python-pyqt5.qsci]
 python-qt5-bindings-quick:
   debian: [python-pyqt5.qtquick]
   ubuntu: [python-pyqt5.qtquick]
-python-qt5-bindings-webkit:
-  arch: [python2-pyqt5]
-  debian:
-    buster: [python-pyqt5.qtwebkit]
-    stretch: [python-pyqt5.qtwebkit]
-  fedora: [python-qt5]
-  freebsd: [py27-qt5-webkit]
-  gentoo: ['dev-python/PyQt5[webkit]']
-  nixos: [pythonPackages.pyqt5_with_qtwebkit]
-  opensuse: [python2-qt5]
-  ubuntu:
-    bionic: [python-pyqt5.qtwebkit]
-python-qtpy:
-  arch: [python-qtpy]
-  debian: [python-qtpy]
-  fedora: [python-QtPy]
-  ubuntu: [python-qtpy]
 python-qwt5-qt4:
   arch: [pyqwt]
   debian: [python-qwt5-qt4]
   gentoo: ['dev-python/pyqwt:5']
   ubuntu: [python-qwt5-qt4]
-python-rdflib:
-  debian: [python-rdflib]
-  fedora: [python-rdflib]
-  gentoo: [dev-python/rdflib]
-  ubuntu: [python-rdflib]
 python-readchar-pip:
   ubuntu:
     pip:
       packages: [readchar]
-python-redis:
-  debian: [python-redis]
-  fedora: [python-redis]
-  gentoo: [dev-python/redis-py]
-  ubuntu: [python-redis]
 python-redis-pip:
   ubuntu:
     pip:
       packages: [redis]
-python-requests:
-  debian: [python-requests]
-  fedora: [python-requests]
-  gentoo: [dev-python/requests]
-  nixos: [pythonPackages.requests]
-  openembedded: ['${PYTHON_PN}-requests@openembedded-core']
-  osx:
-    pip:
-      packages: [requests]
-  ubuntu:
-    '*': [python-requests]
-python-requests-oauthlib:
-  debian: [python-requests-oauthlib]
-  fedora: [python-requests-oauthlib]
-  gentoo: [dev-python/requests-oauthlib]
-  ubuntu: [python-requests-oauthlib]
 python-responses-pip:
   osx:
     pip:
@@ -2718,53 +2168,6 @@ python-responses-pip:
   ubuntu:
     pip:
       packages: [responses]
-python-rosdep:
-  alpine:
-    pip:
-      packages: [rosdep]
-  arch: [python2-rosdep]
-  debian: [python-rosdep]
-  fedora: [python-rosdep]
-  freebsd:
-    pip:
-      packages: [rosdep]
-  gentoo: [dev-util/rosdep]
-  nixos: [pythonPackages.rosdep]
-  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
-  opensuse: [python-rosdep]
-  osx:
-    pip:
-      packages: [rosdep]
-  rhel:
-    '7': [python2-rosdep]
-  slackware:
-    pip:
-      packages: [rosdep]
-  ubuntu:
-    bionic: [python-rosdep]
-python-rosdep-modules:
-  alpine:
-    pip:
-      packages: [rosdep]
-  arch: [python2-rosdep]
-  debian: [python-rosdep-modules]
-  fedora: [python-rosdep]
-  freebsd:
-    pip:
-      packages: [rosdep]
-  gentoo: [dev-util/rosdep]
-  nixos: [pythonPackages.rosdep]
-  openembedded: ['${PYTHON_PN}-rosdep@meta-ros-common']
-  opensuse: [python-rosdep]
-  osx:
-    pip:
-      packages: [rosdep]
-  rhel:
-    '7': [python-rosdep]
-  slackware:
-    pip:
-      packages: [rosdep]
-  ubuntu: [python-rosdep-modules]
 python-rosdistro:
   debian: [python-rosdistro]
   fedora: [python-rosdistro]
@@ -2785,65 +2188,6 @@ python-rosinstall:
     '7': [python-rosinstall]
   ubuntu:
     '*': [python-rosinstall]
-python-rosinstall-generator:
-  arch: [python2-rosinstall-generator]
-  debian:
-    buster: [python-rosinstall-generator]
-    stretch: [python-rosinstall-generator]
-  fedora: [python-rosinstall_generator]
-  gentoo: [dev-python/rosinstall_generator]
-  macports: [py27-rosinstall-generator]
-  rhel:
-    '7': [python2-rosinstall_generator]
-  ubuntu: [python-rosinstall-generator]
-python-rospkg:
-  alpine:
-    pip:
-      packages: [rospkg]
-  arch: [python2-rospkg]
-  debian: [python-rospkg]
-  fedora: [python-rospkg]
-  freebsd:
-    pip:
-      packages: [rospkg]
-  gentoo: [dev-python/rospkg]
-  macports: [py27-rospkg]
-  nixos: [pythonPackages.rospkg]
-  openembedded: ['${PYTHON_PN}-rospkg@meta-ros-common']
-  opensuse: [python-rospkg]
-  osx:
-    pip:
-      packages: [rospkg]
-  rhel:
-    '7': [python2-rospkg]
-  slackware:
-    pip:
-      packages: [rospkg]
-  ubuntu:
-    '*': [python-rospkg]
-python-rospkg-modules:
-  alpine:
-    pip:
-      packages: [rospkg]
-  arch: [python2-rospkg]
-  debian: [python-rospkg-modules]
-  fedora: [python-rospkg]
-  freebsd:
-    pip:
-      packages: [rospkg]
-  gentoo: [dev-python/rospkg]
-  macports: [py27-rospkg]
-  nixos: [pythonPackages.rospkg]
-  opensuse: [python-rospkg]
-  osx:
-    pip:
-      packages: [rospkg]
-  rhel:
-    '7': [python2-rospkg]
-  slackware:
-    pip:
-      packages: [rospkg]
-  ubuntu: [python-rospkg-modules]
 python-rpi.gpio:
   debian:
     buster: [python-rpi.gpio]
@@ -2865,17 +2209,6 @@ python-rpi.gpio-pip:
 python-rrdtool:
   debian: [python-rrdtool]
   gentoo: [net-analyzer/rrdtool]
-python-rtree:
-  debian: [python-rtree]
-  ubuntu: [python-rtree]
-python-ruamel.yaml:
-  debian:
-    buster: [python-ruamel.yaml]
-    stretch: [python-ruamel.yaml]
-  fedora: [python-ruamel-yaml]
-  nixos: [pythonPackages.ruamel_yaml]
-  ubuntu:
-    bionic: [python-ruamel.yaml]
 python-rx-pip:
   debian:
     pip:
@@ -2893,15 +2226,6 @@ python-sbp-pip: &migrate_eol_2027_04_30_python3_sbp_pip
   ubuntu:
     pip:
       packages: [sbp]
-python-scapy:
-  debian: [python-scapy]
-  fedora: [scapy]
-  gentoo: [dev-python/scapy-python3]
-  ubuntu: [python-scapy]
-python-schedule:
-  debian: [python-schedule]
-  nixos: [pythonPackages.schedule]
-  ubuntu: [python-schedule]
 python-scipy:
   arch: [python2-scipy]
   debian: [python-scipy]
@@ -2916,19 +2240,6 @@ python-scipy:
       packages: [scipy]
   ubuntu:
     '*': [python-scipy]
-python-scp:
-  debian: [python-scp]
-  fedora: [python-scp]
-  ubuntu: [python-scp]
-python-seaborn:
-  arch: [python-seaborn]
-  debian: [python-seaborn]
-  fedora:
-    pip:
-      packages: [seaborn]
-  gentoo: [dev-python/seaborn]
-  ubuntu:
-    bionic: [python-seaborn]
 python-selectors2-pip:
   arch:
     pip:
@@ -2956,101 +2267,11 @@ python-selenium-pip:
   ubuntu:
     pip:
       packages: [selenium]
-python-semantic-version:
-  debian: [python-semantic-version]
-  nixos: [pythonPackages.semantic-version]
-  ubuntu:
-    bionic: [python-semantic-version]
-python-semver:
-  debian: [python-semver]
-  fedora: [python-semver]
-  ubuntu: [python-semver]
-python-serial:
-  arch: [python2-pyserial]
-  debian: [python-serial]
-  gentoo: [dev-python/pyserial]
-  nixos: [pythonPackages.pyserial]
-  openembedded: ['${PYTHON_PN}-pyserial@meta-python']
-  opensuse: [python2-pyserial]
-  ubuntu:
-    bionic: [python-serial]
-python-setproctitle:
-  debian: [python-setproctitle]
-  ubuntu: [python-setproctitle]
-python-setuptools:
-  arch: [python2-distribute]
-  debian: [python-setuptools]
-  fedora: [python-setuptools]
-  gentoo: [dev-python/setuptools]
-  macports: [py27-setuptools]
-  nixos: [pythonPackages.setuptools]
-  openembedded: ['${PYTHON_PN}-setuptools@openembedded-core']
-  opensuse: [python2-setuptools]
-  osx:
-    pip:
-      packages: [setuptools]
-  rhel:
-    '7': [python2-setuptools]
-    '8': [python2-setuptools]
-  ubuntu:
-    bionic: [python-setuptools]
-python-sexpdata:
-  debian:
-    '*': [python-sexpdata]
-    stretch:
-      pip:
-        packages: [sexpdata]
-  ubuntu:
-    '*': [python-sexpdata]
-    bionic:
-      pip:
-        packages: [sexpdata]
-python-sh:
-  debian:
-    buster: [python-sh]
-    stretch: [python-sh]
-  fedora: [python-sh]
-  gentoo: [dev-python/sh]
-  ubuntu:
-    bionic: [python-sh]
-python-shapely:
-  debian: [python-shapely]
-  fedora: [python-shapely]
-  gentoo: [sci-libs/Shapely]
-  osx:
-    pip:
-      packages: [shapely]
-  ubuntu:
-    '*': [python-shapely]
-python-simplejson:
-  arch: [python2-simplejson]
-  debian: [python-simplejson]
-  fedora: [python-simplejson]
-  gentoo: [dev-python/simplejson]
-  nixos: [pythonPackages.simplejson]
-  openembedded: ['${PYTHON_PN}-simplejson@meta-python']
-  ubuntu: [python-simplejson]
 python-singledispatch:
   debian: [python-singledispatch]
   fedora: [python-singledispatch]
   gentoo: [virtual/python-singledispatch]
   ubuntu: [python-singledispatch]
-python-sip:
-  arch: [sip, python2-sip]
-  debian: [python-sip-dev]
-  freebsd: [py27-sip]
-  gentoo: [dev-python/sip]
-  macports: [py27-sip]
-  nixos: [pythonPackages.sip_4]
-  openembedded: [sip@meta-oe]
-  opensuse: [python2-sip-devel]
-  rhel:
-    '7': [sip-devel]
-  slackware:
-    slackpkg:
-      packages: [sip]
-  ubuntu:
-    '*': [python-sip-dev]
 python-sip4:
   debian: [python-sip-dev]
   fedora: [sip]
@@ -3064,18 +2285,6 @@ python-six:
   nixos: [pythonPackages.six]
   openembedded: ['${PYTHON_PN}-six@openembedded-core']
   ubuntu: [python-six]
-python-skimage:
-  debian:
-    buster: [python-skimage]
-    stretch: [python-skimage]
-  fedora: [python-scikit-image]
-  gentoo: [sci-libs/scikits_image]
-  nixos: [pythonPackages.scikitimage]
-  osx:
-    pip:
-      packages: [scikit-image]
-  ubuntu:
-    bionic: [python-skimage]
 python-skimage-pip:
   osx:
     pip:
@@ -3083,17 +2292,6 @@ python-skimage-pip:
   ubuntu:
     pip:
       packages: [scikit-image]
-python-sklearn:
-  debian: [python-sklearn]
-  fedora: [python-scikit-learn]
-  gentoo: [sci-libs/scikits_learn]
-  nixos: [pythonPackages.scikitlearn]
-  opensuse: [python2-scikit-learn]
-  osx:
-    pip:
-      packages: [scikit-learn]
-  ubuntu:
-    '*': [python-sklearn]
 python-slackclient-pip:
   debian:
     pip:
@@ -3127,9 +2325,6 @@ python-slycot-pip:
   ubuntu:
     pip:
       packages: [slycot]
-python-smbus:
-  debian: [python-smbus]
-  ubuntu: [python-smbus]
 python-sortedcontainers-pip:
   ubuntu:
     pip:
@@ -3151,35 +2346,6 @@ python-speechrecognition-pip:
   ubuntu:
     pip:
       packages: [speechrecognition]
-python-sphinx:
-  arch: [python2-sphinx]
-  debian: [python-sphinx]
-  fedora: [python-sphinx]
-  freebsd: [py27-sphinx]
-  gentoo: [dev-python/sphinx]
-  macports: [py27-sphinx]
-  nixos: [pythonPackages.sphinx]
-  opensuse: [python-Sphinx]
-  osx:
-    pip:
-      packages: [Sphinx]
-  rhel:
-    '7': [python-sphinx]
-  ubuntu:
-    '*': [python-sphinx]
-python-sphinx-argparse:
-  debian:
-    buster: [python-sphinx-argparse]
-    stretch: [python-sphinx-argparse]
-  ubuntu:
-    bionic: [python-sphinx-argparse]
-python-sphinx-rtd-theme:
-  debian:
-    buster: [python-sphinx-rtd-theme]
-    stretch: [python-sphinx-rtd-theme]
-  opensuse: [python2-sphinx_rtd_theme]
-  ubuntu:
-    bionic: [python-sphinx-rtd-theme]
 python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
   debian:
     '*':
@@ -3192,12 +2358,6 @@ python-spidev-pip: &migrate_eol_2025_04_30_python3_spidev_pip
         packages: [spidev]
     jammy: [python3-spidev]
     noble: [python3-spidev]
-python-sqlalchemy:
-  debian: [python-sqlalchemy]
-  fedora: [python-sqlalchemy]
-  gentoo: [dev-python/sqlalchemy]
-  ubuntu:
-    bionic: [python-sqlalchemy]
 python-sqlite:
   debian: [python-sqlite]
   ubuntu: [python-sqlite]
@@ -3225,33 +2385,10 @@ python-support:
     pip:
       packages: []
   ubuntu: [python-support]
-python-svg.path:
-  debian:
-    buster: [python-svg.path]
-    stretch: [python-svg.path]
-  fedora: [python-svg-path]
-  ubuntu:
-    bionic: [python-svg.path]
 python-svn:
   debian: [python-svn]
   gentoo: [dev-python/pysvn]
   ubuntu: [python-svn]
-python-sympy:
-  debian: [python-sympy]
-  gentoo: [dev-python/sympy]
-  nixos: [pythonPackages.sympy]
-  ubuntu:
-    bionic: [python-sympy]
-python-systemd:
-  debian:
-    buster: [python-systemd]
-    stretch: [python-systemd]
-  nixos: [pythonPackages.systemd]
-  ubuntu:
-    bionic: [python-systemd]
-python-sysv-ipc:
-  debian: [python-sysv-ipc]
-  ubuntu: [python-sysv-ipc]
 python-tablib:
   debian: [python-tablib]
   fedora: [python-tablib]
@@ -3266,14 +2403,6 @@ python-tablib-pip:
   ubuntu:
     pip:
       packages: [tablib]
-python-tabulate:
-  debian:
-    buster: [python-tabulate]
-    stretch: [python-tabulate]
-  gentoo: [dev-python/tabulate]
-  nixos: [pythonPackages.tabulate]
-  ubuntu:
-    bionic: [python-tabulate]
 python-tabulate-pip:
   debian:
     pip:
@@ -3296,32 +2425,6 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
-python-tensorboard-pip:
-  debian:
-    pip:
-      packages: [tensorboard]
-  fedora:
-    pip:
-      packages: [tensorboard]
-  osx:
-    pip:
-      packages: [tensorboard]
-  ubuntu:
-    pip:
-      packages: [tensorboard]
-python-tensorboardX-pip:
-  debian:
-    pip:
-      packages: [tensorboardX]
-  fedora:
-    pip:
-      packages: [tensorboardX]
-  osx:
-    pip:
-      packages: [tensorboardX]
-  ubuntu:
-    pip:
-      packages: [tensorboardX]
 python-tensorflow-gpu-pip:
   debian:
     pip:
@@ -3374,22 +2477,6 @@ python-tensorflow-serving-api-pip:
   ubuntu:
     pip:
       packages: [tensorflow-serving-api]
-python-termcolor:
-  debian:
-    buster: [python-termcolor]
-    stretch: [python-termcolor]
-    wheezy:
-      pip:
-        packages: [termcolor]
-  fedora: [python-termcolor]
-  gentoo: [dev-python/termcolor]
-  nixos: [pythonPackages.termcolor]
-  openembedded: [python3-termcolor@meta-python]
-  osx:
-    pip:
-      packages: [termcolor]
-  ubuntu:
-    '*': [python-termcolor]
 python-testscenarios:
   debian: [python-testscenarios]
   fedora: [python-testscenarios]
@@ -3400,19 +2487,6 @@ python-testtools:
   fedora: [python-testtools]
   gentoo: [dev-python/testtools]
   ubuntu: [python-testtools]
-python-texttable:
-  arch: [python2-texttable]
-  debian:
-    buster: [python-texttable]
-    stretch: [python-texttable]
-  fedora: [python-texttable]
-  gentoo: [dev-python/texttable]
-  nixos: [pythonPackages.texttable]
-  osx:
-    pip:
-      packages: [texttable]
-  ubuntu:
-    bionic: [python-texttable]
 python-tftpy:
   debian: [python-tftpy]
   fedora: [python-tftpy]
@@ -3427,23 +2501,6 @@ python-theano:
   osx:
     pip:
       packages: [Theano]
-python-tilestache:
-  debian: [tilestache]
-  fedora: [python-tilestache]
-  nixos: [pythonPackages.tilestache]
-  ubuntu: [tilestache]
-python-tk:
-  arch: [python2, tk]
-  debian: [python-tk]
-  fedora: [python2-tkinter]
-  nixos: [pythonPackages.tkinter]
-  openembedded: ['${PYTHON_PN}-tkinter@openembedded-core']
-  opensuse: [python-tk]
-  rhel:
-    '7': [tkinter]
-    '8': [python2-tkinter]
-  ubuntu:
-    '*': [python-tk]
 python-toml:
   debian: [python-toml]
   fedora: [python-toml]


### PR DESCRIPTION
Part of Python 2 drop. Links to https://github.com/ros/rosdistro/issues/51715