### PR TITLE
data_tamer_tools: 0.10.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1586,7 +1586,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/data_tamer_tools-release.git
-      version: 0.4.0-3
+      version: 0.10.0-1
     source:
       type: git
       url: https://gitlab.com/jlack/data_tamer_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_tamer_tools` to `0.10.0-1`:

- upstream repository: https://gitlab.com/jlack/data_tamer_tools.git
- release repository: https://github.com/ros2-gbp/data_tamer_tools-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-3`
