### PR TITLE
onnxruntime_vendor: 0.1.0-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5690,6 +5690,11 @@ repositories:
       type: git
       url: https://github.com/ros-controls/onnxruntime_vendor.git
       version: main
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/onnxruntime_vendor-release.git
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/ros-controls/onnxruntime_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `onnxruntime_vendor` to `0.1.0-2`:

- upstream repository: git@github.com:ros-controls/onnxruntime_vendor.git
- release repository: https://github.com/ros2-gbp/onnxruntime_vendor-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## onnxruntime_vendor

```
* Remove added changelog file and reset package version to 0.0.0
* Fix licensing and add ros-controls maintainers
* Fix dependencies
* Add ament_environment_hooks for LD_LIBRARY_PATH
* Add additional platforms
* Add ONNX MIT license doc
* Initial commit to add vendor package
* Initial commit
* Contributors: Julia Jia, Sai Kishor Kothakota
```
