### PR TITLE
mola_lidar_odometry: 2.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4615,7 +4615,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 2.2.0-1
+      version: 2.2.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_lidar_odometry` to `2.2.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_lidar_odometry.git
- release repository: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.0-1`

## mola_lidar_odometry

```
* simple state estimator: MOLA_NAVSTATE_VELOCITY_FILTER is now true by default
* ci: fix Jazzy Jalisco EOL date in CI workflow comment (May 2024 - May 2029)
* ci: scope arm64 apt-cacher-ng proxy to apt only (fix xmllint test) (#82 <https://github.com/MOLAorg/mola_erathos_slam/issues/82>)
* chore: add profiler to unit tests
* ci: add tests run in self-hosted
* fix self-runner label
* CI: add self hosted runner jobs too
* feat: selective disabling each of the imgui tabs
* gicp yaml: expose more viz params and the new velocity filter param
* docs: sync pipeline variables from actual yaml
* Merge pull request #81 <https://github.com/MOLAorg/mola_erathos_slam/issues/81> from MOLAorg/clean-gui-code
  GUI: clear dead code and reorganize ImGui tabs
* fix: multithread issues
* gui: split in 3 tabs when in imgui mode
* chore: remove dead code for mola<2.6.0 compatibility
* Merge pull request #80 <https://github.com/MOLAorg/mola_erathos_slam/issues/80> from MOLAorg/more-robust-multi-sensor
  More robust multi sensor
* fix: gracefully handle missing scans in multi-lidar settings
* chore: add warning if dropped lidar scans in multi-sensor mode
* chore: add debug-level traces for multi-lidar settings
* Contributors: Jose Luis Blanco-Claraco
```
