### PR TITLE
message_filters: 7.4.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4479,7 +4479,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 7.4.1-1
+      version: 7.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_filters` to `7.4.2-1`:

- upstream repository: https://github.com/ros2/message_filters.git
- release repository: https://github.com/ros2-gbp/ros2_message_filters-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.4.1-1`

## message_filters

```
* Tutorials: Add DeltaFilter C++ tutorial (#304 <https://github.com/ros2/message_filters/issues/304>) (#305 <https://github.com/ros2/message_filters/issues/305>)
* Contributors: mergify[bot]
```
