### PR TITLE
rcpputils: 2.13.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7108,7 +7108,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.13.5-1
+      version: 2.13.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.13.6-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.13.5-1`

## rcpputils

```
* Append copies of BSD and CC0 licenses from the works (#223 <https://github.com/ros2/rcpputils/issues/223>) (#224 <https://github.com/ros2/rcpputils/issues/224>)
* Contributors: mergify[bot]
```
