### PR TITLE
jrl_cmakemodules eigenpy nanoeigenpy coal pinocchio crocoddyl eiquadprog tsid linear_feedback_controller_msgs linear_feedback_controller : remove Rdev jobs

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5948,6 +5948,7 @@ repositories:
       url: https://github.com/ros2-gbp/pinocchio-release.git
       version: 4.0.0-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git
       version: devel

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1931,6 +1931,7 @@ repositories:
       url: https://github.com/ros2-gbp/eiquadprog-release.git
       version: 1.3.2-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4123,6 +4123,7 @@ repositories:
       url: https://github.com/ros2-gbp/linear-feedback-controller-release.git
       version: 4.0.1-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/loco-3d/linear-feedback-controller.git
       version: main

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1913,6 +1913,7 @@ repositories:
       url: https://github.com/ros2-gbp/eigenpy-release.git
       version: 3.12.0-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/stack-of-tasks/eigenpy.git
       version: devel

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5097,6 +5097,7 @@ repositories:
       url: https://github.com/ros2-gbp/nanoeigenpy-release.git
       version: 0.5.0-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1219,6 +1219,7 @@ repositories:
       url: https://github.com/ros2-gbp/coal-release.git
       version: 3.0.3-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/coal-library/coal.git
       version: devel

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3554,6 +3554,7 @@ repositories:
       url: https://github.com/ros2-gbp/jrl_cmakemodules-release.git
       version: 1.1.2-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/jrl-umi3218/jrl-cmakemodules.git
       version: master

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4138,6 +4138,7 @@ repositories:
       url: https://github.com/ros2-gbp/linear-feedback-controller-msgs-release.git
       version: 1.2.2-2
     source:
+      test_commits: false
       type: git
       url: https://github.com/loco-3d/linear-feedback-controller-msgs.git
       version: main

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10079,6 +10079,7 @@ repositories:
       url: https://github.com/ros2-gbp/tsid-release.git
       version: 1.10.0-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/stack-of-tasks/tsid.git
       version: devel

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1468,6 +1468,7 @@ repositories:
       url: https://github.com/ros2-gbp/crocoddyl-release.git
       version: 3.2.1-1
     source:
+      test_commits: false
       type: git
       url: https://github.com/loco-3d/crocoddyl.git
       version: devel


### PR DESCRIPTION
Hi,

In those packages, we already have plenty CI systems, including a ROS one.

I think using build.ros2.org resources for those does not make sense, especially since many of them are broken by design (maybe the design is wrong, but that is off-topic) when the patches on the `*-release` repos are not applied.

Also, I was not aware of that, but upstream maintainers of those do get emails, even if they are not in package.xml. 
And they are not super happy about that 😅 

