### PR TITLE
protobuf_comm: 0.9.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6487,11 +6487,15 @@ repositories:
       version: master
     status: maintained
   protobuf_comm:
+    doc:
+      type: git
+      url: https://github.com/fawkesrobotics/protobuf_comm.git
+      version: main
     release:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/protobuf_comm-release.git
-      version: 0.9.3-1
+      version: 0.9.4-1
     source:
       type: git
       url: https://github.com/fawkesrobotics/protobuf_comm.git


### PR DESCRIPTION
Increasing version of package(s) in repository `protobuf_comm` to `0.9.4-1`:

- upstream repository: https://github.com/fawkesrobotics/protobuf_comm.git
- release repository: https://github.com/ros2-gbp/protobuf_comm-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.9.3-1`

## protobuf_comm

```
* project: switch to "new" boost asio API.
  The old API was deprecated almost 10 years ago.
* project: remove obsolete system component
* Contributors: Tarik Viehmann
```
