### PR TITLE
point_cloud_transport: 6.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6243,7 +6243,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 6.0.1-1
+      version: 6.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `6.0.2-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.1-1`

## point_cloud_transport

```
* Make VoidPtr public in PointCloudTransport class (#186 <https://github.com/ros-perception/point_cloud_transport/issues/186>)
* Added rosdoc2 documentation for point_cloud_transport (#155 <https://github.com/ros-perception/point_cloud_transport/issues/155>)
* Contributors: Alejandro Hernández Cordero, Martin Pecka
```

## point_cloud_transport_py

```
* Fixed PointCloudCodec encode/decode in Python (#181 <https://github.com/ros-perception/point_cloud_transport/issues/181>)
* Added rosdoc2 documentation for point_cloud_transport_py (#156 <https://github.com/ros-perception/point_cloud_transport/issues/156>)
* Contributors: Alejandro Hernández Cordero, Martin Pecka
```
