### PR TITLE
rcdiscover: 2.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8295,7 +8295,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcdiscover-release.git
-      version: 1.1.7-2
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcdiscover` to `2.1.2-1`:

- upstream repository: https://github.com/roboception/rcdiscover.git
- release repository: https://github.com/ros2-gbp/rcdiscover-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.7-2`

## rcdiscover

```
* update minimum cmake version to 3.5
* [ci] remove focal, add noble arm64
```
