### PR TITLE
ros_tutorials: 1.11.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8246,7 +8246,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.11.1-1
+      version: 1.11.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_tutorials` to `1.11.2-1`:

- upstream repository: https://github.com/ros/ros_tutorials.git
- release repository: https://github.com/ros2-gbp/ros_tutorials-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.11.1-1`

## turtlesim

```
* replace detached spin thread with std::jthread (#200 <https://github.com/ros/ros_tutorials//issues/200>)
* bump cpp20, contains and std::numbers (#199 <https://github.com/ros/ros_tutorials//issues/199>)
* use make_shared and range-for loops (#198 <https://github.com/ros/ros_tutorials//issues/198>)
* Contributors: Alejandro Hernández Cordero
```

## turtlesim_msgs

- No changes
