### PR TITLE
clearpath_desktop: 2.9.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1546,7 +1546,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 2.7.0-2
+      version: 2.9.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `2.9.0-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.7.0-2`

## clearpath_config_live

```
* Update cmake version to 3.20 (#24 <https://github.com/clearpathrobotics/clearpath_desktop/issues/24>)
* Contributors: luis-camero
```

## clearpath_desktop

```
* Update cmake version to 3.20 (#24 <https://github.com/clearpathrobotics/clearpath_desktop/issues/24>)
* Contributors: luis-camero
```

## clearpath_offboard_sensors

```
* Update cmake version to 3.20 (#24 <https://github.com/clearpathrobotics/clearpath_desktop/issues/24>)
* Contributors: luis-camero
```

## clearpath_viz

```
* Added nav2_rviz_plugins exec dep and changed to clearpath_description to include all meshes. (#29 <https://github.com/clearpathrobotics/clearpath_desktop/issues/29>)
* Update cmake version to 3.20 (#24 <https://github.com/clearpathrobotics/clearpath_desktop/issues/24>)
* Contributors: Tony Baltovski, luis-camero
```
