### PR TITLE
ffmpeg_image_transport: 3.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2288,7 +2288,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
-      version: 3.0.2-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ffmpeg_image_transport` to `3.0.4-1`:

- upstream repository: https://github.com/ros-misc-utilities/ffmpeg_image_transport.git
- release repository: https://github.com/ros2-gbp/ffmpeg_image_transport-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`

## ffmpeg_image_transport

```
* move message_type to the library level in ffmpeg_plugins.xml
* add message_type to ffmpeg publisher and subscriber plugins
* fix gtest issues on humble
* fix tests under rolling and lyrical
* msgs and encoder/decoder are now in all rosdistros
* update required cmake to 3.16
* default gop_size to 10 again, but warn if not set
* use correct img transp version 5.0.0
* Contributors: Bernd Pfrommer, Tony Najjar
```
