### PR TITLE
ros2_controllers: 6.8.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7857,6 +7857,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - magnetometer_broadcaster
       - mecanum_drive_controller
       - motion_primitives_controllers
       - omni_wheel_drive_controller
@@ -7874,7 +7875,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 6.7.0-1
+      version: 6.8.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `6.8.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.7.0-1`

## ackermann_steering_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (#2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>)
* Contributors: Junius Santoso
```

## admittance_controller

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (#2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>)
* Contributors: Junius Santoso
```

## bicycle_steering_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (#2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>)
* Contributors: Junius Santoso
```

## chained_filter_controller

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (#2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>)
* Contributors: Junius Santoso
```

## diff_drive_controller

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Contributors: Junius Santoso
```

## force_torque_sensor_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (#2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>)
* Contributors: Junius Santoso
```

## forward_command_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (#2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>)
* Contributors: Junius Santoso
```

## gpio_controllers

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Contributors: Junius Santoso
```

## gps_sensor_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Contributors: Junius Santoso
```

## imu_sensor_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (#2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>)
* Contributors: Junius Santoso
```

## joint_state_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (#2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>)
* [JSB] Remove dynamic_joint_states and use INDIVIDUAL_BEST_EFFORT for interfaces (#2187 <https://github.com/ros-controls/ros2_controllers/issues/2187>)
* Contributors: Junius Santoso, Sai Kishor Kothakota
```

## joint_trajectory_controller

```
* Trajectory blending with new trajectory deferral (#2401 <https://github.com/ros-controls/ros2_controllers/issues/2401>)
* [JTC] Deliver abort action result before destroying goal handle on preemption (#2422 <https://github.com/ros-controls/ros2_controllers/issues/2422>)
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (#2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>)
* [JTC] Fix segfault when last trajectory segment is skipped (#2359 <https://github.com/ros-controls/ros2_controllers/issues/2359>)
* More general initialization of state from command (#2294 <https://github.com/ros-controls/ros2_controllers/issues/2294>)
* Contributors: Dhruvil Parikh, Junius Santoso, Peter Mitrano (AR), Vedh
```

## magnetometer_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* fix(magnetometer_broadcaster): Refactor to avoid pluginlib in tests (#2387 <https://github.com/ros-controls/ros2_controllers/issues/2387>)
* Add broadcaster for magnetic field values from a magnetometer (#2214 <https://github.com/ros-controls/ros2_controllers/issues/2214>)
* Contributors: Christian Rauch, Christoph Fröhlich, Junius Santoso
```

## mecanum_drive_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (#2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>)
* Added velocity limiting to the mecanum controller. (#2313 <https://github.com/ros-controls/ros2_controllers/issues/2313>)
* Contributors: Junius Santoso, Tony Baltovski
```

## motion_primitives_controllers

```
* fix: correct test_load_controller tests for motion_primitives and pid_controller (#2445 <https://github.com/ros-controls/ros2_controllers/issues/2445>)
* fix: update dead documentation links (#2398 <https://github.com/ros-controls/ros2_controllers/issues/2398>)
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (#2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>)
* Fix motion_primitive_controller TOC in docs (#2221 <https://github.com/ros-controls/ros2_controllers/issues/2221>)
* Contributors: Ishan Pathak, Junius Santoso, Souri Rishik
```

## omni_wheel_drive_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (#2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>)
* Contributors: Junius Santoso
```

## parallel_gripper_controller

```
* Call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (#2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>)
* Contributors: Junius Santoso
```

## pid_controller

```
* fix: correct test_load_controller tests for motion_primitives and pid_controller (#2445 <https://github.com/ros-controls/ros2_controllers/issues/2445>)
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (#2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>)
* Contributors: Junius Santoso, Souri Rishik
```

## pose_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (#2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>)
* Contributors: Junius Santoso
```

## range_sensor_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (#2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>)
* Contributors: Junius Santoso
```

## ros2_controllers

```
* Add broadcaster for magnetic field values from a magnetometer (#2214 <https://github.com/ros-controls/ros2_controllers/issues/2214>)
* Contributors: Christian Rauch
```

## ros2_controllers_test_nodes

```
* Fix SPDX license expression (#2370 <https://github.com/ros-controls/ros2_controllers/issues/2370>)
* Contributors: Shivam Maurya
```

## rqt_joint_trajectory_controller

```
* rqt-jtc: Fix more shutdown races (#2431 <https://github.com/ros-controls/ros2_controllers/issues/2431>)
* rqt-jtc: Add launch test, fix Qt6 API changes and more(#2405 <https://github.com/ros-controls/ros2_controllers/issues/2405>)
* Contributors: Christoph Fröhlich
```

## state_interfaces_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (#2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>)
* Contributors: Junius Santoso
```

## steering_controllers_library

```
* Simplify reduce_wheel_speed_until_steering_reached logic (#2396 <https://github.com/ros-controls/ros2_controllers/issues/2396>)
* Remove deprecated steering_odometry class (#2400 <https://github.com/ros-controls/ros2_controllers/issues/2400>)
* Call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (#2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>)
* Contributors: Christoph Fröhlich, Junius Santoso
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Final test cleanup - call appropriate lifecycle transitions (#2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>)
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (#2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>)
* Contributors: Junius Santoso
```
