### PR TITLE
rviz: 15.2.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9251,7 +9251,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.2.3-1
+      version: 15.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.4-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.2.3-1`

## rviz2

- No changes

## rviz_common

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1776 <https://github.com/ros2/rviz/issues/1776>)
* SelectionManager::select Function Not Returning Empty Selection Result for Invalid Coordinates (#1713 <https://github.com/ros2/rviz/issues/1713>) (#1768 <https://github.com/ros2/rviz/issues/1768>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Merge pull request #1780 <https://github.com/ros2/rviz/issues/1780> from ros2/mergify/bp/lyrical/pr-1775
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1776 <https://github.com/ros2/rviz/issues/1776>)
* Removed warning ros_image_texture.cpp (#1775 <https://github.com/ros2/rviz/issues/1775>)
* Make sure to disconnect subscription callback when unsubscribing (#1742 <https://github.com/ros2/rviz/issues/1742>) (#1743 <https://github.com/ros2/rviz/issues/1743>)
* Fixed Unexpected pixels for mono Image (#1718 <https://github.com/ros2/rviz/issues/1718>) (#1764 <https://github.com/ros2/rviz/issues/1764>)
* Fix when with pitch != width*BBP in Image Display (#1719 <https://github.com/ros2/rviz/issues/1719>) (#1760 <https://github.com/ros2/rviz/issues/1760>)
* ogreQuaternionAngularDistance does not properly handle invalid quaternion input (#1714 <https://github.com/ros2/rviz/issues/1714>) (#1756 <https://github.com/ros2/rviz/issues/1756>)
* Contributors: Alejandro Hernández Cordero, Skyler Medeiros, mergify[bot]
```

## rviz_ogre_vendor

```
* Removed warning rviz_ogre_vendor (#1708 <https://github.com/ros2/rviz/issues/1708>) (#1736 <https://github.com/ros2/rviz/issues/1736>)
* Contributors: mergify[bot]
```

## rviz_rendering

```
* Remove no-op upper_triangle conditional in TrianglePolygon UV mapping (#1717 <https://github.com/ros2/rviz/issues/1717>) (#1752 <https://github.com/ros2/rviz/issues/1752>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
