### PR TITLE
Add Rosdep Keys for Minio, Intervals, and SortedCollections

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6192,6 +6192,9 @@ python3-interpreter:
   rhel: [python3]
   slackware: [python3]
   ubuntu: [python3-minimal]
+python3-intervals:
+  debian: [python3-intervals]
+  ubuntu: [python3-intervals]
 python3-isaaclab-pip:
   '*':
     pip:
@@ -6670,6 +6673,19 @@ python3-minijinja:
     noble:
       pip:
         packages: [minijinja]
+python3-minio-pip:
+  debian:
+    pip:
+      packages: [minio]
+  fedora:
+    pip:
+      packages: [minio]
+  osx:
+    pip:
+      packages: [minio]
+  ubuntu:
+    pip:
+      packages: [minio]
 python3-minimalmodbus-pip:
   debian:
     pip:
@@ -9620,6 +9636,10 @@ python3-socketio:
   ubuntu:
     '*': [python3-socketio]
     bionic: null
+python3-sortedcollections:
+  debian: [python3-sortedcollections]
+  fedora: [python3-sortedcollections]
+  ubuntu: [python3-sortedcollections]
 python3-sortedcollections-pip:
   debian:
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package names:

python3-sortedcollections
python3-intervals
minio

## Package Upstream Sources:

https://github.com/grantjenks/python-sortedcollections
https://github.com/taschini/pyinterval
https://github.com/minio/minio-py

## Purpose of using this:

Sorted Collections is a general python library introducing frameworks for sorted dictionaries and sets. It can be used to sort various tasks a robot can accomplish by priority or by cost.

Intervals allows for using mathematical intervals in python. It's incredibly useful for heavily mathematical planning and physics problems.

Minio allows for locally hosting a server to allow for storing images. Although typically used for web development similar to Amazon s3 it is incredibly useful for allowing websites to display the images captured by robots.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/python3-sortedcollections
  - https://packages.debian.org/stable/python/python3-intervals
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/python3-sortedcollections
  - https://packages.ubuntu.com/noble/python3-intervals
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/python-sortedcollections/python3-sortedcollections/
  - Intervals not available
- Arch: https://www.archlinux.org/packages/
  - Not available
- Gentoo: https://packages.gentoo.org/
  - Not available
- macOS: https://formulae.brew.sh/
  - Not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - Not available
- openSUSE: https://software.opensuse.org/package/
  - Not available
- rhel: https://rhel.pkgs.org/
  - Not available

Minio is only avaliable in PyPi: https://pypi.org/project/minio/