### PR TITLE
urdfdom_headers: 1.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -12743,7 +12743,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdfdom_headers` to `1.1.3-1`:

- upstream repository: https://github.com/ros/urdfdom_headers.git
- release repository: https://github.com/ros2-gbp/urdfdom_headers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.1.2-1`
