### PR TITLE
kompass: 0.6.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3679,7 +3679,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/kompass-release.git
-      version: 0.4.1-3
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/automatika-robotics/kompass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kompass` to `0.6.0-1`:

- upstream repository: https://github.com/automatika-robotics/kompass.git
- release repository: https://github.com/ros2-gbp/kompass-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.1-3`

## kompass

```
* (chore) Bumps required sugarcoat version
* (fix) Fixes controller mode change to handle plugin-based callbacks
* Contributors: ahr, mkabtoul
```

## kompass_interfaces

- No changes
