### PR TITLE
dataspeed_can: 2.0.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2123,7 +2123,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 2.0.6-1
+      version: 2.0.7-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `2.0.7-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.6-1`

## dataspeed_can

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_msg_filters

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_msgs

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_usb

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Update firmware update script for changes to dataspeed_boot_usb
* Contributors: Kevin Hallenbeck
```
