### PR TITLE
aruco_opencv: 7.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -543,7 +543,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/aruco_opencv-release.git
-      version: 6.1.2-1
+      version: 7.0.0-1
     source:
       type: git
       url: https://github.com/fictionlab/ros_aruco_opencv.git


### PR DESCRIPTION
Increasing version of package(s) in repository `aruco_opencv` to `7.0.0-1`:

- upstream repository: https://github.com/fictionlab/ros_aruco_opencv.git
- release repository: https://github.com/ros2-gbp/aruco_opencv-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.1.2-1`

## aruco_opencv

```
* feat: Use image_transport for publishing debug images (#66 <https://github.com/fictionlab/ros_aruco_opencv/issues/66>)
* Contributors: Błażej Sowa
```

## aruco_opencv_msgs

- No changes
