### PR TITLE
naoqi_libqicore: 3.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6543,6 +6543,21 @@ repositories:
       url: https://github.com/ros-naoqi/libqi.git
       version: ros2
     status: maintained
+  naoqi_libqicore:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros2
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-naoqi/libqicore-release.git
+      version: 3.0.1-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqicore.git
+      version: ros2
+    status: maintained
   nav2_minimal_turtlebot_simulation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqicore` to `3.0.1-1`:

- upstream repository: https://github.com/ros-naoqi/libqicore.git
- release repository: https://github.com/ros-naoqi/libqicore-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## naoqi_libqicore

```
* Support for Jazzy
* Update status badges
* Contributors: Victor Paléologue
```
