### PR TITLE
point_cloud_transport: 5.4.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6301,7 +6301,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.4.2-1
+      version: 5.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.4.3-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.4.2-1`

## point_cloud_transport

```
* Make VoidPtr public in PointCloudTransport class (#186 <https://github.com/ros-perception/point_cloud_transport/issues/186>) (#187 <https://github.com/ros-perception/point_cloud_transport/issues/187>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* Fixed PointCloudCodec encode/decode in Python (#181 <https://github.com/ros-perception/point_cloud_transport/issues/181>) (#182 <https://github.com/ros-perception/point_cloud_transport/issues/182>)
* Contributors: mergify[bot]
```
