### PR TITLE
common_interfaces: 5.3.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1768,7 +1768,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.3.7-1
+      version: 5.3.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `common_interfaces` to `5.3.8-1`:

- upstream repository: https://github.com/ros2/common_interfaces.git
- release repository: https://github.com/ros2-gbp/common_interfaces-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `5.3.7-1`

## actionlib_msgs

- No changes

## common_interfaces

- No changes

## diagnostic_msgs

- No changes

## geometry_msgs

```
* Add geometry_msgs/msg/VelocityWithCovarianceStamped (#323 <https://github.com/ros2/common_interfaces/issues/323>) (#336 <https://github.com/ros2/common_interfaces/issues/336>)
  (cherry picked from commit bae9a4897bbfd0d57425f085ae08c6a6d155625c)
  Co-authored-by: Ethan J. Musser <mailto:ethanmusser1@gmail.com>
* Contributors: mergify[bot]
```

## nav_msgs

- No changes

## sensor_msgs

- No changes

## sensor_msgs_py

- No changes

## shape_msgs

- No changes

## std_msgs

- No changes

## std_srvs

- No changes

## stereo_msgs

- No changes

## trajectory_msgs

- No changes

## visualization_msgs

- No changes
