### PR TITLE
Add nav2_config for humble and jazzy

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6529,11 +6529,6 @@ repositories:
       type: git
       url: https://github.com/sutharsan-311/nav2_config.git
       version: main
-    release:
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/sutharsan-311/nav2_config-release.git
-      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/sutharsan-311/nav2_config.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6524,6 +6524,21 @@ repositories:
       url: https://github.com/ros-naoqi/libqicore.git
       version: ros2
     status: maintained
+  nav2_config:
+    doc:
+      type: git
+      url: https://github.com/sutharsan-311/nav2_config.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/sutharsan-311/nav2_config-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/sutharsan-311/nav2_config.git
+      version: main
+    status: developed
   navigation2:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6174,6 +6174,21 @@ repositories:
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
       version: main
     status: maintained
+  nav2_config:
+    doc:
+      type: git
+      url: https://github.com/sutharsan-311/nav2_config.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/sutharsan-311/nav2_config-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/sutharsan-311/nav2_config.git
+      version: main
+    status: developed
   navigation2:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6159,6 +6159,16 @@ repositories:
       url: https://github.com/ros-naoqi/libqi.git
       version: ros2
     status: maintained
+  nav2_config:
+    doc:
+      type: git
+      url: https://github.com/sutharsan-311/nav2_config.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/sutharsan-311/nav2_config.git
+      version: main
+    status: developed
   nav2_minimal_turtlebot_simulation:
     release:
       packages:
@@ -6174,21 +6184,6 @@ repositories:
       url: https://github.com/ros-navigation/nav2_minimal_turtlebot_simulation.git
       version: main
     status: maintained
-  nav2_config:
-    doc:
-      type: git
-      url: https://github.com/sutharsan-311/nav2_config.git
-      version: main
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/sutharsan-311/nav2_config-release.git
-      version: 0.1.0-1
-    source:
-      type: git
-      url: https://github.com/sutharsan-311/nav2_config.git
-      version: main
-    status: developed
   navigation2:
     doc:
       type: git


### PR DESCRIPTION
## Description

Adds `nav2_config` to the ROS2 humble and jazzy distributions.

**nav2_config** is a real-time visual parameter tuning GUI for Nav2. It connects to a live Nav2 stack and lets you tune navigation parameters without killing and relaunching nodes — no more edit–kill–relaunch–wait–test cycles.

- GitHub: https://github.com/sutharsan-311/nav2_config
- Release repo: https://github.com/sutharsan-311/nav2_config-release
- License: Apache-2.0
- 59+ GitHub stars, community-verified on Turtlebot4 + Raspberry Pi 5 (Jazzy) and production AMR deployments (Humble)

**Distros:** humble, jazzy  
**Version:** 0.1.0-1  
**Status:** developed

CI passing on both humble (Ubuntu 22.04) and jazzy (Ubuntu 24.04):
https://github.com/sutharsan-311/nav2_config/actions