### PR TITLE
lusb: 2.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4184,6 +4184,21 @@ repositories:
       url: https://github.com/hatchbed/log_view.git
       version: ros2
     status: developed
+  lusb:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/DataspeedInc-release/lusb-release.git
+      version: 2.0.3-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/lusb.git
+      version: ros2
+    status: maintained
   magic_enum:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lusb` to `2.0.3-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/lusb
- release repository: https://github.com/DataspeedInc-release/lusb-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## lusb

```
* ROS Lyrical: C++20, CMake 3.22 minimum
* Contributors: Kevin Hallenbeck
```
