### PR TITLE
message_filters: 8.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4430,7 +4430,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 8.0.1-1
+      version: 8.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `8.0.2-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `8.0.1-1`

## message_filters

```
* hygiene sweep: fabs→std::abs, empty {} ctors/dtors → = default, etc (#315 <https://github.com/ros2/message_filters/issues/315>)
* Optimize header include (#316 <https://github.com/ros2/message_filters/issues/316>)
* Missed make_shared and removed redundant virtual (#314 <https://github.com/ros2/message_filters/issues/314>)
* Removed CopyMEssageIfNecessary (#313 <https://github.com/ros2/message_filters/issues/313>)
* const-correct comparisons and migration from typedef to the using (#312 <https://github.com/ros2/message_filters/issues/312>)
* replaced the raw new CallbackHelperT(...) with a single std::make_shared in signalX.hpp (#311 <https://github.com/ros2/message_filters/issues/311>)
* typedefs to using and std::bind to lambdas (#310 <https://github.com/ros2/message_filters/issues/310>)
* Tutorials: Add DeltaFilter C++ tutorial (#304 <https://github.com/ros2/message_filters/issues/304>)
* Contributors: Alejandro Hernández Cordero, Pavel Esipov
```
