### PR TITLE
audio_common: 0.4.0-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -648,7 +648,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/audio_common-release.git
-      version: 0.4.0-1
+      version: 0.4.0-2
     source:
       type: git
       url: https://github.com/ros-drivers/audio_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `audio_common` to `0.4.0-2`:

- upstream repository: https://github.com/ros-drivers/audio_common.git
- release repository: https://github.com/ros2-gbp/audio_common-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-1`

## audio_capture

```
* Merge pull request #274 <https://github.com/ros-drivers/audio_common/issues/274> from knorth55/pass-audio-convert
  pass to audio convert after _source
* pass audio convert
* Merge pull request #272 <https://github.com/ros-drivers/audio_common/issues/272> from sbgisen/bugfix/pulsesrc-pipeline
  Fix crash when using wave format with pulsesrc
* Add audioconvert
* Merge pull request #270 <https://github.com/ros-drivers/audio_common/issues/270> from socialminds-ai/audio-capture-qol
  Minor quality-of-life fixes for audio_capture
* Merge pull request #269 <https://github.com/ros-drivers/audio_common/issues/269> from socialminds-ai/capture-src
  audio_capture: make it possible to configure the gstreamer input plugin
* audio_capture: document the node parameters
* audio_capture: print out errors in the gstreamer pipeline
* audio_capture: make it possible to configure the gstreamer input plugin
  This is especially useful to use pulseaudio (pulsesrc) instead of
  alsa, which is convenient when working inside Docker containers
* Merge pull request #267 <https://github.com/ros-drivers/audio_common/issues/267> from knorth55/ros2-fix-rolling
  replace ament_target_dependencies
* remove CMAKE_CXX flags
* replace ament_target_dependencies
* Merge pull request #257 <https://github.com/ros-drivers/audio_common/issues/257> from sbgisen/feature/qos
  Set transient local to audio info publisher
* Merge remote-tracking branch 'origin/ros2' into feature/qos
* Merge pull request #254 <https://github.com/ros-drivers/audio_common/issues/254> from sbgisen/feature/diagnostic
  Publish diagnostic
* Set transient local to audio info publisher
* Auto detect rate
* Publish diagnostic
* Merge pull request #236 <https://github.com/ros-drivers/audio_common/issues/236> from anrp-tri/anrp/info
  Publish audio_info on a schedule
* Merge pull request #237 <https://github.com/ros-drivers/audio_common/issues/237> from anrp-tri/anrp/flexsrc
* Allow audio_capture node to specify src type
  Allows use of pulsesrc and other options.
* Publish audio_info on a schedule
  Make sure that latecomers can get the codec details.
* Merge pull request #224 <https://github.com/ros-drivers/audio_common/issues/224> from knorth55/ros2-backport
* on real systems publish system clock time in capture node
* publish audio stamped in audio_capture.cpp
* The capture node is hard-coded to alsasrc
* Merge pull request #215 <https://github.com/ros-drivers/audio_common/issues/215> from knorth55/weeshal/components
* use include for audio_capture launch.xml
* fix typo in capture_to_file.launch.py
* add missing build_depend
* add launch.pya in audio_capture
* rename to audio_capture_node
* converted nodes to components
* Merge pull request #208 <https://github.com/ros-drivers/audio_common/issues/208> from weeshal/bugfix/parameter_names
* removing ros1 namespacing
* Merge pull request #188 <https://github.com/ros-drivers/audio_common/issues/188> from Patrick-AA/ros2-patch
* changed ns to push-ros-namespace
* Merge pull request #178 <https://github.com/ros-drivers/audio_common/issues/178> from knorth55/ros2
* audio_capture: migrate to ros2
* Contributors: Andrew Patrikalakis, Patrick-AA, Shingo Kitagawa, Séverin Lemaignan, Tatsuro Sakaguchi, Vishal Giridhar, v4hn, vishalgi
```

## audio_common

```
* Merge pull request #264 <https://github.com/ros-drivers/audio_common/issues/264> from knorth55/ros2-sound-play-msgs
  split sound_play_msgs package
* add sound_play_msgs package
* Merge pull request #178 <https://github.com/ros-drivers/audio_common/issues/178> from knorth55/ros2
* audio_common: migrate to ros2
* Contributors: Shingo Kitagawa
```

## audio_common_msgs

