### PR TITLE
rviz: 11.2.27-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11388,7 +11388,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.26-1
+      version: 11.2.27-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.27-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `11.2.26-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1779 <https://github.com/ros2/rviz/issues/1779>)
* SelectionManager::select Function Not Returning Empty Selection Result for Invalid Coordinates (#1713 <https://github.com/ros2/rviz/issues/1713>) (#1771 <https://github.com/ros2/rviz/issues/1771>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Fix disabled displays (addresses #1773 <https://github.com/ros2/rviz/issues/1773>) (#1774 <https://github.com/ros2/rviz/issues/1774>) (#1779 <https://github.com/ros2/rviz/issues/1779>)
* ogreQuaternionAngularDistance does not properly handle invalid quaternion input (backport #1714 <https://github.com/ros2/rviz/issues/1714>) (#1759 <https://github.com/ros2/rviz/issues/1759>)
* Make sure to disconnect subscription callback when unsubscribing (backport #1742 <https://github.com/ros2/rviz/issues/1742>) (#1746 <https://github.com/ros2/rviz/issues/1746>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

- No changes

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
