### PR TITLE
gz_physics_vendor: 0.0.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3933,7 +3933,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_physics_vendor-release.git
-      version: 0.0.7-1
+      version: 0.0.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_physics_vendor` to `0.0.9-1`:

- upstream repository: https://github.com/gazebo-release/gz_physics_vendor.git
- release repository: https://github.com/ros2-gbp/gz_physics_vendor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.7-1`

## gz_physics_vendor

```
* Bump version to 7.8.0 (#22 <https://github.com/gazebo-release/gz_physics_vendor/issues/22>)
  Co-authored-by: Addisu Z. Taddese <mailto:addisuzt@intrinsic.ai>
* Contributors: Jose Luis Rivero
```
