### PR TITLE
roboplan: 0.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7482,6 +7482,19 @@ repositories:
       type: git
       url: https://github.com/open-planning/roboplan.git
       version: main
+    release:
+      packages:
+      - roboplan
+      - roboplan_example_models
+      - roboplan_examples
+      - roboplan_oink
+      - roboplan_rrt
+      - roboplan_simple_ik
+      - roboplan_toppra
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/roboplan-release.git
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/open-planning/roboplan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboplan` to `0.4.0-1`:

- upstream repository: https://github.com/open-planning/roboplan.git
- release repository: https://github.com/ros2-gbp/roboplan-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## roboplan

```
* Add Ubuntu 26.04 and ROS 2 Lyrical to CI (#215 <https://github.com/open-planning/roboplan/issues/215>)
* Add missing gtest and gmock deps in package.xmls (#223 <https://github.com/open-planning/roboplan/issues/223>)
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* OInK self-collision barrier (#207 <https://github.com/open-planning/roboplan/issues/207>)
* Use native mimic joint functionality in Pinocchio (#214 <https://github.com/open-planning/roboplan/issues/214>)
* Support planar joints (#209 <https://github.com/open-planning/roboplan/issues/209>)
* Add Stretch4 model (#208 <https://github.com/open-planning/roboplan/issues/208>)
* Support Pinocchio 4.0 (#205 <https://github.com/open-planning/roboplan/issues/205>)
* Support dual end effectors in action chunk example (#204 <https://github.com/open-planning/roboplan/issues/204>)
* Support cylinder and mesh scene collision objects (#197 <https://github.com/open-planning/roboplan/issues/197>)
* Add CartesianTrajectory type (#203 <https://github.com/open-planning/roboplan/issues/203>)
* Fix bugs in collision object scene operations (#193 <https://github.com/open-planning/roboplan/issues/193>)
* Add SE3 low-pass filter C++ library and Python bindings (#180 <https://github.com/open-planning/roboplan/issues/180>)
* Contributors: Muslim Alaran, Ola Ghattas, Prajwal, Sebastian Castro
```

## roboplan_example_models

```
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* Use native mimic joint functionality in Pinocchio (#214 <https://github.com/open-planning/roboplan/issues/214>)
* Support planar joints (#209 <https://github.com/open-planning/roboplan/issues/209>)
* Add Stretch4 model (#208 <https://github.com/open-planning/roboplan/issues/208>)
* Contributors: Ola Ghattas, Sebastian Castro
```

## roboplan_examples

```
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* OInK self-collision barrier (#207 <https://github.com/open-planning/roboplan/issues/207>)
* Support priorities and nullspace projection in OInK tasks (#206 <https://github.com/open-planning/roboplan/issues/206>)
* Keyboard teleoperation example (#213 <https://github.com/open-planning/roboplan/issues/213>)
* Fix TOPPRA issues when using planar joints (#216 <https://github.com/open-planning/roboplan/issues/216>)
* Use native mimic joint functionality in Pinocchio (#214 <https://github.com/open-planning/roboplan/issues/214>)
* Support planar joints (#209 <https://github.com/open-planning/roboplan/issues/209>)
* Add Stretch4 model (#208 <https://github.com/open-planning/roboplan/issues/208>)
* Lazy import plyfile to not require it in all examples (#194 <https://github.com/open-planning/roboplan/issues/194>)
* Support Pinocchio 4.0 (#205 <https://github.com/open-planning/roboplan/issues/205>)
* Support dual end effectors in action chunk example (#204 <https://github.com/open-planning/roboplan/issues/204>)
* Support cylinder and mesh scene collision objects (#197 <https://github.com/open-planning/roboplan/issues/197>)
* Add CartesianTrajectory type (#203 <https://github.com/open-planning/roboplan/issues/203>)
* Add OInK action chunk tracking example (#196 <https://github.com/open-planning/roboplan/issues/196>)
* Add SE3 low-pass filter C++ library and Python bindings (#180 <https://github.com/open-planning/roboplan/issues/180>)
* Contributors: Muslim Alaran, Ola Ghattas, Prajwal, Sebastian Castro
```

## roboplan_oink

```
* Fix failing OInK test due to dimension mismatch (#225 <https://github.com/open-planning/roboplan/issues/225>)
* Add Ubuntu 26.04 and ROS 2 Lyrical to CI (#215 <https://github.com/open-planning/roboplan/issues/215>)
* Add missing gtest and gmock deps in package.xmls (#223 <https://github.com/open-planning/roboplan/issues/223>)
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* OInK self-collision barrier (#207 <https://github.com/open-planning/roboplan/issues/207>)
* Support priorities and nullspace projection in OInK tasks (#206 <https://github.com/open-planning/roboplan/issues/206>)
* Support planar joints (#209 <https://github.com/open-planning/roboplan/issues/209>)
* Contributors: Ola Ghattas, Sebastian Castro
```

## roboplan_rrt

```
* Add missing gtest and gmock deps in package.xmls (#223 <https://github.com/open-planning/roboplan/issues/223>)
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* Use native mimic joint functionality in Pinocchio (#214 <https://github.com/open-planning/roboplan/issues/214>)
* Support planar joints (#209 <https://github.com/open-planning/roboplan/issues/209>)
* Add Stretch4 model (#208 <https://github.com/open-planning/roboplan/issues/208>)
* Contributors: Ola Ghattas, Sebastian Castro
```

## roboplan_simple_ik

```
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* Use native mimic joint functionality in Pinocchio (#214 <https://github.com/open-planning/roboplan/issues/214>)
* Support planar joints (#209 <https://github.com/open-planning/roboplan/issues/209>)
* Add Stretch4 model (#208 <https://github.com/open-planning/roboplan/issues/208>)
* Contributors: Ola Ghattas, Sebastian Castro
```

## roboplan_toppra

```
* Add missing gtest and gmock deps in package.xmls (#223 <https://github.com/open-planning/roboplan/issues/223>)
* Modularize Python bindings (#221 <https://github.com/open-planning/roboplan/issues/221>)
* Add toppra and nanobind-dev rosdep keys (#219 <https://github.com/open-planning/roboplan/issues/219>)
* Fix TOPPRA issues when using planar joints (#216 <https://github.com/open-planning/roboplan/issues/216>)
* Support Pinocchio 4.0 (#205 <https://github.com/open-planning/roboplan/issues/205>)
* Contributors: Sebastian Castro
```
