### PR TITLE
mobile_robot_simulator: 2.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4559,6 +4559,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
+  mobile_robot_simulator:
+    doc:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/nobleo/mobile_robot_simulator-release.git
+      version: 2.0.1-1
+    source:
+      type: git
+      url: https://github.com/nobleo/mobile_robot_simulator.git
+      version: main
+    status: maintained
   mola:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mobile_robot_simulator` to `2.0.1-1`:

- upstream repository: https://github.com/nobleo/mobile_robot_simulator.git
- release repository: https://github.com/nobleo/mobile_robot_simulator-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mobile_robot_simulator

```
* Fix first movement delta being way too large (#10 <https://github.com/nobleo/mobile_robot_simulator/issues/10>)
* Backport the code to humble
* Contributors: Ramon Wijnands
```
