### PR TITLE
datamodel-code-generator: Fix NixOS entry

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -197,7 +197,7 @@ datamodel-code-generator:
     '*':
       pip:
         packages: [datamodel-code-generator]
-  nixos: [python312Packages.datamodel-code-generator]
+  nixos: [python3Packages.datamodel-code-generator]
   opensuse:
     '*':
       pip:


### PR DESCRIPTION
This fixes the entry added recently in #51568 by @arjo129.

NixOS and Nixpkgs provide Python packages through multiple package sets:
- Version-specific sets, such as python312Packages for Python 3.12
- The generic set python3Packages, which always points to the default Python version in Nixpkgs.

For rosdep, it is preferable to use the generic set, since version-specific sets are eventually removed from Nixpkgs.
