### PR TITLE
crazyswarm2: 1.0.5-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2087,6 +2087,7 @@ repositories:
     release:
       packages:
       - crazyflie
+      - crazyflie_description
       - crazyflie_examples
       - crazyflie_interfaces
       - crazyflie_py
@@ -2095,7 +2096,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/crazyswarm2-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/IMRCLab/crazyswarm2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `crazyswarm2` to `1.0.5-1`:

- upstream repository: https://github.com/IMRCLab/crazyswarm2.git
- release repository: https://github.com/ros2-gbp/crazyswarm2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.4-1`

## crazyflie

```
* fix/fixing unitialized stats count that may cause incorrect statistics warnings
* separate crazyflie_description package
* Contributors: Kimberly N. McGuire, Wolfgang Hönig, dimitriasilveria
```

## crazyflie_description

```
* separate crazyflie_description package
* Contributors: Kimberly N. McGuire
```

## crazyflie_examples

```
* separate crazyflie_description package
* Contributors: Kimberly N. McGuire
```

## crazyflie_interfaces

- No changes

## crazyflie_py

```
* separate crazyflie_description package
* Contributors: Kimberly N. McGuire
```

## crazyflie_server_py

```
* separate crazyflie_description package
* Contributors: Kimberly N. McGuire
```

## crazyflie_sim

- No changes
