### PR TITLE
generate_parameter_library: 1.2.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2510,7 +2510,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `1.2.0-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.0-1`

## generate_parameter_library

- No changes

## generate_parameter_library_py

```
* Made fields in python structs assigned per-instance instead of at the class scope (#351 <https://github.com/PickNikRobotics/generate_parameter_library/issues/351>)
* Fix ParameterDescription of exclusive bounds (#339 <https://github.com/PickNikRobotics/generate_parameter_library/issues/339>)
* Contributors: Alex Navarro, Christoph Fröhlich
```
