### PR TITLE
naoqi_bridge_msgs2: 2.1.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6753,7 +6753,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs2` to `2.1.1-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.0-1`

## naoqi_bridge_msgs

```
* Replace geometry_msgs/Pose2D with local Pose2D (removed in ROS 2 Rolling)
* Support for Jazzy
* Update status badges
* Add CI
* Contributors: Victor Paléologue
```
