### PR TITLE
[openembedded] python2-backports-ssl: remove recipe

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -700,7 +700,6 @@ python-backports.ssl-match-hostname:
   debian: [python-backports.ssl-match-hostname]
   gentoo: [dev-python/backports-ssl-match-hostname]
   nixos: [pythonPackages.backports_ssl_match_hostname]
-  openembedded: ['${PYTHON_PN}-backports-ssl@meta-python']
   ubuntu:
     bionic: [python-backports.ssl-match-hostname]
 python-beautifulsoup:


### PR DESCRIPTION
The Python 2 recipe was removed from meta-python:
https://github.com/openembedded/meta-openembedded/commit/05d0c5eee319055816bbea8b9dd972f723f68019

And there is no dependency in meta-ros on this packages (anymore).

@robwoolley: could you verify?