### PR TITLE
ros2_cheese: 0.1.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9544,7 +9544,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/HowardWhile/ros2_cheese.git
-      version: 0.1.1
+      version: jazzy
     release:
       packages:
       - cheese
@@ -9556,7 +9556,7 @@ repositories:
     source:
       type: git
       url: https://github.com/HowardWhile/ros2_cheese.git
-      version: 0.1.1
+      version: jazzy
     status: developed
   ros2_control:
     doc:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9540,6 +9540,24 @@ repositories:
       url: https://github.com/ros-industrial/ros2_canopen.git
       version: master
     status: developed
+  ros2_cheese:
+    doc:
+      type: git
+      url: https://github.com/HowardWhile/ros2_cheese.git
+      version: 0.1.1
+    release:
+      packages:
+      - cheese
+      - cheese_interfaces
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/HowardWhile/ros2_cheese-release.git
+      version: 0.1.1-1
+    source:
+      type: git
+      url: https://github.com/HowardWhile/ros2_cheese.git
+      version: 0.1.1
+    status: developed
   ros2_control:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_cheese` to `0.1.1-1`:

- upstream repository: https://github.com/HowardWhile/ros2_cheese.git
- release repository: https://github.com/HowardWhile/ros2_cheese-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## cheese

```
* Add trigger-based capture for raw and compressed image topics.
* Add stream health, FPS, bandwidth, failure, and storage statistics.
* Add configurable image retention limits.
* Add launch arguments for topic, output directory, node name, namespace, and
  retention limits.
* Contributors: Howard
```

## cheese_interfaces

```
* Add the ``StringTrigger`` service for capturing images with a filename
  suffix.
* Contributors: Howard
```
