### PR TITLE
rosdep: drop legacy Python 2 keys - Stage 3 (60%)

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -552,103 +552,6 @@ python:
       packages: [python]
   ubuntu:
     bionic: [python-dev]
-python-absl-py-pip:
-  debian:
-    pip:
-      packages: [absl-py]
-  fedora:
-    pip:
-      packages: [absl-py]
-  ubuntu:
-    pip:
-      packages: [absl-py]
-python-adafruit-bno055-pip:
-  debian:
-    pip:
-      packages: [adafruit_bno055]
-  fedora:
-    pip:
-      packages: [adafruit_bno055]
-  ubuntu:
-    pip:
-      packages: [adafruit_bno055]
-python-amqp:
-  debian:
-    buster: [python-amqp]
-    stretch: [python-amqp]
-  fedora: [python-amqp]
-  gentoo: [dev-python/py-amqp]
-  ubuntu: [python-amqp]
-python-aniso8601:
-  debian: [python-aniso8601]
-  gentoo: [dev-python/aniso8601]
-  rhel:
-    '7': [python-aniso8601]
-  ubuntu:
-    bionic: [python-aniso8601]
-python-annoy-pip:
-  debian:
-    pip:
-      packages: [annoy]
-  fedora:
-    pip:
-      packages: [annoy]
-  osx:
-    pip:
-      packages: [annoy]
-  ubuntu:
-    pip:
-      packages: [annoy]
-python-anyjson:
-  debian: [python-anyjson]
-  fedora: [python-anyjson]
-  gentoo: [dev-python/anyjson]
-  ubuntu: [python-anyjson]
-python-argh:
-  debian: [python-argh]
-  fedora: [python-argh]
-  gentoo: [dev-python/argh]
-  ubuntu: [python-argh]
-python-argparse:
-  alpine: [py-argparse]
-  arch: [python2]
-  debian:
-    bullseye: [libpython2.7-stdlib]
-    buster: [libpython2.7-stdlib]
-    squeeze: [python-argparse]
-    stretch: [libpython2.7-stdlib]
-    wheezy: [python-argparse]
-  fedora: [python]
-  freebsd: [py27-argparse]
-  gentoo: [dev-lang/python]
-  macports: [py27-argparse]
-  nixos: [python]
-  openembedded: []
-  opensuse: [python]
-  osx:
-    pip:
-      packages: [argparse]
-  rhel:
-    '7': [python2]
-    '8': [python2]
-  slackware:
-    pip:
-      packages: [argparse]
-  ubuntu:
-    '*': []
-python-astor-pip:
-  debian:
-    pip:
-      packages: [astor]
-  fedora:
-    pip:
-      packages: [astor]
-  osx:
-    pip:
-      packages: [astor]
-  ubuntu:
-    pip:
-      packages: [astor]
 python-astrometry-pip: &migrate_eol_2025_04_30_python3_astrometry_pip
   debian:
     pip:
@@ -659,91 +562,6 @@ python-astrometry-pip: &migrate_eol_2025_04_30_python3_astrometry_pip
   ubuntu:
     pip:
       packages: [astrometry]
