### PR TITLE
Add connection_inspector to the rosdistro index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1951,7 +1951,7 @@ repositories:
   connection_inspector:
     source:
       type: git
-      url: https://github.com/ksatyaki/ros2_connection_inspector.git
+      url: https://github.com/ksatyaki/ros2_node_inspector.git
       version: master
     status: maintained
   console_bridge_vendor:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1948,6 +1948,12 @@ repositories:
       url: https://github.com/ros2/common_interfaces.git
       version: humble
     status: maintained
+  connection_inspector:
+    source:
+      type: git
+      url: https://github.com/ksatyaki/ros2_connection_inspector.git
+      version: master
+    status: maintained
   console_bridge_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1799,7 +1799,7 @@ repositories:
   connection_inspector:
     source:
       type: git
-      url: https://github.com/ksatyaki/ros2_connection_inspector.git
+      url: https://github.com/ksatyaki/ros2_node_inspector.git
       version: master
     status: maintained
   console_bridge_vendor:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1796,6 +1796,12 @@ repositories:
       url: https://github.com/ctu-vras/compass.git
       version: ros2
     status: maintained
+  connection_inspector:
+    source:
+      type: git
+      url: https://github.com/ksatyaki/ros2_connection_inspector.git
+      version: master
+    status: maintained
   console_bridge_vendor:
     doc:
       type: git


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

Jazzy
Humble

# Package name:

connection_inspector

## Package Upstream Source:

[Connection Inspector](https://github.com/ksatyaki/ros2_node_inspector.git)

## Description:

A tool similar to rqt_graph but slightly better.
It shows a list of nodes in the left pane. Selecting a node displays an ego-centric graph with a neat layout. Even hundreds of connections can be clearly visualized using this bipartite graph view. Scroll down and see all topics and nodes that the selected node is connected to! 
 
*This tool can diagnose QoS mismatches.*

Each edge of the graph has a label with a status icon and the topic name. If it shows a red cross, something is wrong, type is missing or wrong type or no data on the topic. Yellow question mark means QoS mismatch. Green tick means alive. And Blue tick means Latched topic. 

There is also a tabular view that shows the same information. 

This would greatly benefit everyone, especially newcomers to ROS2. 

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
