### PR TITLE
ros2_controllers: 4.41.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9594,6 +9594,7 @@ repositories:
       - imu_sensor_broadcaster
       - joint_state_broadcaster
       - joint_trajectory_controller
+      - magnetometer_broadcaster
       - mecanum_drive_controller
       - motion_primitives_controllers
       - omni_wheel_drive_controller
@@ -9613,7 +9614,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.40.1-1
+      version: 4.41.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_controllers` to `4.41.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_controllers.git
- release repository: https://github.com/ros2-gbp/ros2_controllers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.40.1-1`

## ackermann_steering_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2402 <https://github.com/ros-controls/ros2_controllers/issues/2402>)
* Contributors: mergify[bot]
```

## admittance_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (backport #2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>) (#2354 <https://github.com/ros-controls/ros2_controllers/issues/2354>)
* Contributors: mergify[bot]
```

## bicycle_steering_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2414 <https://github.com/ros-controls/ros2_controllers/issues/2414>)
* Contributors: mergify[bot]
```

## chained_filter_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2393 <https://github.com/ros-controls/ros2_controllers/issues/2393>)
* Contributors: mergify[bot]
```

## diff_drive_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Contributors: mergify[bot]
```

## effort_controllers

- No changes

## force_torque_sensor_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2393 <https://github.com/ros-controls/ros2_controllers/issues/2393>)
* Contributors: mergify[bot]
```

## forward_command_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2407 <https://github.com/ros-controls/ros2_controllers/issues/2407>)
* Contributors: mergify[bot]
```

## gpio_controllers

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Contributors: mergify[bot]
```

## gps_sensor_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Contributors: mergify[bot]
```

## gripper_controllers

- No changes

## imu_sensor_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2407 <https://github.com/ros-controls/ros2_controllers/issues/2407>)
* Contributors: mergify[bot]
```

