### PR TITLE
rko_lio: 0.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8674,7 +8674,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rko_lio-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/PRBonn/rko_lio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.3.0-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.0-1`

## rko_lio

```
* misc: adds testing for lyrical, fixes the current ci fails (#142 <https://github.com/PRBonn/rko_lio/issues/142>)
  * adds testing for lyrical, fixes the current ci fails, and switches to leaner images for ci
* use VoxelHash struct to avoid ODR violations (#140 <https://github.com/PRBonn/rko_lio/issues/140>)
  Co-authored-by: Meher Malladi <mailto:rm.meher97@gmail.com>
* core: revert voxel down sample sorted (#141 <https://github.com/PRBonn/rko_lio/issues/141>)
  not a 1-1 improvement over previous behavior
* core: Fix tbb threading using max_num_threads (#137 <https://github.com/PRBonn/rko_lio/issues/137>)
  * core: return the thread limit which was lost in #93 <https://github.com/PRBonn/rko_lio/issues/93>
* core: improved voxel down sampling, use robin set, explicit hash sorting (#136 <https://github.com/PRBonn/rko_lio/issues/136>)
  * tests: add test cases for voxel_down_sample_sorted
* core, python, ros: a series of simplifications (#133 <https://github.com/PRBonn/rko_lio/issues/133>)
  * core: clean up preprocessing result for double deskewing on/off
  * ros: frame parsing simplifications
  * ros: imu rate publishing simplify
  * ros: unify publishers to use lio->state
  * core: simplify point to voxel usage
  * api: fix my embarrassing spelling mistake on correspondences
  * ros: clean up bag progress publish in offline mode
* core: Reject empty input vectors instead of dereferencing end() (#135 <https://github.com/PRBonn/rko_lio/issues/135>)
* ros (bug): fix shared library components not installing properly
* core: time in nanoseconds, everywhere (#132 <https://github.com/PRBonn/rko_lio/issues/132>)
  * switch doubles to nanoseconds end-to-end
  * ros: improve the utils slightly
* ros (+ core): Installable and therefore reusable libs (#131 <https://github.com/PRBonn/rko_lio/issues/131>)
  * make core/ros/ros::utils libs ament-installable + exportable
  * install only on no fetch content. and prevent install on humble
* core: drop Bonxai for tsl::robin_map (#130 <https://github.com/PRBonn/rko_lio/issues/130>)
  * switch to tsl robin map instead of bonxai
  * change method names to snake case for the hash map
* chore: bump FetchContent dependencies (#128 <https://github.com/PRBonn/rko_lio/issues/128>)
* ros: offline node exits once lidar buffer has been emptied (#127 <https://github.com/PRBonn/rko_lio/issues/127>)
  * fix a potential bug that i thought i fixed on imu msgs being leftover
  * catch the potential race with the node dying before reg exits
* docs: overhaul (#126 <https://github.com/PRBonn/rko_lio/issues/126>)
* ros, feat: odometry at imu rate (#125 <https://github.com/PRBonn/rko_lio/issues/125>)
  * feat: publish odometry at imu freq, when running sequentially
  * add a part for the imu rate odom to the docs
* core: simplifications and clean up to core (#124 <https://github.com/PRBonn/rko_lio/issues/124>)
* Add Catch2 tests for core functionalities and related updates (#123 <https://github.com/PRBonn/rko_lio/issues/123>)
  * add catch2 based tests to cover important core functionalities.
  * then related file updates
  * consolidate workflows
* core: error out if keypoints is too small as thats likely a data error (#110 <https://github.com/PRBonn/rko_lio/issues/110>)
* ros: add deskewed scan topic as a config, change default topic names to relative (#108 <https://github.com/PRBonn/rko_lio/issues/108>)
* core: orientation linear system simplifications. move util classes to util (#94 <https://github.com/PRBonn/rko_lio/issues/94>)
* Some code refactoring and execution time improvement. (#93 <https://github.com/PRBonn/rko_lio/issues/93>)
  Co-authored-by: Meher Malladi <mailto:rm.meher97@gmail.com>
* Contributors: Aleksandr Kovalko, Luca Lobefaro, Meher Malladi, Saurabh Gupta, dependabot[bot], muvahhid kılıç
```
