### PR TITLE
performance_test_fixture: 0.2.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7267,7 +7267,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/performance_test_fixture-release.git
-      version: 0.2.1-2
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `performance_test_fixture` to `0.2.2-1`:

- upstream repository: https://github.com/ros2/performance_test_fixture.git
- release repository: https://github.com/ros2-gbp/performance_test_fixture-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.1-2`

## performance_test_fixture

```
* Remove CODEOWNERS and mirror-rolling-to-main workflow. (#28 <https://github.com/ros2/performance_test_fixture/issues/28>) (#29 <https://github.com/ros2/performance_test_fixture/issues/29>)
  They are both outdated and both no longer serving their
  intended purpose.
  (cherry picked from commit 3e0177bcd49ddc898f371ff6ea5b76d7d5ded46d)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
