### PR TITLE
scenario_execution: 1.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10989,7 +10989,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/scenario_execution-release.git
-      version: 1.4.0-1
+      version: 1.5.0-1
     source:
       type: git
       url: https://github.com/IntelLabs/scenario_execution.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scenario_execution` to `1.5.0-1`:

- upstream repository: https://github.com/IntelLabs/scenario_execution.git
- release repository: https://github.com/ros2-gbp/scenario_execution-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `1.4.0-1`

> Note: the release of the packages succeeded, but bloom could not open this PR automatically (the GitHub token it used returned `HTTP 401` on the fork step). This PR was opened manually to complete the release; it contains only the bloom-generated version bump `1.4.0-1` → `1.5.0-1`.
