### PR TITLE
clearpath_desktop: 1.2.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1746,7 +1746,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `1.2.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.0-1`

## clearpath_config_live

```
* [Humble] Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image. (#28 <https://github.com/clearpathrobotics/clearpath_desktop/issues/28>)
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```

## clearpath_desktop

- No changes

## clearpath_viz

```
* [Humble] Added nav2_rviz_plugins exec dep and changed to clearpath_description… (#30 <https://github.com/clearpathrobotics/clearpath_desktop/issues/30>)
  * Added nav2_rviz_plugins exec dep and changed to clearpath_description to include all meshes. (#29 <https://github.com/clearpathrobotics/clearpath_desktop/issues/29>)
  (cherry picked from commit af153e38f69c5f60d8a46feff7c51f667cd31c5d)
  # Conflicts:
  #     clearpath_viz/package.xml
  * Fixed conflicts.
  ---------
  Co-authored-by: Tony Baltovski <mailto:tbaltovski@clearpathrobotics.com>
* Contributors: mergify[bot]
```
