### PR TITLE
libyaml_vendor: 1.6.4-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5212,7 +5212,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/libyaml_vendor-release.git
-      version: 1.6.3-2
+      version: 1.6.4-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libyaml_vendor` to `1.6.4-2`:

- upstream repository: https://github.com/ros2/libyaml_vendor.git
- release repository: https://github.com/ros2-gbp/libyaml_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.3-2`

## libyaml_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#65 <https://github.com/ros2/libyaml_vendor/issues/65>) (#66 <https://github.com/ros2/libyaml_vendor/issues/66>)
  They are both outdated, and both no longer serving their
  intended purpose.
  (cherry picked from commit 855754620fd05bdc7601d464958522b395435f3c)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
