### PR TITLE
scan_2d_merger: 2.0.0-3 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11405,6 +11405,21 @@ repositories:
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
     status: developed
+  scan_2d_merger:
+    doc:
+      type: git
+      url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release.git
+      version: 2.0.0-3
+    source:
+      type: git
+      url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git
+      version: main
+    status: developed
   scenario_execution:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_2d_merger` to `2.0.0-3`:

- upstream repository: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git
- release repository: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
