### PR TITLE
tiago_pro_simulation: 1.17.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12706,11 +12706,12 @@ repositories:
     release:
       packages:
       - tiago_pro_gazebo
+      - tiago_pro_mujoco
       - tiago_pro_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
-      version: 1.14.1-1
+      version: 1.17.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_pro_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `tiago_pro_simulation` to `1.17.1-1`:

- upstream repository: https://github.com/pal-robotics/tiago_pro_simulation.git
- release repository: https://github.com/ros2-gbp/tiago_pro_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.14.1-1`

## tiago_pro_gazebo

```
* Add missing dependency ros_gz_sim
* linters
* typo
* Update package.xml
* Non-passed argument issue removed
* Contributors: Narcis Miguel, Noel Jimenez, martinaannicelli
```

## tiago_pro_mujoco

- No changes

## tiago_pro_simulation

- No changes
