### PR TITLE
ompl: 2.0.1-3 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5649,7 +5649,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
-      version: 2.0.1-1
+      version: 2.0.1-3
     source:
       type: git
       url: https://github.com/ompl/ompl.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl` to `2.0.1-3`:

- upstream repository: https://github.com/ompl/ompl/releases/download/:{version}/ompl-:{version}.tar.gz
- release repository: https://github.com/ros2-gbp/ompl-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-1`
