### PR TITLE
rcutils: 6.9.11-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7159,7 +7159,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.9.10-1
+      version: 6.9.11-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rcutils` to `6.9.11-1`:

- upstream repository: https://github.com/ros2/rcutils.git
- release repository: https://github.com/ros2-gbp/rcutils-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.9.10-1`

## rcutils

```
* skip libatomic if mac (backport #565 <https://github.com/ros2/rcutils/issues/565>) (#567 <https://github.com/ros2/rcutils/issues/567>)
* address warning: statement with no effect. (#559 <https://github.com/ros2/rcutils/issues/559>) (#561 <https://github.com/ros2/rcutils/issues/561>)
* Contributors: mergify[bot]
```
