### PR TITLE
Add NixOS entries for nvidia-cudnn and nvidia-cuda-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8615,10 +8615,12 @@ nvidia-cuda-dev:
   arch: [cuda]
   debian: [nvidia-cuda-dev]
   gentoo: [dev-util/nvidia-cuda-sdk, dev-util/nvidia-cuda-gdk]
+  nixos: [cudaPackages.cudatoolkit]
   ubuntu: [nvidia-cuda-dev]
 nvidia-cudnn:
   arch: [cudnn]
   debian: [nvidia-cudnn]
+  nixos: [cudaPackages.cudnn]
   ubuntu:
     '*': [nvidia-cudnn]
     focal: null


### PR DESCRIPTION
https://github.com/ros/rosdistro/pull/51639 seems to have missed `nvidia-cuda-dev` and `nvidia-cudnn`.