### PR TITLE
linear_feedback_controller: 4.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5241,6 +5241,21 @@ repositories:
       url: https://github.com/david-dorf/lightning_rrt_interfaces.git
       version: jazzy
     status: maintained
+  linear_feedback_controller:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/linear-feedback-controller-release.git
+      version: 4.0.1-1
+    source:
+      type: git
+      url: https://github.com/loco-3d/linear-feedback-controller.git
+      version: main
+    status: maintained
   linear_feedback_controller_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `linear_feedback_controller` to `4.0.1-1`:

- upstream repository: https://github.com/loco-3d/linear-feedback-controller
- release repository: https://github.com/ros2-gbp/linear-feedback-controller-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
