### PR TITLE
rqt_bag: 2.2.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8578,7 +8578,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.2.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.3-1`

## rqt_bag

- No changes

## rqt_bag_plugins

```
* Qt6 fixes (backport #209 <https://github.com/ros-visualization/rqt_bag/issues/209>) (#210 <https://github.com/ros-visualization/rqt_bag/issues/210>)
* Contributors: mergify[bot]
```
