### PR TITLE
rosdep: Add websockify package

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -10863,6 +10863,17 @@ wayland-dev:
   openembedded: [wayland@openembedded-core]
   rhel: [wayland-devel, wayland-protocols-devel]
   ubuntu: [libwayland-dev, wayland-protocols]
+websockify:
+  arch: null
+  debian: [websockify]
+  fedora: [python3-websockify]
+  freebsd: [py312-websockify]
+  gentoo: [dev-python/websockify]
+  nixos: [python313Packages.websockify]
+  openembedded: [python3-websockify]
+  opensuse: [python-websockify]
+  rhel: [python3-websockify]
+  ubuntu: [websockify]
 wget:
   arch: [wget]
   debian: [wget]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -10871,7 +10871,7 @@ websockify:
   freebsd: [py312-websockify]
   gentoo: [dev-python/websockify]
   nixos: [python313Packages.websockify]
-  openembedded: [python3-websockify]
+  openembedded: null
   opensuse: [python-websockify]
   rhel: [python3-websockify]
   ubuntu: [websockify]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -10864,6 +10864,7 @@ wayland-dev:
   rhel: [wayland-devel, wayland-protocols-devel]
   ubuntu: [libwayland-dev, wayland-protocols]
 websockify:
+  alpine: [websockify]
   arch: null
   debian: [websockify]
   fedora: [python3-websockify]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

websockify

## Package Upstream Source:

https://github.com/novnc/websockify

## Purpose of using this:

Bridge between TCP and WebSockets.

Distro packaging links:

## Links to Distribution Packages

- Debian: https://packages.debian.org/trixie/websockify
- Ubuntu: https://packages.ubuntu.com/resolute/websockify
- Fedora: https://packages.fedoraproject.org/pkgs/python-websockify/python3-websockify/
- Arch: N/A
- Gentoo: https://packages.gentoo.org/packages/dev-python/websockify
- macOS: N/A
- Alpine: https://pkgs.alpinelinux.org/package/v3.24/community/x86_64/websockify
- NixOS/nixpkgs: https://search.nixos.org/packages?channel=26.05&query=websockify#show=python313Packages.websockify
- openSUSE: https://software.opensuse.org/package/python-websockify
- rhel: https://packages.fedoraproject.org/pkgs/python-websockify/python3-websockify/
