### PR TITLE
raph_robot: 1.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8122,7 +8122,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/raph_robot-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/RaphRover/raph_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `raph_robot` to `1.1.2-1`:

- upstream repository: https://github.com/RaphRover/raph_robot
- release repository: https://github.com/ros2-gbp/raph_robot-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.1-1`

## raph_bringup

```
* fix: Remove rosbridge parameters that will break (#12 <https://github.com/Rapha-Rover/rapha_robot/issues/12>)
* Contributors: Błażej Sowa
```

## raph_fw

- No changes

## raph_oak

- No changes

## raph_robot

- No changes
