### PR TITLE
rqt_plot: 1.7.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8968,7 +8968,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_plot-release.git
-      version: 1.7.5-3
+      version: 1.7.6-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_plot` to `1.7.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_plot.git
- release repository: https://github.com/ros2-gbp/rqt_plot-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.5-3`

## rqt_plot

```
* Use logger.warning(), f-string , super() and Qt6 fixes (backport #129 <https://github.com/ros-visualization/rqt_plot/issues/129>) (#130 <https://github.com/ros-visualization/rqt_plot/issues/130>)
* Contributors: mergify[bot]
```
