### PR TITLE
automatika_embodied_agents: 0.7.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -649,7 +649,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
-      version: 0.7.0-3
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-agents.git


### PR DESCRIPTION
Increasing version of package(s) in repository `automatika_embodied_agents` to `0.7.4-1`:

- upstream repository: https://github.com/automatika-robotics/ros-agents.git
- release repository: https://github.com/ros2-gbp/automatika_embodied_agents-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.0-3`

## automatika_embodied_agents

```
* (chore) Bumps up sugarcoat version
* (refactor) Adds build url helper for building url schema if none provided
* (fix) Allows say method to raise exceptions to be handled by parent 'execute_method' and fixes attribute check
* (feature) Adds robot plugin serialization/deserialization to the executable
* (fix) Adds using pre-init logger in methods executed before activation
* (fix) Fixes an error where TLS endpoints couldnt be called by clients
* (feature) Adds plugin actions to actions available to cortex and augments planning prompt with robot description from the plugin
* Contributors: ahr, mkabtoul
```
