### PR TITLE
libcaer_driver: 1.5.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5209,7 +5209,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer_driver-release.git
-      version: 1.5.4-1
+      version: 1.5.6-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcaer_driver` to `1.5.6-1`:

- upstream repository: https://github.com/ros-event-camera/libcaer_driver.git
- release repository: https://github.com/ros2-gbp/libcaer_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.5.4-1`

## libcaer_driver

```
* fix formatting errors
* adapt to new camerinfomanager constructor
* Contributors: Bernd Pfrommer
```
