### PR TITLE
rcpputils: 2.4.7-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9255,7 +9255,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.4.6-1
+      version: 2.4.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcpputils` to `2.4.7-1`:

- upstream repository: https://github.com/ros2/rcpputils.git
- release repository: https://github.com/ros2-gbp/rcpputils-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.6-1`

## rcpputils

```
* Append copies of BSD and CC0 licenses from the works (#223 <https://github.com/ros2/rcpputils/issues/223>) (#226 <https://github.com/ros2/rcpputils/issues/226>)
* Contributors: mergify[bot]
```
