### PR TITLE
class_loader: 2.7.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1413,7 +1413,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.7.0-3
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `2.7.1-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.7.0-3`

## class_loader

```
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#215 <https://github.com/ros/class_loader/issues/215>)
  (cherry picked from commit 464fd149cd82e2259d3e1f6f77d6669d1819e124)
* Contributors: Alejandro Hernández Cordero
```
