### PR TITLE
naoqi_driver: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6769,7 +6769,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros-naoqi/naoqi_driver2-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/ros-naoqi/naoqi_driver2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_driver` to `2.1.2-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_driver2.git
- release repository: https://github.com/ros-naoqi/naoqi_driver2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.1-1`

## naoqi_driver

```
* Add dep on ament_index + update cv_bridge header for jazzy
* CI: update GH cache action
* Automatically select port 9503 when password is set
* Fallback when audio extraction fails
* Automatically disable audio if no endpoint is set
* Fallback to 2.9's ALRobotModel if ALMotion.getRobotConfig fails
* README: fix usage of qi_listen_url
* Update README
* README: fix link to boot_config.json
* Contributors: Victor Paléologue
```
