### PR TITLE
compass: 3.0.4-2 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1366,7 +1366,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1366,7 +1366,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.4-1
+      version: 3.0.4-2
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `3.0.4-2`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.3-1`

## compass_conversions

- No changes

## compass_interfaces

- No changes

## magnetic_model

```
* Fixed compatibility with Rolling.
* Contributors: Martin Pecka
```

## magnetometer_compass

- No changes

## magnetometer_pipeline

- No changes
