### PR TITLE
ros2_medkit: 0.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9651,6 +9651,7 @@ repositories:
       version: main
     release:
       packages:
+      - ros2_medkit_action_status_bridge
       - ros2_medkit_beacon_common
       - ros2_medkit_cmake
       - ros2_medkit_diagnostic_bridge
@@ -9660,6 +9661,7 @@ repositories:
       - ros2_medkit_graph_provider
       - ros2_medkit_integration_tests
       - ros2_medkit_linux_introspection
+      - ros2_medkit_log_bridge
       - ros2_medkit_msgs
       - ros2_medkit_param_beacon
       - ros2_medkit_serialization
@@ -9668,7 +9670,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_medkit-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/selfpatch/ros2_medkit.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_medkit` to `0.6.0-1`:

- upstream repository: https://github.com/selfpatch/ros2_medkit.git
- release repository: https://github.com/ros2-gbp/ros2_medkit-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.0-1`

## ros2_medkit_action_status_bridge

```
* Initial release: generic action-status bridge. Watches every
  ``/<action>/_action/status`` topic and turns ABORTED goals into FaultManager
  faults (``<PREFIX>_<ACTION>_ABORTED``), heals on a non-failing terminal state.
  Captures the terminal action verdict that the diagnostic and log bridges
  cannot see (#423 <https://github.com/selfpatch/ros2_medkit/pull/423>).
* Fault state is per-ACTION, derived from the whole ``GoalStatusArray`` on each
  message: a fault is raised only on the ``healthy -> failed`` transition and
  healed only on ``failed -> healthy``, so it is order-independent and resilient
  to dropped terminal messages. Per-goal dedup now only suppresses duplicate log
  lines.
* ``canceled_is_fault`` emits a status-aware ``<PREFIX>_<ACTION>_CANCELED`` code;
  such a fault heals on the next non-failing terminal or when the canceled goal
  ages out of the retained status array.
* Vanished actions (lifecycle deactivate, one-shot nodes) are pruned on rescan.
* Parameters are range-checked/normalized at load; an incompatible action status
  QoS is now warned about instead of silently dropping faults.
* Ships a default configuration so the bridge starts out of the box (#459 <https://github.com/selfpatch/ros2_medkit/pull/459>)
* Fault source is fixed at first report instead of being re-attributed later: faults raised before discovery settles register the server FQN, faults are never attributed to the discovery placeholder node name, and the subscriptions and timer are reset in the destructor (#466 <https://github.com/selfpatch/ros2_medkit/pull/466>)
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_beacon_common

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```

## ros2_medkit_cmake

```
* ``ROS2MedkitTestDomain``: carve dedicated ``ROS_DOMAIN_ID`` ranges for the new log bridge (210-214) and action-status bridge (215-219) test suites out of the integration-tests range (#422 <https://github.com/selfpatch/ros2_medkit/pull/422>)
* Contributors: @mfaferek93
```

## ros2_medkit_diagnostic_bridge

```
* Tests: label ``test_integration`` as an integration test so it runs in the integration suite instead of the unit set (#443 <https://github.com/selfpatch/ros2_medkit/pull/443>)
* Contributors: @bburda
```

## ros2_medkit_fault_manager

```
* Bounded concurrent snapshot capture under fault storms with a ``CaptureThreadPool`` and configurable capture pool / queue / overflow-policy parameters. The rosbag leg is serialized and the cooldown map is bounded, so a burst of simultaneous faults can no longer exhaust capture threads or grow memory without limit (#456 <https://github.com/selfpatch/ros2_medkit/pull/456>)
* Entity-scoped rosbag capture by default (#431 <https://github.com/selfpatch/ros2_medkit/pull/431>)
* Made rosbag capture enablement crash-safe (#430 <https://github.com/selfpatch/ros2_medkit/pull/430>)
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_fault_reporter

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```

## ros2_medkit_gateway

