### PR TITLE
[openembedded] added python3-prettytable

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7722,6 +7722,7 @@ python3-prettytable:
   fedora: [python3-prettytable]
   gentoo: [dev-python/prettytable]
   nixos: [python3Packages.prettytable]
+  openembedded: [python3-prettytable@meta-python]
   ubuntu: [python3-prettytable]
 python3-progressbar:
   arch: [python-progressbar]


### PR DESCRIPTION
see: https://layers.openembedded.org/layerindex/recipe/105997/

@robwoolley: could you review?

There is in meta-ros-common an older recipe for python3-prettytable.  But this one could be removed (@master) because bitbake isn't using it.
