### PR TITLE
rmw_desert: 4.0.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7581,7 +7581,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_desert-release.git
-      version: 4.0.1-4
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_desert` to `4.0.2-1`:

- upstream repository: https://github.com/signetlabdei/rmw_desert.git
- release repository: https://github.com/ros2-gbp/rmw_desert-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.0.1-4`

## rmw_desert

```
* Update README.md
* Add support for ROS_ALLOWED_TOPICS_CONFIG environment variable in configuration loading
* Add option to use env variable
* Contributors: Magform, dcostan
```
