### PR TITLE
tiago_pro_head_robot: 1.12.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12619,7 +12619,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_head_robot-release.git
-      version: 1.9.0-1
+      version: 1.12.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_head_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_head_robot` to `1.12.0-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_head_robot.git
- release repository: https://github.com/ros2-gbp/tiago_pro_head_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.9.0-1`

## tiago_pro_head_bringup

```
* added mujoco args
* Contributors: Ortisa Poci
```

## tiago_pro_head_controller_configuration

- No changes

## tiago_pro_head_description

```
* comment camera for head ros2 control mj simulation
* fix argument
* add check for the values of the sim_type argument
* add missing sim_type parameter
* use value in defined in property for effort in mj
* set mj_ros2_control tag dependent on the sim_type
* add the mujoco default tag
* fix the parameter name to world_name and not world
* add transmission also in mujoco simulation
* create a xacro file with joint properties
* pass sim_type argument as xacro parameter
* move mj_tags to the head.urdf.xacro
* added mujoco ros2 control
* added mujoco description
* added mujoco args
* Contributors: Ortisa Poci
```

## tiago_pro_head_robot

- No changes
