### PR TITLE
marti_common: 3.9.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5537,7 +5537,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/marti_common-release.git
-      version: 3.8.9-1
+      version: 3.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marti_common` to `3.9.0-1`:

- upstream repository: https://github.com/swri-robotics/marti_common.git
- release repository: https://github.com/ros2-gbp/marti_common-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.8.9-1`

## swri_cli_tools

- No changes

## swri_console_util

- No changes

## swri_dbw_interface

- No changes

## swri_geometry_util

- No changes

## swri_image_util

- No changes

## swri_math_util

```
* Lyrical Update (#789 <https://github.com/swri-robotics/marti_common/issues/789>)
  * Removing deprecated headers
  * Fixing logger warning usage
  * Fixing PROJ compatibility
* Contributors: David Anthony
```

## swri_opencv_util

- No changes

## swri_roscpp

- No changes

## swri_route_util

- No changes

## swri_serial_util

- No changes

## swri_transform_util

```
* Lyrical Update (#789 <https://github.com/swri-robotics/marti_common/issues/789>)
  * Removing deprecated headers
  * Fixing logger warning usage
  * Fixing PROJ compatibility
* Contributors: David Anthony
```