-python-attrs-pip:
-  '*':
-    pip:
-      packages: [attrs]
-python-avahi:
-  arch: [avahi]
-  debian: [python-avahi]
-  fedora: [avahi-ui-tools]
-  gentoo: ['net-dns/avahi[python]']
-  nixos: [pythonPackages.avahi]
-  opensuse: [python3-avahi]
-  ubuntu: [python-avahi]
-python-backports.ssl-match-hostname:
-  debian: [python-backports.ssl-match-hostname]
-  gentoo: [dev-python/backports-ssl-match-hostname]
-  nixos: [pythonPackages.backports_ssl_match_hostname]
-  openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
-  ubuntu:
-    bionic: [python-backports.ssl-match-hostname]
-python-beautifulsoup:
-  arch: [python2-beautifulsoup3]
-  debian: [python-beautifulsoup]
-  gentoo: [dev-python/beautifulsoup]
-  ubuntu: [python-beautifulsoup]
-python-bitstring-pip:
-  debian:
-    pip:
-      packages: [bitstring]
-  fedora:
-    pip:
-      packages: [bitstring]
-  osx:
-    pip:
-      packages: [bitstring]
-  ubuntu:
-    pip:
-      packages: [bitstring]
-python-blinker:
-  debian: [python-blinker]
-  fedora: [python-blinker]
-  gentoo: [dev-python/blinker]
-  ubuntu: [python-blinker]
-python-boltons:
-  debian:
-    '*': [python-boltons]
-    wheezy:
-      pip:
-        packages: [boltons]
-  fedora:
-    pip:
-      packages: [boltons]
-  osx:
-    pip:
-      packages: [boltons]
-  ubuntu:
-    '*': [python-boltons]
-python-box2d:
-  debian: [python-box2d]
-  ubuntu: [python-box2d]
-python-cbor:
-  debian: [python-cbor]
-  gentoo: [dev-python/cbor]
-  ubuntu: [python-cbor]
-python-celery:
-  debian: [python-celery]
-  fedora: [python-celery]
-  gentoo: [dev-python/celery]
-  ubuntu: [python-celery]
-python-chainer-mask-rcnn-pip:
-  debian:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainer-mask-rcnn]
-  fedora:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainer-mask-rcnn]
-  osx:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainer-mask-rcnn]
-  ubuntu:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainer-mask-rcnn]
 python-chainer-pip: &migrate_eol_2025_04_30_python3_chainer_pip
   debian:
     pip:
@@ -761,131 +579,6 @@ python-chainer-pip: &migrate_eol_2025_04_30_python3_chainer_pip
   ubuntu:
     pip:
       packages: [chainer]
-python-chainercv-pip:
-  debian:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainercv]
-  fedora:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainercv]
-  osx:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainercv]
-  ubuntu:
-    pip:
-      depends: [cython, python-numpy]
-      packages: [chainercv]
-python-cheetah:
-  debian: [python-cheetah]
-  fedora: [python-cheetah]
-  gentoo: [dev-python/cheetah]
-  nixos: [pythonPackages.cheetah]
-  openembedded: ['${PYTHON_PN}-cheetah@meta-python']
-  opensuse: [python-Cheetah]
-  ubuntu: [python-cheetah]
-python-cherrypy:
-  debian: [python-cherrypy3]
-  fedora: [python-cherrypy]
-  gentoo: [dev-python/cherrypy]
-  nixos: [pythonPackages.cherrypy]
-  ubuntu: [python-cherrypy3]
-python-clearsilver:
-  debian: [python-clearsilver]
-  rhel:
-    '7': [python-clearsilver]
-  ubuntu: [python-clearsilver]
-python-cobs-pip:
-  debian:
-    pip:
-      packages: [cobs]
-  fedora:
-    pip:
-      packages: [cobs]
-  ubuntu:
-    pip:
-      packages: [cobs]
-python-concurrent.futures:
-  debian: [python-concurrent.futures]
-  gentoo: [virtual/python-futures]
-  ubuntu: [python-concurrent.futures]
-python-configparser:
-  arch: [python2-configparser]
-  debian: [python-configparser]
-  gentoo: [dev-python/configparser]
-  ubuntu: [python-configparser]
-python-construct-pip:
-  debian:
-    pip:
-      packages: [construct]
-  ubuntu:
-    pip:
-      packages: [construct]
-python-control-pip:
-  debian:
-    pip:
-      packages: [control]
-  ubuntu:
-    pip:
-      packages: [control]
-python-cookiecutter-pip:
-  debian:
-    pip:
-      packages: [cookiecutter]
-  fedora:
-    pip:
-      packages: [cookiecutter]
-  nixos: [pythonPackages.cookiecutter]
-  osx:
-    pip:
-      packages: [cookiecutter]
-  ubuntu:
-    pip:
-      packages: [cookiecutter]
-python-cpplint:
-  debian:
-    pip:
-      packages: [cpplint]
-  fedora:
-    pip:
-      packages: [cpplint]
-  osx:
-    pip:
-      packages: [cpplint]
-  ubuntu:
-    pip:
-      packages: [cpplint]
-python-crccheck-pip:
-  debian:
-    pip:
-      packages: [crccheck]
-  fedora:
-    pip:
-      packages: [crccheck]
-  nixos: [python3Packages.crccheck]
-  osx:
-    pip:
-      packages: [crccheck]
-  ubuntu:
-    pip:
-      packages: [crccheck]
-python-crypto:
-  alpine: [py-crypto]
-  arch: [python2-crypto]
-  debian: [python-crypto]
-  fedora: [python-crypto]
-  freebsd: [py27-pycrypto]
-  gentoo: [dev-python/pycrypto]
-  nixos: [pythonPackages.pycrypto]
-  openembedded: ['${PYTHON_PN}-pycrypto@meta-python']
-  opensuse: [python2-pycrypto]
-  osx:
-    pip:
-      packages: [pycrypto]
-  ubuntu:
-    bionic: [python-crypto]
 python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   debian:
     pip:
