### PR TITLE
ur_msgs: 2.6.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10721,7 +10721,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.5.0-1
+      version: 2.6.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `2.6.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.0-1`

## ur_msgs

```
* Add inertia matrix and transition_time support to set_payload service (#43 <https://github.com/ros-industrial/ur_msgs/issues/43>)
* Action definition for executing scripts via primary client (#45 <https://github.com/ros-industrial/ur_msgs/issues/45>)
* Increase minimum CMake version (#41 <https://github.com/ros-industrial/ur_msgs/issues/41>)
* Contributors: Felix Exner, Sergi Romero, URJala
```