### PR TITLE
fusioncore: add fusioncore_ublox package in humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3528,7 +3528,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3525,6 +3525,7 @@ repositories:
       - fusioncore_datasets
       - fusioncore_gazebo
       - fusioncore_ros
+      - fusioncore_ublox
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git


### PR DESCRIPTION
Adds fusioncore_ublox as a new package in the humble release.

fusioncore_ublox is a bridge node for u-blox GPS receivers that converts raw NavPVT Doppler velocity to nav_msgs/Odometry for FusionCore. All dependencies (rclcpp, nav_msgs, std_msgs) are rosdep-resolvable. Optional dependency on ublox_msgs is handled via find_package(ublox_msgs QUIET) — the package builds cleanly without it.

This PR is separate from the version bump per reviewer guidance.