### PR TITLE
point_cloud_transport_plugins: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6243,7 +6243,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
-      version: 6.1.0-2
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport_plugins` to `7.0.0-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport_plugins
- release repository: https://github.com/ros2-gbp/point_cloud_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.1.0-2`

## draco_point_cloud_transport

- No changes

## point_cloud_interfaces

- No changes

## point_cloud_transport_plugins

- No changes

## zlib_point_cloud_transport

- No changes

## zstd_point_cloud_transport

- No changes
