### PR TITLE
spdlog_vendor: 1.6.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11467,7 +11467,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/spdlog_vendor-release.git
-      version: 1.6.1-1
+      version: 1.6.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spdlog_vendor` to `1.6.2-1`:

- upstream repository: https://github.com/ros2/spdlog_vendor.git
- release repository: https://github.com/ros2-gbp/spdlog_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.6.1-1`

## spdlog_vendor

```
* Remove CODEOWNERS and mirror-rolling-to-master. (#38 <https://github.com/ros2/spdlog_vendor/issues/38>) (#39 <https://github.com/ros2/spdlog_vendor/issues/39>)
  They are both outdated and both no longer serve their
  intended purpose.
  (cherry picked from commit b391a1d9919273f46a2f6be2496caa4ce19c3f95)
  Co-authored-by: Chris Lalancette <mailto:clalancette@openrobotics.org>
* Contributors: mergify[bot]
```
