### PR TITLE
mrpt_ros: 2.15.19-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6550,7 +6550,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_ros-release.git
-      version: 2.15.18-1
+      version: 2.15.19-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_ros` to `2.15.19-1`:

- upstream repository: https://github.com/MRPT/mrpt_ros.git
- release repository: https://github.com/ros2-gbp/mrpt_ros-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.15.18-1`

## mrpt_apps

- No changes

## mrpt_libapps

- No changes

## mrpt_libbase

```
* fix(system): correct dangling-pointer bug in COutputLogger::logDeregisterCallback
* fix(system): guard COutputLogger's callback list against concurrent register/log
```

## mrpt_libgui

- No changes

## mrpt_libhwdrivers

- No changes

## mrpt_libmaps

- No changes

## mrpt_libmath

```
* fix(math): harden KDTreeCapable save/load index against stale-flag and partial-failure bugs
* feat(math): KDTreeCapable save/load of the KD-tree index (2D and 3D)
```

## mrpt_libnav

- No changes

## mrpt_libobs

- No changes

## mrpt_libopengl

- No changes

## mrpt_libposes

- No changes

## mrpt_libslam

- No changes

## mrpt_libtclap

- No changes
