### PR TITLE
add rmw_int2dds to rolling, jazzy, and humble

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9842,6 +9842,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: humble
     status: developed
+  rmw_int2dds:
+    doc:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: humble
+    status: developed
   rmw_zenoh:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9333,6 +9333,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: jazzy
     status: developed
+  rmw_int2dds:
+    doc:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: jazzy
+    source:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: jazzy
+    status: developed
   rmw_zenoh:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7629,6 +7629,16 @@ repositories:
       url: https://github.com/ros2/rmw_implementation.git
       version: rolling
     status: developed
+  rmw_int2dds:
+    doc:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: rolling
+    source:
+      type: git
+      url: https://github.com/IntellectusCorp/rmw_int2dds.git
+      version: rolling
+    status: developed
   rmw_swiftdds:
     source:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

rolling, jazzy, humble

# The source is here:

https://github.com/IntellectusCorp/rmw_int2dds

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro