### PR TITLE
rtabmap: 0.23.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9218,7 +9218,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.22.1-1
+      version: 0.23.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9213,7 +9213,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: kilted-devel
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -9222,7 +9222,7 @@ repositories:
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: kilted-devel
     status: maintained
   rtabmap_ros:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.23.7-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/ros2-gbp/rtabmap-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.22.1-1`
