### PR TITLE
mrpt3: 3.0.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5003,7 +5003,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.0.4-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.3-1`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

- No changes

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

- No changes

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

- No changes

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

- No changes

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

- No changes

## mrpt_maps

- No changes

## mrpt_math

- No changes

## mrpt_nav

- No changes

## mrpt_obs

- No changes

## mrpt_opengl

```
* fix: conservative use depend to ensure opengl binary libs are added downstream of mrpt_opengl
* Merge pull request #1371 <https://github.com/MRPT/mrpt/issues/1371> from wentasah/export-opengl
  mrpt_opengl: Add opengl build_depend back
* mrpt_opengl: Add opengl build_depend back
  In a recent commit, build_depend was replaced with
  build_export_depend. But it seems that both build_depend and
  build_export_depend need to be specified. Without build_depend, ROS
  build farm complains about OpenGL not being available:
  Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR)
* Contributors: Jose Luis Blanco-Claraco, Michal Sojka
```

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

- No changes

## mrpt_tfest

- No changes

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

- No changes
