### PR TITLE
qt_gui_core: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6613,7 +6613,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `3.0.1-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## qt_dotgraph

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>)
* Removed Python2 references (#336 <https://github.com/ros-visualization/qt_gui_core/issues/336>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_py_common

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>)
* Contributors: Alejandro Hernández Cordero
```
