### PR TITLE
naoqi_libqi: 3.0.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6784,7 +6784,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/libqi-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/ros-naoqi/libqi.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `3.0.3-1`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.2-1`

## naoqi_libqi

```
* Update c++ to 14 for gtest compatability
* Support for Jazzy
* Update badges
* Contributors: Chris Birmingham, Victor Paléologue
```
