### PR TITLE
ros2_control: 6.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7817,7 +7817,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 6.7.1-1
+      version: 6.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `6.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.7.1-1`

## controller_interface

```
* Improve docstring of the semantic_components for consistency (#3338 <https://github.com/ros-controls/ros2_control/issues/3338>)
* Improve docstring of the controller_interface for consistency (#3318 <https://github.com/ros-controls/ros2_control/issues/3318>)
* Contributors: mcereda
```

## controller_manager

```
* Unload controller upon sigterm (#3406 <https://github.com/ros-controls/ros2_control/issues/3406>)
* document Ubuntu realtime kernel on Raspberry Pi (#3397 <https://github.com/ros-controls/ros2_control/issues/3397>)
* Wait to terminate test until spawner exits (#3373 <https://github.com/ros-controls/ros2_control/issues/3373>)
* Increase timeout of test_spawner_unspawner (#3381 <https://github.com/ros-controls/ros2_control/issues/3381>)
* fix typo in state and reference export methods (#3347 <https://github.com/ros-controls/ros2_control/issues/3347>)
* Enforce cleanup_controller on more exit points of configure_controller (#3192 <https://github.com/ros-controls/ros2_control/issues/3192>)
* Fix the initialization of the parsed resource managers (#3346 <https://github.com/ros-controls/ros2_control/issues/3346>)
* Controller Manager recovery from invalid URDF errors (#2775 <https://github.com/ros-controls/ros2_control/issues/2775>)
* Fix duplicate fallback controllers from the controller chain (#3108 <https://github.com/ros-controls/ros2_control/issues/3108>)
* Added default value to the fallback param declarations (#3270 <https://github.com/ros-controls/ros2_control/issues/3270>)
* Contributors: Christian Rauch, Christoph Fröhlich, Kevin Gilliam, Lucas Alvarez, Sai Kishor Kothakota, VitezGabriela
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* hardware_interface: add missing <unordered_set> include in resource_manager (#3431 <https://github.com/ros-controls/ros2_control/issues/3431>)
* Add read_only attribute to JointInfo and ActuatorInfo (#3426 <https://github.com/ros-controls/ros2_control/issues/3426>)
* fix typo in 'synchronized' documentation (#3388 <https://github.com/ros-controls/ros2_control/issues/3388>)
* Fix pure virtual error in the hardware component with async mode (#3321 <https://github.com/ros-controls/ros2_control/issues/3321>)
* Fix the initialization of the parsed resource managers (#3346 <https://github.com/ros-controls/ros2_control/issues/3346>)
* [hardware_interface_testing] Add tests for hardware components exception handling (#3228 <https://github.com/ros-controls/ros2_control/issues/3228>)
* Controller Manager recovery from invalid URDF errors (#2775 <https://github.com/ros-controls/ros2_control/issues/2775>)
* Fixing Hardware components logging spam in tests (#2692 <https://github.com/ros-controls/ros2_control/issues/2692>)
* Contributors: Bence Magyar, Christian Rauch, Sai Kishor Kothakota, Shlok Mehndiratta, Soham Patil, VitezGabriela
```

## hardware_interface_testing

```
* Fix pure virtual error in the hardware component with async mode (#3321 <https://github.com/ros-controls/ros2_control/issues/3321>)
* [hardware_interface_testing] Add tests for hardware components exception handling (#3228 <https://github.com/ros-controls/ros2_control/issues/3228>)
* Contributors: Sai Kishor Kothakota, Shlok Mehndiratta
```

## joint_limits

```
* Fix disable velocity and effort limiting feature (#3425 <https://github.com/ros-controls/ros2_control/issues/3425>)
* fixed docstring of joint_limits (#3414 <https://github.com/ros-controls/ros2_control/issues/3414>)
* Improve docstring of joint_limits for consistency (#3391 <https://github.com/ros-controls/ros2_control/issues/3391>)
* Fix bad optional access in the joint limiters (#3319 <https://github.com/ros-controls/ros2_control/issues/3319>)
* Handle NaNs properly in the joint limiters (#3320 <https://github.com/ros-controls/ros2_control/issues/3320>)
* Contributors: Arhan Chavare, Sai Kishor Kothakota, mcereda
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add read_only attribute to JointInfo and ActuatorInfo (#3426 <https://github.com/ros-controls/ros2_control/issues/3426>)
* Controller Manager recovery from invalid URDF errors (#2775 <https://github.com/ros-controls/ros2_control/issues/2775>)
* Contributors: Sai Kishor Kothakota, VitezGabriela
```

## ros2controlcli

- No changes

## rqt_controller_manager

```
* fix Qt API (#3367 <https://github.com/ros-controls/ros2_control/issues/3367>)
* Contributors: Christian Rauch
```

## transmission_interface

- No changes
