### PR TITLE
naoqi_libqi: 3.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5297,6 +5297,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  naoqi_libqi:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: ros2
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-naoqi/libqi-release.git
+      version: 3.0.3-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/libqi.git
+      version: ros2
+    status: maintained
   nav2_minimal_turtlebot_simulation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `naoqi_libqi` to `3.0.3-1`:

- upstream repository: https://github.com/ros-naoqi/libqi.git
- release repository: https://github.com/ros-naoqi/libqi-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## naoqi_libqi

```
* Update c++ to 14 for gtest compatability
* Support for Jazzy
* Update badges
* Contributors: Chris Birmingham, Victor Paléologue
```
