### PR TITLE
ros2_eventdispatch: 0.2.29-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10039,10 +10039,6 @@ repositories:
       version: humble
     status: developed
   ros2_eventdispatch:
-    doc:
-      type: git
-      url: https://github.com/cyan-at/ros2_eventdispatch.git
-      version: 0.2.29-1
     release:
       packages:
       - eventdispatch_python

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10039,6 +10039,19 @@ repositories:
       version: humble
     status: developed
   ros2_eventdispatch:
+    doc:
+      type: git
+      url: https://github.com/cyan-at/ros2_eventdispatch.git
+      version: 0.2.29-1
+    release:
+      packages:
+      - eventdispatch_python
+      - eventdispatch_ros2
+      - eventdispatch_ros2_interfaces
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_eventdispatch-release.git
+      version: 0.2.29-1
     source:
       type: git
       url: https://github.com/cyan-at/ros2_eventdispatch.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_eventdispatch` to `0.2.29-1`:

- upstream repository: https://github.com/cyan-at/ros2_eventdispatch.git
- release repository: https://github.com/ros2-gbp/ros2_eventdispatch-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
