### PR TITLE
pointcloud_conversions: 0.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6346,6 +6346,21 @@ repositories:
       url: https://github.com/ros-perception/point_cloud_transport_tutorial.git
       version: rolling
     status: maintained
+  pointcloud_conversions:
+    doc:
+      type: git
+      url: https://github.com/li9i/pointcloud-conversions.git
+      version: lyrical-devel
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/li9i/pointcloud-conversions-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/li9i/pointcloud-conversions.git
+      version: lyrical-devel
+    status: maintained
   pointcloud_to_laserscan:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pointcloud_conversions` to `0.0.3-1`:

- upstream repository: https://github.com/li9i/pointcloud-conversions.git
- release repository: https://github.com/li9i/pointcloud-conversions-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
