### PR TITLE
rqt_graph: 1.8.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8888,7 +8888,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.8.3-1
+      version: 1.8.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.8.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.3-1`

## rqt_graph

```
* Removed Python2 references and Qt6 fixes (backport #118 <https://github.com/ros-visualization/rqt_graph/issues/118>) (#119 <https://github.com/ros-visualization/rqt_graph/issues/119>)
* Contributors: mergify[bot]
```
