### PR TITLE
smacc2: remove non-smacc2-prefixed packages from jazzy release

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11276,57 +11276,8 @@ repositories:
       version: jazzy
     release:
       packages:
-      - backward_global_planner
-      - backward_local_planner
-      - cl_foundation_pose
-      - cl_gcalcli
-      - cl_generic_sensor
-      - cl_http
-      - cl_keyboard
-      - cl_lifecycle_node
-      - cl_mission_tracker
-      - cl_modbus_tcp_relay
-      - cl_moveit2z
-      - cl_nav2z
-      - cl_px4_mr
-      - cl_ros2_timer
-      - eg_conditional_generator
-      - eg_random_generator
-      - forward_global_planner
-      - forward_local_planner
-      - nav2z_planners_common
-      - pure_spinning_local_planner
-      - sm_advanced_recovery_1
-      - sm_atomic
-      - sm_atomic_http
-      - sm_atomic_lifecycle
-      - sm_atomic_mode_states
-      - sm_atomic_performance_trace_1
-      - sm_atomic_subscribers_performance_test
-      - sm_branching
-      - sm_cl_gcalcli_test_1
-      - sm_cl_keyboard_unit_test_1
-      - sm_cl_px4_mr_test_1
-      - sm_cl_px4_mr_test_2
-      - sm_cl_ros2_timer_unit_test_1
-      - sm_coretest_transition_speed_1
-      - sm_data_sharing_1
-      - sm_data_sharing_2
-      - sm_modbus_tcp_relay_test_1
-      - sm_multi_stage_1
-      - sm_multithread_test_1
-      - sm_nav2_gazebo_test_1
-      - sm_pack_ml
-      - sm_panda_cl_moveit2z_cb_inventory
-      - sm_panda_cl_moveit2z_cb_inventory_isaacsim
-      - sm_simple_action_client
-      - sm_three_some
       - smacc2
       - smacc2_msgs
-      - sr_all_events_go
-      - sr_conditional
-      - sr_event_countdown
-      - undo_path_global_planner
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/robosoft-ai/SMACC2-release.git


### PR DESCRIPTION
The 3.1.0-2 bloom run included all 54 SMACC2 packages in the jazzy distribution by mistake.
  Only `smacc2` and `smacc2_msgs` should have been approved for general apt release.

  This PR removes those packages, keeping only the two that were intended for release.
  The SMACC2-release repo already has the correct Debian packaging branches and snapshot
  tags for `smacc2` and `smacc2_msgs` at 3.1.0-2.

Sorry for all the confusion.

