### PR TITLE
[openembedded] python3-ujson: move from python(2) entry to python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4463,7 +4463,6 @@ python-ujson:
   fedora: [python-ujson]
   gentoo: [dev-python/ujson]
   nixos: [pythonPackages.ujson]
-  openembedded: [python3-ujson@meta-python]
   osx:
     pip:
       packages: [ujson]
@@ -11118,6 +11117,7 @@ python3-ujson:
   fedora: [python3-ujson]
   gentoo: [dev-python/ujson]
   nixos: [python3Packages.ujson]
+  openembedded: [python3-ujson@meta-python]
   osx:
     pip:
       packages: [ujson]


### PR DESCRIPTION
The python3 package for ujson was under python(2)

@robwoolley Could you review?