### PR TITLE
pmb2_navigation: 4.21.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8190,7 +8190,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pmb2_navigation-release.git
-      version: 4.21.0-1
+      version: 4.21.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_navigation` to `4.21.1-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_navigation.git
- release repository: https://github.com/ros2-gbp/pmb2_navigation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.21.0-1`

## pmb2_2dnav

- No changes

## pmb2_laser_sensors

```
* fix wrong preset
* Contributors: andreacapodacqua
```

## pmb2_navigation

- No changes

## pmb2_rgbd_sensors

- No changes
