### PR TITLE
depthai_ros_v3: 3.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2364,7 +2364,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/luxonis/depthai-ros-v3-release.git
-      version: 3.2.1-1
+      version: 3.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depthai_ros_v3` to `3.3.0-1`:

- upstream repository: https://github.com/luxonis/depthai-ros.git
- release repository: https://github.com/luxonis/depthai-ros-v3-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.2.1-1`

## depthai_bridge_v3

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```

## depthai_examples_v3

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```

## depthai_ros_msgs_v3

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```

## depthai_ros_v3

```
* Require DepthAI 3.7.1 packages.
  * Adds telemetry to help us understand how the library is used so we can improve it
  * To opt out set DEPTHAI_TELEMETRY=0 in the environment
```
