### PR TITLE
ros2_control: 4.46.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9552,7 +9552,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 4.45.2-1
+      version: 4.46.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `4.46.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.45.2-1`

## controller_interface

```
* Improve docstring of the semantic_components for consistency (#3338 <https://github.com/ros-controls/ros2_control/issues/3338>) (#3421 <https://github.com/ros-controls/ros2_control/issues/3421>)
* Improve docstring of the controller_interface for consistency (#3318 <https://github.com/ros-controls/ros2_control/issues/3318>) (#3336 <https://github.com/ros-controls/ros2_control/issues/3336>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Unload controller upon sigterm (#3406 <https://github.com/ros-controls/ros2_control/issues/3406>) (#3427 <https://github.com/ros-controls/ros2_control/issues/3427>)
* document Ubuntu realtime kernel on Raspberry Pi (#3397 <https://github.com/ros-controls/ros2_control/issues/3397>) (#3399 <https://github.com/ros-controls/ros2_control/issues/3399>)
* Wait to terminate test until spawner exits (#3373 <https://github.com/ros-controls/ros2_control/issues/3373>) (#3384 <https://github.com/ros-controls/ros2_control/issues/3384>)
* fix typo in state and reference export methods (#3347 <https://github.com/ros-controls/ros2_control/issues/3347>) (#3357 <https://github.com/ros-controls/ros2_control/issues/3357>)
* Enforce cleanup_controller on more exit points of configure_controller (#3192 <https://github.com/ros-controls/ros2_control/issues/3192>) (#3348 <https://github.com/ros-controls/ros2_control/issues/3348>)
* Fix duplicate fallback controllers from the controller chain (#3108 <https://github.com/ros-controls/ros2_control/issues/3108>) (#3326 <https://github.com/ros-controls/ros2_control/issues/3326>)
* Added default value to the fallback param declarations (#3270 <https://github.com/ros-controls/ros2_control/issues/3270>) (#3314 <https://github.com/ros-controls/ros2_control/issues/3314>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add read_only attribute to JointInfo and ActuatorInfo (#3426 <https://github.com/ros-controls/ros2_control/issues/3426>) (#3429 <https://github.com/ros-controls/ros2_control/issues/3429>)
* fix typo in 'synchronized' documentation (#3388 <https://github.com/ros-controls/ros2_control/issues/3388>) (#3389 <https://github.com/ros-controls/ros2_control/issues/3389>)
* Fix pure virtual error in the hardware component with async mode (#3321 <https://github.com/ros-controls/ros2_control/issues/3321>) (#3377 <https://github.com/ros-controls/ros2_control/issues/3377>)
* hardware_interface: Fix build error with GCC 15 (#3174 <https://github.com/ros-controls/ros2_control/issues/3174>) (#3352 <https://github.com/ros-controls/ros2_control/issues/3352>)
* [hardware_interface_testing] Add tests for hardware components exception handling (backport #3228 <https://github.com/ros-controls/ros2_control/issues/3228>) (#3340 <https://github.com/ros-controls/ros2_control/issues/3340>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix pure virtual error in the hardware component with async mode (#3321 <https://github.com/ros-controls/ros2_control/issues/3321>) (#3377 <https://github.com/ros-controls/ros2_control/issues/3377>)
* [hardware_interface_testing] Add tests for hardware components exception handling (backport #3228 <https://github.com/ros-controls/ros2_control/issues/3228>) (#3340 <https://github.com/ros-controls/ros2_control/issues/3340>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Fix disable velocity and effort limiting feature (#3425 <https://github.com/ros-controls/ros2_control/issues/3425>) (#3436 <https://github.com/ros-controls/ros2_control/issues/3436>)
* fixed docstring of joint_limits (#3414 <https://github.com/ros-controls/ros2_control/issues/3414>) (#3433 <https://github.com/ros-controls/ros2_control/issues/3433>)
* Improve docstring of joint_limits for consistency (#3391 <https://github.com/ros-controls/ros2_control/issues/3391>) (#3423 <https://github.com/ros-controls/ros2_control/issues/3423>)
* Fix bad optional access in the joint limiters (#3319 <https://github.com/ros-controls/ros2_control/issues/3319>) (#3332 <https://github.com/ros-controls/ros2_control/issues/3332>)
* Handle NaNs properly in the joint limiters (#3320 <https://github.com/ros-controls/ros2_control/issues/3320>) (#3324 <https://github.com/ros-controls/ros2_control/issues/3324>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add read_only attribute to JointInfo and ActuatorInfo (#3426 <https://github.com/ros-controls/ros2_control/issues/3426>) (#3429 <https://github.com/ros-controls/ros2_control/issues/3429>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
