### PR TITLE
Add piper and dependency

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1934,6 +1934,13 @@ python-pathos-pip:
       packages: [pathos]
 python-pathtools:
   debian: [python-pathtools]
+python-pathvalidate:
+  ubuntu:
+    pip:
+      packages: [pathvalidate]
+  debian:
+    pip:
+      packages: [pathvalidate]
 python-pbr:
   debian: [python-pbr]
   fedora: [python-pbr]
@@ -2029,6 +2036,13 @@ python-pip:
   openembedded: ['${PYTHON_PN}-pip@meta-python']
   opensuse: [python2-pip]
   ubuntu: [python-pip]
+python-piper-tts:
+  ubuntu:
+    pip:
+      packages: [piper-tts]
+  debian:
+    pip:
+      packages: [piper-tts]
 python-pixel-ring-pip:
   debian:
     pip:


### PR DESCRIPTION
Adds the Piper text-to-speech system.

Please add the following dependency to the rosdep database.

## Package name:

piper-tts

## Package Upstream Source:

https://pypi.org/project/piper-tts/

## Purpose of using this:

Piper is a popular text-to-speech engine, and we wish to use it in the context of ROS.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
- Ubuntu: https://packages.ubuntu.com/
- Fedora:https://packages.fedoraproject.org/pkgs/python-piper-tts/python3-piper-tts/
- Arch: NOT AVAILABLE
- Gentoo: NOT AVAILABLE
- macOS: NOT AVAILABLE
- Alpine: https://github.com/OHF-Voice/piper1-gpl
- openSUSE: NOT AVAILABLE
- rhel: NOT AVAILABLE