### PR TITLE
rclpy: 9.1.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7092,7 +7092,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 9.1.5-1
+      version: 9.1.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclpy` to `9.1.6-1`:

- upstream repository: https://github.com/ros2/rclpy.git
- release repository: https://github.com/ros2-gbp/rclpy-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `9.1.5-1`

## rclpy

```
* Fix incorrect action client/server callback type hints (backport #1616 <https://github.com/ros2/rclpy/issues/1616>) (#1655 <https://github.com/ros2/rclpy/issues/1655>)
* Correct typos (#1619 <https://github.com/ros2/rclpy/issues/1619>) (#1621 <https://github.com/ros2/rclpy/issues/1621>)
* Contributors: Błażej Sowa, mergify[bot]
```
