### PR TITLE
point_cloud_transport_plugins: 6.2.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6211,7 +6211,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 6.1.0-3
+      version: 6.2.0-1
     source:
       test_pull_requests: true
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6200,7 +6200,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport_plugins.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - draco_point_cloud_transport
@@ -6216,7 +6216,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/point_cloud_transport_plugins.git
-      version: rolling
+      version: lyrical
     status: maintained
   point_cloud_transport_tutorial:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `6.2.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.1.0-3`

## draco_point_cloud_transport

- No changes

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

- No changes

## zstd_point_cloud_transport

```
* Explicitly find zstd and remove undefined function  (#83 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/83>) (#84 <https://github.com/ros-perception/point_cloud_transport_plugins/issues/84>)
* Contributors: mergify[bot]
```
