### PR TITLE
rmf_demos: 2.9.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7271,7 +7271,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_demos-release.git
-      version: 2.8.2-4
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmf_demos` to `2.9.0-1`:

- upstream repository: https://github.com/open-rmf/rmf_demos.git
- release repository: https://github.com/ros2-gbp/rmf_demos-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.2-4`

## rmf_demos

- No changes

## rmf_demos_assets

- No changes

## rmf_demos_bridges

```
* Lyrical compatibility (#353 <https://github.com/open-rmf/rmf_demos/issues/353>)
* Contributors: Grey
```

## rmf_demos_fleet_adapter

```
* Lyrical compatibility (#353 <https://github.com/open-rmf/rmf_demos/issues/353>)
* Contributors: Grey
```

## rmf_demos_gz

- No changes

## rmf_demos_maps

- No changes

## rmf_demos_tasks

```
* Lyrical compatibility (#353 <https://github.com/open-rmf/rmf_demos/issues/353>)
* Contributors: Grey
```
