### PR TITLE
rosbot_ros: 1.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10214,7 +10214,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rosbot_ros-release.git
-      version: 0.18.6-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/husarion/rosbot_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbot_ros` to `1.1.1-1`:

- upstream repository: https://github.com/husarion/rosbot_ros.git
- release repository: https://github.com/ros2-gbp/rosbot_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.18.6-1`

## rosbot

```
* Bump husarion_components_description
* Update rosbot body mesh; retune camera mount; bump husarion_components_description
* Adopt custom component: bump dep + link docs in configs (#184 <https://github.com/husarion/rosbot_ros/issues/184>)
  * Bump husarion_components_description (custom component)
  * Link custom component docs in description configs
  * just sim: force NVIDIA EGL vendor to silence Mesa warnings
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_bringup

```
* Update rosbot body mesh; retune camera mount; bump husarion_components_description
* Merge pull request #185 <https://github.com/husarion/rosbot_ros/issues/185> from husarion/tidy-ros-api
  Tidy ROS_API package list + rosbot_mavlink_bridge dep
* Declare rosbot_mavlink_bridge exec_depend in rosbot_bringup
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_controller

```
* controller: make controller_manager spawn timeout a launch arg (default 60s)
  The controller spawner hardcoded --controller-manager-timeout 20. On slower
  SBCs — e.g. Raspberry Pi 5 on ROSbot 3 — the 100 Hz control loop plus
  camera/bridge startup contention can exceed 20 s, so the spawner times out and
  leaves the drive / imu controllers unconfigured (robot won't drive until they
  are activated manually). The NUC-based ROSbot XL has enough headroom to hit 20 s.
  Expose controller_manager_timeout as a launch arg (default 60) in
  controller.yaml + manipulator.yaml and thread it through the manipulator
  include, so slow hosts get more time and it stays tunable per deployment.
* Contributors: dominikn
```

## rosbot_description

```
* Update rosbot body mesh; retune camera mount; bump husarion_components_description
* Adopt custom component: bump dep + link docs in configs (#184 <https://github.com/husarion/rosbot_ros/issues/184>)
  * Bump husarion_components_description (custom component)
  * Link custom component docs in description configs
  * just sim: force NVIDIA EGL vendor to silence Mesa warnings
* Contributors: Rafal Gorecki, rafal-gorecki
```

## rosbot_gazebo

- No changes

## rosbot_hardware_interfaces

- No changes

## rosbot_joy

- No changes

## rosbot_localization

- No changes

## rosbot_moveit

```
* Declare moveit_core dependency in rosbot_moveit
* Contributors: rafal-gorecki
```

## rosbot_utils

```
* Add led_strip/enable service + arm64 simulation image
* Bump firmware to v2.0.2-jazzy
* Contributors: rafal-gorecki
```
