### PR TITLE
pmb2_simulation: 4.12.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8228,7 +8228,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pmb2_simulation-release.git
-      version: 4.11.1-1
+      version: 4.12.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pmb2_simulation` to `4.12.1-1`:

- upstream repository: https://github.com/pal-robotics/pmb2_simulation.git
- release repository: https://github.com/ros2-gbp/pmb2_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.11.1-1`

## pmb2_gazebo

```
* Add missing dependency ros_gz_sim
* Contributors: Noel Jimenez
```

## pmb2_simulation

- No changes
