### PR TITLE
rqt_reconfigure: 1.8.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9013,7 +9013,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_reconfigure-release.git
-      version: 1.8.5-1
+      version: 1.8.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_reconfigure` to `1.8.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt_reconfigure.git
- release repository: https://github.com/ros2-gbp/rqt_reconfigure-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.5-1`

## rqt_reconfigure

```
* Use logger.warning(), f-string and super() (backport #171 <https://github.com/ros-visualization/rqt_reconfigure/issues/171>) (#172 <https://github.com/ros-visualization/rqt_reconfigure/issues/172>)
* Contributors: mergify[bot]
```
