### PR TITLE
qt_gui_core: 2.11.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6658,7 +6658,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.11.0-1
+      version: 2.11.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `2.11.1-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.11.0-1`

## qt_dotgraph

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>) (#338 <https://github.com/ros-visualization/qt_gui_core/issues/338>)
* Contributors: mergify[bot]
```

## qt_gui

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>) (#338 <https://github.com/ros-visualization/qt_gui_core/issues/338>)
* Removed Python2 references (#336 <https://github.com/ros-visualization/qt_gui_core/issues/336>) (#337 <https://github.com/ros-visualization/qt_gui_core/issues/337>)
* Contributors: mergify[bot]
```

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>) (#338 <https://github.com/ros-visualization/qt_gui_core/issues/338>)
* Contributors: mergify[bot]
```

## qt_gui_py_common

```
* Removed dead code, Python 2 to 3 modernization and other fixes (#333 <https://github.com/ros-visualization/qt_gui_core/issues/333>) (#338 <https://github.com/ros-visualization/qt_gui_core/issues/338>)
* Contributors: mergify[bot]
```
