### PR TITLE
ament_black: 0.2.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -171,7 +171,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ament_black-release.git
-      version: 0.2.6-3
+      version: 0.2.7-1
     source:
       type: git
       url: https://github.com/botsandus/ament_black.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_black` to `0.2.7-1`:

- upstream repository: https://github.com/botsandus/ament_black.git
- release repository: https://github.com/ros2-gbp/ament_black-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.6-3`

## ament_black

```
* Support black >= 26.3.0: fall back to ``maybe_use_uvloop`` (black 26.3.0 renamed ``maybe_install_uvloop``, psf/black#4996 <https://github.com/psf/black/issues/4996>) (#18 <https://github.com/botsandus/ament_black/issues/18>)
* Bound black to the 2026 stable-style year (>=26.3,<27)
* Unpin black/uvloop in setup.py for Python 3.14 pip installs
* Fix pytest test collection on Python 3.14: declare pytest via ``setup.cfg`` ``[options.extras_require]`` (setuptools drops the deprecated ``tests_require``, so colcon fell back to unittest, collected 0 tests, and failed the buildfarm with exit code 5)
* Refresh stale ``setup.py`` maintainer metadata
* Contributors: Guillaume Doisy
```

## ament_cmake_black

```
* Bump cmake minimum version (#18 <https://github.com/botsandus/ament_black/issues/18>)
* Contributors: Guillaume Doisy
```
