### PR TITLE
video_to_image_msg_publisher: 0.9.5-8 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13765,6 +13765,15 @@ repositories:
       version: foxy-devel
     status: maintained
   video_to_image_msg_publisher:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/video_to_image_msg_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/video_to_image_msg_publisher-release.git
+      version: 0.9.5-8
     source:
       type: git
       url: https://github.com/gstavrinos/video_to_image_msg_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_to_image_msg_publisher` to `0.9.5-8`:

- upstream repository: https://github.com/gstavrinos/video_to_image_msg_publisher.git
- release repository: https://github.com/ros2-gbp/video_to_image_msg_publisher-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
