### PR TITLE
mrpt3: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4889,6 +4889,58 @@ repositories:
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
       version: main
     status: maintained
+  mrpt3:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    release:
+      packages:
+      - mrpt_apps_cli
+      - mrpt_apps_gui
+      - mrpt_bayes
+      - mrpt_common
+      - mrpt_comms
+      - mrpt_config
+      - mrpt_containers
+      - mrpt_core
+      - mrpt_data
+      - mrpt_examples_cpp
+      - mrpt_expr
+      - mrpt_graphs
+      - mrpt_graphslam
+      - mrpt_gui
+      - mrpt_hwdrivers
+      - mrpt_img
+      - mrpt_imgui
+      - mrpt_io
+      - mrpt_kinematics
+      - mrpt_libapps_cli
+      - mrpt_libapps_gui
+      - mrpt_maps
+      - mrpt_math
+      - mrpt_nav
+      - mrpt_obs
+      - mrpt_opengl
+      - mrpt_poses
+      - mrpt_random
+      - mrpt_rtti
+      - mrpt_serialization
+      - mrpt_slam
+      - mrpt_system
+      - mrpt_tfest
+      - mrpt_topography
+      - mrpt_typemeta
+      - mrpt_viz
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt3-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    status: developed
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.0.0-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

- No changes

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

- No changes

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

- No changes

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

- No changes

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

- No changes

## mrpt_maps

- No changes

## mrpt_math

- No changes

## mrpt_nav

- No changes

## mrpt_obs

- No changes

## mrpt_opengl

- No changes

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

- No changes

## mrpt_tfest

- No changes

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

- No changes
