### PR TITLE
cpp_polyfills: 1.3.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1417,7 +1417,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/cpp_polyfills-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/cpp_polyfills.git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpp_polyfills` to `1.3.2-1`:

- upstream repository: https://github.com/PickNikRobotics/cpp_polyfills.git
- release repository: https://github.com/ros2-gbp/cpp_polyfills-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.1-1`

## tcb_span

- No changes

## tl_expected

```
* SILENCE_DEPRECATION_WARNINGS from parameter_traits (#28 <https://github.com/PickNikRobotics/cpp_polyfills/issues/28>)
* Contributors: Christoph Fröhlich
```
