### PR TITLE
sync_tooling_msgs: 0.2.10-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11577,7 +11577,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
-      version: 0.2.9-1
+      version: 0.2.10-1
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_tooling_msgs` to `0.2.10-1`:

- upstream repository: https://github.com/tier4/sync_tooling_msgs.git
- release repository: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.9-1`

## sync_tooling_msgs

```
* build: fix protobuf gencode runtime version conflict (#4 <https://github.com/tier4/sync_tooling_msgs/issues/4>)
  * build: make build-time protobuf version <= runtime to fix gencode/runtime incompatibility
  * fix: bump protobuf to >=6.33.5 o fix json recursion vuln
  ---------
* Contributors: Max Schmeller
```
