### PR TITLE
ros2_control: 5.15.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7897,7 +7897,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.14.2-1
+      version: 5.15.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.15.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.14.2-1`

## controller_interface

```
* Improve docstring of the semantic_components for consistency (#3338 <https://github.com/ros-controls/ros2_control/issues/3338>) (#3422 <https://github.com/ros-controls/ros2_control/issues/3422>)
* Improve docstring of the controller_interface for consistency (#3318 <https://github.com/ros-controls/ros2_control/issues/3318>) (#3337 <https://github.com/ros-controls/ros2_control/issues/3337>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Unload controller upon sigterm (#3406 <https://github.com/ros-controls/ros2_control/issues/3406>) (#3428 <https://github.com/ros-controls/ros2_control/issues/3428>)
* document Ubuntu realtime kernel on Raspberry Pi (#3397 <https://github.com/ros-controls/ros2_control/issues/3397>) (#3400 <https://github.com/ros-controls/ros2_control/issues/3400>)
* Controller Manager recovery from invalid URDF errors (backport #2775 <https://github.com/ros-controls/ros2_control/issues/2775>) (#3395 <https://github.com/ros-controls/ros2_control/issues/3395>)
* Wait to terminate test until spawner exits (#3373 <https://github.com/ros-controls/ros2_control/issues/3373>) (#3385 <https://github.com/ros-controls/ros2_control/issues/3385>)
* fix typo in state and reference export methods (#3347 <https://github.com/ros-controls/ros2_control/issues/3347>) (#3358 <https://github.com/ros-controls/ros2_control/issues/3358>)
* Enforce cleanup_controller on more exit points of configure_controller (#3192 <https://github.com/ros-controls/ros2_control/issues/3192>) (#3349 <https://github.com/ros-controls/ros2_control/issues/3349>)
* Fix duplicate fallback controllers from the controller chain (#3108 <https://github.com/ros-controls/ros2_control/issues/3108>) (#3327 <https://github.com/ros-controls/ros2_control/issues/3327>)
* Added default value to the fallback param declarations (#3270 <https://github.com/ros-controls/ros2_control/issues/3270>) (#3313 <https://github.com/ros-controls/ros2_control/issues/3313>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Add read_only attribute to JointInfo and ActuatorInfo (#3426 <https://github.com/ros-controls/ros2_control/issues/3426>) (#3430 <https://github.com/ros-controls/ros2_control/issues/3430>)
* hardware_interface: add missing <unordered_set> include in resource_manager (#3431 <https://github.com/ros-controls/ros2_control/issues/3431>) (#3435 <https://github.com/ros-controls/ros2_control/issues/3435>)
* Controller Manager recovery from invalid URDF errors (backport #2775 <https://github.com/ros-controls/ros2_control/issues/2775>) (#3395 <https://github.com/ros-controls/ros2_control/issues/3395>)
* fix typo in 'synchronized' documentation (#3388 <https://github.com/ros-controls/ros2_control/issues/3388>) (#3390 <https://github.com/ros-controls/ros2_control/issues/3390>)
* Fix pure virtual error in the hardware component with async mode (#3321 <https://github.com/ros-controls/ros2_control/issues/3321>) (#3378 <https://github.com/ros-controls/ros2_control/issues/3378>)
* [hardware_interface_testing] Add tests for hardware components exception handling (backport #3228 <https://github.com/ros-controls/ros2_control/issues/3228>) (#3341 <https://github.com/ros-controls/ros2_control/issues/3341>)
* Fixing Hardware components logging spam in tests (#2692 <https://github.com/ros-controls/ros2_control/issues/2692>) (#3335 <https://github.com/ros-controls/ros2_control/issues/3335>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Fix pure virtual error in the hardware component with async mode (#3321 <https://github.com/ros-controls/ros2_control/issues/3321>) (#3378 <https://github.com/ros-controls/ros2_control/issues/3378>)
* [hardware_interface_testing] Add tests for hardware components exception handling (backport #3228 <https://github.com/ros-controls/ros2_control/issues/3228>) (#3341 <https://github.com/ros-controls/ros2_control/issues/3341>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Fix disable velocity and effort limiting feature (#3425 <https://github.com/ros-controls/ros2_control/issues/3425>) (#3437 <https://github.com/ros-controls/ros2_control/issues/3437>)
* fixed docstring of joint_limits (#3414 <https://github.com/ros-controls/ros2_control/issues/3414>) (#3434 <https://github.com/ros-controls/ros2_control/issues/3434>)
* Improve docstring of joint_limits for consistency (#3391 <https://github.com/ros-controls/ros2_control/issues/3391>) (#3424 <https://github.com/ros-controls/ros2_control/issues/3424>)
* Fix bad optional access in the joint limiters (#3319 <https://github.com/ros-controls/ros2_control/issues/3319>) (#3333 <https://github.com/ros-controls/ros2_control/issues/3333>)
* Handle NaNs properly in the joint limiters (#3320 <https://github.com/ros-controls/ros2_control/issues/3320>) (#3325 <https://github.com/ros-controls/ros2_control/issues/3325>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

```
* Add read_only attribute to JointInfo and ActuatorInfo (#3426 <https://github.com/ros-controls/ros2_control/issues/3426>) (#3430 <https://github.com/ros-controls/ros2_control/issues/3430>)
* Controller Manager recovery from invalid URDF errors (backport #2775 <https://github.com/ros-controls/ros2_control/issues/2775>) (#3395 <https://github.com/ros-controls/ros2_control/issues/3395>)
* Contributors: mergify[bot]
```

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
