### PR TITLE
rqt_console: 2.4.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8843,7 +8843,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 2.4.3-3
+      version: 2.4.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_console` to `2.4.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_console.git
- release repository: https://github.com/ros2-gbp/rqt_console-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.3-3`

## rqt_console

```
* Use logger.warning(), f-string and super() (backport #59 <https://github.com/ros-visualization/rqt_console/issues/59>) (#60 <https://github.com/ros-visualization/rqt_console/issues/60>)
  Use logger.warning(), f-string and super() (#59 <https://github.com/ros-visualization/rqt_console/issues/59>)
  (cherry picked from commit e5c93907c6574acc80334d9e024a4d1c2039d8c0)
  Co-authored-by: Alejandro Hernández Cordero <mailto:ahcorde@gmail.com>
* Contributors: mergify[bot]
```
