### PR TITLE
swri_console: 2.1.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9948,7 +9948,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/swri_console-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       type: git
       url: https://github.com/swri-robotics/swri_console.git


### PR DESCRIPTION
Increasing version of package(s) in repository `swri_console` to `2.1.4-1`:

- upstream repository: https://github.com/swri-robotics/swri_console.git
- release repository: https://github.com/ros2-gbp/swri_console-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.3-1`

## swri_console

```
* Backport of https://github.com/swri-robotics/swri_console/pull/78 (#79 <https://github.com/swri-robotics/swri_console/issues/79>)
* Contributors: David Anthony, Ferry Schoenmakers
```
