### PR TITLE
rosidl_typesupport_fastrtps: 3.6.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10128,7 +10128,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.6.3-1
+      version: 3.6.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl_typesupport_fastrtps` to `3.6.4-1`:

- upstream repository: https://github.com/ros2/rosidl_typesupport_fastrtps.git
- release repository: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.6.3-1`

## fastrtps_cmake_module

- No changes

## rosidl_typesupport_fastrtps_c

```
* use variable to control shared/static build type (#138 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/138>) (#147 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/147>)
  (cherry picked from commit 82f41be79fd5017f64c54be9cf0ef30fcb76d753)
  Co-authored-by: Jay Sridharan <mailto:jayasurs@usc.edu>
  Co-authored-by: Jay Sridharan <mailto:jsridharan@relativityspace.com>
* Contributors: mergify[bot]
```

## rosidl_typesupport_fastrtps_cpp

```
* use variable to control shared/static build type (#138 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/138>) (#147 <https://github.com/ros2/rosidl_typesupport_fastrtps/issues/147>)
  (cherry picked from commit 82f41be79fd5017f64c54be9cf0ef30fcb76d753)
  Co-authored-by: Jay Sridharan <mailto:jayasurs@usc.edu>
  Co-authored-by: Jay Sridharan <mailto:jsridharan@relativityspace.com>
* Contributors: mergify[bot]
```
