### PR TITLE
rcutils: 7.1.2-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7111,7 +7111,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 7.1.1-3
+      version: 7.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `7.1.2-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.1.1-3`

## rcutils

```
* skip libatomic if mac (#565 <https://github.com/ros2/rcutils/issues/565>) (#566 <https://github.com/ros2/rcutils/issues/566>)
* address warning: statement with no effect. (#559 <https://github.com/ros2/rcutils/issues/559>) (#560 <https://github.com/ros2/rcutils/issues/560>)
* Contributors: mergify[bot]
```
