### PR TITLE
camera_ros: 0.7.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1026,7 +1026,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/camera_ros-release.git
-      version: 0.6.0-3
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/christianrauch/camera_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `camera_ros` to `0.7.0-1`:

- upstream repository: https://github.com/christianrauch/camera_ros.git
- release repository: https://github.com/ros2-gbp/camera_ros-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.0-3`
