### PR TITLE
urdf_test: 2.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13610,7 +13610,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/urdf_test-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/urdf_test.git


### PR DESCRIPTION
Increasing version of package(s) in repository `urdf_test` to `2.1.2-1`:

- upstream repository: https://github.com/pal-robotics/urdf_test.git
- release repository: https://github.com/ros2-gbp/urdf_test-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.1-1`

## urdf_test

```
* Remove unused setup.py
* Bump cmake version to 3.10
* Contributors: Noel Jimenez
```
