### PR TITLE
visp: 3.7.0-7 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10791,7 +10791,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/visp-release.git
-      version: 3.7.0-5
+      version: 3.7.0-7
     source:
       type: git
       url: https://github.com/lagadic/visp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `visp` to `3.7.0-7`:

- upstream repository: https://github.com/lagadic/visp.git
- release repository: https://github.com/ros2-gbp/visp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.7.0-5`
