### PR TITLE
rcpputils: 2.11.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8454,7 +8454,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.11.3-1
+      version: 2.11.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.11.4-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.11.3-1`

## rcpputils

```
* Append copies of BSD and CC0 licenses from the works (#223 <https://github.com/ros2/rcpputils/issues/223>) (#225 <https://github.com/ros2/rcpputils/issues/225>)
  (cherry picked from commit b5cdd861619e6ac724ba0667f9818fb8186d6617)
  Co-authored-by: Tully Foote <mailto:tullyfoote@intrinsic.ai>
* Contributors: mergify[bot]
```
