### PR TITLE
rosidl_defaults: 1.6.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10006,7 +10006,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_defaults-release.git
-      version: 1.6.0-3
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_defaults` to `1.6.1-1`:

- upstream repository: https://github.com/ros2/rosidl_defaults.git
- release repository: https://github.com/ros2-gbp/rosidl_defaults-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.0-3`

## rosidl_default_generators

- No changes

## rosidl_default_runtime

- No changes
