### PR TITLE
realsense2_camera: 4.58.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7041,7 +7041,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realsense-ros-release.git
-      version: 4.58.1-1
+      version: 4.58.2-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.58.2-1`:

- upstream repository: https://github.com/realsenseai/realsense-ros.git
- release repository: https://github.com/ros2-gbp/realsense-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.58.1-1`

## realsense2_camera

```
* Update CMakeLists.txt to 4.58.2
* Update package.xml to 4.58.2
* Update constants.h to 4.58.2
* PR #3517 <https://github.com/IntelRealSense/realsense-ros/issues/3517> from Gilaadb: Imu handling in component
* Fix _imu_history state corruption on unite_imu_method change
  When switching between COPY and LINEAR_INTERPOLATION at runtime via the
  'unite_imu_method' parameter, _imu_history may contain stale entries from
  the previous mode. Clear it under _imu_callback_mutex to prevent corrupt
  IMU messages (e.g. a GYRO sample being used as accel data in COPY mode).
* PR #3516 <https://github.com/IntelRealSense/realsense-ros/issues/3516> from AviaAv: Reset device at start of test_live_record_db3_play
* Shorten post-reset wait from 10s to 5s
* Fix race on time base variables in components (composable nodes)
  When using components, different sensor threads (video, IMU) can call
  frameSystemTimeSec concurrently on the same instance. The time base
  fields (_ros_time_base, _camera_time_base, _previous_frame_time) had
  no protection, so concurrent init or hardware clock reset could produce
  torn reads and inconsistent timestamp pairs.
  Folded the time base init and reset logic into frameSystemTimeSec
  behind a per-instance mutex, making it the single place that reads and
  writes the time base fields. Removed setBaseTime and the CAS-based
  init blocks in the callbacks, which had a publication window where one
  thread could read uninitialized values after another won the CAS but
  before it had finished writing. Converted _is_initialized_time_base
  from std::atomic_bool to bool since all accesses are now under the
  mutex and the atomic is no longer needed.
* Fix shared IMU callback mutex in components (composable nodes)
  When using components, different realsense cameras are part of the same
  process. The mutex guarding imu_callback_sync was a function-local
  static, so it was shared between all camera components and serialized
  unrelated callbacks across cameras.
  Moved the mutex to an instance member so each component has its own,
  and switched to std::lock_guard which is cleaner and better if an
  exception is ever thrown while the lock is held.
* Fix IMU message pollution in components (composable nodes)
  When using components, different realsense cameras are part of the same
  process. When using a static variable like was done in both unite
  methods, these variables are shared between the different camera
  components and all of them write to the same structure. It caused the
  published IMU messages to have the wrong data because it came from
  different camera sources.
  Moved the buffer to an instance member so each component has its own.
* Fail test_live_record_db3_play if no device, don't skip
* Reset device at start of test_live_record_db3_play
* PR #3513 <https://github.com/IntelRealSense/realsense-ros/issues/3513> from AviaAv: Bump wait_for_frames timeout in live db3 test
* Bump wait_for_frames timeout
* PR #3511 <https://github.com/IntelRealSense/realsense-ros/issues/3511> from AviaAv: Add rosbag2 ROS2 playback test
* Drain live-replay frame queue with keep_frames=True
* Add live db3 record/play test and tweak play check
* Add rosbag2 (.db3) ROS2 playback test
* PR #3505 <https://github.com/IntelRealSense/realsense-ros/issues/3505> from remibettan: Skip RS2_OPTION_REGION_OF_INTEREST in registerDynamicOptions
* PR #3504 <https://github.com/IntelRealSense/realsense-ros/issues/3504> from Nir-Az: Switch CI to ros-core containers for strict dep checking
* needs a development version to be able to work with development branch
* PR #3507 <https://github.com/IntelRealSense/realsense-ros/issues/3507> from Nir-Az: align ros2-development to r/4.57.7
* versions fix
* Merge remote-tracking branch 'origin/r/4.57.7' into ros2-development
  # Conflicts:
  #     realsense2_camera/package.xml
* Add dependency completeness check and fix missing deps
  Add scripts/check_package_deps.sh that validates package.xml declares
  all required dependencies. This catches issues the build farm catches
  but rosdep+apt misses (transitive deps mask missing declarations):
  - .action files require action_msgs in build_depend
  - find_package() calls need matching package.xml entries
  - rosidl_generate_interfaces DEPENDENCIES need matching entries
  The script immediately found two real missing dependencies:
  - realsense2_camera: missing rclcpp_action
  - realsense2_rviz_plugin: missing cv_bridge
  Co-Authored-By: Claude Opus 4.6 (1M context) <mailto:noreply@anthropic.com>
* Skip RS2_OPTION_REGION_OF_INTEREST in registerDynamicOptions
* 4.57.8
* add release notes
* PR #3498 <https://github.com/IntelRealSense/realsense-ros/issues/3498> from SimbeRobotics: Detect and handle hardware timestamp reset
* 4.57.7
* add change log
* add release noted
* changes
* Update package.xml
* Update package.xml
* Update package.xml mail
* log
* bring back comment
* Detect and handle hardware timestamp reset
* Update package.xml
* Update constants.h
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3475 <https://github.com/IntelRealSense/realsense-ros/issues/3475> from remibettan: find package set to last major release version
* find package set to lrs prev major version 2
* PR #3474 <https://github.com/IntelRealSense/realsense-ros/issues/3474> from remibettan: find package set to lrs prev major version
* find package set to lrs prev major version
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* undoing the change in copyright, fixing bagfiles links
* PR #3468 <https://github.com/IntelRealSense/realsense-ros/issues/3468> from remibettan: using legacy libraries for foxy
* using legacy libraries for foxy
* code review corrections
* many intel removed and github user changed
* PR #3450 <https://github.com/IntelRealSense/realsense-ros/issues/3450> from Nir-Az: update to realsenseai
* update to realsenseai
* PR #3448 <https://github.com/IntelRealSense/realsense-ros/issues/3448> from OhadMeir: Add motion_fps to launch file
* Add motion_fps to launch file
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0 - leftovers
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* PR #3437 <https://github.com/IntelRealSense/realsense-ros/issues/3437> from Gilaadb: bug fix(rs_node_setup): Fix topic names that were improperly marked as rect (rectified)
* bug fix(rs_node_setup): Fix topic names that were improperly marked as rect (rectified)
* Contributors: Avia Avraham, Gilad Bretter, Nandini, Nandini Thakur, Nir Azkiel, OhadMeir, Remi Bettan, remibettan
```