@@ -896,146 +589,6 @@ python-cvxpy-pip: &migrate_eol_2025_04_30_python3_cvxpy_pip
   ubuntu:
     pip:
       packages: [cvxpy]
-python-cython-pip:
-  arch:
-    pip:
-      packages: [cython]
-  debian:
-    pip:
-      packages: [cython]
-  fedora:
-    pip:
-      packages: [cython]
-  ubuntu:
-    pip:
-      packages: [cython]
-python-deap-pip:
-  debian:
-    pip: [deap]
-  ubuntu:
-    pip: [deap]
-python-debian:
-  debian: [python-debian]
-  fedora: [python-debian]
-  gentoo: [dev-python/python-debian]
-  ubuntu:
-    bionic: [python-debian]
-python-deepdiff-pip:
-  debian:
-    pip: [deepdiff]
-  fedora:
-    pip: [deepdiff]
-  ubuntu:
-    pip: [deepdiff]
-python-defer-pip:
-  ubuntu:
-    pip:
-      packages: [defer]
-python-dialogflow-pip:
-  arch:
-    pip:
-      packages: [dialogflow]
-  debian:
-    pip:
-      packages: [dialogflow]
-  fedora:
-    pip:
-      packages: [dialogflow]
-  ubuntu:
-    pip:
-      packages: [dialogflow]
-python-docx:
-  fedora: [python-docx]
-  ubuntu:
-    pip: [python-docx]
-python-dt-apriltags-pip:
-  debian:
-    pip: [dt-apriltags]
-  fedora:
-    pip: [dt-apriltags]
-  opensuse:
-    pip: [dt-apriltags]
-  osx:
-    pip: [dt-apriltags]
-  ubuntu:
-    pip: [dt-apriltags]
-python-duckdb-pip:
-  '*':
-    pip: [duckdb]
-python-dxfgrabber-pip:
-  ubuntu:
-    pip: [dxfgrabber]
-python-easygui:
-  debian: [python-easygui]
-  fedora: [python-easygui]
-  ubuntu: [python-easygui]
-python-enum:
-  debian:
-    wheezy: [python-enum]
-  ubuntu: [python-enum]
-python-enum34:
-  debian:
-    buster: [python-enum34]
-    stretch: [python-enum34]
-  gentoo: [virtual/python-enum34]
-  nixos: [pythonPackages.enum34]
-  openembedded: ['${PYTHON_PN}-enum34@meta-python']
-  opensuse: [python-enum34]
-  ubuntu: [python-enum34]
-python-enum34-pip:
-  ubuntu:
-    pip:
-      packages: [enum34]
-python-face-alignment-pip:
-  debian:
-    pip:
-      packages: [face-alignment]
-  fedora:
-    pip:
-      packages: [face-alignment]
-  osx:
-    pip:
-      packages: [face-alignment]
-  ubuntu:
-    pip:
-      packages: [face-alignment]
-python-face-recognition-pip:
-  arch:
-    pip:
-      packages: [face_recognition]
-  debian:
-    pip:
-      packages: [face_recognition]
-  fedora:
-    pip:
-      packages: [face_recognition]
-  ubuntu:
-    pip:
-      packages: [face_recognition]
-python-fastdtw-pip:
-  debian:
-    pip:
-      packages: [python-fastdtw]
-  ubuntu:
-    pip:
-      packages: [python-fastdtw]
-python-fcl-pip:
-  debian:
-    pip:
-      depends: [libfcl-dev]
-      packages: [python-fcl]
-  fedora:
-    pip:
-      depends: [libfcl-dev]
-      packages: [python-fcl]
-  osx:
-    pip:
-      depends: [libfcl-dev]
-      packages: [python-fcl]
-  ubuntu:
-    pip:
-      depends: [libfcl-dev]
-      packages: [python-fcl]
 python-fcn-pip: &migrate_eol_2025_04_30_python3_fcn_pip
   debian:
     pip:
