### PR TITLE
generate_parameter_library: 0.7.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2640,7 +2640,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `generate_parameter_library` to `0.7.4-1`:

- upstream repository: https://github.com/PickNikRobotics/generate_parameter_library.git
- release repository: https://github.com/ros2-gbp/generate_parameter_library-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.3-1`

## generate_parameter_library

- No changes

## generate_parameter_library_py

```
* Fix ParameterDescription of exclusive bounds (backport #339 <https://github.com/PickNikRobotics/generate_parameter_library/issues/339>)
* Contributors: Christoph Froehlich
```

## parameter_traits

- No changes
