### PR TITLE
nao_meshes: 2.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6527,6 +6527,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  nao_meshes:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 2.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    status: maintained
   naoqi_libqi:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `2.1.2-1`:

- upstream repository: https://github.com/ros-naoqi/nao_meshes2.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## nao_meshes

```
* Remove java dependency
* Contributors: Kenji Brameld
```