## joint_state_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2414 <https://github.com/ros-controls/ros2_controllers/issues/2414>)
* Contributors: mergify[bot]
```

## joint_trajectory_controller

```
* Deliver abort action result before destroying goal handle on preemption (backport #2422 <https://github.com/ros-controls/ros2_controllers/issues/2422>) (#2423 <https://github.com/ros-controls/ros2_controllers/issues/2423>)
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2414 <https://github.com/ros-controls/ros2_controllers/issues/2414>)
* [JTC] Fix segfault when last trajectory segment is skipped (backport #2359 <https://github.com/ros-controls/ros2_controllers/issues/2359>) (#2364 <https://github.com/ros-controls/ros2_controllers/issues/2364>)
* More general initialization of state from command (backport #2294 <https://github.com/ros-controls/ros2_controllers/issues/2294>) (#2356 <https://github.com/ros-controls/ros2_controllers/issues/2356>)
* Contributors: mergify[bot]
```

## magnetometer_broadcaster

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* broadcaster for magnetic field values from a magnetometer (backport #2214 <https://github.com/ros-controls/ros2_controllers/issues/2214>) (#2371 <https://github.com/ros-controls/ros2_controllers/issues/2371>)
* Contributors: mergify[bot]
```

## mecanum_drive_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2407 <https://github.com/ros-controls/ros2_controllers/issues/2407>)
* Added velocity limiting to the mecanum controller. (backport #2313 <https://github.com/ros-controls/ros2_controllers/issues/2313>) (#2362 <https://github.com/ros-controls/ros2_controllers/issues/2362>)
* Contributors: mergify[bot]
```

## motion_primitives_controllers

```
* fix: update dead documentation links (backport #2398 <https://github.com/ros-controls/ros2_controllers/issues/2398>) (#2411 <https://github.com/ros-controls/ros2_controllers/issues/2411>)
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2402 <https://github.com/ros-controls/ros2_controllers/issues/2402>)
* Fix motion_primitive_controller TOC in docs (backport #2221 <https://github.com/ros-controls/ros2_controllers/issues/2221>) (#2366 <https://github.com/ros-controls/ros2_controllers/issues/2366>)
* Contributors: mergify[bot]
```

## omni_wheel_drive_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: joint_state_broadcaster, joint_trajectory, omni_wheel_drive, bicycle_steering (backport #2410 <https://github.com/ros-controls/ros2_controllers/issues/2410>) (#2414 <https://github.com/ros-controls/ros2_controllers/issues/2414>)
* Contributors: mergify[bot]
```

## parallel_gripper_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2393 <https://github.com/ros-controls/ros2_controllers/issues/2393>)
* Contributors: mergify[bot]
```

## pid_controller

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2402 <https://github.com/ros-controls/ros2_controllers/issues/2402>)
* Contributors: mergify[bot]
```

## pose_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (backport #2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>) (#2354 <https://github.com/ros-controls/ros2_controllers/issues/2354>)
* Contributors: mergify[bot]
```

## position_controllers

- No changes

## range_sensor_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: forward_command, mecanum_drive, range_sensor, imu_sensor (backport #2406 <https://github.com/ros-controls/ros2_controllers/issues/2406>) (#2407 <https://github.com/ros-controls/ros2_controllers/issues/2407>)
* Contributors: mergify[bot]
```

## ros2_controllers

```
* broadcaster for magnetic field values from a magnetometer (backport #2214 <https://github.com/ros-controls/ros2_controllers/issues/2214>) (#2371 <https://github.com/ros-controls/ros2_controllers/issues/2371>)
* Contributors: mergify[bot]
```

## ros2_controllers_test_nodes

```
* Fix/spdx license expression (backport #2370 <https://github.com/ros-controls/ros2_controllers/issues/2370>) (#2373 <https://github.com/ros-controls/ros2_controllers/issues/2373>)
* Contributors: mergify[bot]
```

## rqt_joint_trajectory_controller

```
* rqt-jtc: Fix more shutdown races (backport #2431 <https://github.com/ros-controls/ros2_controllers/issues/2431>) (#2438 <https://github.com/ros-controls/ros2_controllers/issues/2438>)
* rqt-jtc: Add launch test (backport #2405 <https://github.com/ros-controls/ros2_controllers/issues/2405>) (#2417 <https://github.com/ros-controls/ros2_controllers/issues/2417>)
  Co-authored-by: Christoph Fröhlich <mailto:christophfroehlich@users.noreply.github.com>
* Contributors: mergify[bot]
```

## state_interfaces_broadcaster

```
* Test fix - call appropriate lifecycle transitions in controller tests: pid, motion_primitives, state_interfaces_broadcaster, ackermann_steering (backport #2399 <https://github.com/ros-controls/ros2_controllers/issues/2399>) (#2402 <https://github.com/ros-controls/ros2_controllers/issues/2402>)
* Contributors: mergify[bot]
```

## steering_controllers_library

```
* Simplify reduce_wheel_speed_until_steering_reached logic (backport #2396 <https://github.com/ros-controls/ros2_controllers/issues/2396>) (#2427 <https://github.com/ros-controls/ros2_controllers/issues/2427>)
* Test fix - call appropriate lifecycle transitions in controller tests: force_torque_sensor_broadcaster, chained_filter_controller, parallel_gripper_controller, steering_controllers_library (backport #2382 <https://github.com/ros-controls/ros2_controllers/issues/2382>) (#2393 <https://github.com/ros-controls/ros2_controllers/issues/2393>)
* Contributors: mergify[bot]
```

## tricycle_controller

- No changes

## tricycle_steering_controller

```
* Final test cleanup - call appropriate lifecycle transitions (backport #2429 <https://github.com/ros-controls/ros2_controllers/issues/2429>) (#2432 <https://github.com/ros-controls/ros2_controllers/issues/2432>)
* Test fix - call appropriate lifecycle transitions in controller tests: admittance_controller, pose_broadcaster, tricycle_steering_controller (backport #2345 <https://github.com/ros-controls/ros2_controllers/issues/2345>) (#2354 <https://github.com/ros-controls/ros2_controllers/issues/2354>)
* Contributors: mergify[bot]
```

## velocity_controllers

- No changes
