### PR TITLE
added enpose_tracking to rolling release

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1983,7 +1983,7 @@ repositories:
     source:
       type: git
       url: https://github.com/enpose-tech/enpose-ros.git
-      version: release
+      version: main
     status: developed
   event_camera_codecs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1979,6 +1979,12 @@ repositories:
       url: https://github.com/stack-of-tasks/eiquadprog.git
       version: devel
     status: maintained
+  enpose_tracking:
+    source:
+      type: git
+      url: https://github.com/enpose-tech/enpose-ros.git
+      version: release
+    status: developed
   event_camera_codecs:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1980,6 +1980,10 @@ repositories:
       version: devel
     status: maintained
   enpose_tracking:
+    doc:
+      type: git
+      url: https://github.com/enpose-tech/enpose-ros.git
+      version: main
     source:
       type: git
       url: https://github.com/enpose-tech/enpose-ros.git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/enpose-tech/enpose-ros

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
