### PR TITLE
Add qt6-svg-plugins to libqtsvg for Ubuntu Resolute

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6878,6 +6878,7 @@ libqtsvg:
     'focal': null
     'jammy': null
     'noble': [libqt5svg5]
+    'resolute': [libqt6svg6, qt6-svg-plugins]
 libqtwebkit-dev:
   debian: [libqtwebkit-dev]
   fedora: [qtwebkit-devel]


### PR DESCRIPTION
### Add `resolute` entry for `libqtsvg`

On Ubuntu 26.04 (Resolute) the `qt6-svg` source package is split into the QtSvg runtime library `libqt6svg6` and a separate `qt6-svg-plugins` binary  that ships the Qt SVG plugins (image-format / icon-engine). With
only `libqt6svg6`, the library loads but SVG resources fail to render at runtime, so the `libqtsvg` key needs both on Resolute.

- `ubuntu: resolute: [libqt6svg6, qt6-svg-plugins]`

That solved in particular errors when starting Rviz "Could not load pixmap package: error missing".
