### PR TITLE
foxglove_compressed_video_transport: 3.0.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2559,7 +2559,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
-      version: 3.0.1-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove_compressed_video_transport` to `3.0.3-1`:

- upstream repository: https://github.com/ros-misc-utilities/foxglove_compressed_video_transport.git
- release repository: https://github.com/ros2-gbp/foxglove_compressed_video_transport-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.1-1`

## foxglove_compressed_video_transport

```
* bump cmake version and try to fix gtest on humble
* remove repos file
* added message_type to plugins xml file
* use nodeinterface also for publishing transport
* default gop_size to 1 and warn if not set
* use correct img transp version 5.0.0
* Contributors: Bernd Pfrommer
```
