### PR TITLE
nanoflann: 1.10.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6624,6 +6624,21 @@ repositories:
       url: https://github.com/Simple-Robotics/nanoeigenpy.git
       version: main
     status: developed
+  nanoflann:
+    doc:
+      type: git
+      url: https://github.com/jlblancoc/nanoflann.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/nanoflann-release.git
+      version: 1.10.1-1
+    source:
+      type: git
+      url: https://github.com/jlblancoc/nanoflann.git
+      version: master
+    status: developed
   nao_button_sim:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nanoflann` to `1.10.1-1`:

- upstream repository: https://github.com/jlblancoc/nanoflann.git
- release repository: https://github.com/ros2-gbp/nanoflann-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## nanoflann

```
* Merge pull request #303 <https://github.com/jlblancoc/nanoflann/issues/303> from jlblancoc/refactor/tests-smaller-files
  refactor: unit tests into smaller files
* refactor: unit tests into smaller files
* CHANGELOG: ported to rst format for ROS tools compatibility
* doc: update outdated COPYING dates
* docs: add readme build badges
* docs: add ROS build farm badge table to README
* Add ROS package.xml and integrate BUILD_TESTING for ROS build farm
  - package.xml: plain cmake build_type, BSD-2-Clause, libgtest-dev test_depend
  - CMakeLists.txt: include(CTest), use BUILD_TESTING guard, auto-select
  system GTest when ROS_VERSION env is set
  - tests/CMakeLists.txt: remove redundant project(), rename test target to
  nanoflann_unit_tests to avoid collisions in workspaces
* Contributors: Jose Luis Blanco-Claraco
```
