### PR TITLE
Add festival stub entry for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1123,6 +1123,7 @@ festival:
   debian: [festival, festvox-kallpc16k]
   fedora: [festival, festvox-kal-diphone]
   gentoo: [app-accessibility/festival]
+  nixos: [festival-stub]
   openembedded: [festival@meta-ros1]
   ubuntu: [festival, festvox-kallpc16k]
 festival-dev:


### PR DESCRIPTION
Festival is not available in nixpkgs. There were [some attempts to package it][1], but it seems to be complicated. The soud_play package, which is being ported to ROS 2, depends on it, but only via exec_depend and is still useful without festival. The only place, where festival is needed is [here][2].

Therefore, to have at least some sound_play functionality available with Nix, we add [festival-stub attribute to nix-ros-overlay][3] (the PR will be merged after this one), which allows building the relevant packages. If somebody uses the festival functionality, they'll see the [error message][2] at runtime.

[1]: https://github.com/NixOS/nixpkgs/blob/50338ea4bce54b50d184d68d8fb2885e45053f81/pkgs/development/python-modules/phonemizer/default.nix#L52
[2]: https://github.com/ros-drivers/audio_common/blob/db2770b0ad703c474039914937974c764dc94351/sound_play/scripts/soundplay_node.py#L376-L386
[3]: https://github.com/lopsided98/nix-ros-overlay/pull/876
