### PR TITLE
pal_sea_arm: 2.6.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7801,7 +7801,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_sea_arm-release.git
-      version: 1.23.2-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm` to `2.6.0-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm.git
- release repository: https://github.com/ros2-gbp/pal_sea_arm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.23.2-1`

## pal_sea_arm

- No changes

## pal_sea_arm_bringup

- No changes

## pal_sea_arm_controller_configuration

- No changes

## pal_sea_arm_description

```
* Add condition for 4dof arm without ee
* Change fakeforearm to 4dof without end effector
* Removing incorrect tool offset in 5dof
* Contributors: Aina, Óscar Martínez
```
