### PR TITLE
smacc2: 3.1.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11227,12 +11227,61 @@ repositories:
       version: jazzy
     release:
       packages:
+      - backward_global_planner
+      - backward_local_planner
+      - cl_foundation_pose
+      - cl_gcalcli
+      - cl_generic_sensor
+      - cl_http
+      - cl_keyboard
+      - cl_lifecycle_node
+      - cl_mission_tracker
+      - cl_modbus_tcp_relay
+      - cl_moveit2z
+      - cl_nav2z
+      - cl_px4_mr
+      - cl_ros2_timer
+      - eg_conditional_generator
+      - eg_random_generator
+      - forward_global_planner
+      - forward_local_planner
+      - nav2z_planners_common
+      - pure_spinning_local_planner
+      - sm_advanced_recovery_1
+      - sm_atomic
+      - sm_atomic_http
+      - sm_atomic_lifecycle
+      - sm_atomic_mode_states
+      - sm_atomic_performance_trace_1
+      - sm_atomic_subscribers_performance_test
+      - sm_branching
+      - sm_cl_gcalcli_test_1
+      - sm_cl_keyboard_unit_test_1
+      - sm_cl_px4_mr_test_1
+      - sm_cl_px4_mr_test_2
+      - sm_cl_ros2_timer_unit_test_1
+      - sm_coretest_transition_speed_1
+      - sm_data_sharing_1
+      - sm_data_sharing_2
+      - sm_modbus_tcp_relay_test_1
+      - sm_multi_stage_1
+      - sm_multithread_test_1
+      - sm_nav2_gazebo_test_1
+      - sm_pack_ml
+      - sm_panda_cl_moveit2z_cb_inventory
+      - sm_panda_cl_moveit2z_cb_inventory_isaacsim
+      - sm_simple_action_client
+      - sm_three_some
       - smacc2
       - smacc2_msgs
+      - sr_all_events_go
+      - sr_conditional
+      - sr_event_countdown
+      - undo_path_global_planner
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git
-      version: 3.0.1-1
+      version: 3.1.0-2
     source:
       type: git
       url: https://github.com/robosoft-ai/SMACC2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `smacc2` to `3.1.0-2`:

- upstream repository: https://github.com/robosoft-ai/SMACC2.git
- release repository: https://github.com/robosoft-ai/SMACC2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.0.1-1`

## cl_ros2_timer

```
### Changed (Breaking)
- **cl_ros2_timer duration-based API** (#61 <https://github.com/robosoft-ai/SMACC2/issues/61>)
* **ClRos2Timer** is now a pure marker client — the duration constructor argument has been
  removed. ``or_timer.hpp`` files simply call ``createClient<ClRos2Timer>()`` with no args.
### Removed
- ``CbRos2Timer`` — was unused in all reference state machines; removed.
- ``CpTimerListener1`` — now orphaned after the tick-stack removal; removed.
### Contributors
- Brett Aldrich
```

## smacc2

```
### Changed
- **cl_ros2_timer duration-based API** (#61 <https://github.com/robosoft-ai/SMACC2/issues/61>)
### Removed
- ``CbRos2Timer`` client behavior (unused).
- ``CpTimerListener1`` component (orphaned after tick-stack removal).
### Contributors
- Brett Aldrich
```
