### PR TITLE
rqt_shell: 1.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9104,7 +9104,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_shell-release.git
-      version: 1.4.1-3
+      version: 1.4.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_shell.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_shell` to `1.4.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_shell.git
- release repository: https://github.com/ros2-gbp/rqt_shell-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.1-3`

## rqt_shell

```
* Use logger.warning(), f-string and super() (backport #31 <https://github.com/ros-visualization/rqt_shell//issues/31>) (#33 <https://github.com/ros-visualization/rqt_shell//issues/33>)
* Removed Python2 references (backport #30 <https://github.com/ros-visualization/rqt_shell//issues/30>) (#32 <https://github.com/ros-visualization/rqt_shell//issues/32>)
* Contributors: mergify[bot]
```
