### PR TITLE
image_transport_plugins: 5.1.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3480,7 +3480,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_transport_plugins-release.git
-      version: 5.1.2-1
+      version: 5.1.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_transport_plugins` to `5.1.3-1`:

- upstream repository: https://github.com/ros-perception/image_transport_plugins.git
- release repository: https://github.com/ros2-gbp/image_transport_plugins-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.1.2-1`

## compressed_depth_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#236 <https://github.com/ros-perception/image_transport_plugins/issues/236>)
* Contributors: mergify[bot]
```

## compressed_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#236 <https://github.com/ros-perception/image_transport_plugins/issues/236>)
* Contributors: mergify[bot]
```

## image_transport_plugins

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#236 <https://github.com/ros-perception/image_transport_plugins/issues/236>)
* Contributors: mergify[bot]
```

## theora_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#236 <https://github.com/ros-perception/image_transport_plugins/issues/236>)
* Contributors: mergify[bot]
```

## zstd_image_transport

```
* Update CMakeLists minimum version (#229 <https://github.com/ros-perception/image_transport_plugins/issues/229>) (#236 <https://github.com/ros-perception/image_transport_plugins/issues/236>)
* Contributors: mergify[bot]
```
