### PR TITLE
leo_examples: 1.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5094,7 +5094,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/leo_examples-ros2-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/LeoRover/leo_examples-ros2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `leo_examples` to `1.1.0-1`:

- upstream repository: https://github.com/LeoRover/leo_examples-ros2.git
- release repository: https://github.com/ros2-gbp/leo_examples-ros2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## leo_example_follow_aruco_marker

```
* feat: Update follow aruco (#8 <https://github.com/LeoRover/leo_examples-ros2/issues/8>)
* fix: AttributeError in aruco_follower when reading odometry pose (#6 <https://github.com/LeoRover/leo_examples-ros2/issues/6>)
* Contributors: Filip Szkudlarek, Juan Carlos Tique
```

## leo_example_line_follower

- No changes

## leo_example_object_detection

- No changes

## leo_examples

- No changes
