### PR TITLE
rmf_visualization: 2.6.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7453,7 +7453,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization-release.git
-      version: 2.5.1-3
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_visualization` to `2.6.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_visualization.git
- release repository: https://github.com/ros2-gbp/rmf_visualization-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.1-3`

## rmf_visualization

```
* Fix nummber typo in visualization.launch.xml (#93 <https://github.com/open-rmf/rmf_visualization/issues/93>)
  Co-authored-by: Lots-ninety-nine <mailto:261080291+Lots-ninety-nine@users.noreply.github.com>
* Contributors: Mosiwon
```

## rmf_visualization_building_systems

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Contributors: Luca Della Vedova
```

## rmf_visualization_fleet_states

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Contributors: Luca Della Vedova
```

## rmf_visualization_floorplans

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Add static cast for buffer data (#92 <https://github.com/open-rmf/rmf_visualization/issues/92>)
* Contributors: Luca Della Vedova
```

## rmf_visualization_navgraphs

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Contributors: Luca Della Vedova
```

## rmf_visualization_obstacles

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Contributors: Luca Della Vedova
```

## rmf_visualization_rviz2_plugins

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Resolve warnings (#90 <https://github.com/open-rmf/rmf_visualization/issues/90>)
  * resolve compilation warnings
  * missing return
  ---------
* Contributors: Aaron Chong, Luca Della Vedova
```

## rmf_visualization_schedule

```
* Use default CI matrix (#94 <https://github.com/open-rmf/rmf_visualization/issues/94>)
  Co-authored-by: Michael X. Grey <mailto:mxgrey@intrinsic.ai>
* Resolve warnings (#90 <https://github.com/open-rmf/rmf_visualization/issues/90>)
  * resolve compilation warnings
  * missing return
  ---------
* Contributors: Aaron Chong, Luca Della Vedova
```
