### PR TITLE
Please add the package ias_rviz_plugins to Jazzy Jalisco.

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4399,6 +4399,29 @@ repositories:
       url: https://github.com/p2p-industries/hyveos_ros_msgs.git
       version: main
     status: developed
+  ias_rviz_plugins:
+    doc:
+      type: git
+      url: https://github.com/weraleiso/ias_rviz_plugins.git
+      version: jazzy
+    release:
+      packages:
+      - ias_rviz_plugins
+      - rviz_plugin_display_lighting
+      - rviz_plugin_display_particles
+      - rviz_plugin_display_projector
+      - rviz_plugin_display_stereoscopic
+      - rviz_plugin_view_animated
+      - rviz_plugin_view_animated_msgs
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/weraleiso/ias_rviz_plugins-release.git
+      version: 1.0.0
+    source:
+      type: git
+      url: https://github.com/weraleiso/ias_rviz_plugins.git
+      version: jazzy
+    status: developed
   iceoryx:
     release:
       packages:


### PR DESCRIPTION
This package provides a collection of RViz plugins for the InterActiveSpace (IAS). The package contains classical and new, ROS1 packages that were recently ported to ROS2 Jazzy Jalisco. As suggested by [#1783 (comment)](https://github.com/ros2/rviz/issues/1783#issuecomment-4669018555), the authors would like to make this collection available to the community as release package. 

# Please Add This Package to be indexed in the rosdistro.
Jazzy Jalisco

# The source is here:
https://github.com/weraleiso/ias_rviz_plugins

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro