### PR TITLE
protobuf_comm: 0.9.4-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8416,6 +8416,20 @@ repositories:
       url: https://github.com/rai-opensource/proto2ros.git
       version: main
     status: developed
+  protobuf_comm:
+    doc:
+      type: git
+      url: https://github.com/fawkesrobotics/protobuf_comm.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/protobuf_comm-release.git
+      version: 0.9.4-1
+    source:
+      type: git
+      url: https://github.com/fawkesrobotics/protobuf_comm.git
+      version: main
   proxsuite:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `protobuf_comm` to `0.9.4-1`:

- upstream repository: https://github.com/fawkesrobotics/protobuf_comm.git
- release repository: https://github.com/ros2-gbp/protobuf_comm-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## protobuf_comm

```
* project: switch to "new" boost asio API.
  The old API was deprecated almost 10 years ago.
* project: remove obsolete system component
* Contributors: Tarik Viehmann
```
