### PR TITLE
Index mola_input_rosbag1 in humble (doc + source)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5992,6 +5992,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_input_ouster.git
       version: develop
     status: developed
+  mola_input_rosbag1:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_rosbag1.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_rosbag1.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The source is here:

https://github.com/MOLAorg/mola_input_rosbag1

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
