### PR TITLE
Add libqt6-gui dependencies

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6619,6 +6619,23 @@ libqt6-core:
     '*': [libqt6core6t64]
     'focal': null
     'jammy': [libqt6core6]
+libqt6-gui:
+  alpine: [qt6-qtbase]
+  arch: [qt6-base]
+  debian:
+    '*': [libqt6gui6t64]
+    bookworm: [libqt6gui6]
+  fedora: [qt6-qtbase-gui]
+  gentoo: ['dev-qt/qtgui:6']
+  nixos: [qt6.qtbase]
+  openembedded: [qtbase@meta-qt6]
+  rhel:
+    '*': [qt6-qtbase-gui]
+    '8': null
+  slackware: [qt6]
+  ubuntu:
+    '*': [libqt6gui6]
+    'focal': null
 libqt6-multimedia:
   arch: [qt6-multimedia]
   debian: [libqt6multimedia6]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6633,8 +6633,8 @@ libqt6-gui:
   slackware: [qt6]
   ubuntu:
     '*': [libqt6gui6]
-    'noble': [libqt6gui6t64]
     'focal': null
+    'noble': [libqt6gui6t64]
 libqt6-multimedia:
   arch: [qt6-multimedia]
   debian: [libqt6multimedia6]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6622,9 +6622,7 @@ libqt6-core:
 libqt6-gui:
   alpine: [qt6-qtbase]
   arch: [qt6-base]
-  debian:
-    '*': [libqt6gui6t64]
-    bookworm: [libqt6gui6]
+  debian: [libqt6gui6]
   fedora: [qt6-qtbase-gui]
   gentoo: ['dev-qt/qtgui:6']
   nixos: [qt6.qtbase]
@@ -6635,6 +6633,7 @@ libqt6-gui:
   slackware: [qt6]
   ubuntu:
     '*': [libqt6gui6]
+    'noble': [libqt6gui6t64]
     'focal': null
 libqt6-multimedia:
   arch: [qt6-multimedia]


### PR DESCRIPTION
Adding `libqt6-gui` equivalent dependencies of the existing `libqt5-gui` key.
