### PR TITLE
ros2_echo_graphic: 0.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9355,6 +9355,21 @@ repositories:
       url: https://github.com/ros-controls/ros2_controllers.git
       version: jazzy
     status: developed
+  ros2_echo_graphic:
+    doc:
+      type: git
+      url: https://github.com/codevilot/echo-graphic.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/codevilot/echo-graphic-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/codevilot/echo-graphic.git
+      version: main
+    status: developed
   ros2_eventdispatch:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_echo_graphic` to `0.1.0-1`:

- upstream repository: https://github.com/codevilot/echo-graphic.git
- release repository: https://github.com/codevilot/echo-graphic-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
