### PR TITLE
rqt_reconfigure: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8989,7 +8989,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `2.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-1`

## rqt_reconfigure

```
* Use logger.warning(), f-string and super() (#171 <https://github.com/ros-visualization/rqt_reconfigure/issues/171>)
* Removed Python2 references (#170 <https://github.com/ros-visualization/rqt_reconfigure/issues/170>)
* Contributors: Alejandro Hernández Cordero
```
