### PR TITLE
mola_input_rosbag1: 0.2.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4676,6 +4676,21 @@ repositories:
       url: https://github.com/MOLAorg/mola_input_ouster.git
       version: develop
     status: developed
+  mola_input_rosbag1:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_rosbag1.git
+      version: develop
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
+      version: 0.2.0-1
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_input_rosbag1.git
+      version: develop
+    status: developed
   mola_lidar_odometry:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_input_rosbag1` to `0.2.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_input_rosbag1.git
- release repository: https://github.com/ros2-gbp/mola_input_rosbag1-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mola_input_rosbag1

```
* Update mrpt_ros_bridge submodule
* fix: build of ros1 headers in gcc15
* fix: enforce c++17 so build doesn't fail with GCC-15+
* Add loader for NTU viral dataset
* Contributors: Jose Luis Blanco-Claraco
```
