### PR TITLE
point_cloud_transport: 6.0.1-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6243,7 +6243,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 6.0.1-1
+      version: 6.0.1-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `6.0.1-2`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.1-1`

## point_cloud_transport

```
* Removed deprecated API (#160 <https://github.com/ros-perception/point_cloud_transport/issues/160>)
* getPubLoader() and getSubLoader() marked deprecated (#159 <https://github.com/ros-perception/point_cloud_transport/issues/159>)
* Added version.h (#163 <https://github.com/ros-perception/point_cloud_transport/issues/163>)
* Cleanups headers and avoid use std::cout (#158 <https://github.com/ros-perception/point_cloud_transport/issues/158>)
* Contributors: Alejandro Hernández Cordero, Martin Pecka
```

## point_cloud_transport_py

```
* Cleanups headers and avoid use std::cout (#158 <https://github.com/ros-perception/point_cloud_transport/issues/158>)
* Contributors: Alejandro Hernández Cordero
```
