### PR TITLE
foxglove-sdk: 3.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2481,7 +2481,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 3.4.1-1
+      version: 3.4.2-1
     source:
       type: git
       url: https://github.com/foxglove/foxglove-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `foxglove-sdk` to `3.4.2-1`:

- upstream repository: https://github.com/foxglove/foxglove-sdk.git
- release repository: https://github.com/ros2-gbp/foxglove_bridge-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.4.1-1`

## foxglove_bridge

```
* Fix a bug where the bridge would not initialize SDK logging unless ``debug:=true``
* ROS bridge connections now identify themselves as ``foxglove-bridge/<version>`` in library headers
* Update Foxglove SDK version to 0.25.3
```

## foxglove_msgs

```
* Version bump for foxglove_bridge 3.4.2 release
```
