### PR TITLE
imu_tools: 2.2.4-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3464,7 +3464,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/imu_tools-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `imu_tools` to `2.2.4-1`:

- upstream repository: https://github.com/CCNYRoboticsLab/imu_tools.git
- release repository: https://github.com/ros2-gbp/imu_tools-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.2.3-1`

## imu_complementary_filter

- No changes

## imu_filter_madgwick

- No changes

## imu_tools

- No changes

## rviz_imu_plugin

```
* Fix build failures in update methods (#233 <https://github.com/CCNYRoboticsLab/imu_tools/issues/233>)
* Contributors: Michal Sojka
```
