### PR TITLE
fusioncore 0.3.1-1 in jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3459,10 +3459,11 @@ repositories:
       - fusioncore_datasets
       - fusioncore_gazebo
       - fusioncore_ros
+      - fusioncore_ublox
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Releasing fusioncore 0.3.1-1 in jazzy.

Also adds fusioncore_ublox as a new package in the release (bridge node for u-blox GPS receivers; deps are rclcpp, nav_msgs, std_msgs — all rosdep-resolvable).

This release was generated with bloom-release 0.14.3.

Changelog: https://github.com/manankharwar/fusioncore/blob/main/CHANGELOG.md#031-2026-06-24