### PR TITLE
crazyswarm2: 1.0.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2044,11 +2044,12 @@ repositories:
       - crazyflie_examples
       - crazyflie_interfaces
       - crazyflie_py
+      - crazyflie_server_py
       - crazyflie_sim
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/crazyswarm2-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/IMRCLab/crazyswarm2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crazyswarm2` to `1.0.4-1`:

- upstream repository: https://github.com/IMRCLab/crazyswarm2.git
- release repository: https://github.com/ros2-gbp/crazyswarm2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.3-1`

## crazyflie

```
* support for Lyrical
* install dependencies through rosdep ci
* remove broken dependency on tf_transformations
* remove nicegui
* Seperating cflib server to its own package
* move simple mapper to examples
* seperate velmux and add hover to python library
* add support for Crazyradio 2 (firmware >= 5.1)
* adding cmd_velocity_world for cpp and cflib backends
* Contributors: Aarsh Thakker, Kimberly N. McGuire, Wolfgang Hönig
```

## crazyflie_examples

```
* refactoring of code and minor bugfixes
* add support for Crazyradio 2 (firmware >= 5.1)
* Contributors: Kimberly N. McGuire, Wolfgang Hönig
```

## crazyflie_interfaces

- No changes

## crazyflie_py

```
* Lyrical support
* seperate velmux and add hover to python library
* Contributors: Kimberly N. McGuire, Mikhael Sunil, Wolfgang Hönig
```

## crazyflie_server_py

```
* Separating cflib server to its own package
* Contributors: Kimberly N. McGuire, Wolfgang Hönig
```

## crazyflie_sim

- No changes
