### PR TITLE
rqt: 1.10.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8799,7 +8799,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.10.5-1
+      version: 1.10.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt` to `1.10.6-1`:

- upstream repository: https://github.com/ros-visualization/rqt.git
- release repository: https://github.com/ros2-gbp/rqt-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.10.5-1`

## rqt

- No changes

## rqt_gui

```
* Use logger.warning(), f-string , super() and Qt6 fixes (#354 <https://github.com/ros-visualization/rqt/issues/354>) (#356 <https://github.com/ros-visualization/rqt/issues/356>)
* Removed Python2 references and improve executor (#353 <https://github.com/ros-visualization/rqt/issues/353>) (#355 <https://github.com/ros-visualization/rqt/issues/355>)
* Contributors: mergify[bot]
```

## rqt_gui_cpp

- No changes

## rqt_gui_py

```
* Use logger.warning(), f-string , super() and Qt6 fixes (#354 <https://github.com/ros-visualization/rqt/issues/354>) (#356 <https://github.com/ros-visualization/rqt/issues/356>)
* Removed Python2 references and improve executor (#353 <https://github.com/ros-visualization/rqt/issues/353>) (#355 <https://github.com/ros-visualization/rqt/issues/355>)
* Contributors: mergify[bot]
```

## rqt_py_common

```
* Use logger.warning(), f-string , super() and Qt6 fixes (#354 <https://github.com/ros-visualization/rqt/issues/354>) (#356 <https://github.com/ros-visualization/rqt/issues/356>)
* Removed dead code (#349 <https://github.com/ros-visualization/rqt/issues/349>) (#351 <https://github.com/ros-visualization/rqt/issues/351>)
* Contributors: mergify[bot]
```
