### PR TITLE
Add python3-azure-storage-blob-pip to rosdep/python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4235,7 +4235,7 @@ python3-awsiotsdk-pip:
   ubuntu:
     pip:
       packages: [awsiotsdk]
-python3-azure-storage-blob:
+python3-azure-storage:
   debian: [python3-azure-storage]
   fedora: [python3-azure-storage-blob]
   ubuntu: [python3-azure-storage]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -101,16 +101,6 @@ azure-mgmt-storage-pip:
   ubuntu:
     pip:
       packages: [azure-mgmt-storage]
-azure-storage-blob-pip:
-  debian:
-    pip:
-      packages: [azure-storage-blob]
-  fedora:
-    pip:
-      packages: [azure-storage-blob]
-  ubuntu:
-    pip:
-      packages: [azure-storage-blob]
 azure-storage-file-share-pip:
   debian:
     pip:
@@ -5077,6 +5067,16 @@ python3-awsiotsdk-pip:
   ubuntu:
     pip:
       packages: [awsiotsdk]
+python3-azure-storage-blob-pip:
+  debian:
+    pip:
+      packages: [azure-storage-blob]
+  fedora:
+    pip:
+      packages: [azure-storage-blob]
+  ubuntu:
+    pip:
+      packages: [azure-storage-blob]
 python3-babel:
   debian: [python3-babel]
   fedora: [python3-babel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5067,16 +5067,10 @@ python3-awsiotsdk-pip:
   ubuntu:
     pip:
       packages: [awsiotsdk]
-python3-azure-storage-blob-pip:
-  debian:
-    pip:
-      packages: [azure-storage-blob]
-  fedora:
-    pip:
-      packages: [azure-storage-blob]
-  ubuntu:
-    pip:
-      packages: [azure-storage-blob]
+python3-azure-storage-blob:
+  debian: [python3-azure-storage]
+  fedora: [python3-azure-storage-blob]
+  ubuntu: [python3-azure-storage]
 python3-babel:
   debian: [python3-babel]
   fedora: [python3-babel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -101,6 +101,16 @@ azure-mgmt-storage-pip:
   ubuntu:
     pip:
       packages: [azure-mgmt-storage]
+azure-storage-blob-pip:
+  debian:
+    pip:
+      packages: [azure-storage-blob]
+  fedora:
+    pip:
+      packages: [azure-storage-blob]
+  ubuntu:
+    pip:
+      packages: [azure-storage-blob]
 azure-storage-file-share-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-azure-storage-blob-pip

## Package Upstream Source:

https://pypi.org/project/azure-storage-blob/

## Purpose of using this:

This dependency is being used for uploading data on a remote Azure blob server which is a type of server optimize to store massive amount of unstructured data. This is very relevant in robotics to store data such as bags, videos and other high volume data. This is why I think it's valuable to be added to the rosdep database.

Distro packaging links: https://pypi.org/project/azure-storage-blob/

## Links to Distribution Packages
- pypi.python.org
https://pypi.org/project/azure-storage-blob/

# Documentation
https://learn.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob?view=azure-python

# The source is here:

https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob/azure/storage/blob

# Checks
 - [x] All packages have a declared license in the PyPi.org
 - [x] This repository has a LICENSE file in the PyPi.org in its source code
 - [x] This pip package was tested via rosdep resolve, rosdep install and via the pytest of the rosdistro.