### PR TITLE
rosidl: 4.6.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9986,7 +9986,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.6.8-1
+      version: 4.6.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosidl` to `4.6.9-1`:

- upstream repository: https://github.com/ros2/rosidl.git
- release repository: https://github.com/ros2-gbp/rosidl-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.6.8-1`

## rosidl_adapter

- No changes

## rosidl_cli

- No changes

## rosidl_cmake

- No changes

## rosidl_generator_c

```
* Merge pull request #972 <https://github.com/ros2/rosidl/issues/972> from ros2/guard_sequence_overflow_jazzy
  Add integer overflow guards to rosidl sequence init and copy functions
* Add integer overflow guards to rosidl sequence init and copy functions
  Check that target size multiplied by item size does not overflow SIZE_MAX.
  This prevents undersized heap allocations when sequence length inputs are malicious or overflow.
* Contributors: Michael Carroll, Skyler Medeiros
```

## rosidl_generator_cpp

- No changes

## rosidl_generator_type_description

- No changes

## rosidl_parser

- No changes

## rosidl_pycommon

- No changes

## rosidl_runtime_c

```
* Merge pull request #972 <https://github.com/ros2/rosidl/issues/972> from ros2/guard_sequence_overflow_jazzy
  Add integer overflow guards to rosidl sequence init and copy functions
* Add integer overflow guards to rosidl sequence init and copy functions
  Check that target size multiplied by item size does not overflow SIZE_MAX.
  This prevents undersized heap allocations when sequence length inputs are malicious or overflow.
* Contributors: Michael Carroll, Skyler Medeiros
```

## rosidl_runtime_cpp

- No changes

## rosidl_typesupport_interface

- No changes

## rosidl_typesupport_introspection_c

- No changes

## rosidl_typesupport_introspection_cpp

- No changes
