### PR TITLE
image_common: 6.4.10-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3306,7 +3306,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 6.4.9-1
+      version: 6.4.10-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `6.4.10-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.4.9-1`

## camera_calibration_parsers

- No changes

## camera_info_manager

- No changes

## camera_info_manager_py

```
* Zoom Camera Info manager properly ported to ROS 2 (backport #407 <https://github.com/ros-perception/image_common/issues/407>) (#422 <https://github.com/ros-perception/image_common/issues/422>)
* Contributors: mergify[bot]
```

## image_common

- No changes

## image_transport

- No changes

## image_transport_py

```
* Removed build status
* Contributors: Alejandro Hernandez Cordero
```
