### PR TITLE
pal_robotiq_gripper: 2.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7755,7 +7755,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_robotiq_gripper-release.git
-      version: 2.2.0-1
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_robotiq_gripper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_robotiq_gripper` to `2.3.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_robotiq_gripper.git
- release repository: https://github.com/ros2-gbp/pal_robotiq_gripper-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.2.0-1`

## pal_robotiq_controller_configuration

- No changes

## pal_robotiq_description

```
* Add safety controller to prevent the gripper to get stuck in simulation with a small epsilon
* Add arguments to support the new gazebo
* Fix gripper link
* Contributors: thomas.peyrucain, thomaspeyrucain
```

## pal_robotiq_gripper

- No changes
