### PR TITLE
mrpt3: 3.0.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6385,7 +6385,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.0.2-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.1-1`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

```
* fix: BUILD_TESTING=OFF default was ignored due to include(CTest) ordering
  CTest's own option(BUILD_TESTING ... ON) ran first and created the cache
  variable, making our subsequent option(BUILD_TESTING ... OFF) a no-op.
  This left BUILD_TESTING=ON on the ROS build farm (which doesn't pass
  -DBUILD_TESTING=OFF), causing find_package(GTest REQUIRED) to fail and
  break the mrpt_core binary build.
  Also fix CI workflows to pass the correct -DBUILD_TESTING=ON flag
  (macOS/Windows previously used the non-existent MRPT_BUILD_TESTING,
  and Linux relied on the buggy default).
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

- No changes

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

- No changes

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

- No changes

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

```
* Fix: add missing build deps on wxWidgets
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_maps

- No changes

## mrpt_math

- No changes

## mrpt_nav

- No changes

## mrpt_obs

- No changes

## mrpt_opengl

- No changes

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

- No changes

## mrpt_tfest

- No changes

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

- No changes
