### PR TITLE
image_transport_plugins: 6.2.6-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3472,7 +3472,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 6.2.5-1
+      version: 6.2.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `6.2.6-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.2.5-1`

## compressed_depth_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#235 <https://github.com/ros-perception/image_transport_plugins/issues/235>)
* Contributors: mergify[bot]
```

## compressed_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#235 <https://github.com/ros-perception/image_transport_plugins/issues/235>)
* Contributors: mergify[bot]
```

## image_transport_plugins

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#235 <https://github.com/ros-perception/image_transport_plugins/issues/235>)
* Contributors: mergify[bot]
```

## theora_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#235 <https://github.com/ros-perception/image_transport_plugins/issues/235>)
* Contributors: mergify[bot]
```

## zstd_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#235 <https://github.com/ros-perception/image_transport_plugins/issues/235>)
* Contributors: mergify[bot]
```
