### PR TITLE
rosidl_runtime_py: 0.13.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10072,7 +10072,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
-      version: 0.13.1-2
+      version: 0.13.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_runtime_py` to `0.13.2-1`:

- upstream repository: https://github.com/ros2/rosidl_runtime_py.git
- release repository: https://github.com/ros2-gbp/rosidl_runtime_py-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.13.1-2`

## rosidl_runtime_py

```
* Remove CODEOWNERS and mirror-rolling-to-master. (#31 <https://github.com/ros2/rosidl_runtime_py/issues/31>) (#32 <https://github.com/ros2/rosidl_runtime_py/issues/32>)
  They are both outdated and they both are not serving
  their intended purpose anymore.
  (cherry picked from commit e6c860fec22ffc44556d6d87f730e2d07a8cc62b)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
