### PR TITLE
foxglove-sdk: 3.4.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3292,7 +3292,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.4.0-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.3.0-1`

## foxglove_bridge

```
* Fix an issue where the ``parameters`` implementation would occasionally stall message forwarding for several seconds
* Fix an issue where the bridge was not refcounting parameter subscriptions properly when a WebSocket server and Remote Access gateway were simultaneously in use
* Fix an issue where the parameter whitelist would randomly prevent subscribing to or setting unrelated parameters
* Add ``message_backlog_size`` option to configure the outgoing message buffer
* Update Foxglove SDK version to 0.25.0
```

## foxglove_msgs

```
* Version bump for foxglove_bridge 3.4.0 release
```
