### PR TITLE
Add libsimpleini-dev entry for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7077,6 +7077,7 @@ libsimage-dev:
 libsimpleini-dev:
   debian: [libsimpleini-dev]
   fedora: [simpleini-devel]
+  nixos: [simpleini]
   ubuntu: [libsimpleini-dev]
 libsndfile1-dev:
   arch: [libsndfile]


### PR DESCRIPTION
See https://search.nixos.org/packages?channel=unstable&query=simpleini.