### PR TITLE
Remove `roboplan` and `roboplan_ros` from Humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9811,26 +9811,6 @@ repositories:
       url: https://github.com/suchetanrs/roadmap-explorer.git
       version: main
     status: developed
-  roboplan:
-    doc:
-      type: git
-      url: https://github.com/open-planning/roboplan.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/open-planning/roboplan.git
-      version: main
-    status: developed
-  roboplan_ros:
-    doc:
-      type: git
-      url: https://github.com/open-planning/roboplan-ros.git
-      version: main
-    source:
-      type: git
-      url: https://github.com/open-planning/roboplan-ros.git
-      version: main
-    status: developed
   robosoft_openai:
     doc:
       type: git


### PR DESCRIPTION
`nanobind` dependency means these packages are not in a position to work with the ROS buildfarm on Humble (refer to https://github.com/ros/rosdistro/pull/49894 for some details).

So, I'm removing these packages of ours from the Humble distribution list unless something changes down the line between now and its EOL in 2027.