### PR TITLE
[kilted] mrpt_ros: mark as end-of-life

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5092,7 +5092,8 @@ repositories:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git
       version: main
-    status: developed
+    status: end-of-life
+    status_description: Deprecated, replaced by colcon native mrpt3 repository
   mrpt_ros_bridge:
     doc:
       type: git


### PR DESCRIPTION
Mark `mrpt_ros` repository as end-of-life for the kilted distribution.

- **status**: end-of-life
- **status_description**: Deprecated, replaced by colcon native mrpt3 repository

The `mrpt_ros` package is superseded by the new colcon-native `mrpt3` repository.