### PR TITLE
lusb: 2.0.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5321,7 +5321,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/lusb-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/lusb.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.3-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.2-1`

## lusb

```
* ROS Lyrical: C++20, CMake 3.22 minimum
* Contributors: Kevin Hallenbeck
```
