### PR TITLE
ros2_controllers: 5.16.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7938,6 +7938,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - magnetometer_broadcaster
       - mecanum_drive_controller
       - motion_primitives_controllers
       - omni_wheel_drive_controller
@@ -7957,7 +7958,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 5.15.1-1
+      version: 5.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `5.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.15.1-1`

## ackermann_steering_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2403 <https://github.com/ros-controls/ros2_controllers/issues/2403>)
* Contributors: mergify[bot]
```

## admittance_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (backport #2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>) (#2355 <https://github.com/ros-controls/ros2_controllers/issues/2355>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2415 <https://github.com/ros-controls/ros2_controllers/issues/2415>)
* Contributors: mergify[bot]
```

## chained_filter_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2394 <https://github.com/ros-controls/ros2_controllers/issues/2394>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2394 <https://github.com/ros-controls/ros2_controllers/issues/2394>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2408 <https://github.com/ros-controls/ros2_controllers/issues/2408>)
* Contributors: mergify[bot]
```

## gpio_controllers

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Contributors: mergify[bot]
```

## gps_sensor_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Contributors: mergify[bot]
```

## imu_sensor_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2408 <https://github.com/ros-controls/ros2_controllers/issues/2408>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2415 <https://github.com/ros-controls/ros2_controllers/issues/2415>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Deliver abort action result before destroying goal handle on preemption (backport #2422 <https://github.com/ros-controls/ros2_controllers/issues/2422>) (#2424 <https://github.com/ros-controls/ros2_controllers/issues/2424>)
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2415 <https://github.com/ros-controls/ros2_controllers/issues/2415>)
* [JTC] Fix segfault when last trajectory segment is skipped (backport #2359 <https://github.com/ros-controls/ros2_controllers/issues/2359>) (#2365 <https://github.com/ros-controls/ros2_controllers/issues/2365>)
* More general initialization of state from command (backport #2294 <https://github.com/ros-controls/ros2_controllers/issues/2294>) (#2357 <https://github.com/ros-controls/ros2_controllers/issues/2357>)
* Contributors: mergify[bot]
```

## magnetometer_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* broadcaster for magnetic field values from a magnetometer (backport #2214 <https://github.com/ros-controls/ros2_controllers/issues/2214>) (#2372 <https://github.com/ros-controls/ros2_controllers/issues/2372>)
  Co-authored-by: Christian Rauch <mailto:Rauch.Christian@gmx.de>
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2408 <https://github.com/ros-controls/ros2_controllers/issues/2408>)
* Added velocity limiting to the mecanum controller. (backport #2313 <https://github.com/ros-controls/ros2_controllers/issues/2313>) (#2363 <https://github.com/ros-controls/ros2_controllers/issues/2363>)
* Contributors: mergify[bot]
```

## motion_primitives_controllers

```
* fix: update dead documentation links (backport #2398 <https://github.com/ros-controls/ros2_controllers/issues/2398>) (#2412 <https://github.com/ros-controls/ros2_controllers/issues/2412>)
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2403 <https://github.com/ros-controls/ros2_controllers/issues/2403>)
* Fix motion_primitive_controller TOC in docs (backport #2221 <https://github.com/ros-controls/ros2_controllers/issues/2221>) (#2367 <https://github.com/ros-controls/ros2_controllers/issues/2367>)
* Contributors: mergify[bot]
```

## omni_wheel_drive_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2415 <https://github.com/ros-controls/ros2_controllers/issues/2415>)
* Contributors: mergify[bot]
```

## parallel_gripper_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2394 <https://github.com/ros-controls/ros2_controllers/issues/2394>)
* Contributors: mergify[bot]
```

## pid_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2403 <https://github.com/ros-controls/ros2_controllers/issues/2403>)
* Contributors: mergify[bot]
```

## pose_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (backport #2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>) (#2355 <https://github.com/ros-controls/ros2_controllers/issues/2355>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2408 <https://github.com/ros-controls/ros2_controllers/issues/2408>)
* Contributors: mergify[bot]
```

## ros2_controllers

```
* broadcaster for magnetic field values from a magnetometer (backport #2214 <https://github.com/ros-controls/ros2_controllers/issues/2214>) (#2372 <https://github.com/ros-controls/ros2_controllers/issues/2372>)
  Co-authored-by: Christian Rauch <mailto:Rauch.Christian@gmx.de>
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
  Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

```
* Fix/spdx license expression (backport #2370 <https://github.com/ros-controls/ros2_controllers/issues/2370>) (#2374 <https://github.com/ros-controls/ros2_controllers/issues/2374>)
* Contributors: mergify[bot]
```

## rqt_joint_trajectory_controller

```
* rqt-jtc: Fix more shutdown races (backport #2431 <https://github.com/ros-controls/ros2_controllers/issues/2431>) (#2439 <https://github.com/ros-controls/ros2_controllers/issues/2439>)
* rqt-jtc: Add launch test (backport #2405 <https://github.com/ros-controls/ros2_controllers/issues/2405>) (#2418 <https://github.com/ros-controls/ros2_controllers/issues/2418>)
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2403 <https://github.com/ros-controls/ros2_controllers/issues/2403>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Simplify reduce_wheel_speed_until_steering_reached logic (backport #2396 <https://github.com/ros-controls/ros2_controllers/issues/2396>) (#2428 <https://github.com/ros-controls/ros2_controllers/issues/2428>)
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2394 <https://github.com/ros-controls/ros2_controllers/issues/2394>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2433 <https://github.com/ros-controls/ros2_controllers/issues/2433>)
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (backport #2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>) (#2355 <https://github.com/ros-controls/ros2_controllers/issues/2355>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
