### PR TITLE
rcutils: 7.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7033,7 +7033,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.2.0-1
+      version: 7.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.2.1-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.2.0-1`

## rcutils

```
* move __STDC_WANT_LIB_EXT1__ macro to CMakeLists.txt. (#555 <https://github.com/ros2/rcutils/issues/555>)
* skip libatomic if mac (#565 <https://github.com/ros2/rcutils/issues/565>)
* address warning: statement with no effect. (#559 <https://github.com/ros2/rcutils/issues/559>)
* Contributors: Griffin Tabor, Tomoya Fujita
```
