### PR TITLE
rqt_plot: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8944,7 +8944,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 2.0.0-2
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `2.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-2`

## rqt_plot

```
* Use logger.warning(), f-string , super() and Qt6 fixes (#129 <https://github.com/ros-visualization/rqt_plot/issues/129>)
* Contributors: Alejandro Hernández Cordero
```
