### PR TITLE
warehouse_ros_sqlite: 1.0.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -11131,7 +11131,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
-      version: 1.0.5-2
+      version: 1.0.8-1
     source:
       type: git
       url: https://github.com/ros-planning/warehouse_ros_sqlite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `warehouse_ros_sqlite` to `1.0.8-1`:

- upstream repository: https://github.com/ros-planning/warehouse_ros_sqlite.git
- release repository: https://github.com/ros2-gbp/warehouse_ros_sqlite-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.5-2`

## warehouse_ros_sqlite

```
* Remove 'system' component from Boost package (#61 <https://github.com/moveit/warehouse_ros_sqlite/issues/61>)
  According to https://www.boost.org/releases/1.89.0, the system library is header-only since Boost 1.69 and the corresponding cmake component has been dropped in 1.89.
* CI: Update GHA versions (#60 <https://github.com/moveit/warehouse_ros_sqlite/issues/60>)
* Contributors: Felix Exner (fexner), mosfet80
```
