### PR TITLE
automatika_ros_sugar: 0.7.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -664,7 +664,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.6.1-3
+      version: 0.7.1-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_ros_sugar` to `0.7.1-1`:

- upstream repository: https://github.com/automatika-robotics/ros-sugar.git
- release repository: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.1-3`

## automatika_ros_sugar

```
* (fix) Fixes stale reference in logged warning
* (chore) Adds more tests for plugins, http transport, route via host and telemetry bus
* (refactor) Changes from tcp to AF_UNIX sockets in transport bus and fixes pubilishing from multiple threads on the same sock via locks
* (fix) Makes rclpy_context test fixture tolerant of a pre-initialized context
* (docs) Updates robot plugins doc
* (feature) Adds robot config from plugin when defined
* (fix) Adds handling callbacks and publishers dict as sources of truth instead of in_topic and out_topic
* (chore) Adds correct docstring for plugin metadata
* (chore) Updates robot plugin tests
* (feature) Adds use_plugin to topic to get take topic type from plugin
  - Disambiguates topics of similar type by matching topic name with keys
  available in plugin
  - Keys can surface in errors or avaialble via inspection
* (feature) Adds plugin_action decorator for robot actions exposed by plugins
* (chore) Adds test for robot plugin feature
* (feature) Adds initialization and tear down of robot plugin host to the launcher
* (feature) Adds serialization of robot plugin in the generic executable
* (feature) Adds handling of external plugin topics and events blackboard in the monitor
* (feature) Wires the robot plugin handling in the component
* (feature) Adds robot command type that subclasses publisher for generalized publishing to robot via plugins
* (refactor) Removes old plugin init from serialized config
* (feautre) Adds new general purpose robot plugin infrastructure (feedback, robot commands, transports and plugin classes)
* (chore) Removes rolling from deb package build
* Contributors: ahr
```
