### PR TITLE
rosidl: 5.3.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8215,7 +8215,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.3.0-1
+      version: 5.3.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.3.1-2`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.3.0-1`

## rosidl_adapter

- No changes

## rosidl_buffer

```
* Remove tests in rosidl_buffer for unconventional cases (#969 <https://github.com/ros2/rosidl/issues/969>)
* Avoid warnings from use of default constructed iterators (#966 <https://github.com/ros2/rosidl/issues/966>)
* Contributors: CY Chen, Miguel Company
```

## rosidl_buffer_backend

- No changes

## rosidl_buffer_backend_registry

- No changes

## rosidl_buffer_py

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Add integer overflow guards to rosidl sequence init and copy functions
* Contributors: Michael Carroll
```

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* Add integer overflow guards to rosidl sequence init and copy functions
* Contributors: Michael Carroll
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
