### PR TITLE
clips_vendor: 6.4.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1183,11 +1183,15 @@ repositories:
       version: master
     status: maintained
   clips_vendor:
+    doc:
+      type: git
+      url: https://github.com/carologistics/clips_vendor.git
+      version: main
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/clips_vendor-release.git
-      version: 6.4.3-1
+      version: 6.4.4-1
     source:
       type: git
       url: https://github.com/carologistics/clips_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clips_vendor` to `6.4.4-1`:

- upstream repository: https://github.com/carologistics/clips_vendor.git
- release repository: https://github.com/ros2-gbp/clips_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.4.3-1`

## clips_vendor

```
* Merge pull request #9 <https://github.com/carologistics/clips_vendor/issues/9> from carologistics/tviehmann/bump-version
  bump to latest release
* Merge pull request #8 <https://github.com/carologistics/clips_vendor/issues/8> from carologistics/twendt/patches
  add patch for missing callbacks
* Contributors: Tarik Viehmann, Tim Wendt
```