## realsense2_camera_msgs

```
* Update package.xml to 4.58.2
* PR #3507 <https://github.com/IntelRealSense/realsense-ros/issues/3507> from Nir-Az: align ros2-development to r/4.57.7
* versions fix
* Merge remote-tracking branch 'origin/r/4.57.7' into ros2-development
  # Conflicts:
  #     realsense2_camera/package.xml
* Revert "TEST: Remove action_msgs to verify CI catches it"
  This reverts commit 10c0aa79dae72aa366d3c387308620a905e2f9bd.
* TEST: Remove action_msgs to verify CI catches it
  This commit should cause CI to fail. Revert after verification.
  Co-Authored-By: Claude Opus 4.6 (1M context) <mailto:noreply@anthropic.com>
* Revert "TEST: Remove action_msgs dependency to verify CI catches it"
  This reverts commit 386560cee21b615ff722ca9faea55fcbdb99432f.
* TEST: Remove action_msgs dependency to verify CI catches it
  This commit intentionally removes the action_msgs dependency from
  realsense2_camera_msgs/package.xml to verify that the ros-core based
  CI detects missing dependency declarations. This commit should be
  reverted after verification.
  Co-Authored-By: Claude Opus 4.6 (1M context) <mailto:noreply@anthropic.com>
* 4.57.8
* add release notes
* Update package.xml fix co pilot comment
* PR #3503 <https://github.com/IntelRealSense/realsense-ros/issues/3503> from realsenseai: Update package.xml to incude missing depends
* Update package.xml fix co pilot comments
* Update package.xml to incude missing depends
* Update package.xml to include missing depends
* 4.57.7
* add change log
* add release noted
* Update package.xml
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* many intel removed and github user changed
* PR #3447 <https://github.com/IntelRealSense/realsense-ros/issues/3447> from Nir-Az: Update maintainers before Realsense migration
* update maintainers list
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* Contributors: Nir Azkiel, Remi Bettan, remibettan
```

## realsense2_description

```
* Update package.xml to 4.58.2
* PR #3507 <https://github.com/IntelRealSense/realsense-ros/issues/3507> from Nir-Az: align ros2-development to r/4.57.7
* versions fix
* Merge remote-tracking branch 'origin/r/4.57.7' into ros2-development
  # Conflicts:
  #     realsense2_camera/package.xml
* 4.57.8
* add release notes
* 4.57.7
* add change log
* add release noted
* Update package.xml
* PR #3485 <https://github.com/IntelRealSense/realsense-ros/issues/3485> from Nir-Az: Fix GHA flow
* install missing packages
* PR #3476 <https://github.com/IntelRealSense/realsense-ros/issues/3476> from nivgo: Add support for Intel RealSense D436 Camera
* typos fix
* Add Intel realsense D436 URDF model
* PR #3462 <https://github.com/IntelRealSense/realsense-ros/issues/3462> from remibettan: intel removed and github user changed
* many intel removed and github user changed
* PR #3447 <https://github.com/IntelRealSense/realsense-ros/issues/3447> from Nir-Az: Update maintainers before Realsense migration
* update maintainers list
* PR #3442 <https://github.com/IntelRealSense/realsense-ros/issues/3442> from remibettan/restore-minor-version-to-0: minor versions back to 0
* minor back to 0
* PR #3441 <https://github.com/IntelRealSense/realsense-ros/issues/3441> from remibettan/ros2-development: merging 4.57.3 to ros2-development
* Merge tag '4.57.3' into ros2-development
* Contributors: Nir Azkiel, Niv Goren, Remi Bettan, remibettan
```