```
* Merge pull request #267 <https://github.com/ros-drivers/audio_common/issues/267> from knorth55/ros2-fix-rolling
  replace ament_target_dependencies
* remove CMAKE_CXX flags
* Merge pull request #224 <https://github.com/ros-drivers/audio_common/issues/224> from knorth55/ros2-backport
* add AudioDataStamped.msg
* Merge pull request #178 <https://github.com/ros-drivers/audio_common/issues/178> from knorth55/ros2
* audio_common_msgs: migrate to ros2
* Contributors: Shingo Kitagawa
```

## audio_play

```
* Merge pull request #267 <https://github.com/ros-drivers/audio_common/issues/267> from knorth55/ros2-fix-rolling
  replace ament_target_dependencies
* remove CMAKE_CXX flags
* replace ament_target_dependencies
* Merge pull request #224 <https://github.com/ros-drivers/audio_common/issues/224> from knorth55/ros2-backport
* refactor audio_play launch files
* unref buffer in audio_play to avoid memory leak
* Merge pull request #215 <https://github.com/ros-drivers/audio_common/issues/215> from knorth55/weeshal/components
* add missing build_depend
* add play.launch.py in audio_play
* rename to audio_play_node
* converted nodes to components
* Merge pull request #208 <https://github.com/ros-drivers/audio_common/issues/208> from weeshal/bugfix/parameter_names
* removing ros1 namespacing
* Merge pull request #188 <https://github.com/ros-drivers/audio_common/issues/188> from Patrick-AA/ros2-patch
* changed ns to push-ros-namespace
* Merge pull request #178 <https://github.com/ros-drivers/audio_common/issues/178> from knorth55/ros2
* audio_play: migrate to ros2
* Merge pull request #179 <https://github.com/ros-drivers/audio_common/issues/179> from tkmtnt7000/PR-remap-audio-topic
* audio_play: add audio_topic option
* Contributors: Naoto Tsukamoto, Patrick-AA, Shingo Kitagawa, Vishal Giridhar, vishalgi
```

## sound_play

```
* Merge pull request #267 <https://github.com/ros-drivers/audio_common/issues/267> from knorth55/ros2-fix-rolling
  replace ament_target_dependencies
* remove CMAKE_CXX flags
* Merge pull request #264 <https://github.com/ros-drivers/audio_common/issues/264> from knorth55/ros2-sound-play-msgs
  split sound_play_msgs package
* follow review
* Merge pull request #262 <https://github.com/ros-drivers/audio_common/issues/262> from knorth55/ros2-remove-error
  remove unnecessary logerror
* modify python code
* add sound_play_msgs package
* remove unnecessary logerror
* Merge pull request #260 <https://github.com/ros-drivers/audio_common/issues/260> from peci1/ros2-encodings
  add support for different encodings
* add support for different encodings
* Merge remote-tracking branch 'origin/ros2' into feature/qos
* Merge pull request #255 <https://github.com/ros-drivers/audio_common/issues/255> from knorth55/fix-245
  Fix #245 <https://github.com/ros-drivers/audio_common/issues/245>
* set feedback first
* Merge pull request #224 <https://github.com/ros-drivers/audio_common/issues/224> from knorth55/ros2-backport
* refactor is_speaking
* fix typo causing file open issue
* add default_voice in soundplay_node.launch
* Improve is_speaking by checking goal status
* Merge pull request #217 <https://github.com/ros-drivers/audio_common/issues/217> from knorth55/ros2-missing-buildtool-depend
* add rosidl_generator_py in buildtool_depend
* Merge pull request #178 <https://github.com/ros-drivers/audio_common/issues/178> from knorth55/ros2
* sound_play: migrate to ros2
* Merge pull request #176 <https://github.com/ros-drivers/audio_common/issues/176> from iory/is-speeching
* Add is_speaking.py to catkin_install_python
* Fixed name speeching to speaking
* Add is_speeching node for checking robot is speaking
* Contributors: Martin Pecka, Shingo Kitagawa, Tatsuro Sakaguchi, iory
```

## sound_play_msgs

```
* Merge pull request #267 <https://github.com/ros-drivers/audio_common/issues/267> from knorth55/ros2-fix-rolling
  replace ament_target_dependencies
* remove CMAKE_CXX flags
* Merge pull request #264 <https://github.com/ros-drivers/audio_common/issues/264> from knorth55/ros2-sound-play-msgs
  split sound_play_msgs package
* follow review
* add sound_play_msgs package
* Contributors: Shingo Kitagawa
```
