### PR TITLE
rviz: 14.1.22-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10869,7 +10869,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.21-1
+      version: 14.1.22-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.22-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `14.1.21-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1778 <https://github.com/ros2/rviz/issues/1778>)
  (cherry picked from commit 26b578fa1d3a4c4a3578d57bd4c24c36feba1f67)
  Co-authored-by: Tom Moore <mailto:automatom@protonmail.com>
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1778 <https://github.com/ros2/rviz/issues/1778>)
  (cherry picked from commit 26b578fa1d3a4c4a3578d57bd4c24c36feba1f67)
  Co-authored-by: Tom Moore <mailto:automatom@protonmail.com>
* Fix when with pitch != width*BBP in Image Display (backport #1719 <https://github.com/ros2/rviz/issues/1719>) (#1762 <https://github.com/ros2/rviz/issues/1762>)
  (cherry picked from commit 9eebc57c6b949466c95869d6a31a878cf10bf222)
  Co-authored-by: Alejandro Hernández Cordero <mailto:alejandro@openrobotics.org>
  Co-authored-by: Alejandro Hernandez Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
