### PR TITLE
mola_sm_loop_closure: 1.2.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6092,7 +6092,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
-      version: 1.2.0-1
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_sm_loop_closure.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_sm_loop_closure` to `1.2.2-1`:

- upstream repository: https://github.com/MOLAorg/mola_sm_loop_closure.git
- release repository: https://github.com/ros2-gbp/mola_sm_loop_closure-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.0-1`

## mola_sm_loop_closure

```
* update robin and kiss-matcher submodules
* Contributors: Jose Luis Blanco-Claraco
```
