### PR TITLE
husarion_components_description: 0.1.1-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4337,7 +4337,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/husarion_components_description-release.git
-      version: 0.1.0-1
+      version: 0.1.1-2
     source:
       type: git
       url: https://github.com/husarion/husarion_components_description.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husarion_components_description` to `0.1.1-2`:

- upstream repository: https://github.com/husarion/husarion_components_description.git
- release repository: https://github.com/ros2-gbp/husarion_components_description-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.0-1`

## husarion_components_description

```
* Add readable component-type names
* Add LPX-E3/T1, Velodyne & Astra meshes; improve RPLidar meshes (#23 <https://github.com/husarion/husarion_components_description/issues/23>)
* rack example (#22 <https://github.com/husarion/husarion_components_description/issues/22>)
* Add all rplidar mesh models
* Add custom component type for user URDF/mesh (#21 <https://github.com/husarion/husarion_components_description/issues/21>)
* Use upstream zed_description for ZED camera URDF (#20 <https://github.com/husarion/husarion_components_description/issues/20>)
* Rails elements (#17 <https://github.com/husarion/husarion_components_description/issues/17>)
* Fix os0-32 ranges (#16 <https://github.com/husarion/husarion_components_description/issues/16>)
* Add reling component (#15 <https://github.com/husarion/husarion_components_description/issues/15>)
* Contributors: Dawid Kmak, Jakub Delicat, Rafal Gorecki, rafal-gorecki
```
