### PR TITLE
rcl: 9.2.11-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8322,7 +8322,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 9.2.10-1
+      version: 9.2.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcl` to `9.2.11-1`:

- upstream repository: https://github.com/ros2/rcl.git
- release repository: https://github.com/ros2-gbp/rcl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `9.2.10-1`

## rcl

- No changes

## rcl_action

```
* fix: Prevent short time endless loop in expire_timer (#1303 <https://github.com/ros2/rcl/issues/1303>) (#1305 <https://github.com/ros2/rcl/issues/1305>)
  * fix: Prevent short time endless loop in expire_timer
  There were multiple bugs in this area:
  - The expire of goals and the re computation of the expire period
  had a < vs <= issue, leading to goals not expiring, while the
  period for the next expire was compute as 0 leading to a direct
  recall of the expire timer. In combination with sim time this lead
  to 100% CPU spikes.
  - The period of the expire timer was changed after the reset of the timer,
  leading to an incorrect next call time of the timer.
  - The timer was not canceled after the expire event was issued
  * chore: Removed unneeded line
  ---------
  (cherry picked from commit 927a33e55963aa00a23286658af7747fac1aaf87)
  resolve merge conflicts
  Co-authored-by: Janosch Machowinski <mailto:jmachowinski@users.noreply.github.com>
* Contributors: mergify[bot]
```

## rcl_lifecycle

- No changes

## rcl_yaml_param_parser

- No changes
