### PR TITLE
Update feetech_ros2_driver repository URL (kilted's version)

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2261,7 +2261,7 @@ repositories:
       version: 0.2.1-1
     source:
       type: git
-      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      url: https://github.com/ros-physical-ai/feetech_ros2_driver.git
       version: main
     status: developed
   ffmpeg_encoder_decoder:


### PR DESCRIPTION
We recently moved this repo's organization, so just fixing here.