### PR TITLE
rtabmap_ros: 0.23.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11348,6 +11348,7 @@ repositories:
     release:
       packages:
       - rtabmap_conversions
+      - rtabmap_costmap_plugins
       - rtabmap_demos
       - rtabmap_examples
       - rtabmap_launch
@@ -11363,7 +11364,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.22.1-1
+      version: 0.23.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.23.7-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.22.1-1`
