### PR TITLE
omni_base_robot: 2.17.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7387,7 +7387,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/omni_base_robot-release.git
-      version: 2.15.1-1
+      version: 2.17.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/omni_base_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `omni_base_robot` to `2.17.0-1`:

- upstream repository: https://github.com/pal-robotics/omni_base_robot.git
- release repository: https://github.com/ros2-gbp/omni_base_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.1-1`

## omni_base_bringup

```
* Add pal configuration
* Add compatibility for namespace
* Switch to pal_joy + Update layout
* Contributors: thomaspeyrucain
```

## omni_base_controller_configuration

- No changes

## omni_base_description

- No changes

## omni_base_robot

- No changes
