### PR TITLE
naoqi_bridge_msgs2: 2.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6527,6 +6527,23 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  naoqi_bridge_msgs2:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    release:
+      packages:
+      - naoqi_bridge_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
+      version: 2.1.1-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
+      version: main
+    status: maintained
   naoqi_libqi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_bridge_msgs2` to `2.1.1-1`:

- upstream repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2.git
- release repository: https://github.com/ros-naoqi/naoqi_bridge_msgs2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## naoqi_bridge_msgs

```
* Replace geometry_msgs/Pose2D with local Pose2D (removed in ROS 2 Rolling)
* Support for Jazzy
* Update status badges
* Add CI
* Contributors: Victor Paléologue
```
