### PR TITLE
mrpt_path_planning: 1.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5025,7 +5025,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 0.3.0-3
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `1.0.0-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.0-3`

## mrpt_path_planning

```
* feat(TPS_Astar): weighted A* via ``heuristic_epsilon`` param (default 1.0 = exact A*); eps in [1.5, 2] cuts median plan time ~4-5x at ~3-8% longer paths
* feat(TPS_Astar): analytic expansion / early termination to goal (#25 <https://github.com/MRPT/mrpt_path_planning/issues/25>): accept a direct-to-goal PTG edge as soon as it lands in the goal cell, skipping unnecessary expansions
* feat(TPS_Astar): optional 2D-Dijkstra obstacle-aware heuristic (#24 <https://github.com/MRPT/mrpt_path_planning/issues/24>): opt-in ``use_obstacle_heuristic`` pre-computes a cost-to-go grid; ~5x fewer expansions on hard BARN worlds
* feat(TPS_Astar): wire ``stateGoal.vel`` into goal-cell exit speed (#18 <https://github.com/MRPT/mrpt_path_planning/issues/18>)
* feat(viz): SVG exporter for plans (#29 <https://github.com/MRPT/mrpt_path_planning/issues/29>): ``mpp::save_plan_to_svg()`` — dependency-free 2D vector export of motion tree, solution path, footprint, and start/goal markers; new ``--save-svg`` CLI option
* feat(gui): viz now shows selected point coordinates
* perf(TPS_Astar): batch TP-obstacle collision check per node expansion (#26 <https://github.com/MRPT/mrpt_path_planning/issues/26>): O(candidates×N) → O(N); ~2-3x faster on hard BARN worlds
* perf(TPS_Astar): defer per-edge path interpolation to the final solution (#27 <https://github.com/MRPT/mrpt_path_planning/issues/27>): ~17-21% additional speedup
* perf(TPS_Astar): coarsen default ``grid_resolution_yaw`` from 5° to 7.5°; ~23-37% faster with equal or better success rate on BARN/HouseExpo benchmarks
* perf(P3): xy-cell obstacle cache in ``cached_local_obstacles()`` (#20 <https://github.com/MRPT/mrpt_path_planning/issues/20>): ~6x per-call speedup; cache keyed by (ix,iy) and cleared each ``plan()``
* fix(TPS_Astar): obstacle cache ignored heading, causing collision false negatives (#28 <https://github.com/MRPT/mrpt_path_planning/issues/28>): cache now stores heading-independent clipped cloud; heading-dependent transform done per call
* fix: ``refine_trajectory()`` distance overshoot
* fix: SVG draw now honors any-heading goals
* fix: restore A* admissibility by converting heuristic cost to seconds (#16 <https://github.com/MRPT/mrpt_path_planning/issues/16>)
* fix: store ``ptgTrimmableSpeed`` in best-path replacement block (#15 <https://github.com/MRPT/mrpt_path_planning/issues/15>)
* fix: replace ``NodeCoordsHash`` with ``boost::hash_combine`` avalanche pattern to eliminate bucket clustering in large lattices
* fix: bind ``obs_xs``/``obs_ys`` by const ref in ``transform_pc_square_clipping`` to avoid O(N) copy (#14 <https://github.com/MRPT/mrpt_path_planning/issues/14>)
* fix: remove dead ``THROW_EXCEPTION`` branches in ``edge_interpolated_path`` (#17 <https://github.com/MRPT/mrpt_path_planning/issues/17>)
* test: end-to-end A* tests for C-PTG forward and reverse motion (#23 <https://github.com/MRPT/mrpt_path_planning/issues/23>)
* test: add UnreachableGoal, Timeout, MultiPTG, MotionTree, and obstacle-cache unit tests (#22 <https://github.com/MRPT/mrpt_path_planning/issues/22>)
* build: bump minimum CMake version to 3.22 (#19 <https://github.com/MRPT/mrpt_path_planning/issues/19>)
* ci: install ``libgtest-dev`` so GTest suite is actually built and run
* docs: add ROS 2 Lyrical badge, update Rolling to Ubuntu 26.04 (Resolute)
* Contributors: Jose Luis Blanco-Claraco, SRai22
```
