### PR TITLE
autoware_cmake: 1.4.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -980,6 +980,10 @@ repositories:
       version: master
     status: developed
   autoware_cmake:
+    doc:
+      type: git
+      url: https://github.com/autowarefoundation/autoware_cmake.git
+      version: 1.4.0
     release:
       packages:
       - autoware_cmake
@@ -987,7 +991,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/autoware_cmake-release.git
-      version: 1.2.0-3
+      version: 1.4.0-1
     source:
       type: git
       url: https://github.com/autowarefoundation/autoware_cmake.git


### PR DESCRIPTION
Increasing version of package(s) in repository `autoware_cmake` to `1.4.0-1`:

- upstream repository: https://github.com/autowarefoundation/autoware_cmake.git
- release repository: https://github.com/ros2-gbp/autoware_cmake-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.0-3`

## autoware_cmake

```
* fix(autoware_cmake): remove workaround, fixed in https://github.com/ros2/tinyxml2_vendor/pull/23 (#30 <https://github.com/autowarefoundation/autoware_cmake/issues/30>)
* Contributors: Esteve Fernandez
```

## autoware_lint_common

- No changes
