### PR TITLE
Merge humble/jazzy depthai source versions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2380,7 +2380,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: v3_humble
+      version: develop-old
     release:
       packages:
       - depthai_bridge_v3
@@ -2398,13 +2398,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: v3_humble
+      version: develop-old
     status: developed
   depthai_v3:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-core.git
-      version: v3_humble
+      version: ros-old-devel
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2414,7 +2414,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-core.git
-      version: v3_humble
+      version: ros-old-devel
     status: developed
   depthimage_to_laserscan:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2308,7 +2308,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: v3_jazzy
+      version: develop-old
     release:
       packages:
       - depthai_bridge_v3
@@ -2326,9 +2326,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: v3_jazzy
+      version: develop-old
     status: developed
   depthai_v3:
+    doc:
+      type: git
+      url: https://github.com/luxonis/depthai-core.git
+      version: ros-old-devel
     release:
       tags:
         release: release/jazzy/{package}/{version}
@@ -2338,7 +2342,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-core.git
-      version: v3-jazzy
+      version: ros-old-devel
     status: developed
   depthimage_to_laserscan:
     doc:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1578,7 +1578,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-core.git
-      version: kilted
+      version: ros-devel
     release:
       tags:
         release: release/kilted/{package}/{version}
@@ -1588,13 +1588,13 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-core.git
-      version: kilted
+      version: ros-devel
     status: developed
   depthai-ros:
     doc:
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: kilted
+      version: develop
     release:
       packages:
       - depthai-ros
@@ -1612,7 +1612,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/luxonis/depthai-ros.git
-      version: kilted
+      version: develop
     status: developed
   depthimage_to_laserscan:
     doc:


### PR DESCRIPTION
Merge branches for jazzy and humble for depthai-core and depthai-ros packages. The previous split branches made releases more difficult than necessary. Also renames the kilted branch to be in line with the new merged humble/jazzy branch.