### PR TITLE
ur_robot_driver: 2.13.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -13521,7 +13521,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.13.0-1
+      version: 2.13.2-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `2.13.2-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.13.0-1`

## ur

- No changes

## ur_bringup

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Use a realtime_tools::RealtimePublisher for publishing the state (backport #1822 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1822>) (#1823 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1823>)
* Make GPIO controller publishers realtime safe (backport #1807 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1807>) (#1827 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1827>)
* Contributors: mergify[bot]
```

## ur_dashboard_msgs

```
* Update safety status msg with new IO plane stop (backport #1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>) (#1818 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1818>)
* Contributors: mergify[bot]
```

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Explicitly send MODE_STOPPED when returning control to the robot (backport #1678 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1678>) (#1830 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1830>)
* Fail example move on error (backport #1795 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1795>) (#1796 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1796>)
* Contributors: mergify[bot]
```
