### PR TITLE
mrpt3: 3.1.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5013,7 +5013,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.1.1-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.0-1`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

- No changes

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

- No changes

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

- No changes

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

- No changes

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

- No changes

## mrpt_maps

```
* test(mrpt_maps): skip kdtree save/load-index tests on old nanoflann
  These tests require nanoflann >= v1.5.0's index save/load API; on
  older versions they threw and failed the suite instead of skipping.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_math

```
* math: add nanoflann as rosdep dependency (more up-to-date than system libnanoflann-dev)
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav

- No changes

## mrpt_obs

- No changes

## mrpt_opengl

- No changes

## mrpt_poses

```
* add more mrpt_poses unit tests
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

- No changes

## mrpt_tfest

- No changes

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

- No changes
