### PR TITLE
rc_genicam_api: 2.8.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6591,7 +6591,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.8.1-2
+      version: 2.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.8.5-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.1-2`

## rc_genicam_api

```
* set CMP0045 policy to NEW to support newer cmake versions
```
