### PR TITLE
rqt_msg: 1.7.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8953,7 +8953,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_msg-release.git
-      version: 1.7.2-3
+      version: 1.7.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_msg.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_msg` to `1.7.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_msg.git
- release repository: https://github.com/ros2-gbp/rqt_msg-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.2-3`

## rqt_msg

```
* Use logger.warning(), f-string and super() (backport #28 <https://github.com/ros-visualization/rqt_msg/issues/28>) (#29 <https://github.com/ros-visualization/rqt_msg/issues/29>)
* Contributors: mergify[bot]
```
