### PR TITLE
example_interfaces: 0.12.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2884,7 +2884,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/example_interfaces-release.git
-      version: 0.12.0-3
+      version: 0.12.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `example_interfaces` to `0.12.1-1`:

- upstream repository: https://github.com/ros2/example_interfaces.git
- release repository: https://github.com/ros2-gbp/example_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.12.0-3`

## example_interfaces

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#19 <https://github.com/ros2/example_interfaces/issues/19>) (#20 <https://github.com/ros2/example_interfaces/issues/20>)
  They are both outdated and both no longer serving their
  intended purpose.
  (cherry picked from commit 00cb25584ab611c34686e024a06a47728550ef72)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
