### PR TITLE
scan_detection_fusion: 0.1.0-2 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11295,6 +11295,22 @@ repositories:
       url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git
       version: main
     status: developed
+  scan_detection_fusion:
+    doc:
+      type: git
+      url: https://github.com/HexboxRC/scan_detection_fusion.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/HexboxRC/scan_detection_fusion-release.git
+      version: 0.1.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/HexboxRC/scan_detection_fusion.git
+      version: main
+    status: developed
   scenario_execution:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_detection_fusion` to `0.1.0-2`:

- upstream repository: https://github.com/HexboxRC/scan_detection_fusion.git
- release repository: https://github.com/HexboxRC/scan_detection_fusion-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
