### PR TITLE
mrpt3: 3.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4976,6 +4976,58 @@ repositories:
       url: https://github.com/ika-rwth-aachen/mqtt_client.git
       version: main
     status: maintained
+  mrpt3:
+    doc:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    release:
+      packages:
+      - mrpt_apps_cli
+      - mrpt_apps_gui
+      - mrpt_bayes
+      - mrpt_common
+      - mrpt_comms
+      - mrpt_config
+      - mrpt_containers
+      - mrpt_core
+      - mrpt_data
+      - mrpt_examples_cpp
+      - mrpt_expr
+      - mrpt_graphs
+      - mrpt_graphslam
+      - mrpt_gui
+      - mrpt_hwdrivers
+      - mrpt_img
+      - mrpt_imgui
+      - mrpt_io
+      - mrpt_kinematics
+      - mrpt_libapps_cli
+      - mrpt_libapps_gui
+      - mrpt_maps
+      - mrpt_math
+      - mrpt_nav
+      - mrpt_obs
+      - mrpt_opengl
+      - mrpt_poses
+      - mrpt_random
+      - mrpt_rtti
+      - mrpt_serialization
+      - mrpt_slam
+      - mrpt_system
+      - mrpt_tfest
+      - mrpt_topography
+      - mrpt_typemeta
+      - mrpt_viz
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/mrpt3-release.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/MRPT/mrpt.git
+      version: develop
+    status: developed
   mrpt_msgs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.0.3-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

- No changes

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

- No changes

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

```
* Merge pull request #1364 <https://github.com/MRPT/mrpt/issues/1364> from MRPT/fix/rdev-test-failures-3.0.3
  Fix/rdev test failures 3.0.3
* fix: alignment crash
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_graphs

- No changes

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

- No changes

## mrpt_imgui

- No changes

## mrpt_io

```
* Increase unit test coverage for mrpt_math, mrpt_io, mrpt_system (#1365 <https://github.com/MRPT/mrpt/issues/1365>)
  * Increase unit test coverage for mrpt_math, mrpt_io, mrpt_system
  Add unit tests for TTwist3D, TObject2D/TObject3D (serialization and
  2D/3D casting), RANSAC line fitting, CFileStream, CPipe, and
  CDirectoryExplorer.
  Fix a bug in TObject2D::operator<< and TObject3D::operator<< where
  serialization always threw "Unexpected type index" regardless of the
  actual variant content, due to an unconditional THROW_EXCEPTION after
  the if/else-if chain instead of in an else branch.
  * Apply clang-format-14 to new test files
  * Fix MSVC build: M_PI_2 is not a standard macro
  Use M_PI / 2 instead, matching the M_PI definition already provided
  by mrpt_core's bits_math.h for all platforms.
  * Fix CDirectoryExplorer::explore() on Windows to skip "." and ".." entries
  The Windows (FindFirstFile/FindNextFile) implementation listed "." and
  ".." as regular directory entries, unlike the POSIX implementation
  which already skips them. This caused the new
  CDirectoryExplorer_unittest.cpp tests to fail on Windows CI.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

```
* Fix rawlog-edit CLI unittest failure on Windows CI (#1370 <https://github.com/MRPT/mrpt/issues/1370>)
* Merge pull request #1369 <https://github.com/MRPT/mrpt/issues/1369> from MRPT/test/rawlog-edit-cli-coverage
  Add rawlog-edit CLI test coverage and fix related bugs
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_libapps_gui

- No changes

## mrpt_maps

```
* Fix rawlog-edit CLI unittest failure on Windows CI (#1370 <https://github.com/MRPT/mrpt/issues/1370>)
* Update nanoflann to 1.10.1 and add KD-tree query tests for CPointsMap
* Merge pull request #1366 <https://github.com/MRPT/mrpt/issues/1366> from MRPT/feature/occgrid2d-test-coverage-completion
  test(mrpt_maps): complete COccupancyGridMap2D unit test coverage
* test(mrpt_maps): add COccupancyGridMap2D coverage for subSample, simulate, likelihood, matching
  Adds a subSampleHalvesResolution unit test and three new test files covering
  laser/sonar scan simulation, all TLikelihoodMethod likelihood computations,
  and determineMatching2D.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_math

```
* Increase unit test coverage for mrpt_math, mrpt_io, mrpt_system (#1365 <https://github.com/MRPT/mrpt/issues/1365>)
* Merge pull request #1364 <https://github.com/MRPT/mrpt/issues/1364> from MRPT/fix/rdev-test-failures-3.0.3
  Fix/rdev test failures 3.0.3
* fix: alignment crash
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav

- No changes

## mrpt_obs

```
* Fix rawlog-edit CLI unittest failure on Windows CI (#1370 <https://github.com/MRPT/mrpt/issues/1370>)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_opengl

```
* Merge pull request #1368 <https://github.com/MRPT/mrpt/issues/1368> from wentasah/export-opengl
  mrpt_opengl: Export opengl dependency
* Contributors: Jose Luis Blanco-Claraco, Michal Sojka
```

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

```
* Fix rawlog-edit CLI unittest failure on Windows CI (#1370 <https://github.com/MRPT/mrpt/issues/1370>)
* Increase unit test coverage for mrpt_math, mrpt_io, mrpt_system (#1365 <https://github.com/MRPT/mrpt/issues/1365>)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tfest

- No changes

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

- No changes
