### PR TITLE
mrpt3: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6385,7 +6385,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.0.1-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

```
* fix: clang-format include order in perf-graphslam.cpp
* fix: enable isolated/Debian-package builds of apps_gui
  Two issues surface when building packages in isolation (as the ROS build farm
  and .deb packaging do), where sibling modules are only available as installed
  packages, not as source:
  - mrpt-performance/perf-graphslam.cpp reached into another module's test
  sources via a relative path (../../../modules/mrpt_graphslam/tests/...).
  Vendor a local copy of the small test helper header instead.
  - mrpt_gui installs the public header nanogui/opengl.h which includes
  <GLFW/glfw3.h>, but only declared libglfw3-dev as a build dependency. Make it
  a public <depend> so downstream consumers get the GLFW headers.
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* fix: missing include
* fix: KF math errors
* fix: build errors from limiting Eigen3 visibility + KF Joseph form
  Fix CI build failures introduced by making Eigen3 a private build
  dependency:
  - 2d-slam-demo: drop unnecessary Eigen::aligned_allocator from
  m_historicData; a plain std::vector suffices and no longer needs
  Eigen headers transitively.
  - topography_gps_coords_example: this example genuinely uses MRPT
  matrix methods that require <Eigen/Dense> in the calling TU, so
  link Eigen3::Eigen explicitly instead of relying on transitive
  exposure.
  Also fix a correctness bug in the new dense Joseph-form covariance
  update: it added K*S*K^T (S = H*P*H^T + R), double-counting the
  H*P*H^T*K^T term already present in (I-K*H)*P*(I-K*H)^T. Use the
  measurement noise K*R*K^T instead, matching the algebraically
  correct sparse update path.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_bayes

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* fix: build errors from limiting Eigen3 visibility + KF Joseph form
  Fix CI build failures introduced by making Eigen3 a private build
  dependency:
  - 2d-slam-demo: drop unnecessary Eigen::aligned_allocator from
  m_historicData; a plain std::vector suffices and no longer needs
  Eigen headers transitively.
  - topography_gps_coords_example: this example genuinely uses MRPT
  matrix methods that require <Eigen/Dense> in the calling TU, so
  link Eigen3::Eigen explicitly instead of relying on transitive
  exposure.
  Also fix a correctness bug in the new dense Joseph-form covariance
  update: it added K*S*K^T (S = H*P*H^T + R), double-counting the
  H*P*H^T*K^T term already present in (I-K*H)*P*(I-K*H)^T. Use the
  measurement noise K*R*K^T instead, matching the algebraically
  correct sparse update path.
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_common

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* cmake: default BUILD_TESTING to OFF to fix FTBFS on Humble build farm
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* fix: restore lean libfyaml-core.h include; disable libfyaml tests
  Revert yaml.cpp back to including <libfyaml/libfyaml-core.h> (as in develop)
  instead of the monolithic <libfyaml.h>, which pulls in <stdatomic.h> and
  breaks the C++ build on macOS (<atomic> incompatible with <stdatomic.h>) and
  gcc. The submodule is back on the fork commit that ships libfyaml-core.h.
  Also pass -DBUILD_TESTING=OFF to the embedded libfyaml so it does not
  FetchContent the 'check' test framework (needs network; breaks isolated and
  Debian-package builds).
* submodule: revert libfyaml to fork commit with Windows/macOS fixes
  The previous bump to upstream 9a4d9b2 lost the fork's portability fixes
  (MSVC ssize_t / C++17 atomic fallback) and used cmake_minimum_required(3.0),
  breaking the Windows and macOS CI. Revert to 1ed7581, which builds on all
  platforms (matches develop).
* fix: allow libfyaml to configure with recent CMake (>=4.0)
  The bundled libfyaml uses cmake_minimum_required(VERSION 3.0), which is
  rejected by CMake >=4.0 (macOS/Windows CI runners). Pass
  CMAKE_POLICY_VERSION_MINIMUM=3.5 to its ExternalProject configure step.
* submodule: update libfyaml
* fix: KF math errors
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* fix: build errors from limiting Eigen3 visibility + KF Joseph form
  Fix CI build failures introduced by making Eigen3 a private build
  dependency:
  - 2d-slam-demo: drop unnecessary Eigen::aligned_allocator from
  m_historicData; a plain std::vector suffices and no longer needs
  Eigen headers transitively.
  - topography_gps_coords_example: this example genuinely uses MRPT
  matrix methods that require <Eigen/Dense> in the calling TU, so
  link Eigen3::Eigen explicitly instead of relying on transitive
  exposure.
  Also fix a correctness bug in the new dense Joseph-form covariance
  update: it added K*S*K^T (S = H*P*H^T + R), double-counting the
  H*P*H^T*K^T term already present in (I-K*H)*P*(I-K*H)^T. Use the
  measurement noise K*R*K^T instead, matching the algebraically
  correct sparse update path.
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_expr

- No changes

## mrpt_graphs

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_graphslam

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_gui

```
* fix: enable isolated/Debian-package builds of apps_gui
  Two issues surface when building packages in isolation (as the ROS build farm
  and .deb packaging do), where sibling modules are only available as installed
  packages, not as source:
  - mrpt-performance/perf-graphslam.cpp reached into another module's test
  sources via a relative path (../../../modules/mrpt_graphslam/tests/...).
  Vendor a local copy of the small test helper header instead.
  - mrpt_gui installs the public header nanogui/opengl.h which includes
  <GLFW/glfw3.h>, but only declared libglfw3-dev as a build dependency. Make it
  a public <depend> so downstream consumers get the GLFW headers.
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_hwdrivers

- No changes

## mrpt_img

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_maps

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_math

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* fix: KF math errors
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_obs

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_opengl

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_poses

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_system

- No changes

## mrpt_tfest

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

```
* Merge pull request #1363 <https://github.com/MRPT/mrpt/issues/1363> from MRPT/fix/dont-export-eigen3-dep
  refactor: limit visibility of eigen3 as build dep
* refactor: limit visibility of eigen3 as build dep
* Contributors: Jose Luis Blanco-Claraco
```
