### PR TITLE
mp2p_icp: 2.11.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4993,7 +4993,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mp2p_icp-release.git
-      version: 2.10.3-1
+      version: 2.11.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mp2p_icp.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mp2p_icp` to `2.11.0-1`:

- upstream repository: https://github.com/MOLAorg/mp2p_icp.git
- release repository: https://github.com/ros2-gbp/mp2p_icp-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.10.3-1`

## mp2p_icp

```
* Merge pull request #72 <https://github.com/MOLAorg/mp2p_icp/issues/72> from MOLAorg/fix/filterdeskew-graceful-imu-anchor
  fix(FilterDeskew): never let IMU trajectory errors crash the pipeline
* Merge pull request #71 <https://github.com/MOLAorg/mp2p_icp/issues/71> from MOLAorg/feat/prior-referenced-robust-kernel
  Prior-referenced robust kernel for the Gauss-Newton solver
* Merge pull request #70 <https://github.com/MOLAorg/mp2p_icp/issues/70> from MOLAorg/fix/filtermerge-view-vector-rotation
  Fix view-direction vector frame mismatch in FilterMerge
* chore: demo sm2mm files updated for LIO localization maps
* demos: add sm2mm_pointcloud_voxelize_merged_keyframe_map.yaml
* Merge pull request #69 <https://github.com/MOLAorg/mp2p_icp/issues/69> from MOLAorg/feat/filter-decimate-range-adaptive
  feat: FilterDecimateRangeAdaptive (EllipseLIO range-adaptive scan filter)
* feat: add FilterBase::enabled for env-based pipeline toggling
  Adds an enabled boolean field to FilterBase (default: true)
* feat: add FilterDecimateRangeAdaptive (EllipseLIO range-adaptive scan filter)
* Fix build status badge for ROS 2 Lyrical arm64
* docs: add ROS 2 Lyrical badge row, update Rolling to Ubuntu 26.04 (resolute)
* Merge pull request #68 <https://github.com/MOLAorg/mp2p_icp/issues/68> from MOLAorg/feature/filter-polygon-2d
* Contributors: Jose Luis Blanco-Claraco
```
