### PR TITLE
[humble] mrpt_ros: mark as end-of-life

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6474,7 +6474,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, replaced by colcon native mrpt3 repository
   mrpt_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
Mark `mrpt_ros` repository as end-of-life for the humble distribution.

- **status**: end-of-life
- **status_description**: Deprecated, replaced by colcon native mrpt3 repository

The `mrpt_ros` package is superseded by the new colcon-native `mrpt3` repository.