### PR TITLE
geometry2: 0.46.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2632,7 +2632,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.46.0-1
+      version: 0.46.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.46.1-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.46.0-1`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Optimize header includes (#952 <https://github.com/ros2/geometry2/issues/952>)
* Move implementation from hpp to cpp (#951 <https://github.com/ros2/geometry2/issues/951>)
* Cleanup headers (#928 <https://github.com/ros2/geometry2/issues/928>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_bullet

```
* Cleanup headers (#928 <https://github.com/ros2/geometry2/issues/928>)
* Contributors: Alejandro Hernández Cordero
```

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Optimize header includes (#952 <https://github.com/ros2/geometry2/issues/952>)
* Move implementation from hpp to cpp (#951 <https://github.com/ros2/geometry2/issues/951>)
* Change constructor overloads to sidestep uncrustify differences (#949 <https://github.com/ros2/geometry2/issues/949>)
* Cleanup headers (#928 <https://github.com/ros2/geometry2/issues/928>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```

## tf2_ros_py

- No changes

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