@@ -1053,98 +606,6 @@ python-fcn-pip: &migrate_eol_2025_04_30_python3_fcn_pip
     pip:
       depends: [liblapack-dev]
       packages: [fcn]
-python-fixtures:
-  debian: [python-fixtures]
-  fedora: [python-fixtures]
-  gentoo: [dev-python/fixtures]
-  ubuntu: [python-fixtures]
-python-flask-appbuilder-pip:
-  debian:
-    pip:
-      packages: [flask-appbuilder]
-  fedora:
-    pip:
-      packages: [flask-appbuilder]
-  osx:
-    pip:
-      packages: [flask-appbuilder]
-  ubuntu:
-    pip:
-      packages: [flask-appbuilder]
-python-flask-cors-pip:
-  debian:
-    pip:
-      packages: [flask-cors]
-  ubuntu:
-    pip:
-      packages: [flask-cors]
-python-flask-restful:
-  debian: [python-flask-restful]
-  fedora: [python-flask-restful]
-  gentoo: [dev-python/flask-restful]
-  nixos: [pythonPackages.flask-restful]
-python-flatdict-pip:
-  ubuntu:
-    pip:
-      packages: [flatdict]
-python-freezegun-pip:
-  debian:
-    pip:
-      packages: [freezegun]
-  fedora:
-    pip:
-      packages: [freezegun]
-  nixos: [pythonPackages.freezegun]
-  opensuse:
-    pip:
-      packages: [freezegun]
-  osx:
-    pip:
-      packages: [freezegun]
-  ubuntu:
-    pip:
-      packages: [freezegun]
-python-frozendict:
-  debian: [python-frozendict]
-  fedora: [python-frozendict]
-  ubuntu: [python-frozendict]
-python-fuzzywuzzy-pip:
-  debian:
-    pip:
-      packages: [fuzzywuzzy]
-  fedora:
-    pip:
-      packages: [fuzzywuzzy]
-  ubuntu:
-    pip:
-      packages: [fuzzywuzzy]
-python-fysom:
-  debian:
-    buster: [python-fysom]
-    stretch: [python-fysom]
-  fedora:
-    pip:
-      packages: [fysom]
-  osx:
-    pip:
-      packages: [fysom]
-  ubuntu:
-    pip:
-      packages: [fysom]
-python-gTTS-pip:
-  debian:
-    pip:
-      packages: [gTTS]
-  fedora:
-    pip:
-      packages: [gTTS]
-  ubuntu:
-    pip:
-      packages: [gTTS]
-python-gcloud-pip:
-  ubuntu:
-    pip:
-      packages: [gcloud]
 python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
   debian:
     pip:
@@ -1158,34 +619,6 @@ python-gdown-pip: &migrate_eol_2025_04_30_python3_gdown_pip
   ubuntu:
     pip:
       packages: [gdown]
-python-genshi:
-  debian: [python-genshi]
-  fedora: [python-genshi]
-  gentoo: [dev-python/genshi]
-  ubuntu: [python-genshi]
-python-geocoder-pip:
-  debian:
-    pip:
-      packages: [geocoder]
-  ubuntu:
-    pip:
-      packages: [geocoder]
-python-gevent:
-  debian: [python-gevent]
-  fedora: [python-gevent]
-  gentoo: [dev-python/gevent]
-  ubuntu: [python-gevent]
-python-github-pip:
-  osx:
-    pip:
-      packages: [PyGithub]
-  ubuntu:
-    pip:
-      packages: [PyGithub]
-python-gitpython-pip:
-  ubuntu:
-    pip:
-      packages: [gitpython]
 python-glpk-pip: &migrate_eol_2025_04_30_python3_glpk_pip
   debian:
     pip:
