### PR TITLE
pal_maps: 0.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7696,7 +7696,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_maps-release.git
-      version: 0.5.0-1
+      version: 0.6.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_maps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_maps` to `0.6.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_maps.git
- release repository: https://github.com/ros2-gbp/pal_maps-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.5.0-1`

## pal_maps

```
* adding navigation gym map
* Contributors: martinaannicelli
```
