### PR TITLE
microstrain_inertial: 4.9.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4496,7 +4496,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.8.0-1
+      version: 4.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.9.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.8.0-1`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* Updates submodules(#402 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/402>)
  -Adding support for Nova GNSS development kit
  -Adding experimental GNSS receiver reset service and conservative RTK mode
* Contributors: Aidan
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* Updates submodules(#402 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/402>)
  -Adding support for Nova GNSS development kit
  -Adding experimental GNSS receiver reset service and conservative RTK mode
* Contributors: Aidan
```

## microstrain_inertial_rqt

- No changes