@@ -1196,36 +629,6 @@ python-glpk-pip: &migrate_eol_2025_04_30_python3_glpk_pip
   ubuntu:
     pip:
       packages: [glpk]
-python-gobject:
-  arch: [python2-gobject]
-  debian:
-    '*': null
-    buster: [python-gobject]
-    stretch: [python-gobject]
-  gentoo: [dev-python/pygobject]
-  nixos: [pythonPackages.pygobject2]
-  opensuse: [python2-gobject]
-  ubuntu:
-    '*': null
-    bionic: [python-gobject]
-    focal: [python-gobject]
-python-google-cloud-bigquery-pip:
-  debian:
-    pip:
-      packages: [google-cloud-bigquery]
-  ubuntu:
-    pip:
-      packages: [google-cloud-bigquery]
-python-google-cloud-speech-pip:
-  debian:
-    pip:
-      packages: [google-cloud-speech]
-  fedora:
-    pip:
-      packages: [google-cloud-speech]
-  ubuntu:
-    pip:
-      packages: [google-cloud-speech]
 python-google-cloud-storage-pip: &migrate_eol_2025_04_30_python3_google_cloud_storage_pip
   debian:
     pip:
@@ -1246,49 +649,6 @@ python-google-cloud-texttospeech-pip: &migrate_eol_2025_04_30_python3_google_clo
   ubuntu:
     pip:
       packages: [google-cloud-texttospeech]
-python-google-cloud-vision-pip:
-  debian:
-    pip:
-      packages: [google-cloud-vision]
-  fedora:
-    pip:
-      packages: [google-cloud-vision]
-  ubuntu:
-    pip:
-      packages: [google-cloud-vision]
-python-gputil-pip:
-  debian:
-    pip:
-      packages: [gputil]
-  fedora:
-    pip:
-      packages: [gputil]
-  osx:
-    pip:
-      packages: [gputil]
-  ubuntu:
-    pip:
-      packages: [gputil]
-python-graphitesend-pip:
-  debian:
-    pip:
-      packages: [graphitesend]
-  ubuntu:
-    pip:
-      packages: [graphitesend]
-python-graphviz-pip:
-  debian:
-    pip:
-      packages: [graphviz]
-  fedora:
-    pip:
-      packages: [graphviz]
-  ubuntu:
-    pip:
-      packages: [graphviz]
-python-gridfs:
-  debian: [python-gridfs]
-  fedora: [python-pymongo-gridfs]
 python-gst:
   arch: [gstreamer0.10-python]
   debian:
@@ -2501,21 +1861,6 @@ python-theano:
   osx:
     pip:
       packages: [Theano]
-python-toml:
-  debian: [python-toml]
-  fedora: [python-toml]
-  ubuntu: [python-toml]
-python-tornado:
-  arch: [python-tornado]
-  debian: [python-tornado]
-  fedora: [python-tornado]
-  gentoo: [www-servers/tornado]
-  nixos: [pythonPackages.tornado]
-  openembedded: [python-tornado45@meta-ros-python2]
-  osx:
-    pip:
-      packages: [tornado]
-  ubuntu: [python-tornado]
 python-tornado-couchdb-pip:
   ubuntu:
     pip:
@@ -2533,13 +1878,6 @@ python-tornado-pip:
   ubuntu:
     pip:
       packages: [tornado]
-python-tqdm:
-  debian:
-    buster: [python-tqdm]
-    stretch: [python-tqdm]
-  fedora: [python-tqdm]
-  ubuntu:
-    bionic: [python-tqdm]
 python-transforms3d-pip:
   debian:
     pip:
@@ -2547,14 +1885,6 @@ python-transforms3d-pip:
   ubuntu:
     pip:
       packages: [transforms3d]
-python-transitions:
-  debian:
-    '*': [python-transitions]
-    stretch:
-      pip:
-        packages: [transitions]
-  ubuntu:
-    bionic: [python-transitions]
 python-trep:
   debian:
     pip:
