### PR TITLE
ply_utils: 0.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6028,6 +6028,21 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: lyrical
     status: maintained
+  ply_utils:
+    doc:
+      type: git
+      url: https://github.com/li9i/ply-utils.git
+      version: lyrical-devel
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/li9i/ply-utils-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/li9i/ply-utils.git
+      version: lyrical-devel
+    status: maintained
   point_cloud_msg_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ply_utils` to `0.0.3-1`:

- upstream repository: https://github.com/li9i/ply-utils.git
- release repository: https://github.com/li9i/ply-utils-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
