### PR TITLE
launch_pal: 0.21.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5065,7 +5065,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/launch_pal-release.git
-      version: 0.20.1-1
+      version: 0.21.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_pal` to `0.21.1-1`:

- upstream repository: https://github.com/pal-robotics/launch_pal.git
- release repository: https://github.com/ros2-gbp/launch_pal-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.20.1-1`

## launch_pal

```
* Update documentation for generate_component_list function
* Add optional namespace parameter
* Use extras_require instead of test_require
* Contributors: Isaac Acevedo, Noel Jimenez
```
