### PR TITLE
fkie_message_filters: 3.4.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2394,7 +2394,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/fkie_message_filters-release.git
-      version: 3.3.1-1
+      version: 3.4.0-1
     source:
       type: git
       url: https://github.com/fkie/message_filters.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fkie_message_filters` to `3.4.0-1`:

- upstream repository: https://github.com/fkie/message_filters.git
- release repository: https://github.com/ros2-gbp/fkie_message_filters-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.3.1-1`

## fkie_message_filters

```
* Compatibility fixes for image_transport 6.4
  - This enables full support for alternative node implementations
* Contributors: Timo Röhling
```
