### PR TITLE
nao_meshes: 2.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5297,6 +5297,21 @@ repositories:
       url: https://github.com/ros-sports/nao_lola.git
       version: rolling
     status: developed
+  nao_meshes:
+    doc:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros-naoqi/nao_meshes-release.git
+      version: 2.1.2-1
+    source:
+      type: git
+      url: https://github.com/ros-naoqi/nao_meshes2.git
+      version: main
+    status: maintained
   nav2_minimal_turtlebot_simulation:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `nao_meshes` to `2.1.2-1`:

- upstream repository: https://github.com/ros-naoqi/nao_meshes2.git
- release repository: https://github.com/ros-naoqi/nao_meshes-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## nao_meshes

```
* Remove java dependency
* Contributors: Kenji Brameld
```
