### PR TITLE
septentrio_gnss_driver: 1.4.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9362,7 +9362,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
-      version: 1.4.6-3
+      version: 1.4.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `septentrio_gnss_driver` to `1.4.7-1`:

- upstream repository: https://github.com/septentrio-gnss/septentrio_gnss_driver
- release repository: https://github.com/ros2-gbp/septentrio_gnss_driver_ros2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.4.6-3`

## septentrio_gnss_driver

```
* Improvements
  
  Add Lyrical Luth to supported ROS versions.
  
  Update deprecated boost and ROS functions.
  
  Add support for GLGSV (thanks @peci1)
  
  Fix spacing in README (thanks @benmccann)
* Contributors: Ben McCann, Martin Pecka,Thomas Emter, Tibor Dome, septentrio-users
```
