### PR TITLE
rmf_traffic: 3.8.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7326,7 +7326,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.7.0-3
+      version: 3.8.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_traffic` to `3.8.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_traffic.git
- release repository: https://github.com/ros2-gbp/rmf_traffic-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.7.0-3`

## rmf_traffic

```
* Update CI to be consistent with other Open-RMF packages (#135 <https://github.com/open-rmf/rmf_traffic/issues/135>)
* Add missing <cstdint> headers for GCC 15 compatibility (#134 <https://github.com/open-rmf/rmf_traffic/issues/134>)
  Several headers were using uint64_t and other fixed-width types without explicitly including <cstdint>, which causes compilation failures on newer toolchains (e.g. Ubuntu 26.04 Resolute).
  Assisted-by: Gemini CLI:2.0-Flash [run_shell_command, replace, write_file, read_file]
* chore: resolve C++ compiler warnings in agv planning and graph (#132 <https://github.com/open-rmf/rmf_traffic/issues/132>)
  * chore: resolve C++ compiler warnings in agv planning and graph
  * Update rmf_traffic/src/rmf_traffic/agv/planning/DifferentialDrivePlanner.cpp
  Co-authored-by: Aaron Chong <mailto:aaronchongth@gmail.com>
  * chore: remove unused entry_event_cost variable
  ---------
  Co-authored-by: Aaron Chong <mailto:aaronchongth@gmail.com>
* Fix build with GCC 15 (#131 <https://github.com/open-rmf/rmf_traffic/issues/131>)
* fix: install package.xml to support ros2 doctor (#125 <https://github.com/open-rmf/rmf_traffic/issues/125>) (#130 <https://github.com/open-rmf/rmf_traffic/issues/130>)
* Contributors: Aryan Gupta, Grey, Michael Carroll, Michal Sojka
```

## rmf_traffic_examples

- No changes