@@ -2566,29 +1896,6 @@ python-trep:
   ubuntu:
     pip:
       packages: [trep]
-python-triangle-pip:
-  debian:
-    pip:
-      packages: [triangle]
-  fedora:
-    pip:
-      packages: [triangle]
-  osx:
-    pip:
-      packages: [triangle]
-  ubuntu:
-    pip:
-      packages: [triangle]
-python-trimesh-pip:
-  debian:
-    pip:
-      packages: [trimesh]
-  fedora:
-    pip:
-      packages: [trimesh]
-  ubuntu:
-    pip:
-      packages: [trimesh]
 python-twilio-pip:
   debian:
     pip:
@@ -2639,36 +1946,11 @@ python-typing-pip:
   ubuntu:
     pip:
       packages: [typing]
-python-tz:
-  arch: [python2-pytz]
-  debian: [python-tz]
-  gentoo: [dev-python/pytz]
-  nixos: [pythonPackages.pytz]
-  ubuntu: [python-tz]
 python-tzlocal-pip:
   nixos: [pythonPackages.tzlocal]
   ubuntu:
     pip:
       packages: [tzlocal]
-python-ubjson:
-  debian:
-    buster: [python-ubjson]
-    stretch: [python-ubjson]
-  ubuntu:
-    bionic: [python-ubjson]
-python-ujson:
-  debian:
-    buster: [python-ujson]
-    stretch: [python-ujson]
-  fedora: [python-ujson]
-  gentoo: [dev-python/ujson]
-  nixos: [pythonPackages.ujson]
-  openembedded: [python3-ujson@meta-python]
-  osx:
-    pip:
-      packages: [ujson]
-  ubuntu:
-    bionic: [python-ujson]
 python-unittest2:
   debian: [python-unittest2]
   nixos: [pythonPackages.unittest2]
@@ -2688,19 +1970,6 @@ python-urlgrabber:
       packages: [pycurl, urlgrabber]
   slackware: [urlgrabber]
   ubuntu: [python-urlgrabber]
-python-urllib3:
-  arch: [python-urllib3]
-  debian: [python-urllib3]
-  fedora: [python-urllib3]
-  gentoo: [dev-python/urllib3]
-  nixos: [pythonPackages.urllib3]
-  ubuntu: [python-urllib3]
-python-usb:
-  debian: [python-usb]
-  gentoo: [dev-python/pyusb]
-  nixos: [pythonPackages.pyusb]
-  openembedded: ['${PYTHON_PN}-pyusb@meta-python']
-  ubuntu: [python-usb]
 python-utm-pip:
   debian:
     pip:
@@ -2718,12 +1987,6 @@ python-validictory-pip:
   ubuntu:
     pip:
       packages: [validictory]
-python-vcstool:
-  debian:
-    buster: [python-vcstool]
-    stretch: [python-vcstool]
-  fedora: [python-vcstool]
-  ubuntu: [python-vcstool]
 python-vcstools:
   debian:
     buster: [python-vcstools]
@@ -2731,16 +1994,6 @@ python-vcstools:
   fedora: [python-vcstools]
   gentoo: [dev-python/vcstools]
   macports: [py27-vcstools]
-python-vedo-pip:
-  debian:
-    pip:
-      packages: [vedo]
-  fedora:
-    pip:
-      packages: [vedo]
-  ubuntu:
-    pip:
-      packages: [vedo]
 python-vine-pip:
   ubuntu:
     pip:
@@ -2772,12 +2025,6 @@ python-vlc-pip:
   ubuntu:
     pip:
       packages: [python-vlc]
-python-voluptuous:
-  debian: [python-voluptuous]
-  fedora: [python-voluptuous]
-  gentoo: [dev-python/voluptuous]
-  nixos: [pythonPackages.voluptuous]
-  ubuntu: [python-voluptuous]
 python-vtk:
   arch: [vtk]
   debian: [python-vtk]
@@ -2791,32 +2038,16 @@ python-w1thermsensor-pip:
   ubuntu:
     pip:
       packages: [w1thermsensor]
