### PR TITLE
coal: 3.0.3-3 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1244,7 +1244,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/coal-release.git
-      version: 3.0.3-2
+      version: 3.0.3-3
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `coal` to `3.0.3-3`:

- upstream repository: https://github.com/coal-library/coal.git
- release repository: https://github.com/ros2-gbp/coal-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.3-2`
