### PR TITLE
rtabmap_ros: 0.23.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9259,7 +9259,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
-      version: rolling-devel
+      version: lyrical-devel
     release:
       packages:
       - rtabmap_conversions
@@ -9282,7 +9282,7 @@ repositories:
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
-      version: rolling-devel
+      version: lyrical-devel
     status: maintained
   rtcm_msgs:
     doc:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9260,6 +9260,25 @@ repositories:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git
       version: rolling-devel
+    release:
+      packages:
+      - rtabmap_conversions
+      - rtabmap_demos
+      - rtabmap_examples
+      - rtabmap_launch
+      - rtabmap_msgs
+      - rtabmap_odom
+      - rtabmap_python
+      - rtabmap_ros
+      - rtabmap_rviz_plugins
+      - rtabmap_slam
+      - rtabmap_sync
+      - rtabmap_util
+      - rtabmap_viz
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/introlab/rtabmap_ros-release.git
+      version: 0.23.7-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rtabmap_ros` to `0.23.7-1`:

- upstream repository: https://github.com/introlab/rtabmap_ros.git
- release repository: https://github.com/introlab/rtabmap_ros-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
