### PR TITLE
ros2_tracing: 8.2.6-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9525,7 +9525,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_tracing-release.git
-      version: 8.2.5-1
+      version: 8.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_tracing` to `8.2.6-1`:

- upstream repository: https://github.com/ros2/ros2_tracing.git
- release repository: https://github.com/ros2-gbp/ros2_tracing-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `8.2.5-1`

## lttngpy

```
* Use <lttng/lttng.h> in lttngpy and clean up includes (backport #222 <https://github.com/ros2/ros2_tracing/issues/222>) (#232 <https://github.com/ros2/ros2_tracing/issues/232>)
  (cherry picked from commit 91ff6165773e1177a5fd41431d1b1dc274ac4ee1)
  Co-authored-by: RHolland <mailto:17493785+reeceholland@users.noreply.github.com>
  Co-authored-by: Christophe Bedard <mailto:bedard.christophe@gmail.com>
* Contributors: mergify[bot]
```

## ros2trace

- No changes

## tracetools

- No changes

## tracetools_launch

- No changes

## tracetools_read

- No changes

## tracetools_test

- No changes

## tracetools_trace

- No changes
