### PR TITLE
Add Qt6 widgets dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6701,6 +6701,20 @@ libqt6-websockets:
   ubuntu:
     '*': [libqt6websockets6]
     'focal': null
+libqt6-widgets:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian: [libqt6widgets6]
+  fedora: [qt6-qtbase]
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase]
+    '8': null
+  ubuntu:
+    '*': [libqt6widgets6]
+    'focal': null
+    'noble': [libqt6widgetst64]
 libqt6bluetooth6:
   alpine: [qt6-qtconnectivity]
   arch: [qt6-connectivity]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6714,7 +6714,7 @@ libqt6-widgets:
   ubuntu:
     '*': [libqt6widgets6]
     'focal': null
-    'noble': [libqt6widgetst64]
+    'noble': [libqt6widgets6t64]
 libqt6bluetooth6:
   alpine: [qt6-qtconnectivity]
   arch: [qt6-connectivity]


### PR DESCRIPTION
Adding qt6-widgets dependencies to support new distributions that do not support Qt5.
