### PR TITLE
tiago_pro_robot: 2.4.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12692,7 +12692,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_robot-release.git
-      version: 1.35.4-1
+      version: 2.4.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_robot.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_robot` to `2.4.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_robot.git
- release repository: https://github.com/ros2-gbp/tiago_pro_robot-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.35.4-1`

## tiago_pro_bringup

- No changes

## tiago_pro_controller_configuration

```
* ci/cd test
* ci/cd errors
* defined argument to spawn a subset of tsid controllers specified in the list at the beginning of the launch file
* Contributors: francescodorazio
```

## tiago_pro_description

```
* frequency of ros2_controllers in simulation from 100Hz to 1kHz
* Contributors: francescodorazio
```

## tiago_pro_robot

- No changes
