### PR TITLE
nao_meshes: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6735,7 +6735,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/nao_meshes-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-naoqi/nao_meshes2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `2.1.2-1`:

- upstream repository: https://github.com/ros-naoqi/nao_meshes2.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.1-1`

## nao_meshes

```
* Remove java dependency
* Contributors: Kenji Brameld
```
