### PR TITLE
librealsense2: 2.58.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4141,7 +4141,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/librealsense2-release.git
-      version: 2.58.1-1
+      version: 2.58.2-1
     source:
       type: git
       url: https://github.com/IntelRealSense/librealsense.git


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2` to `2.58.2-1`:

- upstream repository: https://github.com/realsenseai/librealsense.git
- release repository: https://github.com/ros2-gbp/librealsense2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.58.1-1`
