### PR TITLE
rqt_shell: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9080,7 +9080,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `2.0.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-1`

## rqt_shell

```
* Use logger.warning(), f-string and super() (#31 <https://github.com/ros-visualization/rqt_shell//issues/31>)
* Removed Python2 references (#30 <https://github.com/ros-visualization/rqt_shell//issues/30>)
* Contributors: Alejandro Hernández Cordero
```
