### PR TITLE
Update feetech_ros2_driver repository URL (humble's version)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3061,7 +3061,7 @@ repositories:
       version: 0.1.0-2
     source:
       type: git
-      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      url: https://github.com/ros-physical-ai/feetech_ros2_driver.git
       version: main
     status: developed
   ffmpeg_encoder_decoder:


### PR DESCRIPTION
We recently moved this repo's organization, so just fixing here.