### PR TITLE
naoqi_libqicore: 3.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6799,7 +6799,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/libqicore-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ros-naoqi/libqicore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `3.0.1-1`:

- upstream repository: https://github.com/ros-naoqi/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## naoqi_libqicore

```
* Support for Jazzy
* Update status badges
* Contributors: Victor Paléologue
```
