### PR TITLE
random_numbers: 2.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8801,7 +8801,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/random_numbers-release.git
-      version: 2.0.1-3
+      version: 2.0.5-1
     source:
       type: git
       url: https://github.com/ros-planning/random_numbers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `random_numbers` to `2.0.5-1`:

- upstream repository: https://github.com/ros-planning/random_numbers.git
- release repository: https://github.com/ros2-gbp/random_numbers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-3`

## random_numbers

```
* Switch to find_package(Boost CONFIG)
* Fix link to Boost::thread imported target (#52 <https://github.com/moveit/random_numbers/issues/52>)
* Contributors: Robert Haschke, Silvio Traversaro
```