-python-waitress:
-  debian: [python-waitress]
-  fedora: [python-waitress]
-  gentoo: [dev-python/waitress]
-  nixos: [pythonPackages.waitress]
-  ubuntu: [python-waitress]
 python-walrus-pip:
   ubuntu:
     pip:
       packages: [walrus]
-python-watchdog:
-  debian: [python-watchdog]
-  ubuntu:
-    bionic: [python-watchdog]
 python-webob:
   debian: [python-webob]
   fedora: [python-webob]
   gentoo: [dev-python/webob]
   nixos: [pythonPackages.webob]
   ubuntu: [python-webob]
-python-webpy:
-  arch: [python2-webpy]
-  debian: [python-webpy]
-  fedora: [python-webpy]
-  gentoo: [dev-python/webpy]
-  ubuntu: [python-webpy]
 python-webrtcvad-pip:
   debian:
     pip:
@@ -2830,39 +2061,11 @@ python-webrtcvad-pip:
   ubuntu:
     pip:
       packages: [webrtcvad]
-python-websocket:
-  debian: [python-websocket]
-  fedora: [python-websocket-client]
-  gentoo: [dev-python/websocket-client]
-  nixos: [pythonPackages.websocket_client]
-  openembedded: ['${PYTHON_PN}-websocket-client@meta-python']
-  opensuse: [python2-websocket-client]
-  ubuntu:
-    bionic: [python-websocket]
 python-webtest:
   debian: [python-webtest]
   fedora: [python-webtest]
   gentoo: [dev-python/webtest]
   ubuntu: [python-webtest]
-python-werkzeug:
-  arch: [python-werkzeug]
-  debian: [python-werkzeug]
-  fedora: [python-werkzeug]
-  gentoo: [dev-python/werkzeug]
-  nixos: [pythonPackages.werkzeug]
-  ubuntu: [python-werkzeug]
-python-wheel:
-  debian: [python-wheel]
-  fedora: [python-wheel]
-  gentoo: [dev-python/wheel]
-  ubuntu: [python-wheel]
-python-whichcraft:
-  debian: [python-whichcraft]
-  nixos: [pythonPackages.whichcraft]
-  ubuntu: [python-whichcraft]
-python-wrapt:
-  debian: [python-wrapt]
-  ubuntu: [python-wrapt]
 python-ws4py:
   debian: [python-ws4py]
   ubuntu: [python-ws4py]
@@ -2894,18 +2097,6 @@ python-wxtools:
   rhel:
     '7': [wxPython]
   ubuntu: [python-wxtools]
-python-xdot:
-  debian: [xdot]
-  fedora: [python-xdot]
-  gentoo: [media-gfx/xdot]
-  nixos: [xdot]
-  ubuntu: [xdot]
-python-xlib:
-  debian: [python-xlib]
-  fedora: [python-xlib]
-  gentoo: [dev-python/python-xlib]
-  nixos: [pythonPackages.xlib]
-  ubuntu: [python-xlib]
 python-xlrd:
   debian: [python-xlrd]
   fedora: [python-xlrd]
@@ -2920,14 +2111,6 @@ python-xmlplain-pip:
   ubuntu:
     pip:
       packages: [xmlplain]
-python-xmltodict:
-  debian:
-    buster: [python-xmltodict]
-    stretch: [python-xmltodict]
-  fedora: [python-xmltodict]
-  gentoo: [dev-python/xmltodict]
-  ubuntu:
-    bionic: [python-xmltodict]
 python-yamale-pip:
   debian:
     pip:
@@ -2958,18 +2141,6 @@ python-yaml:
   ubuntu:
     bionic: [python-yaml]
     focal: [python-yaml]
-python-zbar:
-  debian: [python-zbar]
-  gentoo: ['media-gfx/zbar[python]']
-  ubuntu: [python-zbar]
-python-zmq:
-  arch: [python2-pyzmq]
-  debian: [python-zmq]
-  fedora: [python-zmq]
-  gentoo: [dev-python/pyzmq]
-  nixos: [pythonPackages.pyzmq]
-  ubuntu:
-    '*': [python-zmq]
 python3:
   alpine: [python3]
   arch: [python]


### PR DESCRIPTION
Part of Python 2 drop. Links to https://github.com/ros/rosdistro/issues/51715