### PR TITLE
Move pal-gbp repositories to ros2-gbp

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7345,7 +7345,7 @@ repositories:
       - omni_base_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/omni_base_navigation-release.git
+      url: https://github.com/ros2-gbp/omni_base_navigation-release.git
       version: 2.22.0-1
     source:
       type: git
@@ -7365,7 +7365,7 @@ repositories:
       - omni_base_robot
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/omni_base_robot-release.git
+      url: https://github.com/ros2-gbp/omni_base_robot-release.git
       version: 2.15.1-1
     source:
       type: git
@@ -7383,7 +7383,7 @@ repositories:
       - omni_base_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/omni_base_simulation-release.git
+      url: https://github.com/ros2-gbp/omni_base_simulation-release.git
       version: 2.11.1-1
     source:
       type: git
@@ -7605,7 +7605,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
+      url: https://github.com/ros2-gbp/pal_gazebo_plugins-release.git
       version: 4.1.1-1
     source:
       type: git
@@ -7620,7 +7620,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
+      url: https://github.com/ros2-gbp/pal_gazebo_worlds-release.git
       version: 4.14.0-1
     source:
       type: git
@@ -7640,7 +7640,7 @@ repositories:
       - pal_gripper_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_gripper-release.git
+      url: https://github.com/ros2-gbp/pal_gripper-release.git
       version: 3.6.5-1
     source:
       type: git
@@ -7659,7 +7659,7 @@ repositories:
       - pal_hey5_description
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_hey5-release.git
+      url: https://github.com/ros2-gbp/pal_hey5-release.git
       version: 4.2.0-1
     source:
       type: git
@@ -7674,7 +7674,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_maps-release.git
+      url: https://github.com/ros2-gbp/pal_maps-release.git
       version: 0.5.0-1
     source:
       type: git
@@ -7693,7 +7693,7 @@ repositories:
       - pal_navigation_cfg_params
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
+      url: https://github.com/ros2-gbp/pal_navigation_cfg_public-release.git
       version: 3.0.6-1
     source:
       type: git
@@ -7733,7 +7733,7 @@ repositories:
       - pal_robotiq_gripper
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pal_robotiq_gripper-release.git
+      url: https://github.com/ros2-gbp/pal_robotiq_gripper-release.git
       version: 2.2.0-1
     source:
       type: git
@@ -8153,7 +8153,7 @@ repositories:
       - pmb2_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
+      url: https://github.com/ros2-gbp/pmb2_navigation-release.git
       version: 4.21.0-1
     source:
       type: git
@@ -8173,7 +8173,7 @@ repositories:
       - pmb2_robot
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pmb2_robot-gbp.git
+      url: https://github.com/ros2-gbp/pmb2_robot-release.git
       version: 5.11.2-1
     source:
       type: git
@@ -8191,7 +8191,7 @@ repositories:
       - pmb2_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/pmb2_simulation-release.git
+      url: https://github.com/ros2-gbp/pmb2_simulation-release.git
       version: 4.11.1-1
     source:
       type: git
@@ -12254,7 +12254,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/talos_moveit_config-release.git
+      url: https://github.com/ros2-gbp/talos_moveit_config-release.git
       version: 2.0.4-1
     source:
       type: git
@@ -12272,7 +12272,7 @@ repositories:
       - talos_robot
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/talos_robot-release.git
+      url: https://github.com/ros2-gbp/talos_robot-release.git
       version: 2.10.3-1
     source:
       type: git
@@ -12285,7 +12285,7 @@ repositories:
       - talos_gazebo
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/talos_simulation-release.git
+      url: https://github.com/ros2-gbp/talos_simulation-release.git
       version: 2.0.3-1
     source:
       type: git
@@ -12507,7 +12507,7 @@ repositories:
     release:
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_moveit_config-release.git
+      url: https://github.com/ros2-gbp/tiago_moveit_config-release.git
       version: 3.1.2-1
     source:
       type: git
@@ -12527,7 +12527,7 @@ repositories:
       - tiago_rgbd_sensors
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_navigation-release.git
+      url: https://github.com/ros2-gbp/tiago_navigation-release.git
       version: 4.12.0-1
     source:
       type: git
@@ -12658,7 +12658,7 @@ repositories:
       - tiago_robot
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_robot-release.git
+      url: https://github.com/ros2-gbp/tiago_robot-release.git
       version: 4.24.1-1
     source:
       type: git
@@ -12676,7 +12676,7 @@ repositories:
       - tiago_simulation
       tags:
         release: release/humble/{package}/{version}
-      url: https://github.com/pal-gbp/tiago_simulation-release.git
+      url: https://github.com/ros2-gbp/tiago_simulation-release.git
       version: 4.10.1-1
     source:
       type: git


### PR DESCRIPTION
This PR moves all the released pal-robotics release repositories to ros2-gbp, handled [here](https://github.com/ros2-gbp/ros2-gbp-github-org/commit/667dca98f46d93f0e98434b2f0234fee0753efe3).

It also fixes some urls that were wrong.