### PR TITLE
motion_capture_tracking: 1.0.9-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5984,7 +5984,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/motion_capture_tracking-release.git
-      version: 1.0.6-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://github.com/IMRCLab/motion_capture_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `motion_capture_tracking` to `1.0.9-1`:

- upstream repository: https://github.com/IMRCLab/motion_capture_tracking.git
- release repository: https://github.com/ros2-gbp/motion_capture_tracking-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.6-1`

## motion_capture_tracking

```
* Optitrack: remove debug prints
* Contributors: Wolfgang Hoenig
```

## motion_capture_tracking_interfaces

- No changes
