### PR TITLE
rqt_publisher: 1.10.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8983,7 +8983,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_publisher-release.git
-      version: 1.10.3-1
+      version: 1.10.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_publisher` to `1.10.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_publisher.git
- release repository: https://github.com/ros2-gbp/rqt_publisher-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.10.3-1`

## rqt_publisher

```
* Use logger.warning(), f-string , super() and Qt6 fixes (backport #59 <https://github.com/ros-visualization/rqt_publisher/issues/59>) (#60 <https://github.com/ros-visualization/rqt_publisher/issues/60>)
* Contributors: mergify[bot]
```
