### PR TITLE
inverse_dynamics_solver: 3.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3545,6 +3545,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/inverse_dynamics_solver-release.git
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `inverse_dynamics_solver` to `3.0.0-1`:

- upstream repository: https://github.com/unisa-acg/inverse-dynamics-solver.git
- release repository: https://github.com/ros2-gbp/inverse_dynamics_solver-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## franka_inria_inverse_dynamics_solver

```
* Merge pull request #20 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/20> from wentasah/argparse-dep
  Don't depend on Python 2 argparse
* [FIX] Fix deprecation warnings
* Merge pull request #15 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/15> from unisa-acg/bugfix/realtime_safeness
  bugfix/realtime_safeness
* Merge branch 'main' into bugfix/realtime_safeness
* Merge branch 'main' into bugfix/empty_tip_root
* [REF] Optimizes code for computation time performance
* [FIX] Enforce real-time safeness by avoiding dynamic allocations of vectors
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```

## inverse_dynamics_solver

```
* Merge pull request #20 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/20> from wentasah/argparse-dep
  Don't depend on Python 2 argparse
* [FIX] Fix deprecation warnings
* Don't depend Python 2 argparse
  It's rosdep entry is going to be removed.
  See https://github.com/ros/rosdistro/issues/51715.
  argparse is in Python 3 standard library so it doesn't need to be
  referenced explicitly.
* Merge pull request #15 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/15> from unisa-acg/bugfix/realtime_safeness
  bugfix/realtime_safeness
* [MAK] Add trailing underscore to private member attributes
* [FIX] Deallocate variables
  - [REF] Use new instead of malloc
  - [ADD] Initialize pointers
  - [ADD] Measure performance in terms of computation time
* Merge branch 'main' into bugfix/realtime_safeness
* Merge branch 'main' into bugfix/empty_tip_root
* Contributors: Enrico Ferrentino, Michal Sojka, Vincenzo Petrone
```

## kdl_inverse_dynamics_solver

```
* Merge pull request #20 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/20> from wentasah/argparse-dep
  Don't depend on Python 2 argparse
* [FIX] Fix deprecation warnings
* Merge pull request #15 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/15> from unisa-acg/bugfix/realtime_safeness
  bugfix/realtime_safeness
* [REF] Use mutable instead of pointers
* Merge branch 'main' into bugfix/realtime_safeness
* Merge pull request #13 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/13> from unisa-acg/bugfix/empty_tip_root
  bugfix/empty_tip_root
* [REF] Use param_namespace instead of ns in warning/error messages to print the namespace without a trailing dot
  - [DOC] Fix Doxygen and inline documentation to comply to the last implementation and fix typos
* [FIX] Deallocate variables
  - [REF] Use new instead of malloc
  - [ADD] Initialize pointers
  - [ADD] Measure performance in terms of computation time
* [REF] Manages missing/empty root/tip parameters with different logics
  - [TST] Add related tests
* [REF] Reorder dependencies alphabetically
* Merge branch 'main' into bugfix/realtime_safeness
* Merge branch 'main' into bugfix/empty_tip_root
* [FIX] Fix allocation of zero-vector
* [FIX] Avoid dynamic allocation when returning a zero-vector
* [FIX] Enforce real-time safeness by avoiding dynamic allocations of vectors
* [FIX] Handle empty root and tip parameters
  - [ADD] With empty root, defaults to chain root
  - [ADD] With empty tip, raises an exception
  - [TST] Add two test fixtures to test the two scenarios above
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```

## ur10_inverse_dynamics_solver

```
* Merge pull request #20 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/20> from wentasah/argparse-dep
  Don't depend on Python 2 argparse
* [FIX] Fix deprecation warnings
* Merge pull request #15 <https://github.com/unisa-acg/inverse-dynamics-solver/issues/15> from unisa-acg/bugfix/realtime_safeness
  bugfix/realtime_safeness
* [DOC] Fix inline comment
* [FIX] Avoid heap allocations with mutable variables
* [FIX] Deallocate variables
  - [REF] Use new instead of malloc
  - [ADD] Initialize pointers
  - [ADD] Measure performance in terms of computation time
* Merge branch 'main' into bugfix/realtime_safeness
* Merge branch 'main' into bugfix/empty_tip_root
* [REF] Optimizes code for computation time performance
* [FIX] Enforce real-time safeness by avoiding dynamic allocations of vectors
* Contributors: Enrico Ferrentino, Vincenzo Petrone
```
