### PR TITLE
gz_launch_vendor: 0.3.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2972,7 +2972,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gz_launch_vendor-release.git
-      version: 0.3.1-3
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_launch_vendor` to `0.3.2-1`:

- upstream repository: https://github.com/gazebo-release/gz_launch_vendor.git
- release repository: https://github.com/ros2-gbp/gz_launch_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.1-3`

## gz_launch_vendor

```
* Bump version to 9.0.1 (#12 <https://github.com/gazebo-release/gz_launch_vendor/issues/12>)
* Contributors: Arjo Chakravarty
```
