### PR TITLE
husarion_ugv_ros: 2.3.2-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4381,7 +4381,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       type: git
       url: https://github.com/husarion/husarion_ugv_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `husarion_ugv_ros` to `2.3.2-1`:

- upstream repository: https://github.com/husarion/husarion_ugv_ros.git
- release repository: https://github.com/ros2-gbp/husarion_ugv_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.3.1-1`

## husarion_ugv_description

```
* Add parameter to disable orientation (#639 <https://github.com/husarion/husarion_ugv_ros/issues/639>)
* Remapped CM diagnostics to the namespace (#633 <https://github.com/husarion/husarion_ugv_ros/issues/633>)
* Removed emulate_tty | added COLORIZED_OUTPUT for main bringups (#631 <https://github.com/husarion/husarion_ugv_ros/issues/631>)
* husarion_components_description refactor compatibility (2) (#617 <https://github.com/husarion/husarion_ugv_ros/issues/617>)
* Add ground truth for lynx (#619 <https://github.com/husarion/husarion_ugv_ros/issues/619>)
* Revert "husarion_components_description refactor compatibility (#611 <https://github.com/husarion/husarion_ugv_ros/issues/611>)" (#616 <https://github.com/husarion/husarion_ugv_ros/issues/616>)
* husarion_components_description refactor compatibility (#611 <https://github.com/husarion/husarion_ugv_ros/issues/611>)
* add ground truth odometry and tf (#612 <https://github.com/husarion/husarion_ugv_ros/issues/612>)
* Add twist mux controller (#609 <https://github.com/husarion/husarion_ugv_ros/issues/609>)
* Fix gazebosim mecanum wheels (#608 <https://github.com/husarion/husarion_ugv_ros/issues/608>)
* Contributors: Dawid Kmak, Jakub Delicat, husarafal, zuz-mej
```

## husarion_ugv_msgs

```
* Add extra animations (#622 <https://github.com/husarion/husarion_ugv_ros/issues/622>)
* Contributors: Stefan
```
