### PR TITLE
Adding python3-absl key

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3953,6 +3953,21 @@ python3-aabbtree-pip:
   '*':
     pip:
       packages: [aabbtree]
+python3-absl:
+  alpine:
+    pip:
+      packages: [absl-py]
+  arch: [python-absl]
+  debian: [python3-absl]
+  fedora: [python3-absl-py]
+  gentoo: [dev-python/abseil-py]
+  nixos: [python3Packages.absl-py]
+  opensuse: [python3-abseil]
+  ubuntu:
+    '*': [python3-absl]
+    focal:
+      pip:
+        packages: [absl-py]
 python3-adafruit-blinka-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -3963,6 +3963,7 @@ python3-absl:
   gentoo: [dev-python/abseil-py]
   nixos: [python3Packages.absl-py]
   opensuse: [python3-abseil]
+  rhel: [python3-absl-py]
   ubuntu:
     '*': [python3-absl]
     focal:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

python3-absl

## Package Upstream Source:

https://github.com/abseil/abseil-py

## Purpose of using this:

This dependency is used for standardized ROS dependency management of Python applications/skills utilizing the Google Abseil Common Libraries (absl-py).

Distro packaging links:

## Links to Distribution Packages

- Debian:
  - https://packages.debian.org/bookworm/python3-absl
- Ubuntu:
  - https://packages.ubuntu.com/jammy/python3-absl
- Fedora:
  - https://packages.fedoraproject.org/pkgs/python-absl-py/python3-absl-py/
- Arch:
  - https://archlinux.org/packages/extra/any/python-absl/
- Gentoo:
  - https://packages.gentoo.org/packages/dev-python/abseil-py
- macOS:
  - not available
- Alpine:
  - not available (uses pip fallback)
- NixOS/nixpkgs:
  - https://search.nixos.org/packages?channel=unstable&query=python3Packages.absl-py
- openSUSE:
  - https://software.opensuse.org/package/python3-abseil
- rhel:
  - not available
