### PR TITLE
rmf_task: 2.10.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7308,7 +7308,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.9.0-3
+      version: 2.10.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_task` to `2.10.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_task.git
- release repository: https://github.com/ros2-gbp/rmf_task-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.0-3`

## rmf_task

```
* Fix poorly defined nlohmann_json conversion (#137 <https://github.com/open-rmf/rmf_task/issues/137>)
* Resolve warnings (#135 <https://github.com/open-rmf/rmf_task/issues/135>)
  * resolve warnings
  * resolve UB
  ---------
* add charge to labels (#134 <https://github.com/open-rmf/rmf_task/issues/134>)
  Co-authored-by: Xiyu <mailto:ohxiyu@gmail.com>
* add missing includes for GCC 15 (#133 <https://github.com/open-rmf/rmf_task/issues/133>)
* Prepare for release 2.9 (#131 <https://github.com/open-rmf/rmf_task/issues/131>)
  * Update changelogs
  * Remove out of date version numbers
  * 2.9.0
  * Put version numbers back in
  ---------
* Customizable weights for task assignment cost (#129 <https://github.com/open-rmf/rmf_task/issues/129>)
* Contributors: Aaron Chong, Grey, Guilhem Saurel, kj
```

## rmf_task_sequence

```
* Fix poorly defined nlohmann_json conversion (#137 <https://github.com/open-rmf/rmf_task/issues/137>)
* Resolve warnings (#135 <https://github.com/open-rmf/rmf_task/issues/135>)
  * resolve warnings
  * resolve UB
  ---------
* Prepare for release 2.9 (#131 <https://github.com/open-rmf/rmf_task/issues/131>)
  * Update changelogs
  * Remove out of date version numbers
  * 2.9.0
  * Put version numbers back in
  ---------
* Fix nullopt dereference in GoToPlace goal selection (#130 <https://github.com/open-rmf/rmf_task/issues/130>)
* Introduce start_at_departure option for go_to_place event (#128 <https://github.com/open-rmf/rmf_task/issues/128>)
* Contributors: Aaron Chong, Grey, kj
```
