### PR TITLE
pal_sea_arm_simulation: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7830,11 +7830,12 @@ repositories:
     release:
       packages:
       - pal_sea_arm_gazebo
+      - pal_sea_arm_mujoco
       - pal_sea_arm_simulation
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pal_sea_arm_simulation-release.git
-      version: 1.0.4-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_sea_arm_simulation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pal_sea_arm_simulation` to `1.1.2-1`:

- upstream repository: https://github.com/pal-robotics/pal_sea_arm_simulation.git
- release repository: https://github.com/ros2-gbp/pal_sea_arm_simulation-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.4-1`

## pal_sea_arm_gazebo

```
* drop gazebo hardcoded model configs
* setting default launch arguments
* Fixed mujoco simulation launch file
* Contributors: Ortisa Poci
```

## pal_sea_arm_mujoco

```
* Update version in the pal_sea_arm_mujoco
* add mujoco-ros2-control dependence
* improved structure
* removed extra argument and comment
* updated pids
* first align to mujoco-ros2-control
* align to the new mujoco-ros2-control
* set default mujoco scene
* Removed cofig folder
* Removed controller used for inference
* Improved structure for the launch file
* Fixed mujoco simulation launch file
* managed arm controller configuration file
* added mujoco simulatiion
* Contributors: Ortisa Poci, ileniaperrella
```

## pal_sea_arm_simulation

```
* added mujoco simulatiion
* Contributors: Ortisa Poci
```
