### PR TITLE
rosbag_timing_inspector: 1.0.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8273,6 +8273,21 @@ repositories:
       url: https://github.com/fictionlab/rosbag2_to_video.git
       version: ros2
     status: maintained
+  rosbag_timing_inspector:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/rosbag_timing_inspector.git
+      version: develop
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/rosbag_timing_inspector-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/rosbag_timing_inspector.git
+      version: develop
+    status: developed
   rosbridge_suite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_timing_inspector` to `1.0.0-1`:

- upstream repository: https://github.com/MOLAorg/rosbag_timing_inspector.git
- release repository: https://github.com/ros2-gbp/rosbag_timing_inspector-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## rosbag_timing_inspector

```
* fix: add opengl and libglfw3-dev as build dependencies
  Required by the ImGui/ImPlot renderer but missing from package.xml,
  causing ROS build farm failures (CMake could not find OpenGL/GLFW).
* fix: remove storage plugins from package.xml dependencies
  rosbag2_storage_mcap and rosbag2_storage_sqlite3 are auto-discovered
  runtime plugins and are not valid rosdep keys, causing build farm
  failures. They ship with a standard ROS 2 desktop install.
* fix: declare storage plugins as exec_depend, not depend
  rosbag2_storage_mcap and rosbag2_storage_sqlite3 are runtime-loaded
  plugins; the code only includes headers from rosbag2_cpp/rosbag2_storage.
  Using <depend> caused build farm rosdep resolution failures.
* docs: add Humble row to ROS build farm status table
* docs: add ROS build farm status badge table (Jazzy, Kilted, Lyrical, Rolling)
* Replace image in README with updated version
  Updated image in README with a new source and dimensions.
* Update README with image and features details
  Added an image to the README and expanded the features section.
* add more visual features
* install exe in bin
* Initial commit
* Contributors: Jose Luis Blanco-Claraco
```
