### PR TITLE
pick_ik: 1.1.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7585,7 +7585,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git


### PR DESCRIPTION
Increasing version of package(s) in repository `pick_ik` to `1.1.2-1`:

- upstream repository: https://github.com/PickNikRobotics/pick_ik.git
- release repository: https://github.com/ros2-gbp/pick_ik-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.1-1`

## pick_ik

```
* Adds header file for pick_ik_plugin (#79 <https://github.com/PickNikRobotics/pick_ik/issues/79>)
* Contributors: Mark Johnson
```
