### PR TITLE
rc_genicam_api: 2.8.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6565,7 +6565,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rc_genicam_api-release.git
-      version: 2.8.1-3
+      version: 2.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rc_genicam_api` to `2.8.6-1`:

- upstream repository: https://github.com/roboception/rc_genicam_api.git
- release repository: https://github.com/ros2-gbp/rc_genicam_api-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.1-3`

## rc_genicam_api

```
* don't try to install lintian overrides file via cmake
```
