### PR TITLE
novatel_gps_driver: 4.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5318,7 +5318,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.2.0-5
+      version: 4.2.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.2.1-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.2.0-5`

## novatel_gps_driver

```
* Added support for CORRIMUS and INSPVAS, also replaying PCAP in loop. (#125 <https://github.com/swri-robotics/novatel_gps_driver/issues/125>)
  * corrimus and inspvas added
  * loop replay for pcap
  ---------
  Co-authored-by: Abhishek_khoyani <mailto:abhishek.khoyani@hexagon.com>
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Contributors: Abhishek Khoyani
```

## novatel_gps_msgs

```
* Added support for CORRIMUS and INSPVAS, also replaying PCAP in loop. (#125 <https://github.com/swri-robotics/novatel_gps_driver/issues/125>)
  * corrimus and inspvas added
  * loop replay for pcap
  ---------
  Co-authored-by: Abhishek_khoyani <mailto:abhishek.khoyani@hexagon.com>
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Contributors: Abhishek Khoyani
```
