### PR TITLE
robot_state_publisher: 3.3.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9160,7 +9160,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/robot_state_publisher-release.git
-      version: 3.3.3-3
+      version: 3.3.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_state_publisher` to `3.3.4-1`:

- upstream repository: https://github.com/ros/robot_state_publisher.git
- release repository: https://github.com/ros2-gbp/robot_state_publisher-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.3.3-3`

## robot_state_publisher

```
* Remove CODEOWNERS and mirror-rolling-to-main workflow (#229 <https://github.com/ros/robot_state_publisher/issues/229>) (#230 <https://github.com/ros/robot_state_publisher/issues/230>)
  (cherry picked from commit 34a7b23c15af2d2e4f863d5041c54922aa9bf675)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
