### PR TITLE
Updating libjsoncpp to 26 for resolute.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4773,10 +4773,11 @@ libjsoncpp:
   opensuse: [libjsoncpp19]
   rhel: [jsoncpp]
   ubuntu:
-    '*': [libjsoncpp25]
+    '*': [libjsoncpp26]
     bionic: [libjsoncpp1]
     focal: [libjsoncpp1]
-    resolute: [libjsoncpp26]
+    jammy: [libjsoncpp25]
+    noble: [libjsoncpp25]
 libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4776,6 +4776,7 @@ libjsoncpp:
     '*': [libjsoncpp25]
     bionic: [libjsoncpp1]
     focal: [libjsoncpp1]
+    resolute: [libjsoncpp26]
 libjsoncpp-dev:
   arch: [jsoncpp]
   debian: [libjsoncpp-dev]


### PR DESCRIPTION
I noticed in Ubuntu 26.04 that libjsoncpp's package has updated from libjsoncpp25 to libjsoncpp26
