### PR TITLE
rqt_bag: 2.2.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8833,7 +8833,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_bag-release.git
-      version: 2.2.4-1
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_bag.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_bag` to `2.2.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_bag.git
- release repository: https://github.com/ros2-gbp/rqt_bag-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.4-1`

## rqt_bag

```
* Modernizes python: super(), f-string and others (backport #211 <https://github.com/ros-visualization/rqt_bag/issues/211>) (#212 <https://github.com/ros-visualization/rqt_bag/issues/212>)
* Contributors: mergify[bot]
```

## rqt_bag_plugins

```
* Modernizes python: super(), f-string and others (backport #211 <https://github.com/ros-visualization/rqt_bag/issues/211>) (#212 <https://github.com/ros-visualization/rqt_bag/issues/212>)
* Contributors: mergify[bot]
```
