### PR TITLE
tiago_pro_moveit_config: 1.5.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12652,7 +12652,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_moveit_config-release.git
-      version: 1.4.1-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_moveit_config` to `1.5.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_moveit_config.git
- release repository: https://github.com/ros2-gbp/tiago_pro_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.1-1`

## tiago_pro_moveit_config

```
* Fix prefix module move_group
* Contributors: Aina
```
