### PR TITLE
rtabmap: 0.23.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9244,7 +9244,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: lyrical-devel
     release:
       tags:
         release: release/lyrical/{package}/{version}
@@ -9253,7 +9253,7 @@ repositories:
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git
-      version: rolling-devel
+      version: lyrical-devel
     status: maintained
   rtabmap_ros:
     doc:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9249,7 +9249,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.22.1-3
+      version: 0.23.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap` to `0.23.7-1`:

- upstream repository: https://github.com/introlab/rtabmap.git
- release repository: https://github.com/ros2-gbp/rtabmap-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.22.1-3`
