### PR TITLE
point_cloud_transport: 5.1.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6374,7 +6374,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 5.1.7-1
+      version: 5.1.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `5.1.8-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.1.7-1`

## point_cloud_transport

```
* Make VoidPtr public in PointCloudTransport class (#186 <https://github.com/ros-perception/point_cloud_transport/issues/186>) (#188 <https://github.com/ros-perception/point_cloud_transport/issues/188>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* Fixed PointCloudCodec encode/decode in Python (#181 <https://github.com/ros-perception/point_cloud_transport/issues/181>) (#183 <https://github.com/ros-perception/point_cloud_transport/issues/183>)
* Contributors: mergify[bot]
```
