### PR TITLE
launch_ros: 0.29.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3970,7 +3970,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.29.8-1
+      version: 0.29.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.29.9-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.29.8-1`

## launch_ros

```
* fix: reject deprecated node-name frontend key (#538 <https://github.com/ros2/launch_ros/issues/538>) (#545 <https://github.com/ros2/launch_ros/issues/545>)
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* Fix Pytest 8/9 compatibility in launch_testing_ros hooks (backport #540 <https://github.com/ros2/launch_ros/issues/540>) (#541 <https://github.com/ros2/launch_ros/issues/541>)
* Contributors: mergify[bot]
```

## ros2launch

- No changes
