### PR TITLE
rviz: 16.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9263,7 +9263,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 16.0.0-1
+      version: 16.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `16.0.1-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `16.0.0-1`

## rviz2

```
* Don't use windeployqt (#1738 <https://github.com/ros2/rviz/issues/1738>)
* Contributors: Shane Loretz
```

## rviz_common

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>)
* QosProfileProperty Destructor (#1715 <https://github.com/ros2/rviz/issues/1715>)
* SelectionManager::select Function Not Returning Empty Selection Result for Invalid Coordinates (#1713 <https://github.com/ros2/rviz/issues/1713>)
* Removed deprecated API (#1731 <https://github.com/ros2/rviz/issues/1731>)
* Removed unused code in render_window.cpp (#1722 <https://github.com/ros2/rviz/issues/1722>)
* Removed URDF dependency in rviz_common (#1723 <https://github.com/ros2/rviz/issues/1723>)
* Fixed Qcolor deprecation (#1725 <https://github.com/ros2/rviz/issues/1725>)
* Contributors: Alejandro Hernández Cordero, Tom Moore
```

## rviz_default_plugins

```
* Add Smooth scaling option to Image and Camera displays (#1740 <https://github.com/ros2/rviz/issues/1740>)
* XYOrbitViewController support Z translation (#1721 <https://github.com/ros2/rviz/issues/1721>)
* Removed warning ros_image_texture.cpp (#1775 <https://github.com/ros2/rviz/issues/1775>)
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>)
* Support capsule geometry in robot links (#1735 <https://github.com/ros2/rviz/issues/1735>)
* Fix when with pitch != width*BBP in Image Display (#1719 <https://github.com/ros2/rviz/issues/1719>)
* ogreQuaternionAngularDistance does not properly handle invalid quaternion input (#1714 <https://github.com/ros2/rviz/issues/1714>)
* Fixed Unexpected pixels for mono Image (#1718 <https://github.com/ros2/rviz/issues/1718>)
* Make sure to disconnect subscription callback when unsubscribing (#1742 <https://github.com/ros2/rviz/issues/1742>)
* Show pixel co-ordinate with their pixel value in image (#1716 <https://github.com/ros2/rviz/issues/1716>)
* Persist per-link/per-joint properties across RobotModel reloads (#1729 <https://github.com/ros2/rviz/issues/1729>)
* Contributors: Alejandro Hernández Cordero, Arne Baeyens, Saif Sidhik, Tom Moore, Yixuan Xu, cwit-vcas
```

## rviz_ogre_vendor

```
* Suppress the CMake unused variable warning (#1772 <https://github.com/ros2/rviz/issues/1772>)
* Removed warning rviz_ogre_vendor (#1708 <https://github.com/ros2/rviz/issues/1708>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```

## rviz_rendering

```
* Support capsule geometry in robot links (#1735 <https://github.com/ros2/rviz/issues/1735>)
* Remove no-op upper_triangle conditional in TrianglePolygon UV mapping (#1717 <https://github.com/ros2/rviz/issues/1717>)
* Removed unused code in render_window.cpp (#1722 <https://github.com/ros2/rviz/issues/1722>)
* Contributors: Alejandro Hernández Cordero, Yixuan Xu
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
