### PR TITLE
fusioncore 0.3.1-1 in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3525,10 +3525,11 @@ repositories:
       - fusioncore_datasets
       - fusioncore_gazebo
       - fusioncore_ros
+      - fusioncore_ublox
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7074,6 +7074,10 @@ libsimage-dev:
   debian: [libsimage-dev]
   gentoo: [media-libs/simage]
   ubuntu: [libsimage-dev]
+libsimpleini-dev:
+  debian: [libsimpleini-dev]
+  fedora: [simpleini-devel]
+  ubuntu: [libsimpleini-dev]
 libsndfile1-dev:
   arch: [libsndfile]
   debian: [libsndfile1-dev]


### PR DESCRIPTION
Releasing fusioncore 0.3.1-1 in humble.

Also adds fusioncore_ublox as a new package in the release (bridge node for u-blox GPS receivers; deps are rclcpp, nav_msgs, std_msgs — all rosdep-resolvable).

This release was generated with bloom-release 0.14.3.

Changelog: https://github.com/manankharwar/fusioncore/blob/main/CHANGELOG.md#031-2026-06-24