### PR TITLE
Add pip entries for dash and dash-cytoscape

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3602,6 +3602,14 @@ python3-cycler:
     '*': [python3-cycler]
     '7': null
   ubuntu: [python3-cycler]
+python3-dash-cytoscape-pip:
+  '*':
+    pip:
+      packages: [dash-cytoscape]
+python3-dash-pip:
+  '*':
+    pip:
+      packages: [dash]
 python3-dataclasses-json:
   debian: [python3-dataclasses-json]
   freebsd: [py39-dataclasses-json]
@@ -3612,14 +3620,6 @@ python3-dataclasses-json:
     '*': [python3-dataclasses-json]
     bionic: null
     focal: null
-python3-dash-cytoscape-pip:
-  '*':
-    pip:
-      packages: [dash-cytoscape]
-python3-dash-pip:
-  '*':
-    pip:
-      packages: [dash]
 python3-datadog-pip:
   ubuntu:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3612,6 +3612,14 @@ python3-dataclasses-json:
     '*': [python3-dataclasses-json]
     bionic: null
     focal: null
+python3-dash-cytoscape-pip:
+  '*':
+    pip:
+      packages: [dash-cytoscape]
+python3-dash-pip:
+  '*':
+    pip:
+      packages: [dash]
 python3-datadog-pip:
   ubuntu:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

dash
dash-cytoscape


## Package Upstream Source:

https://github.com/plotly/dash
https://github.com/plotly/dash-cytoscape


## Purpose of using this:

These are Python packages for building interactive web-based dashboards. They are used by ROS2 packages that provide browser-based visualization dashboards for monitoring robot state. dash-cytoscape specifically was flagged as a missing dependency for a ROS2 package.

## Links to Distribution Packages

  - Debian: https://packages.debian.org/
    - not available
  - Ubuntu: https://packages.ubuntu.com/
    - not available
  - Fedora: https://packages.fedoraproject.org/
    - not available
  - Arch: https://www.archlinux.org/packages/
    - not available
  - Gentoo: https://packages.gentoo.org/
    - not available
  - macOS: https://formulae.brew.sh/
    - not available
  - Alpine: https://pkgs.alpinelinux.org/packages
    - not available
  - NixOS/nixpkgs: https://search.nixos.org/packages
    - not available
  - openSUSE: https://software.opensuse.org/package/
    - not available
  - rhel: https://rhel.pkgs.org/
    - not available
