### PR TITLE
image_common: 7.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3318,7 +3318,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 7.0.1-1
+      version: 7.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `7.0.2-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.0.1-1`

## camera_calibration_parsers

```
* Cleanups and removed unused files (#406 <https://github.com/ros-perception/image_common/issues/406>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager

```
* Cleanups and removed unused files (#406 <https://github.com/ros-perception/image_common/issues/406>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager_py

```
* Zoom Camera Info manager properly ported to ROS 2 (#407 <https://github.com/ros-perception/image_common/issues/407>)
* Cleanups and removed unused files (#406 <https://github.com/ros-perception/image_common/issues/406>)
* Contributors: Alejandro Hernández Cordero
```

## image_common

- No changes

## image_transport

```
* Added rosdoc2 documentation to image_transport (#401 <https://github.com/ros-perception/image_common/issues/401>)
* Cleanups and removed unused files (#406 <https://github.com/ros-perception/image_common/issues/406>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

```
* Cleanups and removed unused files (#406 <https://github.com/ros-perception/image_common/issues/406>)
* Contributors: Alejandro Hernández Cordero
```
