### PR TITLE
mola_imu_preintegration: 1.17.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6103,7 +6103,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.16.1-1
+      version: 1.17.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.17.0-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.16.1-1`

## mola_imu_preintegration

```
* Merge pull request #9 <https://github.com/MOLAorg/mola_imu_preintegration/issues/9> from MOLAorg/fix/trajectory-empty-on-insufficient-data
* Merge pull request #8 <https://github.com/MOLAorg/mola_imu_preintegration/issues/8> from MOLAorg/fix/imu-initial-calibrator-rotated-mount-orientation
* fix: apply IMU extrinsics to orientation in ImuInitialCalibrator
* Merge pull request #7 <https://github.com/MOLAorg/mola_imu_preintegration/issues/7> from MOLAorg/improve/imu-review-fixes
* ci: update and fix CI jobs
* fix: prune relative to true latest timestamp, not just-inserted time
* fix: clear() preserves parameters; documents what is reset
* docs: add agents.md with key insights for the package
* test: add unit tests for ImuTransformer
* feat: lossless timestamp encoding in LocalVelocityBuffer YAML
* refactor: remove unused tolerance_search_stamp parameter
* docs: fix incorrect doxygen comments
* fix: guard against empty IMU samples in trajectory_from_buffer
* docs: add ROS 2 Lyrical badge row, update Rolling to Ubuntu 26.04 (resolute)
* ci: fix Jazzy Jalisco EOL date in CI workflow comment (May 2024 - May 2029)
* Contributors: Jose Luis Blanco-Claraco
```
