### PR TITLE
rviz: 14.1.21-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10853,7 +10853,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.20-2
+      version: 14.1.21-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.21-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `14.1.20-2`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* SelectionManager::select Function Not Returning Empty Selection Result for Invalid Coordinates (#1713 <https://github.com/ros2/rviz/issues/1713>) (#1770 <https://github.com/ros2/rviz/issues/1770>)
  (cherry picked from commit 73c3d45c27a0c426d7dce3ef502b4a64b813ee6f)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fixed Unexpected pixels for mono Image (#1718 <https://github.com/ros2/rviz/issues/1718>) (#1766 <https://github.com/ros2/rviz/issues/1766>)
  (cherry picked from commit 4b8d1e07fef900cb0a27c215356f6cc942698ee0)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* ogreQuaternionAngularDistance does not properly handle invalid quaternion input (backport #1714 <https://github.com/ros2/rviz/issues/1714>) (#1758 <https://github.com/ros2/rviz/issues/1758>)
  * ogreQuaternionAngularDistance does not properly handle invalid quaternion input (#1714 <https://github.com/ros2/rviz/issues/1714>)
  (cherry picked from commit 90078fd641dfc69cc77fdb5b99139be1192acdbe)
  # Conflicts:
  #     rviz_default_plugins/src/rviz_default_plugins/displays/odometry/quaternion_helper.hpp
  * fix merge
  ---------
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Make sure to disconnect subscription callback when unsubscribing (backport #1742 <https://github.com/ros2/rviz/issues/1742>) (#1745 <https://github.com/ros2/rviz/issues/1745>)
  (cherry picked from commit c853c3c4be79836dee3bf8419caa9ff64bc0ccfa)
  Co-authored-by: cwit-vcas <mailto:cwit@vestergaardcompany.com>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Remove redundant compilation of test fixtures (#1673 <https://github.com/ros2/rviz/issues/1673>) (#1680 <https://github.com/ros2/rviz/issues/1680>)
  (cherry picked from commit 6a1832e0239b6493b9ed0fa30757db9b421494f8)
  Co-authored-by: Michael Carroll <mailto:carroll.michael@gmail.com>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Remove no-op upper_triangle conditional in TrianglePolygon UV mapping (#1717 <https://github.com/ros2/rviz/issues/1717>) (#1754 <https://github.com/ros2/rviz/issues/1754>)
  (cherry picked from commit 3675442f67f8a8b0f07a4dd9d643c36cca899234)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
* fix for ubuntu 26 (#1694 <https://github.com/ros2/rviz/issues/1694>) (#1696 <https://github.com/ros2/rviz/issues/1696>)
  (cherry picked from commit 2a7947c0bee94d11c2694ce61339ae56ef26fa5e)
  Co-authored-by: Michael Carlstrom <mailto:rmc@carlstrom.com>
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
