### PR TITLE
ompl: 2.0.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5679,7 +5679,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 1.7.0-4
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/ompl/ompl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `2.0.1-1`:

- upstream repository: https://github.com/ompl/ompl/releases/download/:{version}/ompl-:{version}.tar.gz
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.7.0-4`
