### PR TITLE
rclcpp: 32.0.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7028,7 +7028,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 32.0.0-1
+      version: 32.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclcpp` to `32.0.1-1`:

- upstream repository: https://github.com/ros2/rclcpp.git
- release repository: https://github.com/ros2-gbp/rclcpp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `32.0.0-1`

## rclcpp

```
* node_parameters: reject non-finite values in floating-point range check (#3143 <https://github.com/ros2/rclcpp/issues/3143>) (#3161 <https://github.com/ros2/rclcpp/issues/3161>)
* chore: fix typo in test_time_source.cpp (#3145 <https://github.com/ros2/rclcpp/issues/3145>) (#3147 <https://github.com/ros2/rclcpp/issues/3147>)
* Deprecate memory strategy (#3136 <https://github.com/ros2/rclcpp/issues/3136>) (#3141 <https://github.com/ros2/rclcpp/issues/3141>)
* Contributors: mergify[bot]
```

## rclcpp_action

- No changes

## rclcpp_components

```
* Call rclcpp::shutdown() in the component containers (#3158 <https://github.com/ros2/rclcpp/issues/3158>) (#3162 <https://github.com/ros2/rclcpp/issues/3162>)
* Contributors: mergify[bot]
```

## rclcpp_lifecycle

- No changes
