### PR TITLE
rqt_tf_tree: 1.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8908,7 +8908,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.6-3
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.1.0-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros2-gbp/rqt_tf_tree-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.6-3`

## rqt_tf_tree

```
* added flake8 and pep257 (#60 <https://github.com/ros-visualization/rqt_tf_tree/issues/60>)
* Removed license warning (#61 <https://github.com/ros-visualization/rqt_tf_tree/issues/61>)
* Replaced the deprecated tests_require=['pytest'] (#59 <https://github.com/ros-visualization/rqt_tf_tree/issues/59>)
* Fix some issues (#58 <https://github.com/ros-visualization/rqt_tf_tree/issues/58>)
* Contributors: Alejandro Hernández Cordero
```
