### PR TITLE
Update feetech_ros2_driver repository URL (rolling's version)

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2172,7 +2172,7 @@ repositories:
       version: 0.2.1-2
     source:
       type: git
-      url: https://github.com/JafarAbdi/feetech_ros2_driver.git
+      url: https://github.com/ros-physical-ai/feetech_ros2_driver.git
       version: main
     status: developed
   ffmpeg_encoder_decoder:


### PR DESCRIPTION
We recently moved this repo's organization, so just fixing here.