### PR TITLE
Add rosdep rule for simpleini

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7074,6 +7074,10 @@ libsimage-dev:
   debian: [libsimage-dev]
   gentoo: [media-libs/simage]
   ubuntu: [libsimage-dev]
+libsimpleini-dev:
+  debian: [libsimpleini-dev]
+  fedora: [simpleini-devel]
+  ubuntu: [libsimpleini-dev]
 libsndfile1-dev:
   arch: [libsndfile]
   debian: [libsndfile1-dev]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

simpleini

## Package Upstream Source:

https://github.com/brofield/simpleini

## Links to Distribution Packages

- Debian: https://packages.debian.org/sid/libsimpleini-dev
- Ubuntu: https://packages.ubuntu.com/noble/libsimpleini-dev
- Fedora: https://packages.fedoraproject.org/pkgs/simpleini/simpleini-devel/
- Arch: not available (AUR only)
- Gentoo: not available
- macOS: not available
- Alpine: not available
- NixOS/nixpkgs: not available
- openSUSE: not available
- rhel: not available