### PR TITLE
ffmpeg_image_transport_msgs: 1.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3103,7 +3103,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
-      version: 1.1.2-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport_msgs` to `1.3.0-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.2-1`
