### PR TITLE
linear_feedback_controller: 4.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4116,7 +4116,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/linear-feedback-controller-release.git
-      version: 3.2.0-2
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/loco-3d/linear-feedback-controller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller` to `4.0.1-1`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.2.0-2`
