### PR TITLE
depthai-ros: 3.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1603,7 +1603,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-release.git
-      version: 3.2.1-1
+      version: 3.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai-ros` to `3.3.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.2.1-1`

## depthai-ros

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```

## depthai_bridge

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```

## depthai_examples

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```

## depthai_ros_msgs

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```
