### PR TITLE
nebula: 1.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6795,7 +6795,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/nebula-release.git
-      version: 1.0.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/tier4/nebula.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nebula` to `1.1.1-1`:

- upstream repository: https://github.com/tier4/nebula.git
- release repository: https://github.com/ros2-gbp/nebula-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## continental_msgs

- No changes

## continental_srvs

- No changes

## nebula

- No changes

## nebula_continental

- No changes

## nebula_continental_common

- No changes

## nebula_continental_decoders

- No changes

## nebula_continental_hw_interfaces

- No changes

## nebula_core_common

- No changes

## nebula_core_decoders

- No changes

## nebula_core_hw_interfaces

- No changes

## nebula_core_ros

```
* fix(nebula_agnocast_wrapper): add agnocast intra process subscription count (#447 <https://github.com/tier4/nebula/issues/447>)
  * fix: add intra_sub_count
  * chore: re-trigger CI
  * chore: re-trigger CI
  ---------
* Contributors: Yutaro Kobayashi
```

## nebula_hesai

- No changes

## nebula_hesai_common

- No changes

## nebula_hesai_decoders

- No changes

## nebula_hesai_hw_interfaces

- No changes

## nebula_msgs

- No changes

## nebula_robosense

- No changes

## nebula_robosense_common

- No changes

## nebula_robosense_decoders

- No changes

## nebula_robosense_hw_interfaces

- No changes

## nebula_sample

- No changes

## nebula_sample_common

- No changes

## nebula_sample_decoders

- No changes

## nebula_sample_hw_interfaces

- No changes

## nebula_velodyne

```
* fix(nebula_velodyne): fix inconsistent angle units in phase_diff logic (#441 <https://github.com/tier4/nebula/issues/441>)
  * Fix inconsistent angle units in phase_diff logic
  * Replace magic number 90 with named constant for angle threshold
  * Update VLP16 decoder test to handle angle unit mismatch
  * Regenerate ground truth PCDs using PCDWriter
  * Revert "Update VLP16 decoder test to handle angle unit mismatch"
  This reverts commit 313a80c6e484e7e02291b8949f322880bf46f0dc.
* Contributors: koji-oka-fsi
```

## nebula_velodyne_common

- No changes

## nebula_velodyne_decoders

```
* fix(nebula_velodyne): fix inconsistent angle units in phase_diff logic (#441 <https://github.com/tier4/nebula/issues/441>)
  * Fix inconsistent angle units in phase_diff logic
  * Replace magic number 90 with named constant for angle threshold
  * Update VLP16 decoder test to handle angle unit mismatch
  * Regenerate ground truth PCDs using PCDWriter
  * Revert "Update VLP16 decoder test to handle angle unit mismatch"
  This reverts commit 313a80c6e484e7e02291b8949f322880bf46f0dc.
* Contributors: koji-oka-fsi
```

## nebula_velodyne_hw_interfaces

- No changes

## pandar_msgs

- No changes

## robosense_msgs

- No changes
