### PR TITLE
mobile_robot_simulator: 2.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5739,7 +5739,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/nobleo/mobile_robot_simulator-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/nobleo/mobile_robot_simulator.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_robot_simulator` to `2.0.1-1`:

- upstream repository: https://github.com/nobleo/mobile_robot_simulator.git
- release repository: https://github.com/nobleo/mobile_robot_simulator-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-1`

## mobile_robot_simulator

```
* Fix first movement delta being way too large (#10 <https://github.com/nobleo/mobile_robot_simulator/issues/10>)
* Backport the code to humble
* Contributors: Ramon Wijnands
```
