### PR TITLE
mimick_vendor: 0.6.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5627,7 +5627,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mimick_vendor-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/ros2/mimick_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mimick_vendor` to `0.6.3-1`:

- upstream repository: https://github.com/ros2/mimick_vendor.git
- release repository: https://github.com/ros2-gbp/mimick_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.6.2-1`

## mimick_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#40 <https://github.com/ros2/mimick_vendor/issues/40>) (#41 <https://github.com/ros2/mimick_vendor/issues/41>)
  They are both outdated and both no longer serving their
  intended purpose.
  (cherry picked from commit 55401a749abb29047fb6a80227f945c6883150c7)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