```
* SOVD entity status and lifecycle control endpoints: ``GET /apps/{id}/status`` and ``GET /components/{id}/status``, plus lifecycle control routes backed by a new ``LifecycleProvider`` plugin interface and plugin-manager routing. Control returns ``501 Not Implemented`` until a provider is registered; the routes are RBAC-gated, advertised via a ``status`` link on app and component detail, and declared under the OpenAPI ``Lifecycle`` tag (#437 <https://github.com/selfpatch/ros2_medkit/pull/437>)
* Accurate app and component status: app status is read from the managed-node lifecycle state through a ``GetState``-backed reader, and a component reports ``notReady`` when all hosted apps are offline while staying ``ready`` as long as it is reachable (#455 <https://github.com/selfpatch/ros2_medkit/pull/455>)
* Bounded the executor and HTTP server thread pools, sized to the cold-wait plus SSE budget, with misconfiguration guards and a bounded keep-alive timeout (#457 <https://github.com/selfpatch/ros2_medkit/pull/457>)
* Startup discovery summary logged at boot, with an empty-graph warning when no entities are discovered (#438 <https://github.com/selfpatch/ros2_medkit/pull/438>)
* Bounded the unsupported-message-type cache and exposed its size; unknown message types now warn once instead of on every sample (#450 <https://github.com/selfpatch/ros2_medkit/pull/450>)
* OpenAPI query parameters are derived from a typed query contract, tightening the query-parameter schema and its regression gate (#417 <https://github.com/selfpatch/ros2_medkit/pull/417>)
* ``PluginContext`` can aggregate peer faults across daisy-chained gateways through the SOVD service interface (#419 <https://github.com/selfpatch/ros2_medkit/pull/419>)
* Single-command bringup of the local medkit stack via ``bringup.launch.py`` and ``bringup_params.yaml`` (#439 <https://github.com/selfpatch/ros2_medkit/pull/439>)
* Docker image enables CORS for the documented web UI path and uses explicit web UI origins instead of wildcard CORS (#452 <https://github.com/selfpatch/ros2_medkit/pull/452>)
* Docker image bundles the CycloneDDS RMW as an opt-in alternative implementation (#451 <https://github.com/selfpatch/ros2_medkit/pull/451>)
* Native gateway launch enables web UI CORS by default and honors the CORS settings from a supplied ``config_file`` (#461 <https://github.com/selfpatch/ros2_medkit/pull/461>)
* Incremental, embedded-hardened entity cache: ``ThreadSafeEntityCache`` stores entities in a fixed-capacity ``SlotStore`` object pool indexed by open-addressed flat hash maps, and ``update_all`` reconciles the discovery output by id (add / remove / change only) so steady-state refresh does zero structural allocations. Capacity is reserved via ``entity_cache.capacity`` (default 256) and cache stats are exposed on ``/health`` as ``x-medkit-entity-cache``. Discovery refreshes are debounced via ``discovery.refresh_debounce_ms`` (default 1000) and operation ``type_info`` schemas resolve lazily, cutting gateway CPU under graph churn roughly 4x. Entity detail ``operations[]`` no longer embeds schemas eagerly; the schemas remain on the ``/operations`` resource (#462 <https://github.com/selfpatch/ros2_medkit/pull/462>)
* Contributors: @bburda, @mfaferek93
```

## ros2_medkit_graph_provider

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```

## ros2_medkit_integration_tests

```
* New suites covering the SOVD entity status endpoints (REQ_INTEROP_076), lifecycle-aware app and component status (#455 <https://github.com/selfpatch/ros2_medkit/pull/455>), and fault-storm capture liveness under bounded concurrency (#456 <https://github.com/selfpatch/ros2_medkit/pull/456>)
* Contributors: @bburda
```

## ros2_medkit_linux_introspection

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```

## ros2_medkit_log_bridge

```
* Initial release: promote ``/rosout`` log entries (WARN/ERROR/FATAL) to
  FaultManager faults, attributed to the originating node via a per-source
  FaultReporter, with auto-generated stable fault codes (#422 <https://github.com/selfpatch/ros2_medkit/pull/422>)
* Ships a default configuration so the bridge starts out of the box (#449 <https://github.com/selfpatch/ros2_medkit/pull/449>)
* Skips the medkit stack's own nodes by default, matching on the raw logger name (#460 <https://github.com/selfpatch/ros2_medkit/pull/460>)
* Contributors: @mfaferek93
```

## ros2_medkit_msgs

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```

## ros2_medkit_param_beacon

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```

## ros2_medkit_serialization

```
* ``TypeIntrospection`` resolves service and action ``type_info`` schemas lazily and caches them as shared, immutable per-type objects, so discovery no longer rebuilds and deep-copies operation schemas on every refresh (#462 <https://github.com/selfpatch/ros2_medkit/pull/462>)
* Contributors: @bburda
```

## ros2_medkit_sovd_service_interface

```
* ``list_entity_faults`` handles a fault ``status`` returned as an object (not just a string), supporting peer-fault aggregation across daisy-chained gateways (#419 <https://github.com/selfpatch/ros2_medkit/pull/419>)
* Contributors: @bburda
```

## ros2_medkit_topic_beacon

```
* No functional changes; version bump for the coordinated 0.6.0 release.
* Contributors: @bburda
```
