### PR TITLE
Update alsa-utils entry for NixOS

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -62,7 +62,7 @@ alsa-utils:
   debian: [alsa-utils]
   fedora: [alsa-utils]
   gentoo: [media-sound/alsa-utils]
-  nixos: [alsaUtils]
+  nixos: [alsa-utils]
   openembedded: [alsa-utils@openembedded-core]
   opensuse: [alsa-utils]
   rhel: [alsa-utils]


### PR DESCRIPTION
`alsaUtils` was renamed to `alsa-utils` in https://github.com/NixOS/nixpkgs/pull/126440. The `alsaUtils` alias was removed in https://github.com/NixOS/nixpkgs/pull/456065.