### PR TITLE
video_to_image_msg_publisher: 0.9.5-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10793,6 +10793,15 @@ repositories:
       version: ros2
     status: developed
   video_to_image_msg_publisher:
+    doc:
+      type: git
+      url: https://github.com/gstavrinos/video_to_image_msg_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/video_to_image_msg_publisher-release.git
+      version: 0.9.5-2
     source:
       type: git
       url: https://github.com/gstavrinos/video_to_image_msg_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `video_to_image_msg_publisher` to `0.9.5-2`:

- upstream repository: https://github.com/gstavrinos/video_to_image_msg_publisher.git
- release repository: https://github.com/ros2-gbp/video_to_image_msg_publisher-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
