### PR TITLE
test_interface_files: 0.11.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11761,7 +11761,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/test_interface_files-release.git
-      version: 0.11.0-3
+      version: 0.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `test_interface_files` to `0.11.1-1`:

- upstream repository: https://github.com/ros2/test_interface_files.git
- release repository: https://github.com/ros2-gbp/test_interface_files-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.11.0-3`

## test_interface_files

```
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#23 <https://github.com/ros2/test_interface_files/issues/23>) (#24 <https://github.com/ros2/test_interface_files/issues/24>)
  They are both out of date, and both no longer serving their
  intended purpose.
  (cherry picked from commit 25d4b699e4bcd28ab4d900dd73540ea341b8c508)
  Co-authored-by: Chris Lalancette <mailto:clalancette@gmail.com>
* Contributors: mergify[bot]
```
