### PR TITLE
mola_state_estimation: 2.4.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6047,7 +6047,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_state_estimation-release.git
-      version: 2.4.1-1
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_state_estimation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_state_estimation` to `2.4.2-1`:

- upstream repository: https://github.com/MOLAorg/mola_state_estimation.git
- release repository: https://github.com/ros2-gbp/mola_state_estimation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.1-1`

## mola_georeferencing

- No changes

## mola_gtsam_factors

- No changes

## mola_state_estimation

- No changes

## mola_state_estimation_simple

```
* feat(#33 <https://github.com/MOLAorg/mola_state_estimation/issues/33>): velocity filter now handles multi-rate interleaved sources via per-component clocks, fixing linear velocity starvation when LiDAR pose stamps lag IMU stamps
* feat: velocity filter enabled by default (set ``velocity_filter_enabled: false`` to restore legacy behavior)
* feat: opt-in CSV instrumentation via ``MOLA_VEL_FILTER_DUMP`` and ``MOLA_NAVSTATE_DUMP`` env vars
* fix: missing ``vel_filter_P`` reset
* test: multi-rate interleaved velocity regression test
* Contributors: Jose Luis Blanco-Claraco
```

## mola_state_estimation_smoother

- No changes
