### PR TITLE
fastdds: 3.6.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2165,7 +2165,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastdds-release.git
-      version: 3.6.1-2
+      version: 3.6.2-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `fastdds` to `3.6.2-1`:

- upstream repository: https://github.com/eProsima/Fast-DDS.git
- release repository: https://github.com/ros2-gbp/fastdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.6.1-2`
