### PR TITLE
hitch_estimation_apriltag_array: 0.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3151,6 +3151,21 @@ repositories:
       url: https://github.com/HebiRobotics/hebi_msgs.git
       version: main
     status: maintained
+  hitch_estimation_apriltag_array:
+    doc:
+      type: git
+      url: https://github.com/li9i/hitch-estimation-apriltag-array.git
+      version: lyrical-devel
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/li9i/hitch-estimation-apriltag-array.git
+      version: lyrical-devel
+    status: maintained
   hls_lfcd_lds_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `hitch_estimation_apriltag_array` to `0.0.3-1`:

- upstream repository: https://github.com/li9i/hitch-estimation-apriltag-array.git
- release repository: https://github.com/li9i/hitch-estimation-apriltag-array-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
