### PR TITLE
rmw_gurumdds: 7.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7626,6 +7626,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_gurumdds-release.git
+      version: 7.0.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_gurumdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_gurumdds` to `7.0.0-1`:

- upstream repository: https://github.com/ros2/rmw_gurumdds.git
- release repository: https://github.com/ros2-gbp/rmw_gurumdds-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## gurumdds_cmake_module

```
* Lyrical Luth update
* 6.0.1
* Replace deprecated ament_target_dependencies
* Contributors: kumazuma, mmminjae
```

## rmw_gurumdds_cpp

```
* Lyrical Luth update
* 6.0.1
* Fix cpplint warnings
* Replace deprecated ament_target_dependencies
* Contributors: kumazuma, mmminjae
```
