### PR TITLE
Add source and doc for kangaroo repositories

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4687,6 +4687,36 @@ repositories:
       url: https://github.com/jrl-umi3218/jrl-cmakemodules.git
       version: master
     status: developed
+  kangaroo_moveit_config:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/kangaroo_moveit_config.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/kangaroo_moveit_config.git
+      version: humble-devel
+    status: developed
+  kangaroo_robot:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/kangaroo_robot.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/kangaroo_robot.git
+      version: humble-devel
+    status: developed
+  kangaroo_simulation:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/kangaroo_simulation.git
+      version: humble-devel
+    source:
+      type: git
+      url: https://github.com/pal-robotics/kangaroo_simulation.git
+      version: humble-devel
+    status: developed
   kdl_parser:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

humble

# The sources are here:

- https://github.com/pal-robotics/kangaroo_moveit_config.git
- https://github.com/pal-robotics/kangaroo_robot.git
- https://github.com/pal-robotics/kangaroo_simulation.git

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro