### PR TITLE
pal_gripper: 3.6.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7662,7 +7662,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_gripper-release.git
-      version: 3.6.5-1
+      version: 3.6.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_gripper` to `3.6.6-1`:

- upstream repository: https://github.com/pal-robotics/pal_gripper.git
- release repository: https://github.com/ros2-gbp/pal_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.6.5-1`

## pal_gripper

- No changes

## pal_gripper_controller_configuration

```
* Fixing open loop param
* Contributors: vivianamorlando
```

## pal_gripper_description

```
* add calibration tool
* Contributors: susannamastromauro
```

## pal_gripper_simulation

- No changes
