### PR TITLE
mola_input_rosbag1: 0.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6052,7 +6052,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_input_rosbag1.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_input_rosbag1` to `0.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_input_rosbag1.git
- release repository: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.0-1`

## mola_input_rosbag1

```
* Update mrpt_ros_bridge submodule
* fix: build of ros1 headers in gcc15
* fix: enforce c++17 so build doesn't fail with GCC-15+
* Add loader for NTU viral dataset
* Contributors: Jose Luis Blanco-Claraco
```
