### PR TITLE
rqt_publisher: 2.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8959,7 +8959,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 2.0.0-1
+      version: 2.0.1-2
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `2.0.1-2`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-1`

## rqt_publisher

```
* Use logger.warning(), f-string , super() and Qt6 fixes (#59 <https://github.com/ros-visualization/rqt_publisher/issues/59>)
* Contributors: Alejandro Hernández Cordero
```
