### PR TITLE
foxglove_sdk_vendor: 0.2.0-5 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2409,7 +2409,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_sdk_vendor-release.git
-      version: 0.2.0-4
+      version: 0.2.0-5
     source:
       type: git
       url: https://gitlab.com/jlack/foxglove_sdk_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_sdk_vendor` to `0.2.0-5`:

- upstream repository: https://gitlab.com/jlack/foxglove_sdk_vendor.git
- release repository: https://github.com/ros2-gbp/foxglove_sdk_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `0.2.0-4`
