### PR TITLE
[openembedded] python3-smbus2: added recipe

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10419,6 +10419,7 @@ python3-smbus:
 python3-smbus2:
   debian: [python3-smbus2]
   nixos: [python3Packages.smbus2]
+  openembedded: [python3-smbus2@meta-python]
   ubuntu:
     '*': [python3-smbus2]
     focal: null


### PR DESCRIPTION
@see: https://layers.openembedded.org/layerindex/recipe/60953/

@robwoolley This one was undefined in the generated files