### PR TITLE
point_cloud_transport: 1.0.23-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8308,7 +8308,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/point_cloud_transport-release.git
-      version: 1.0.22-1
+      version: 1.0.23-1
     source:
       type: git
       url: https://github.com/ros-perception/point_cloud_transport.git


### PR DESCRIPTION
Increasing version of package(s) in repository `point_cloud_transport` to `1.0.23-1`:

- upstream repository: https://github.com/ros-perception/point_cloud_transport
- release repository: https://github.com/ros2-gbp/point_cloud_transport-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.22-1`

## point_cloud_transport

```
* Make VoidPtr public in PointCloudTransport class (#186 <https://github.com/ros-perception/point_cloud_transport/issues/186>) (#190 <https://github.com/ros-perception/point_cloud_transport/issues/190>)
* Contributors: mergify[bot]
```

## point_cloud_transport_py

```
* Fixed PointCloudCodec encode/decode in Python (#181 <https://github.com/ros-perception/point_cloud_transport/issues/181>) (#185 <https://github.com/ros-perception/point_cloud_transport/issues/185>)
* Contributors: mergify[bot]
```
