### PR TITLE
image_transport_plugins: 7.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3432,7 +3432,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 7.0.0-1
+      version: 7.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `7.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.0.0-1`

## compressed_depth_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>)
* Remoed parameter event alias (#226 <https://github.com/ros-perception/image_transport_plugins/issues/226>)
* Contributors: Alejandro Hernández Cordero
```

## compressed_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>)
* Remoed parameter event alias (#226 <https://github.com/ros-perception/image_transport_plugins/issues/226>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_plugins

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>)
* Contributors: Alejandro Hernández Cordero
```

## theora_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>)
* Remoed parameter event alias (#226 <https://github.com/ros-perception/image_transport_plugins/issues/226>)
* Removed clang warning (#221 <https://github.com/ros-perception/image_transport_plugins/issues/221>)
* Contributors: Alejandro Hernández Cordero
```

## zstd_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>)
* Remoed parameter event alias (#226 <https://github.com/ros-perception/image_transport_plugins/issues/226>)
* Contributors: Alejandro Hernández Cordero
```
