### PR TITLE
fusioncore 0.3.1-1 in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3528,7 +3528,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Releasing fusioncore 0.3.1-1 in humble.

This release was generated with bloom-release 0.14.3.

Changelog: https://github.com/manankharwar/fusioncore/blob/main/CHANGELOG.md#031-2026-06-24