### PR TITLE
visp: 3.7.0-7 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10762,7 +10762,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/visp-release.git
-      version: 3.7.0-6
+      version: 3.7.0-7
     source:
       type: git
       url: https://github.com/lagadic/visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.7.0-7`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/ros2-gbp/visp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `3.7.0-6`
