### PR TITLE
mrpt_path_planning: 1.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6521,7 +6521,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt_path_planning-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt_path_planning.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt_path_planning` to `1.0.1-1`:

- upstream repository: https://github.com/MRPT/mrpt_path_planning.git
- release repository: https://github.com/ros2-gbp/mrpt_path_planning-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## mrpt_path_planning

```
* feat: bidirectional TP-Space A* solver (TPS_Astar_Bidir) (#32 <https://github.com/MRPT/mrpt_path_planning/issues/32>)
* feat(cli): add --no-gui and SVG motion-tree decimation (#31 <https://github.com/MRPT/mrpt_path_planning/issues/31>)
* fix(TPS_Astar): defer analytic goal expansion to avoid suboptimal goal loops (#30 <https://github.com/MRPT/mrpt_path_planning/issues/30>)
* Contributors: Jose Luis Blanco-Claraco
```
