### PR TITLE
rcutils: 6.7.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8505,7 +8505,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.7.5-1
+      version: 6.7.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.7.6-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `6.7.5-1`

## rcutils

```
* skip libatomic if mac (backport #565 <https://github.com/ros2/rcutils/issues/565>) (#568 <https://github.com/ros2/rcutils/issues/568>)
  (cherry picked from commit 45756eb6a4c532bfa06b7c8865d00be3afabca24)
  Co-authored-by: Griffin Tabor <mailto:tabor473@gmail.com>
  Co-authored-by: Tomoya.Fujita <mailto:tomoya.fujita825@gmail.com>
* address warning: statement with no effect. (backport #559 <https://github.com/ros2/rcutils/issues/559>) (#562 <https://github.com/ros2/rcutils/issues/562>)
  (cherry picked from commit e04f58b43e153bf575ba89f44d946eb22676b61f)
  Co-authored-by: Tomoya Fujita <mailto:Tomoya.Fujita@sony.com>
  Co-authored-by: Tomoya.Fujita <mailto:tomoya.fujita825@gmail.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
