### PR TITLE
mola_state_estimation: 2.4.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4634,7 +4634,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.4.0-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.4.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.0-1`

## mola_georeferencing

```
* cmake: remove mola_yaml as dep, added GTSAM as public dep
* Contributors: Jose Luis Blanco-Claraco
```

## mola_gtsam_factors

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* Merge pull request #32 <https://github.com/MOLAorg/mola_state_estimation/issues/32> from MOLAorg/feat/1d-kalman-velocities
  feat: new 1D kalman velocity filter
* feat: new 1D kalman velocity filter
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

- No changes
