### PR TITLE
rclcpp: 28.1.20-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8438,7 +8438,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 28.1.19-1
+      version: 28.1.20-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `28.1.20-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `28.1.19-1`

## rclcpp

```
* Add Callback Group Events Executor (Jazzy Backport) (#3163 <https://github.com/ros2/rclcpp/issues/3163>)
  * initial backport commit
  * remove C++20 features (designated initializers)
  * update executor tests
  * add component_container_events_cbg
  * change to use shared_ptr by value
  * explicit type
  * remove fix non-applicable to jazzy
  * lint
  ---------
  Co-authored-by: Skyler Medeiros <mailto:skye@polymathrobotics.com>
* Contributors: Skyler Medeiros
```

## rclcpp_action

```
* Initialize GenericClient result response offsets (backport #2790 <https://github.com/ros2/rclcpp/issues/2790>) (#3139 <https://github.com/ros2/rclcpp/issues/3139>)
* Contributors: Lidang Jiang
```

## rclcpp_components

```
* Add Callback Group Events Executor (Jazzy Backport) (#3163 <https://github.com/ros2/rclcpp/issues/3163>)
  * initial backport commit
  * remove C++20 features (designated initializers)
  * update executor tests
  * add component_container_events_cbg
  * change to use shared_ptr by value
  * explicit type
  * remove fix non-applicable to jazzy
  * lint
  ---------
  Co-authored-by: Skyler Medeiros <mailto:skye@polymathrobotics.com>
* Contributors: Skyler Medeiros
```

## rclcpp_lifecycle

- No changes
