### PR TITLE
connection_inspector: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1972,6 +1972,11 @@ repositories:
       version: humble
     status: maintained
   connection_inspector:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/DynoRobotics/connection_inspector-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ksatyaki/ros2_node_inspector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `connection_inspector` to `1.0.1-1`:

- upstream repository: https://github.com/ksatyaki/ros2_node_inspector.git
- release repository: https://github.com/DynoRobotics/connection_inspector-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
