### PR TITLE
Add rplidar_driver package to Jazzy for indexing

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10500,6 +10500,7 @@ repositories:
       type: git
       url: https://github.com/frozenreboot/rplidar_driver.git
       version: main
+    status: maintained
   rplidar_ros:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10495,6 +10495,11 @@ repositories:
       url: https://github.com/AIS-Bonn/rot_conv_lib.git
       version: master
     status: maintained
+  rplidar_driver:
+    source:
+      type: git
+      url: https://github.com/frozenreboot/rplidar_driver.git
+      version: main
   rplidar_ros:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

rplidar_driver

# The source is here:

https://github.com/frozenreboot/rplidar_driver

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

# Additional info

This is NOT an official driver for RPLIDAR, only an alternative to Slamtec's `rplidar_ros` package which is poorly maintained (or not at all).