### PR TITLE
novatel_gps_driver: 4.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6992,7 +6992,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/novatel_gps_driver-release.git
-      version: 4.2.1-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `novatel_gps_driver` to `4.3.0-1`:

- upstream repository: https://github.com/swri-robotics/novatel_gps_driver.git
- release repository: https://github.com/ros2-gbp/novatel_gps_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.2.1-1`

## novatel_gps_driver

```
* Updating for Lyrical (#130 <https://github.com/swri-robotics/novatel_gps_driver/issues/130>)
  * Updating CMakeList for new ament functionality
  * Updating boost usage for new versions of boost
  * Using standard library threads instead of boost threads.
* Contributors: David Anthony
```

## novatel_gps_msgs

- No changes
