### PR TITLE
geometric_shapes: 2.3.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3689,7 +3689,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometric_shapes-release.git
-      version: 2.3.2-1
+      version: 2.3.4-1
     source:
       type: git
       url: https://github.com/ros-planning/geometric_shapes.git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometric_shapes` to `2.3.4-1`:

- upstream repository: https://github.com/ros-planning/geometric_shapes.git
- release repository: https://github.com/ros2-gbp/geometric_shapes-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.3.2-1`

## geometric_shapes

```
* Remove octomap dependency (#269 <https://github.com/ros-planning/geometric_shapes/issues/269>)
* Bump minimum cmake version (#265 <https://github.com/ros-planning/geometric_shapes/issues/265>)
* Fix compiler warnings
* Contributors: Felix Exner, Nathan Brooks, Robert Haschke, mosfet80
```
