### PR TITLE
Add source and doc for tiago_dual repositories

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12320,6 +12320,46 @@ repositories:
       url: https://github.com/MetroRobots/the_navigation_gauntlet.git
       version: main
     status: developed
+  tiago_dual_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_moveit_config.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_moveit_config.git
+      version: humble-devel
+    status: developed
+  tiago_dual_navigation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_navigation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_navigation.git
+      version: humble-devel
+    status: developed
+  tiago_dual_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_robot.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_robot.git
+      version: humble-devel
+    status: developed
+  tiago_dual_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_simulation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/tiago_dual_simulation.git
+      version: humble-devel
+    status: developed
   tiago_moveit_config:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The sources are here:

- https://github.com/pal-robotics/tiago_dual_moveit_config.git
- https://github.com/pal-robotics/tiago_dual_navigation.git
- https://github.com/pal-robotics/tiago_dual_robot.git
- https://github.com/pal-robotics/tiago_dual_simulation.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro: