### PR TITLE
Update feetech_ros2_driver repository URL (lyrical's version)

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2201,7 +2201,7 @@ repositories:
       version: 0.2.1-3
     source:
       type: git
-      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      url: https://github.com/ros-physical-ai/feetech_ros2_driver.git
       version: main
     status: developed
   ffmpeg_encoder_decoder:


### PR DESCRIPTION
We recently moved this repo's organization, so just fixing here.