### PR TITLE
microstrain_inertial: 4.9.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4468,7 +4468,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 4.8.0-2
+      version: 4.9.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `microstrain_inertial` to `4.9.0-1`:

- upstream repository: https://github.com/LORD-MicroStrain/microstrain_inertial.git
- release repository: https://github.com/ros2-gbp/microstrain_inertial-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.8.0-2`

## microstrain_inertial_description

- No changes

## microstrain_inertial_driver

```
* Updates submodules(#402 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/402>)
  -Adding support for Nova GNSS development kit
  -Adding experimental GNSS receiver reset service and conservative RTK mode
* Contributors: Aidan
```

## microstrain_inertial_examples

- No changes

## microstrain_inertial_msgs

```
* Updates submodules(#402 <https://github.com/LORD-MicroStrain/microstrain_inertial/issues/402>)
  -Adding support for Nova GNSS development kit
  -Adding experimental GNSS receiver reset service and conservative RTK mode
* Contributors: Aidan
```

## microstrain_inertial_rqt

- No changes
