### PR TITLE
rviz: 15.0.13-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9229,7 +9229,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.12-1
+      version: 15.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.13-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.0.12-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1777 <https://github.com/ros2/rviz/issues/1777>)
* SelectionManager::select Function Not Returning Empty Selection Result for Invalid Coordinates (#1713 <https://github.com/ros2/rviz/issues/1713>) (#1769 <https://github.com/ros2/rviz/issues/1769>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Merge pull request #1781 <https://github.com/ros2/rviz/issues/1781> from ros2/mergify/bp/kilted/pr-1775
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1777 <https://github.com/ros2/rviz/issues/1777>)
* Removed warning ros_image_texture.cpp (#1775 <https://github.com/ros2/rviz/issues/1775>)
* Fixed Unexpected pixels for mono Image (#1718 <https://github.com/ros2/rviz/issues/1718>) (#1765 <https://github.com/ros2/rviz/issues/1765>)
* Fix when with pitch != width*BBP in Image Display (#1719 <https://github.com/ros2/rviz/issues/1719>) (#1761 <https://github.com/ros2/rviz/issues/1761>)
* ogreQuaternionAngularDistance does not properly handle invalid quaternion input (backport #1714 <https://github.com/ros2/rviz/issues/1714>) (#1757 <https://github.com/ros2/rviz/issues/1757>)
* Make sure to disconnect subscription callback when unsubscribing (backport #1742 <https://github.com/ros2/rviz/issues/1742>) (#1744 <https://github.com/ros2/rviz/issues/1744>)
* Remove redundant compilation of test fixtures (#1673 <https://github.com/ros2/rviz/issues/1673>) (#1679 <https://github.com/ros2/rviz/issues/1679>)
* Contributors: Alejandro Hernández Cordero, Skyler Medeiros, mergify[bot]
```

## rviz_ogre_vendor

```
* Removed warning rviz_ogre_vendor (#1708 <https://github.com/ros2/rviz/issues/1708>) (#1737 <https://github.com/ros2/rviz/issues/1737>)
* Contributors: mergify[bot]
```

## rviz_rendering

```
* Remove no-op upper_triangle conditional in TrianglePolygon UV mapping (#1717 <https://github.com/ros2/rviz/issues/1717>) (#1753 <https://github.com/ros2/rviz/issues/1753>)
* fix for ubuntu 26 (#1694 <https://github.com/ros2/rviz/issues/1694>) (#1695 <https://github.com/ros2/rviz/issues/1695>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
