### PR TITLE
behaviortree_cpp_v4: 4.9.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1195,7 +1195,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.9.0-1
+      version: 4.9.1-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git


### PR DESCRIPTION
Increasing version of package(s) in repository `behaviortree_cpp_v4` to `4.9.1-1`:

- upstream repository: https://github.com/BehaviorTree/BehaviorTree.CPP.git
- release repository: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.9.0-1`

## behaviortree_cpp

```
* Merge pull request #1139 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1139> from mini-1235/patch-3
  Fix -Wfree-nonheap-object and -Wunused-result
* Fix -Wfree-nonheap-object and -Wnull-dereference
* Merge pull request #1128 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1128> from XinyuKhan/patch-1
  Rename header guard for shared_library.h
* Rename header guard for shared_library.h
* Merge pull request #1126 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1126> from BehaviorTree/dependabot/github_actions/prefix-dev/setup-pixi-0.9.5
  Bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5
* Merge pull request #1127 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1127> from botsandus/add-sleep-override
  Add Tree::wakeUpSignal() getter
* Merge pull request #1121 <https://github.com/BehaviorTree/BehaviorTree.CPP/issues/1121> from PickNikRobotics/fix-subtree-literal-numeric-types
  Preserve numeric types for literal subtree port values
* version 2
* lint
* Add support for custom sleep override function in Tree class
* Bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5
  Bumps [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) from 0.9.4 to 0.9.5.
  - [Release notes](https://github.com/prefix-dev/setup-pixi/releases)
  - [Commits](https://github.com/prefix-dev/setup-pixi/compare/v0.9.4...v0.9.5)
  ---
  updated-dependencies:
  - dependency-name: prefix-dev/setup-pixi
  dependency-version: 0.9.5
  dependency-type: direct:production
  update-type: version-update:semver-patch
  ...
* Preserve numeric types for literal subtree port values
  When literal values are passed to SubTree ports (not blackboard remapping),
  detect numeric types (int64_t, double) before storing them in the child
  blackboard. Previously all literals were stored as std::string, which caused
  type-mismatch errors in Script expressions that tried to do arithmetic.
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
* Contributors: Davide Faconti, Ladislav Skvarka, Tony Najjar, Xinyu Han, dependabot[bot], mini-1235
```
