### PR TITLE
Revert "rosbot_ros: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]"

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9933,7 +9933,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbot_ros-release.git
-      version: 1.0.0-1
+      version: 0.18.6-1
     source:
       type: git
       url: https://github.com/husarion/rosbot_ros.git


### PR DESCRIPTION
Reverts ros/rosdistro#50833

Reverting this because version `1.0.0-1` creates a [regression in ubuntu](https://build.ros2.org/view/Jbin_uN64/job/Jsrc_uN__rosbot_utils__ubuntu_noble__source/). It seems like there are some Debian dependency keys that can't resolve: `husarion_gz_worlds`, `micro_ros_agent` and `tf_namespace_bridge`, in consequence it seems that the release repo misses the release branches for those packages.

FYI @rafal-gorecki 

