### PR TITLE
Remove ply_utils entry from jazzy/distribution.yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7742,21 +7742,6 @@ repositories:
       url: https://github.com/ros/pluginlib.git
       version: jazzy
     status: maintained
-  ply_utils:
-    doc:
-      type: git
-      url: https://github.com/li9i/ply-utils.git
-      version: jazzy-devel
-    release:
-      tags:
-        release: release/jazzy/{package}/{version}
-      url: https://github.com/li9i/ply-utils-release.git
-      version: 0.0.2-1
-    source:
-      type: git
-      url: https://github.com/li9i/ply-utils.git
-      version: jazzy-devel
-    status: maintained
   point_cloud_msg_wrapper:
     doc:
       type: git


### PR DESCRIPTION
Removes the `ply_utils` entry from `jazzy/distribution.yaml`. This package is superseded by `pointcloud_conversions` (added in #52339) and is no longer maintained under this name.

See also https://github.com/ros/rosdistro/pull/51904#issuecomment-4817024736 and https://github.com/ros/rosdistro/pull/52338#issuecomment-4871008771