### PR TITLE
Add the ros_snapd_interfaces repo

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10411,6 +10411,16 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.4.0-1
+  ros_snapd_interfaces:
+    doc:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    status: maintained
   ros_testing:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9772,6 +9772,16 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.5.4-3
+  ros_snapd_interfaces:
+    doc:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    status: developed
   ros_testing:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9781,7 +9781,7 @@ repositories:
       type: git
       url: https://github.com/canonical/ros_snapd_interfaces.git
       version: ros2
-    status: developed
+    status: maintained
   ros_testing:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8130,6 +8130,16 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.5.4-2
+  ros_snapd_interfaces:
+    doc:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    status: maintained
   ros_testing:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8039,6 +8039,16 @@ repositories:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.5.4-3
+  ros_snapd_interfaces:
+    doc:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    status: maintained
   ros_testing:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8126,6 +8126,16 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git
       version: 0.5.4-2
+  ros_snapd_interfaces:
+    doc:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/canonical/ros_snapd_interfaces.git
+      version: ros2
+    status: maintained
   ros_testing:
     doc:
       type: git


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

ros_snapd_interfaces

## Package Upstream Source:

https://github.com/canonical/ros_snapd_interfaces

## Purpose of using this:

This repository provides the service definitions intended to interact with the following snapd bridges: https://snapcraft.io/ros2-snapd


Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/
  - IF AVAILABLE
- Arch: https://www.archlinux.org/packages/
  - IF AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - IF AVAILABLE
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - IF AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages
  - OPTIONAL
- openSUSE: https://software.opensuse.org/package/
  - IF AVAILABLE
- rhel: https://rhel.pkgs.org/
  - IF AVAILABLE

# Please Add This Package to be indexed in the rosdistro.

humble
jazzy
kilted
lyrical
rolling

# The source is here:

https://github.com/canonical/ros_snapd_interfaces

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
