### PR TITLE
Add source entry for unbag in rolling

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10563,6 +10563,12 @@ repositories:
       url: https://github.com/flynneva/udp_msgs.git
       version: main
     status: maintained
+  unbag:
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/ros2_unbag.git
+      version: main
+    status: maintained
   uncrustify_vendor:
     release:
       tags:


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling

# The source is here:

https://github.com/ika-rwth-aachen/ros2_unbag.git

This adds the `unbag` source entry for ROS 2 Rolling.

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro