### PR TITLE
[rosdep] Added python3-pynvml.

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8950,6 +8950,13 @@ python3-pynput:
   ubuntu:
     '*': [python3-pynput]
     focal: null
+python3-pynvml:
+  debian: [python3-pynvml]
+  fedora:
+    pip:
+      packages: [pynvml]
+  nixos: [python3Packages.pynvml]
+  ubuntu: [python3-pynvml]
 python3-pyosmium:
   debian: [python3-pyosmium]
   fedora: [python3-osmium]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

python3-pynvml

## Package Upstream Source:

https://github.com/gpuopenanalytics/pynvml

## Purpose of using this:

`pynvml` provides Python bindings to the NVIDIA Management Library (NVML) for monitoring and managing NVIDIA GPU state.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?keywords=python3-pynvml
  - https://packages.debian.org/trixie/python3-pynvml
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-pynvml
  - https://packages.ubuntu.com/noble/python3-pynvml
- Fedora: Fedora: https://packages.fedoraproject.org/search?query=pynvml
 - not available (pip)
Arch: https://www.archlinux.org/packages/
not available (only in AUR, which is not permitted)
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - not available
- Gentoo: https://packages.gentoo.org/
  - not available
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages?query=pynvml
  - python3Packages.pynvml
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

