### PR TITLE
orocos_kdl_vendor: 0.5.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7062,7 +7062,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
-      version: 0.5.1-2
+      version: 0.5.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `orocos_kdl_vendor` to `0.5.2-1`:

- upstream repository: https://github.com/ros2/orocos_kdl_vendor.git
- release repository: https://github.com/ros2-gbp/orocos_kdl_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.5.1-2`

## orocos_kdl_vendor

```
* Resolve compatibility issue with Eigen 5.0.0 (min c++14) (backport #39 <https://github.com/ros2/orocos_kdl_vendor/issues/39>) (#42 <https://github.com/ros2/orocos_kdl_vendor/issues/42>)
  * Resolve compatibility issue with Eigen 5.0.0 (min c++14) (#39 <https://github.com/ros2/orocos_kdl_vendor/issues/39>)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
  (cherry picked from commit 98a9e0686b58fb4684c77f28c824d86765a58bb9)
* Contributors: mergify[bot]
```

## python_orocos_kdl_vendor

- No changes
