### PR TITLE
pal_pro_gripper: 1.12.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7732,11 +7732,12 @@ repositories:
       - pal_pro_gripper_bringup
       - pal_pro_gripper_controller_configuration
       - pal_pro_gripper_description
+      - pal_pro_gripper_simulation
       - pal_pro_gripper_wrapper
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_pro_gripper-release.git
-      version: 1.11.3-1
+      version: 1.12.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_pro_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_pro_gripper` to `1.12.5-1`:

- upstream repository: https://github.com/pal-robotics/pal_pro_gripper.git
- release repository: https://github.com/ros2-gbp/pal_pro_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.11.3-1`

## pal_pro_gripper

- No changes

## pal_pro_gripper_bringup

- No changes

## pal_pro_gripper_controller_configuration

- No changes

## pal_pro_gripper_description

```
* Merge branch 'add/mj_tag_properties' into 'humble-devel'
  Add MuJoCo tag properties for mujoco simulation
  See merge request robots/pal_pro_gripper!55
* Add MuJoCo tag properties for mujoco simulation
* Contributors: Sai Kishor Kothakota
```

## pal_pro_gripper_simulation

- No changes

## pal_pro_gripper_wrapper

- No changes
