### PR TITLE
rosidl: 5.2.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8180,7 +8180,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 5.2.0-3
+      version: 5.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `5.2.1-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.2.0-3`

## rosidl_adapter

- No changes

## rosidl_buffer

- No changes

## rosidl_buffer_backend

- No changes

## rosidl_buffer_backend_registry

- No changes

## rosidl_buffer_py

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Add integer overflow guards to rosidl sequence init and copy functions (#970 <https://github.com/ros2/rosidl/issues/970>)
* Contributors: Michael Carroll
```

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* Add integer overflow guards to rosidl sequence init and copy functions (#970 <https://github.com/ros2/rosidl/issues/970>)
* Contributors: Michael Carroll
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
