### PR TITLE
Add chafa rosdep key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -551,6 +551,12 @@ cgal-qt5-dev:
   fedora: [CGAL-devel]
   gentoo: ['sci-mathematics/cgal[qt5]']
   ubuntu: [libcgal-qt5-dev]
+chafa:
+  arch: [chafa]
+  debian: [chafa]
+  fedora: [chafa]
+  rhel: [chafa]
+  ubuntu: [chafa]
 checkinstall:
   debian: [checkinstall]
   nixos: [checkinstall]


### PR DESCRIPTION
Adds a rosdep key for the chafa terminal graphics tool.\n\nThis is needed by echo_graphic so the runtime dependency can be declared in package.xml and installed automatically by standard ROS dependency tooling.\n\nMappings added:\n- arch: chafa\n- debian: chafa\n- fedora: chafa\n- rhel: chafa\n- ubuntu: chafa