### PR TITLE
index lgdx_rplidar_c1 in jazzy, lyrical

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5150,6 +5150,12 @@ repositories:
       url: https://github.com/LeoRover/leo_simulator-ros2.git
       version: jazzy
     status: maintained
+  lgdxrobot2_rplidar_c1:
+    source:
+      type: git
+      url: https://gitlab.com/lgdxrobotics/lgdxrobot2-rplidar-c1.git
+      version: jazzy
+    status: maintained
   lgsvl_msgs:
     release:
       tags:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4072,6 +4072,12 @@ repositories:
       url: https://github.com/LeoRover/leo_simulator-ros2.git
       version: ros2
     status: maintained
+  lgdxrobot2_rplidar_c1:
+    source:
+      type: git
+      url: https://gitlab.com/lgdxrobotics/lgdxrobot2-rplidar-c1.git
+      version: lyrical
+    status: maintained
   lgsvl_msgs:
     release:
       tags:


### PR DESCRIPTION


# Please Add This Package to be indexed in the rosdistro.

jazzy, lyrical

# The source is here:

https://gitlab.com/lgdxrobotics/lgdxrobot2-rplidar-c1

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro

I am upgrading my project to Lyrical, but I found that the RPLIDAR package was unable to compile due to its CMake settings. After updating the CMake file, I saw a lot of warnings, so I decided to rewrite the ROS wrapper using C++20. This might also be useful for other people adopting Lyrical.

