### PR TITLE
omni_base_simulation: 2.14.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7405,7 +7405,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/omni_base_simulation-release.git
-      version: 2.11.1-1
+      version: 2.14.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_simulation` to `2.14.1-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_simulation.git
- release repository: https://github.com/ros2-gbp/omni_base_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.11.1-1`

## omni_base_gazebo

```
* Add missing ros_gz dependencies
* Contributors: Noel Jimenez
```

## omni_base_simulation

- No changes
