### PR TITLE
rclcpp: 33.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6950,7 +6950,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 33.0.1-1
+      version: 33.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `33.0.2-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `33.0.1-1`

## rclcpp

```
* Optimize header include (#3179 <https://github.com/ros2/rclcpp/issues/3179>)
* Move implementation from hpp to cpp (#3177 <https://github.com/ros2/rclcpp/issues/3177>)
* test: add regression test for KEEP_ALL QoS with transient-local caching (#3152 <https://github.com/ros2/rclcpp/issues/3152>)
* Fixed flaky test busy waiting test (#3155 <https://github.com/ros2/rclcpp/issues/3155>)
* node_parameters: reject non-finite values in floating-point range check (#3143 <https://github.com/ros2/rclcpp/issues/3143>)
* Contributors: Alejandro Hernández Cordero, Janosch Machowinski, Tony Najjar, bartalor
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Call rclcpp::shutdown() in the component containers (#3158 <https://github.com/ros2/rclcpp/issues/3158>)
* Contributors: Hugal31
```

## rclcpp_lifecycle

```
* Optimize header include (#3179 <https://github.com/ros2/rclcpp/issues/3179>)
* Contributors: Alejandro Hernández Cordero
```
