### PR TITLE
rmw_connextdds: 1.3.0-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7472,7 +7472,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_connextdds-release.git
-      version: 1.3.0-1
+      version: 1.3.0-2
     source:
       type: git
       url: https://github.com/ros2/rmw_connextdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_connextdds` to `1.3.0-2`:

- upstream repository: https://github.com/ros2/rmw_connextdds.git
- release repository: https://github.com/ros2-gbp/rmw_connextdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.0-1`

## rmw_connextdds

```
* fix: Fixed compilation on MSVC 2022 (#225 <https://github.com/ros2/rmw_connextdds/issues/225>)
* Contributors: Janosch Machowinski
```

## rmw_connextdds_common

```
* fix: Fixed compilation on MSVC 2022 (#225 <https://github.com/ros2/rmw_connextdds/issues/225>)
* Contributors: Janosch Machowinski
```

## rti_connext_dds_cmake_module

- No changes
