### PR TITLE
connection_inspector: 1.0.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1849,6 +1849,15 @@ repositories:
       version: ros2
     status: maintained
   connection_inspector:
+    doc:
+      type: git
+      url: https://github.com/ksatyaki/ros2_node_inspector.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/DynoRobotics/connection_inspector-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ksatyaki/ros2_node_inspector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `connection_inspector` to `1.0.1-1`:

- upstream repository: https://github.com/ksatyaki/ros2_node_inspector.git
- release repository: https://github.com/DynoRobotics/connection_inspector-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
