### PR TITLE
ros2_controllers: 2.53.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10134,7 +10134,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.53.1-1
+      version: 2.53.2-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `2.53.2-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.53.1-1`

## ackermann_steering_controller

- No changes

## admittance_controller

- No changes

## bicycle_steering_controller

- No changes

## diff_drive_controller

- No changes

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

- No changes

## forward_command_controller

- No changes

## gpio_controllers

- No changes

## gripper_controllers

- No changes

## imu_sensor_broadcaster

- No changes

## joint_state_broadcaster

- No changes

## joint_trajectory_controller

```
* fix JTC userdoc YAML indentation and stray quote (backport #2327 <https://github.com/ros-controls/ros2_controllers/issues/2327>) (#2328 <https://github.com/ros-controls/ros2_controllers/issues/2328>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

- No changes

## pid_controller

```
* Add lyrical workflows, update README, and fix gcc-15 issues (backport #2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>) (#2351 <https://github.com/ros-controls/ros2_controllers/issues/2351>)
* Contributors: mergify[bot]
```

## pose_broadcaster

- No changes

## position_controllers

- No changes

## range_sensor_broadcaster

- No changes

## ros2_controllers

- No changes

## ros2_controllers_test_nodes

```
* Add lyrical workflows, update README, and fix gcc-15 issues (backport #2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>) (#2351 <https://github.com/ros-controls/ros2_controllers/issues/2351>)
* Contributors: mergify[bot]
```

## rqt_joint_trajectory_controller

```
* rqt-jtc: Fix more shutdown races (backport #2431 <https://github.com/ros-controls/ros2_controllers/issues/2431>) (#2437 <https://github.com/ros-controls/ros2_controllers/issues/2437>)
* rqt-jtc: Add launch test (backport #2405 <https://github.com/ros-controls/ros2_controllers/issues/2405>) (#2416 <https://github.com/ros-controls/ros2_controllers/issues/2416>)
* Add lyrical workflows, update README, and fix gcc-15 issues (backport #2344 <https://github.com/ros-controls/ros2_controllers/issues/2344>) (#2351 <https://github.com/ros-controls/ros2_controllers/issues/2351>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Simplify reduce_wheel_speed_until_steering_reached logic (backport #2396 <https://github.com/ros-controls/ros2_controllers/issues/2396>) (#2426 <https://github.com/ros-controls/ros2_controllers/issues/2426>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

- No changes

## velocity_controllers

- No changes
