### PR TITLE
control_msgs: 6.10.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1406,7 +1406,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/control_msgs-release.git
-      version: 6.9.0-3
+      version: 6.10.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `control_msgs` to `6.10.0-1`:

- upstream repository: https://github.com/ros-controls/control_msgs.git
- release repository: https://github.com/ros2-gbp/control_msgs-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.9.0-3`

## control_msgs

```
* Add JointCommand.msg as semantic alternative to Float64MultiArray (#304 <https://github.com/ros-controls/control_msgs/issues/304>)
* Contributors: Shahazad Abdulla
```
