### PR TITLE
random_numbers: 2.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6669,7 +6669,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/random_numbers-release.git
-      version: 2.0.4-2
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `2.0.5-1`:

- upstream repository: https://github.com/moveit/random_numbers.git
- release repository: https://github.com/ros2-gbp/random_numbers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.4-2`

## random_numbers

```
* Switch to find_package(Boost CONFIG)
* Fix link to Boost::thread imported target (#52 <https://github.com/moveit/random_numbers/issues/52>)
* Contributors: Robert Haschke, Silvio Traversaro
```
