### PR TITLE
ros_gz: 4.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8068,7 +8068,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.8-2
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `4.0.0-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.8-2`

## ros_gz

- No changes

## ros_gz_bridge

```
* Fix bridge params xml parse (#903 <https://github.com/gazebosim/ros_gz/issues/903>)
* Fix bridge_params TypeError (#899 <https://github.com/gazebosim/ros_gz/issues/899>)
* Added missing headers in convert (#888 <https://github.com/gazebosim/ros_gz/issues/888>)
* sensor_msgs bounds fixes (#882 <https://github.com/gazebosim/ros_gz/issues/882>)
* Restore rolling CI on Ubuntu 26.04 resolute (#883 <https://github.com/gazebosim/ros_gz/issues/883>)
* Contributors: Alejandro Hernández Cordero, Carlos Agüero, JBeck-SRW
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Fixed tests failures (#900 <https://github.com/gazebosim/ros_gz/issues/900>)
* Added rosdoc2 documentatation for ros_gz_sim (#876 <https://github.com/gazebosim/ros_gz/issues/876>)
* Restore rolling CI on Ubuntu 26.04 resolute (#883 <https://github.com/gazebosim/ros_gz/issues/883>)
* Contributors: Alejandro Hernández Cordero, Carlos Agüero
```

## ros_gz_sim_demos

- No changes
