### PR TITLE
rqt_py_console: 1.5.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8998,7 +8998,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_py_console-release.git
-      version: 1.5.2-4
+      version: 1.5.3-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_py_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_py_console` to `1.5.3-1`:

- upstream repository: https://github.com/ros-visualization/rqt_py_console.git
- release repository: https://github.com/ros2-gbp/rqt_py_console-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.5.2-4`

## rqt_py_console

```
* Use logger.warning(), f-string and super() (backport #26 <https://github.com/ros-visualization/rqt_py_console/issues/26>) (#27 <https://github.com/ros-visualization/rqt_py_console/issues/27>)
* Contributors: mergify[bot]
```
