### PR TITLE
rosbag2: 0.26.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9828,7 +9828,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag2-release.git
-      version: 0.26.10-2
+      version: 0.26.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag2` to `0.26.11-1`:

- upstream repository: https://github.com/ros2/rosbag2.git
- release repository: https://github.com/ros2-gbp/rosbag2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.26.10-2`

## liblz4_vendor

- No changes

## mcap_vendor

- No changes

## ros2bag

- No changes

## rosbag2

- No changes

## rosbag2_compression

```
* Add validation for empty file path in compression process (#2398 <https://github.com/ros2/rosbag2/issues/2398>) (#2411 <https://github.com/ros2/rosbag2/issues/2411>)
  (cherry picked from commit b7370e4061b398c943a3fa7bc71e6210f0d6474b)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_compression_zstd

- No changes

## rosbag2_cpp

- No changes

## rosbag2_examples_cpp

- No changes

## rosbag2_examples_py

- No changes

## rosbag2_interfaces

- No changes

## rosbag2_performance_benchmarking

- No changes

## rosbag2_performance_benchmarking_msgs

- No changes

## rosbag2_py

- No changes

## rosbag2_storage

- No changes

## rosbag2_storage_default_plugins

- No changes

## rosbag2_storage_mcap

- No changes

## rosbag2_storage_sqlite3

- No changes

## rosbag2_test_common

```
* Reduce flakiness in rosbag2 recorder end-to-end tests (#2370 <https://github.com/ros2/rosbag2/issues/2370>) (#2415 <https://github.com/ros2/rosbag2/issues/2415>)
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## rosbag2_test_msgdefs

- No changes

## rosbag2_tests

- No changes

## rosbag2_transport

```
* [kilted] Address flakiness in the "rosbag2_transport::test_record_services" tests (backport #2368 <https://github.com/ros2/rosbag2/issues/2368>) (#2379 <https://github.com/ros2/rosbag2/issues/2379>) (#2400 <https://github.com/ros2/rosbag2/issues/2400>)
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* [kilted] Fix QoS overrides ignored when topic name has no leading slash (backport #2394 <https://github.com/ros2/rosbag2/issues/2394>) (#2405 <https://github.com/ros2/rosbag2/issues/2405>) (#2413 <https://github.com/ros2/rosbag2/issues/2413>)
  Co-authored-by: Sahil Lakhmani <mailto:126493645+lakhmanisahil@users.noreply.github.com>
  Co-authored-by: Michael Orlov <mailto:morlovmr@gmail.com>
* Contributors: mergify[bot]
```

## shared_queues_vendor

- No changes

## sqlite3_vendor

- No changes

## zstd_vendor

- No changes
