### PR TITLE
launch_ros: 0.28.6-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3942,7 +3942,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.28.5-1
+      version: 0.28.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch_ros` to `0.28.6-1`:

- upstream repository: https://github.com/ros2/launch_ros.git
- release repository: https://github.com/ros2-gbp/launch_ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.28.5-1`

## launch_ros

```
* fix: reject deprecated node-name frontend key (#538 <https://github.com/ros2/launch_ros/issues/538>) (#546 <https://github.com/ros2/launch_ros/issues/546>)
* Expose lifecycle_node (#327 <https://github.com/ros2/launch_ros/issues/327>) (with test) (#482 <https://github.com/ros2/launch_ros/issues/482>) (#532 <https://github.com/ros2/launch_ros/issues/532>)
* Correct typos (backport #524 <https://github.com/ros2/launch_ros/issues/524>) (#525 <https://github.com/ros2/launch_ros/issues/525>)
* Contributors: mergify[bot]
```

## launch_testing_ros

```
* Correct typos (backport #524 <https://github.com/ros2/launch_ros/issues/524>) (#525 <https://github.com/ros2/launch_ros/issues/525>)
* Contributors: mergify[bot]
```

## ros2launch

```
* Correct typos (backport #524 <https://github.com/ros2/launch_ros/issues/524>) (#525 <https://github.com/ros2/launch_ros/issues/525>)
* Contributors: mergify[bot]
```
