### PR TITLE
mapviz: 2.6.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5477,7 +5477,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.6.4-1
+      version: 2.6.5-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `2.6.5-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.6.4-1`

## mapviz

```
* Fix plugin export (#875 <https://github.com/swri-robotics/mapviz/issues/875>)
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
  (cherry picked from commit 667d284ac3138bcb726e32cca478a9a768b8dc0c)
* Contributors: DangitBen
```

## mapviz_interfaces

- No changes

## mapviz_plugins

- No changes

## multires_image

- No changes

## tile_map

```
* Fix plugin export (#875 <https://github.com/swri-robotics/mapviz/issues/875>)
  Co-authored-by: Ben Andrew <mailto:benjamin.andrew@swri.org>
  (cherry picked from commit 667d284ac3138bcb726e32cca478a9a768b8dc0c)
* Contributors: DangitBen, David Anthony
```
