### PR TITLE
rosbag_timing_inspector: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8338,7 +8338,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosbag_timing_inspector-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/rosbag_timing_inspector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbag_timing_inspector` to `1.0.1-1`:

- upstream repository: https://github.com/MOLAorg/rosbag_timing_inspector.git
- release repository: https://github.com/ros2-gbp/rosbag_timing_inspector-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## rosbag_timing_inspector

```
* fix: vendor imgui, implot and tinyfiledialogs as git submodules
  Replace FetchContent live git clones with pinned submodules under
  third_party/, so the package no longer depends on network access
  during the CMake configure step of a build.
* docs: add ROS 2 Lyrical badge row, update Rolling to Ubuntu 26.04 (resolute)
* Contributors: Jose Luis Blanco-Claraco
```
