### PR TITLE
[humble] fusioncore 0.3.0-1

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3485,7 +3485,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.2.4-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Bump fusioncore to 0.3.0-1 in Humble.

What's new in 0.3.0:
- /fusion/debug/gnss_status and /fusion/debug/filter_health observability topics
- Lever arm correction gated on heading sigma (gnss.lever_arm_max_heading_sigma_deg)
- Configurable GPS track heading motion thresholds
- 64 tests passing

Release repo: https://github.com/manankharwar/fusioncore-release