### PR TITLE
Disable source builds of OMPL for Jazzy/Kilted

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7135,10 +7135,6 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.7.0-2
-    source:
-      type: git
-      url: https://github.com/ompl/ompl.git
-      version: main
     status: developed
   onnxruntime_vendor:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5800,10 +5800,6 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ompl-release.git
       version: 1.7.0-3
-    source:
-      type: git
-      url: https://github.com/ompl/ompl.git
-      version: main
     status: developed
   onnxruntime_vendor:
     doc:


### PR DESCRIPTION
Remove the `source:` block from the `ompl` entry in `jazzy/distribution.yaml` and `kilted/distribution.yaml`. `release:` blocks are untouched, so apt users on those distros keep getting the existing `1.7.0-X` deb.


OMPL upstream `main` is now `2.0.x` but jazzy and kilted are pinned to `1.7.0-X`, and there is no `1.7-maintenance` branch upstream that the source jobs could track.
