### PR TITLE
Add Resolute support for gurumdds-3.2

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1994,6 +1994,7 @@ gurumdds-3.2:
   ubuntu:
     jammy: [gurumdds-3.2]
     noble: [gurumdds-3.2]
+    resolute: [gurumdds-3.2]
 gv:
   debian: [gv]
   fedora: [gv]


### PR DESCRIPTION
Add Ubuntu Resolute support for the gurumdds-3.2 rosdep key.

The package is available from our public APT repository and is required by rmw_gurumdds for ROS 2 Lyrical.