### PR TITLE
clearpath_config: 2.9.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1474,7 +1474,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.9.3-1
+      version: 2.9.4-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.9.4-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.3-1`

## clearpath_config

```
* Bump actions/checkout from 3 to 6 (#234 <https://github.com/clearpathrobotics/clearpath_config/issues/234>)
  Bumps [actions/checkout](https://github.com/actions/checkout) from 3 to 6.
  - [Release notes](https://github.com/actions/checkout/releases)
  - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/actions/checkout/compare/v3...v6)
  ---
  updated-dependencies:
  - dependency-name: actions/checkout
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Bump actions/setup-python from 3 to 6 (#233 <https://github.com/clearpathrobotics/clearpath_config/issues/233>)
  Bumps [actions/setup-python](https://github.com/actions/setup-python) from 3 to 6.
  - [Release notes](https://github.com/actions/setup-python/releases)
  - [Commits](https://github.com/actions/setup-python/compare/v3...v6)
  ---
  updated-dependencies:
  - dependency-name: actions/setup-python
  dependency-version: '6'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Bump ros-tooling/action-ros-ci from 0.3 to 0.4 (#232 <https://github.com/clearpathrobotics/clearpath_config/issues/232>)
  Bumps [ros-tooling/action-ros-ci](https://github.com/ros-tooling/action-ros-ci) from 0.3 to 0.4.
  - [Release notes](https://github.com/ros-tooling/action-ros-ci/releases)
  - [Commits](https://github.com/ros-tooling/action-ros-ci/compare/v0.3...v0.4)
  ---
  updated-dependencies:
  - dependency-name: ros-tooling/action-ros-ci
  dependency-version: '0.4'
  dependency-type: direct:production
  update-type: version-update:semver-minor
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Bump actions/github-script from 7 to 9 (#231 <https://github.com/clearpathrobotics/clearpath_config/issues/231>)
  Bumps [actions/github-script](https://github.com/actions/github-script) from 7 to 9.
  - [Release notes](https://github.com/actions/github-script/releases)
  - [Commits](https://github.com/actions/github-script/compare/v7...v9)
  ---
  updated-dependencies:
  - dependency-name: actions/github-script
  dependency-version: '9'
  dependency-type: direct:production
  update-type: version-update:semver-major
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Added dependabot and pre-commit. (#228 <https://github.com/clearpathrobotics/clearpath_config/issues/228>)
* Fixed missing directory creation in write_yaml. (#227 <https://github.com/clearpathrobotics/clearpath_config/issues/227>)
* Contributors: Tony Baltovski, dependabot[bot]
```
