### PR TITLE
Add dynamicfeed_ros (humble, jazzy)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2499,7 +2499,7 @@ repositories:
       url: https://github.com/pradyum/dual_laser_merger.git
       version: humble
     status: developed
-  dynamicfeed-ros:
+  dynamicfeed_ros:
     source:
       type: git
       url: https://github.com/dynamicfeed/dynamicfeed-ros.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2499,6 +2499,12 @@ repositories:
       url: https://github.com/pradyum/dual_laser_merger.git
       version: humble
     status: developed
+  dynamicfeed-ros:
+    source:
+      type: git
+      url: https://github.com/dynamicfeed/dynamicfeed-ros.git
+      version: main
+    status: developed
   dynamixel_hardware:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2377,7 +2377,7 @@ repositories:
       url: https://github.com/pradyum/dual_laser_merger.git
       version: jazzy
     status: developed
-  dynamicfeed-ros:
+  dynamicfeed_ros:
     source:
       type: git
       url: https://github.com/dynamicfeed/dynamicfeed-ros.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2377,6 +2377,12 @@ repositories:
       url: https://github.com/pradyum/dual_laser_merger.git
       version: jazzy
     status: developed
+  dynamicfeed-ros:
+    source:
+      type: git
+      url: https://github.com/dynamicfeed/dynamicfeed-ros.git
+      version: main
+    status: developed
   dynamixel_hardware:
     doc:
       type: git


### PR DESCRIPTION
Adds a source entry for [dynamicfeed-ros](https://github.com/dynamicfeed/dynamicfeed-ros) to the `humble` and `jazzy` distributions.

dynamicfeed-ros publishes live, Ed25519-signature-verified world-data topics for ROS 2 (weather, natural hazards, GPS interference, air quality, space weather) from the keyless Dynamic Feed API, with the signature verified on the robot.

Packages in the repository (all `package.xml` format 3, version 0.1.0, maintainer and license set):

- `dynamicfeed_msgs` — message interfaces (Provenance trust envelope, HazardAlert, GpsInterference, AirQuality, SpaceWeather)
- `dynamicfeed_awareness` — `ament_python` node publishing the signed data as standard ROS topics
- `dynamicfeed_bringup` — launch files and configuration

Checklist:

- [x] Top-level `LICENSE` file (MIT, OSI-approved); license reflected in every `package.xml`
- [x] Public source repository: https://github.com/dynamicfeed/dynamicfeed-ros
- [x] Repository contains ROS packages (3 `package.xml`, format 3)
- [x] Package names comply with REP-144
- [x] `version` is a branch (`main`); no tag of the same name exists
- [x] CI green on Humble and Jazzy (colcon build) at the indexed branch
- [x] Not a fork of an existing ROS package; brand-new to the ecosystem

Documentation: https://dynamicfeed.ai/standard

🤖 Generated with [Claude Code](https://claude.com/claude-code)