### PR TITLE
mrpt3: 3.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6253,7 +6253,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.0.4-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.1.0-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.4-1`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

- No changes

## mrpt_comms

- No changes

## mrpt_config

```
* Merge pull request #1377 <https://github.com/MRPT/mrpt/issues/1377> from MRPT/feat/options-capable-in-config
  feat(mrpt_config): add OptionsCapable mixin, implement in map classes
* fix(mrpt_config): mark trySetCreationOptions() [[nodiscard]]
  Ignoring the return value would silently leave creation options unapplied.
  Address coderabbitai review comment on PR #1377 <https://github.com/MRPT/mrpt/issues/1377>.
* feat(mrpt_config): add OptionsCapable mixin, implement in map classes
  Backports mola::OptionsCapable (MOLAorg/mola) into mrpt_config, next to
  CLoadableOptions: a virtual interface exposing a class' CLoadableOptions
  members generically by name, plus a safe creation-options setter. This lets
  generic tooling (de)serialize a map's insertion/likelihood/render options
  without knowing the concrete class.
  Implement it in every mrpt_maps class that holds CLoadableOptions-derived
  members: COccupancyGridMap2D, COccupancyGridMap3D, CPointsMap,
  CHeightGridMap2D, CHeightGridMap2D_MRF, CWirelessPowerGridMap2D,
  CGasConcentrationGridMap2D, CRandomFieldGridMap3D, CReflectivityGridMap2D,
  CBeaconMap, COctoMapBase and CVoxelMapOccupancyBase.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_containers

- No changes

## mrpt_core

```
* chore: ASSERT_ macros better logging
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

- No changes

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

```
* chore: remove undesired bin file
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

- No changes

## mrpt_maps

```
* Merge pull request #1377 <https://github.com/MRPT/mrpt/issues/1377> from MRPT/feat/options-capable-in-config
  feat(mrpt_config): add OptionsCapable mixin, implement in map classes
* feat(mrpt_config): add OptionsCapable mixin, implement in map classes
  Backports mola::OptionsCapable (MOLAorg/mola) into mrpt_config, next to
  CLoadableOptions: a virtual interface exposing a class' CLoadableOptions
  members generically by name, plus a safe creation-options setter. This lets
  generic tooling (de)serialize a map's insertion/likelihood/render options
  without knowing the concrete class.
  Implement it in every mrpt_maps class that holds CLoadableOptions-derived
  members: COccupancyGridMap2D, COccupancyGridMap3D, CPointsMap,
  CHeightGridMap2D, CHeightGridMap2D_MRF, CWirelessPowerGridMap2D,
  CGasConcentrationGridMap2D, CRandomFieldGridMap3D, CReflectivityGridMap2D,
  CBeaconMap, COctoMapBase and CVoxelMapOccupancyBase.
* Merge pull request #1376 <https://github.com/MRPT/mrpt/issues/1376> from MRPT/port/2x-fixes-jul2026
  Port 2.x fixes: COutputLogger thread-safety, octomap build flag
* Merge pull request #1374 <https://github.com/MRPT/mrpt/issues/1374> from MRPT/feat/kdtree-save-load-index
  feat(math): KDTreeCapable save/load of the KD-tree index (2D and 3D)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_math

```
* Merge pull request #1376 <https://github.com/MRPT/mrpt/issues/1376> from MRPT/port/2x-fixes-jul2026
  Port 2.x fixes: COutputLogger thread-safety, octomap build flag
* Merge pull request #1374 <https://github.com/MRPT/mrpt/issues/1374> from MRPT/feat/kdtree-save-load-index
  feat(math): KDTreeCapable save/load of the KD-tree index (2D and 3D)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav

- No changes

## mrpt_obs

- No changes

## mrpt_opengl

- No changes

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

```
* Merge pull request #1376 <https://github.com/MRPT/mrpt/issues/1376> from MRPT/port/2x-fixes-jul2026
  Port 2.x fixes: COutputLogger thread-safety, octomap build flag
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_tfest

- No changes

## mrpt_topography

- No changes

## mrpt_typemeta

```
* fix: static_string build error for i386
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_viz

```
* chore: clean warnings
* Contributors: Jose Luis Blanco-Claraco
```
