### PR TITLE
lanelet2: 1.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4939,7 +4939,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/lanelet2-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lanelet2` to `1.2.3-1`:

- upstream repository: https://github.com/fzi-forschungszentrum-informatik/lanelet2.git
- release repository: https://github.com/ros2-gbp/lanelet2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.2-1`

## lanelet2

```
* Increase minimum CMake version and remove Ubuntu 20.04 pip tests to fix CI pipeline (#401 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/401>)
* Contributors: Fabian Immel
```

## lanelet2_core

```
* Add missing yield_line to LinestringTagging.md (#405 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/405>)
* Fix compilation with Boost 1.87 (#399 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/399>)
* Contributors: Johannes Schmitz, Martin Škoudlil
```

## lanelet2_examples

```
* Enable subclassing of RoutingCost from python (#384 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/384>)
* Add pyi stub files for python interface (#385 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/385>)
* Contributors: poggenhans
```

## lanelet2_io

- No changes

## lanelet2_maps

```
* lanelet2_maps: Remove empty C++ library (#406 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/406>)
* Fine-tune the phrasing of area description (#398 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/398>)
* Contributors: Michael Hoss, Michal Sojka
```

## lanelet2_matching

- No changes

## lanelet2_projection

- No changes

## lanelet2_python

```
* add driving direction (one_way) info to debug routing graph osm output (#400 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/400>)
* More repr, fix infinite loop when calling repr on a lanele->regelem->lanelet cycle (#383 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/383>)
* Enable subclassing of RoutingCost from python (#384 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/384>)
* Add pyi stub files for python interface (#385 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/385>)
* Update wheel build to include the type stubs (#422 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/pull/422>)
* Contributors: R-Fehler, poggenhans
```

## lanelet2_routing

```
* Fix route calculation when using nonzero cost id (#382 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/382>)
* Contributors: poggenhans
```

## lanelet2_traffic_rules

```
* Added BusLane to ParticipantMap with participants: Bus, Emergency, and Taxi, and to SpeedLimitLookup. (#414 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/414>)
* Fix typo ParticantsMap => ParticipantsMap (#395 <https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/395>)
* Contributors: Edgar Sepp, Kotaro Yoshimoto
```

## lanelet2_validation

- No changes
