### PR TITLE
naoqi_bridge_msgs2: 2.1.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5327,6 +5327,24 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  naoqi_bridge_msgs2:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    release:
+      packages:
+      - naoqi_bridge_msgs
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    status: maintained
+    status_description: maintained
   nav2_minimal_turtlebot_simulation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs2` to `2.1.1-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## naoqi_bridge_msgs

```
* Replace geometry_msgs/Pose2D with local Pose2D (removed in ROS 2 Rolling)
* Support for Jazzy
* Update status badges
* Add CI
* Contributors: Victor Paléologue
```
