### PR TITLE
ros_gz: 3.0.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7968,7 +7968,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: ros2
+      version: lyrical
     release:
       packages:
       - ros_gz
@@ -7985,7 +7985,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/gazebosim/ros_gz.git
-      version: ros2
+      version: lyrical
     status: developed
   ros_image_to_qimage:
     doc:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7980,7 +7980,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 3.0.8-3
+      version: 3.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_gz` to `3.0.9-1`:

- upstream repository: https://github.com/gazebosim/ros_gz
- release repository: https://github.com/ros2-gbp/ros_ign-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.8-3`

## ros_gz

- No changes

## ros_gz_bridge

```
* Fix bridge params xml parse (#903 <https://github.com/gazebosim/ros_gz/issues/903>) (#904 <https://github.com/gazebosim/ros_gz/issues/904>)
* Fix bridge_params TypeError (#899 <https://github.com/gazebosim/ros_gz/issues/899>) (#901 <https://github.com/gazebosim/ros_gz/issues/901>)
* Added missing headers in convert (#888 <https://github.com/gazebosim/ros_gz/issues/888>) (#889 <https://github.com/gazebosim/ros_gz/issues/889>)
* sensor_msgs bounds fixes (#882 <https://github.com/gazebosim/ros_gz/issues/882>)
* Restore rolling CI on Ubuntu 26.04 resolute (#883 <https://github.com/gazebosim/ros_gz/issues/883>)
* Contributors: Carlos Agüero, mergify[bot]
```

## ros_gz_image

- No changes

## ros_gz_interfaces

- No changes

## ros_gz_sim

```
* Restore rolling CI on Ubuntu 26.04 resolute (#883 <https://github.com/gazebosim/ros_gz/issues/883>)
* Contributors: Carlos Agüero
```

## ros_gz_sim_demos

- No changes
