### PR TITLE
ros2_medkit: 0.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9431,11 +9431,12 @@ repositories:
       - ros2_medkit_msgs
       - ros2_medkit_param_beacon
       - ros2_medkit_serialization
+      - ros2_medkit_sovd_service_interface
       - ros2_medkit_topic_beacon
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_medkit-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/selfpatch/ros2_medkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_medkit` to `0.5.0-1`:

- upstream repository: https://github.com/selfpatch/ros2_medkit.git
- release repository: https://github.com/ros2-gbp/ros2_medkit-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-1`

## ros2_medkit_beacon_common

```
* Updated include paths for the gateway core / ROS 2 ``PluginContext`` layer split and removal of backwards-compat shim headers
* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
* Contributors: @bburda
```

## ros2_medkit_cmake

```
* ``ROS2MedkitWarnings.cmake`` module centralizes compiler warning flags across all packages, with selective ``-Werror`` (namespaced ``MEDKIT_ENABLE_WERROR``, defaults OFF) applied only to flags safe against external headers
* ``ROS2MedkitSanitizers.cmake`` module adds ASan/UBSan and TSan support for sanitizer CI jobs
* ``ROS2MedkitTestDomain.cmake`` centralizes ``ROS_DOMAIN_ID`` allocation for per-test DDS isolation
* Vendored cpp-httplib 0.14.3 as a build-farm fallback (``VENDORED_DIR`` parameter), marked as a SYSTEM include to suppress third-party warnings
* ``medkit_find_cpp_httplib`` caps cpp-httplib at ``< 0.20`` across both the pkg-config and ``find_package(httplib)`` tiers, so distros shipping 0.20+ (Ubuntu 26.04 ships 0.26, which dropped the multipart ``Request::has_file`` API the gateway uses) fall through to the vendored 0.14.3 header instead of failing the build; ``ROS2MedkitCompat.cmake`` extended to cover ROS 2 Lyrical / Ubuntu 26.04 Resolute (rclcpp 32, ``yaml_cpp_vendor`` target export, ``ament_target_dependencies`` removal in ament_cmake 2.8.5+), which replaces Rolling in CI (#405 <https://github.com/selfpatch/ros2_medkit/pull/405>)
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_diagnostic_bridge

```
* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
* Tests: use centralized ``ROS_DOMAIN_ID`` allocation for DDS isolation
* Contributors: @bburda
```

## ros2_medkit_fault_manager

```
* ``ClearFault`` honors the new ``skip_correlation_auto_clear`` request flag so per-entity fault clears can opt out of cascade-clearing correlated symptom fault codes (#395 <https://github.com/selfpatch/ros2_medkit/issues/395>)
* Three-layer protection against unbounded snapshot growth (bounded buffers plus pruning)
* Concurrency and lifetime hardening: serialize concurrent subscription creation in ``SnapshotCapture``, join capture threads in the ``FaultManagerNode`` destructor, and defense-in-depth shutdown guards to prevent teardown crashes across distros
* Aggregation security hardening and improved test coverage
* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules and ``bugprone`` / ``special-member-functions`` clang-tidy checks
* Contributors: @bburda
```

## ros2_medkit_fault_reporter

```
* ``LocalFilter`` now debounces ``PASSED`` events with the same threshold / window filtering as ``FAILED``, preventing rapid CONFIRMED/CLEARED status cycling from triggering unbounded snapshot recapture (#308 <https://github.com/selfpatch/ros2_medkit/issues/308>)
* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_gateway

```
**Breaking Changes:**
* Typed router refactor. ``HandlerContext`` no longer carries
  ``send_json`` / ``send_error`` / ``send_plugin_error`` / ``send_dto`` /
  ``parse_body``: handlers return ``http::Result<TResponse>`` and the
  framework owns response writing through ``RouteRegistry``. The raw
  ``void(httplib::Request, httplib::Response)`` ``RouteRegistry`` lambda
  overloads are removed - call sites must use the typed
  ``reg.get<T>`` / ``reg.post<TBody, T>`` / ``reg.del<T>`` overloads, the
  multi-shape ``reg.post_alternates<TBody, TAlt...>`` /
  ``reg.del_alternates<TAlt...>``, or one of the named escape hatches
  (``reg.sse`` / ``reg.binary_download`` / ``reg.multipart_upload<T>`` /
  ``reg.static_asset`` / ``reg.docs_endpoint`` / ``reg.docs_subtree``).
  ``static_assert(dto::has_dto_shape_v<T>)`` gates every typed overload, so
  non-DTO return types fail at compile time. The plugin ABI is unaffected:
  ``PluginResponse`` keeps its ``send_json`` / ``send_error`` surface and
  now routes through the same internal ``http::detail::write_json_body``
  primitive as the framework, so plugin wire format is unchanged
  (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* Provider ABI typed. ``FaultProvider``, ``DataProvider``,
  ``OperationProvider``, and ``UpdateProvider::get_update`` return typed
  DTO envelopes (``FaultListResult`` / ``FaultDetailResult`` /
  ``FaultClearResult`` / the matching ``Data*Result`` and
  ``Operation*Result`` shapes / ``UpdateStatusResult``) instead of raw
  ``tl::expected<nlohmann::json, ErrorInfo>``. The wire bytes are
  byte-identical because each envelope wraps an opaque ``content`` object
  emitted verbatim by ``JsonWriter``; commercial and out-of-tree plugins
  must wrap their existing JSON in the matching envelope type
  (mechanical: ``Result.content = std::move(json_payload)``). The plugin
  ABI itself (``PluginRoute`` shape, ``PluginResponse`` ctor, plugin api
  version) is locked by ``test_plugin_abi_conformance`` and is unchanged
  (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* ``SchemaWriter`` emits optional DTO fields as
  ``anyOf: [<inner>, {type: "null"}]`` (the OpenAPI 3.1 idiom) instead of
  ``nullable: true``. Generated clients see ``T | null`` for every optional
  field rather than ``T | undefined``. Wire format is unchanged - the
  gateway still omits absent optional fields, and ``JsonReader`` continues
  to accept absent fields; the schema change only opts the published spec
  into round-tripping a literal ``null`` value cleanly for clients that
  prefer to send one. As part of this, a handful of fields that were
  previously emitted as an explicit JSON ``null`` when absent are now omitted
  entirely (consistent with the optional-omission policy): the script
  execution fields ``progress`` / ``started_at`` / ``completed_at`` /
  ``parameters`` / ``error`` (``GET .../scripts/{id}/executions/{eid}``) and
  the script ``parameters_schema`` field (``GET .../scripts/{id}``). Clients
  that tested ``field === null`` or relied on the key always being present must
  treat an absent key the same as ``null``
  (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* Synchronous operation-execution service-call failures
  (``POST /api/v1/{entity-path}/operations/{id}/executions`` when the underlying
  ROS 2 service call fails) now return the standard SOVD ``GenericError`` envelope
  (``{"error_code": "vendor-error", "vendor_code":
  "x-medkit-ros2-service-unavailable", "message": "Service call failed", ...}``,
  HTTP status 500 unchanged) instead of the previous bespoke nested
  ``{"error": {"code", "message", "details"}}`` object. This aligns the one
  remaining non-standard error path with every other gateway error; clients that
  parsed ``error.code`` / ``error.details`` for this specific failure must read
  ``vendor_code`` / ``parameters`` instead
  (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* ``GET /api/v1/{entity-path}/data`` now publishes the opaque ``DataListResult``
  schema (``{type: object, additionalProperties: true, x-medkit-opaque: true}``),
  matching how ``GET .../faults`` already publishes ``FaultListResult``. The wire
  payload is unchanged for runtime (ROS 2) entities - it is still
  ``{"items": [...], "x-medkit": {...}}`` built from the typed
  ``Collection<DataItem, DataListXMedkit>`` - but for plugin-owned entities the
  provider's free-form per-item shape now passes through verbatim instead of
  being re-parsed into ``Collection<DataItem>``. This fixes a regression in which
  plugin per-item fields (the OPC-UA plugin's ``value`` / ``unit`` / ``data_type``
  / ``writable``) were silently dropped by the typed re-parse. Clients that
  generated a typed ``DataItem`` model from the previous spec for this route now
  see an opaque object instead
  (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* Entity responses (areas, components, apps, functions - list items and detail)
  now always carry a top-level ``type`` discriminator (an enum of
  ``area`` / ``component`` / ``app`` / ``function``). Previously list items had no
  ``type`` and detail responses exposed it only inside ``x-medkit.entityType``.
  Additive and tolerant-client-safe; consumers keying on the entity kind can now
  read the top-level ``type``
  (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* ``ros2_medkit_msgs/srv/ClearFault`` request gains a ``bool skip_correlation_auto_clear`` field (see the per-entity fault scope entry below for the in-tree motivation). Adding a request field changes the service type hash, so out-of-tree callers that invoke the service directly (for example ``ros2 service call /fault_manager/clear_fault ros2_medkit_msgs/srv/ClearFault ...`` as documented in the ``ros2_medkit_fault_manager`` README) must rebuild against the new ``ros2_medkit_msgs`` to keep talking to ``fault_manager``. The in-tree gateway client and server are updated together (#395 <https://github.com/selfpatch/ros2_medkit/issues/395>)
* Per-entity fault routes are now correctly scoped to the entity's hosted apps. ``GET /api/v1/{entity-path}/faults/{fault_code}``, ``DELETE /api/v1/{entity-path}/faults/{fault_code}``, ``GET /api/v1/{entity-path}/faults``, and ``DELETE /api/v1/{entity-path}/faults`` previously fell back to a prefix match against the entity's ``namespace_path``; when that was empty (host-derived / synthetic components, manifest components without a ``namespace`` field, Areas, Functions, and Apps with a wildcard ``ros_binding.namespace_pattern``) the scope filter was silently disabled and the routes exposed - and on ``DELETE``, cleared - faults reported by apps that belonged to entirely different entities. All four handlers now resolve the addressed entity to its hosted-app FQN set (via the new ``HandlerContext::resolve_entity_source_fqns`` helper) and apply a strict all-sources scope check: a fault counts as in scope only when **every** entry in its ``reporting_sources`` is owned by the entity (exact FQN match, or strict path-child via ``<fqn>/...``). Per-fault routes return ``404 Resource Not Found`` for any fault that fails the check; collection routes return an empty ``items`` array. The underlying ``GetFault.srv`` contract is unchanged; ``ClearFault.srv`` gains a new ``skip_correlation_auto_clear`` request flag so per-entity DELETE can opt out of cascade-clearing correlated symptom fault codes that may live in other entities. Per-entity collection responses no longer include the global ``muted_count`` / ``cluster_count`` / ``muted_faults`` / ``clusters`` correlation metadata; those remain on the global ``GET /api/v1/faults`` route. Behavior changes visible to clients: (a) faults reported by apps outside the addressed entity are no longer returned or cleared via that entity's route, (b) **mixed-source** faults that include at least one out-of-entity reporter are likewise rejected with ``404`` on per-fault routes and excluded from per-entity collection responses (use the global ``GET /api/v1/faults`` to see them), (c) per-entity DELETE no longer cascade-clears correlated symptoms outside the entity (#395 <https://github.com/selfpatch/ros2_medkit/issues/395>)
* ``GET /api/v1/updates/{id}/status`` no longer returns ``404`` for a registered-but-idle package; ``POST /api/v1/updates`` now seeds a ``pending`` status, so the endpoint returns ``200 {"status": "pending"}`` immediately after registration. ``404`` is reserved for packages that are not registered. Clients that used ``404`` as a signal for "registered but nothing started yet" must adapt (#378 <https://github.com/selfpatch/ros2_medkit/issues/378>)
**Features:**
* Typed ``fan_out_collection<T>`` aggregating helper replaces raw-JSON ``merge_peer_items`` on the typed collection routes (data, operations, config, logs). Peer items are decoded via ``dto::JsonReader<T>``; items that fail validation are removed from the merged ``items`` array, recorded in ``x-medkit.peer_dropped_items`` with the JsonReader error plus a best-effort ``source_id``, and logged at ``WARN``. Items that parse successfully are re-serialized through the local ``dto::JsonWriter<T>``, so any peer-supplied fields outside the local DTO schema are dropped from the merged response (the previous raw passthrough preserved unknown peer fields verbatim). Previously, malformed peer items silently disappeared into the merged response; fleet operators can now detect inter-gateway schema drift directly on the wire (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* ``Collection<T, XMedkitT>`` is now a 2-parameter template. Domain list endpoints (faults, config, logs) reference their richer per-domain collection x-medkit struct (``FaultListXMedkit``, ``ConfigListXMedkit``, ``LogListXMedkit``) directly in the published schema instead of the generic ``XMedkitCollection``, so generated clients see aggregation counts, peer provenance, and ``peer_dropped_items`` from the schema. The data list builds the same typed ``Collection<DataItem, DataListXMedkit>`` internally (so the wire still carries those fields) but publishes the opaque ``DataListResult`` envelope, because plugin-owned data entities can return vendor per-item fields the typed item schema cannot describe (see the data-list breaking-change entry above) (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* New ``opaque_object("key", &T::field)`` DTO field descriptor in ``dto/contract.hpp``. Binds a ``nlohmann::json`` member as a typed "any JSON object" field: ``JsonWriter`` emits it verbatim, ``JsonReader`` rejects scalars / arrays / null, ``SchemaWriter`` emits ``{type: object, additionalProperties: true, x-medkit-opaque: true}``. Used for fields whose runtime shape is decided by an upstream component the gateway cannot introspect (live ROS message payloads, plugin-defined fault envelopes, action results) (#403 <https://github.com/selfpatch/ros2_medkit/issues/403>)
* ``GET /api/v1/faults/stream`` event payloads now carry an optional ``x-medkit`` SOVD payload-extension object with ``entity_type`` and ``entity_id`` fields. When the gateway can resolve the fault's first reporting source back to a SOVD entity (via the manifest-mode linking index, or a runtime-mode last-segment match against an existing App), consumers can hit ``/{entity_type}/{entity_id}/bulk-data/rosbags/{fault_code}`` directly instead of HEAD-probing every entity. Resolution is snapshotted at event arrival, so a discovery refresh between enqueue and stream-out cannot retroactively change the entity reported to consumers. The ``x-medkit`` object is omitted entirely when no entity can be resolved, so existing SSE consumers ignore the addition (#380 <https://github.com/selfpatch/ros2_medkit/issues/380>)
* Plugin API version bumped to v7. Adds ``PluginContext::notify_entities_changed(EntityChangeScope)`` lifecycle hook for plugins that mutate the entity surface at runtime; default no-op keeps v6 source code compiling unchanged against v7 headers. Binary compatibility is not provided: the plugin loader uses a strict equality check on ``plugin_api_version()``, so out-of-tree plugins must be recompiled (#376 <https://github.com/selfpatch/ros2_medkit/issues/376>)
* New ``discovery.manifest.fragments_dir`` parameter: gateway scans the directory for ``*.yaml`` / ``*.yml`` fragment files on every manifest load / reload and merges apps, components, and functions on top of the base manifest. Fragments are forbidden from declaring top-level ``areas``, ``metadata``, ``discovery``, ``scripts``, ``capabilities``, or ``lock_overrides`` - those stay in the base manifest. Presence of any forbidden key (including empty-valued ones like ``areas: []``) is reported as a ``FRAGMENT_FORBIDDEN_FIELD`` validation error that fails the load / reload. Unknown top-level keys (typos such as ``app:`` vs ``apps:``) are ignored with a warning log. Files merged in alphabetical order for deterministic duplicate-id errors (#376 <https://github.com/selfpatch/ros2_medkit/issues/376>)
* Fragment files are size-capped at 1 MiB (``ManifestParser::kMaxFragmentBytes``) before being read into memory, and any symlink resolving outside the canonical ``fragments_dir`` is skipped with a warning, so misconfigurations or symlink-based escapes cannot hand arbitrary bytes to the YAML parser (#376 <https://github.com/selfpatch/ros2_medkit/issues/376>)
* All-or-nothing fragment semantics: a single malformed or forbidden fragment fails the entire load / reload and keeps the previously-loaded manifest active (#376 <https://github.com/selfpatch/ros2_medkit/issues/376>)
* ``ManifestParser::parse_fragment_file`` convenience entrypoint that injects a synthetic ``manifest_version`` header when the fragment omits one
* See ``design/plugin_entity_notifications.rst`` for the lifecycle, merge-rule, and plugin-side write-contract walkthrough
* New ``GET /api/v1/apps/{app_id}/belongs-to`` discovery endpoint returning the areas and components an app belongs to; the ``belongs-to`` URI is advertised on ``GET /apps/{app_id}`` (#196 <https://github.com/selfpatch/ros2_medkit/issues/196>)
* Pool-backed ``TopicDataProvider`` for live topic data: a shared subscription pool owned by a single-writer executor node, with LRU and idle eviction and publisher-QoS matching, replacing per-request subscriptions. Pool and executor health are surfaced as the ``x-medkit-subscription-executor`` vendor-extension stats on ``GET /api/v1/health``, read atomically so ``/health`` never blocks under load (#384 <https://github.com/selfpatch/ros2_medkit/issues/384>)
* ``GET /api/v1/updates/{id}/status`` exposes the update lifecycle ``phase`` under the response ``x-medkit`` object
* ``gateway.launch.py`` and ``gateway_https.launch.py`` accept a ``config_file`` launch argument pointing at an external parameter YAML. Parameters present in the file override the matching gateway defaults; parameters the file omits keep their launch defaults instead of being reset (#408 <https://github.com/selfpatch/ros2_medkit/pull/408>)
* Plugin-facing headers are httplib-free across the ``.so`` boundary: the handler-result vocabulary (``Result``, ``NoContent``, ``Forwarded``, ``ValidatorResult``, ``ResponseAttachments``) moved to a new leaf header ``http/handler_result.hpp`` so provider and DTO interfaces no longer transitively include ``<httplib.h>``. Out-of-tree plugins built against the installed gateway (build-farm / Docker topology, where the vendored httplib is not on the include path) compile again; no ABI, wire, or behaviour change. A pre-push gate and CI scan keep the plugin-facing headers httplib-free (#411 <https://github.com/selfpatch/ros2_medkit/pull/411>)
* Contributors: @bburda, @eclipse0922, @evTessellate, @mfaferek93
```

## ros2_medkit_graph_provider

```
* Migrated ``GraphProviderPlugin`` to the ``get_routes()`` plugin API and fixed a route-separator bug
* Added shutdown guards and ``noexcept`` destructors that reset rclcpp resources before member destruction, preventing teardown SIGSEGV
* Added post-shutdown guard unit tests; dropped the cpp-httplib source install from the Dockerfile (now vendored via ``ros2_medkit_cmake``)
* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
* Contributors: @bburda
```

## ros2_medkit_integration_tests

```
* New peer-aggregation suites: peer aggregation, cross-ECU fan-out across all resource types, daisy-chain hierarchical aggregation, leaf-collision aggregation, and cross-ECU log aggregation
* New SOVD-aligned entity-model suites: runtime entity model, flat entity tree without areas, hybrid suppression, and per-entity fault scope isolation
* New OpenAPI conformance suites: ``test_openapi_callability`` and ``test_openapi_response_drift`` validate the published spec against live responses
* New graph-event discovery suite covering rclcpp graph-event driven discovery refresh
* Coverage for the ``GET /apps/{id}/belongs-to`` discovery endpoint, nested ``x-medkit`` vendor payloads (#385 <https://github.com/selfpatch/ros2_medkit/issues/385>), version-info aggregation, and pending-after-register update status (#378 <https://github.com/selfpatch/ros2_medkit/issues/378>)
* Tests: centralized ``ROS_DOMAIN_ID`` allocation and widened shutdown timeouts for sanitizer overhead
* Contributors: @bburda, @eclipse0922
```

## ros2_medkit_linux_introspection

```
* Migrated the introspection plugins to the ``get_routes()`` plugin API
* Declared ``pkg-config`` as a ``buildtool_depend`` and fixed a route-separator bug
* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
* Contributors: @bburda
```

## ros2_medkit_msgs

```
* New service definitions ``ListEntities.srv``, ``GetEntityData.srv``, ``GetCapabilities.srv`` and the ``EntityInfo.msg`` type for exposing the entity tree over ROS 2 services (#330 <https://github.com/selfpatch/ros2_medkit/issues/330>)
* ``ClearFault.srv`` request gains a ``bool skip_correlation_auto_clear`` field so callers can opt out of cascade-clearing correlated symptom fault codes; out-of-tree callers must rebuild against the new message (#395 <https://github.com/selfpatch/ros2_medkit/issues/395>)
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_param_beacon

```
* Migrated ``ParameterBeaconPlugin`` to the ``get_routes()`` plugin API
* Added shutdown guards and ``noexcept`` destructors that reset rclcpp resources before member destruction, preventing teardown SIGSEGV; the graph poll now swallows ``rcl`` "context invalid" during shutdown
* Added post-shutdown guard unit tests
* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
* Contributors: @bburda
```

## ros2_medkit_serialization

```
* ``TypeIntrospection`` relocated into this package as part of the gateway core / ROS 2 layer split
* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
* Contributors: @bburda
```

## ros2_medkit_sovd_service_interface

```
* Initial release - gateway plugin that exposes the medkit entity tree and fault data over standard ROS 2 services, so other ROS 2 nodes can query entities and faults without going through the HTTP API (#330 <https://github.com/selfpatch/ros2_medkit/issues/330>)
* Creates ROS 2 services under a configurable prefix (default ``/medkit``): ``list_entities``, ``list_entity_faults``, and ``get_capabilities``; a ``get_entity_data`` service is also registered but currently returns "not implemented" (use the HTTP REST API for topic data) pending (#351 <https://github.com/selfpatch/ros2_medkit/issues/351>)
* Runs as a gateway MODULE plugin with read-only ``PluginContext`` access to the entity cache and fault manager; implements no provider interfaces
* Shutdown guards and ``noexcept`` destructors reset ROS resources before member destruction to prevent teardown crashes
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_topic_beacon

```
* Migrated ``TopicBeaconPlugin`` to the ``get_routes()`` plugin API
* Added shutdown guards and ``noexcept`` destructors (with ``override``) that reset rclcpp resources before member destruction, preventing teardown SIGSEGV
* Added post-shutdown guard unit tests
* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
* Contributors: @bburda
```
