### PR TITLE
dataspeed_can: 2.0.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1588,6 +1588,27 @@ repositories:
       url: https://gitlab.com/jlack/data_tamer_tools.git
       version: main
     status: developed
+  dataspeed_can:
+    doc:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
+      version: ros2
+    release:
+      packages:
+      - dataspeed_can
+      - dataspeed_can_msg_filters
+      - dataspeed_can_msgs
+      - dataspeed_can_tools
+      - dataspeed_can_usb
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
+      version: 2.0.7-1
+    source:
+      type: git
+      url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
+      version: ros2
+    status: maintained
   demos:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `dataspeed_can` to `2.0.7-1`:

- upstream repository: https://bitbucket.org/dataspeedinc/dataspeed_can.git
- release repository: https://github.com/DataspeedInc-release/dataspeed_can-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## dataspeed_can

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_msg_filters

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_msgs

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_tools

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Contributors: Kevin Hallenbeck
```

## dataspeed_can_usb

```
* ROS Lyrical, C++20, CMake 3.22 minimum, replace ament_target_dependencies() with target_link_libraries()
* Update firmware update script for changes to dataspeed_boot_usb
* Contributors: Kevin Hallenbeck
```
