### PR TITLE
rqt_robot_steering: 4.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8806,7 +8806,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: rolling
+      version: lyrical
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -8815,7 +8815,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
-      version: rolling
+      version: lyrical
     status: maintained
   rqt_runtime_monitor:
     doc:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8811,7 +8811,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_robot_steering-release.git
-      version: 4.0.2-3
+      version: 4.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_robot_steering` to `4.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_robot_steering.git
- release repository: https://github.com/ros2-gbp/rqt_robot_steering-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.2-3`

## rqt_robot_steering

```
* Support Qt5 and Qt6 (#29 <https://github.com/ros-visualization/rqt_robot_steering/issues/29>)
* Contributors: Alejandro Hernández Cordero
```
