### PR TITLE
pal_sea_arm_moveit_config: 1.0.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7816,7 +7816,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_sea_arm_moveit_config-release.git
-      version: 1.0.5-1
+      version: 1.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm_moveit_config` to `1.0.7-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm_moveit_config.git
- release repository: https://github.com/ros2-gbp/pal_sea_arm_moveit_config-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.5-1`

## pal_sea_arm_moveit_config

```
* Fix prefix module move_group
* Contributors: Aina
```
