### PR TITLE
Add python3-ezdxf-pip rosdep key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5157,6 +5157,10 @@ python3-ezdxf:
     focal:
       pip:
         packages: [ezdxf]
+python3-ezdxf-pip:
+  '*':
+    pip:
+      packages: [ezdxf]
 python3-fabric:
   alpine: [fabric]
   arch: [fabric]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

ezdxf

## Package Upstream Source:

https://pypi.org/project/ezdxf/

## Purpose of using this:

ezdxf is a Python library for reading and writing DXF (Drawing Exchange Format) files. A native python3-ezdxf rosdep key already exists, however the apt version is too old and lacks features required for our use case. This pip key is needed for from-source ROS builds that require a more recent version.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/search?keywords=python3-ezdxf
  - REQUIRED
- Ubuntu: https://packages.ubuntu.com/search?keywords=python3-ezdxf
  - REQUIRED
- Fedora: https://packages.fedoraproject.org/pkgs/python-ezdxf/python-ezdxf-doc/
  - https://packages.fedoraproject.org/pkgs/python-ezdxf/python-ezdxf-doc/
- Arch: https://www.archlinux.org/packages/
  - NOT AVAILABLE
- Gentoo: https://packages.gentoo.org/
  - NOT AVAILABLE
- macOS: https://formulae.brew.sh/
  - NOT AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - NOT AVAILABLE
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=26.05&query=ezdxf#show=python314Packages.ezdxf
  - https://search.nixos.org/packages?channel=26.05&query=ezdxf#show=python314Packages.ezdxf
- openSUSE: https://software.opensuse.org/
  - https://software.opensuse.org/search?baseproject=ALL&q=ezdxf
- rhel: https://pkgs.org/
  - https://pkgs.org/search/?q=ezdxf

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->
