### PR TITLE
callback_isolated_executor: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1300,6 +1300,26 @@ repositories:
       url: https://github.com/nobleo/boost_sml_vendor.git
       version: main
     status: maintained
+  callback_isolated_executor:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/callback_isolated_executor.git
+      version: main
+    release:
+      packages:
+      - callback_isolated_executor
+      - cie_config_msgs
+      - cie_sample_application
+      - cie_thread_configurator
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/callback_isolated_executor-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/autowarefoundation/callback_isolated_executor.git
+      version: main
+    status: developed
   camera_aravis2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `callback_isolated_executor` to `1.0.0-1`:

- upstream repository: https://github.com/autowarefoundation/callback_isolated_executor.git
- release repository: https://github.com/ros2-gbp/callback_isolated_executor-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## callback_isolated_executor

```
* First release. See https://autowarefoundation.github.io/callback_isolated_executor_doc/ for documentation.
```

## cie_config_msgs

```
* First release. See https://autowarefoundation.github.io/callback_isolated_executor_doc/ for documentation.
```

## cie_sample_application

```
* First release. See https://autowarefoundation.github.io/callback_isolated_executor_doc/ for documentation.
```

## cie_thread_configurator

```
* First release. See https://autowarefoundation.github.io/callback_isolated_executor_doc/ for documentation.
```
