### PR TITLE
ur_client_library: 2.13.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -10646,7 +10646,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
-      version: 2.12.0-1
+      version: 2.13.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_client_library` to `2.13.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_Client_Library
- release repository: https://github.com/ros2-gbp/Universal_Robots_Client_Library-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.12.0-1`

## ur_client_library

```
* [ScriptCommandInterface] Add set_target_payload support to ScriptCommandInterface (#515 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/515>)
* [Primary] sendScriptBlocking: Restart interface and resend script on readOnlyInterfaceException (#522 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/522>)
* [DashboardClientX] Apply httplib timeouts; wire setReceiveTimeout() (#518 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/518>)
* [Docs] Remove section about URCapX in development (#521 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/521>)
* [Primary] Send script blocking return refactor (#520 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/520>)
* Add missing robot types to helper functions (#513 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/513>)
* [RTDE] Add new controller_step RTDE field (#514 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/514>)
* [Primary] Primary client script execution feedback (#484 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/484>)
* Add robotSeriesString function (#510 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/510>)
* Contributors: Felix Exner, Sergi Romero, URJala, Vinicius de Oliveira, dependabot[bot]
```
