### PR TITLE
marti_messages: 1.6.1-4 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4276,7 +4276,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/marti_messages-release.git
-      version: 1.6.1-3
+      version: 1.6.1-4
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_messages` to `1.6.1-4`:

- upstream repository: https://github.com/swri-robotics/marti_messages.git
- release repository: https://github.com/ros2-gbp/marti_messages-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.6.1-3`

## marti_can_msgs

- No changes

## marti_common_msgs

- No changes

## marti_dbw_msgs

- No changes

## marti_introspection_msgs

- No changes

## marti_nav_msgs

- No changes

## marti_perception_msgs

- No changes

## marti_sensor_msgs

- No changes

## marti_status_msgs

- No changes

## marti_visualization_msgs

- No changes
