### PR TITLE
remove libgstreamer-plugins-good1.0-0 for resolute and above

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1882,8 +1882,8 @@ gstreamer1.0-plugins-good:
   rhel: [gstreamer1-plugins-good]
   ubuntu:
     '*': [gstreamer1.0-plugins-good]
-    noble: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
     jammy: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
+    noble: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
   arch: [gst-plugins-ugly]
   debian: [gstreamer1.0-plugins-ugly]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1880,7 +1880,10 @@ gstreamer1.0-plugins-good:
   openembedded: [gstreamer1.0-plugins-good@openembedded-core]
   opensuse: [gstreamer-plugins-good]
   rhel: [gstreamer1-plugins-good]
-  ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
+  ubuntu:
+    '*': [gstreamer1.0-plugins-good]
+    noble: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
+    jammy: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
   arch: [gst-plugins-ugly]
   debian: [gstreamer1.0-plugins-ugly]


### PR DESCRIPTION
libgstreamer-plugins-good1.0-0 is now removed in ubuntu resolute (26.04).

- resolute: `1.28.x` `libgstreamer-plugins-good1.0-0` is removed
  - https://launchpad.net/ubuntu/+source/gst-plugins-good1.0/1.28.2-2
- noble: `1.24.x`: `libgstreamer-plugins-good1.0-0` exists
  - https://launchpad.net/ubuntu/+source/gst-plugins-good1.0/1.24.2-1ubuntu1
