### PR TITLE
rtabmap: 0.23.7-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10935,7 +10935,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: jazzy-devel
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -10944,7 +10944,7 @@ repositories:
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: jazzy-devel
     status: maintained
   rtabmap_ros:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10940,7 +10940,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.22.1-1
+      version: 0.23.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.23.7-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/ros2-gbp/rtabmap-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.22.1-1`
