### PR TITLE
mqtt_client: 2.4.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4961,7 +4961,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
-      version: 2.4.1-3
+      version: 2.4.2-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.4.2-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ros2-gbp/mqtt_client-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `2.4.1-3`

## mqtt_client

```
* Merge pull request #96 <https://github.com/ika-rwth-aachen/mqtt_client/issues/96> from Eternal-Robotics/eternal/v2.4.1
* Merge pull request #93 <https://github.com/ika-rwth-aachen/mqtt_client/issues/93> from nim65s/main
* Merge pull request #94 <https://github.com/ika-rwth-aachen/mqtt_client/issues/94> from nim65s/ament_target_dependencies
* Merge pull request #91 <https://github.com/ika-rwth-aachen/mqtt_client/issues/91> from martfra/main
* Merge pull request #89 <https://github.com/ika-rwth-aachen/mqtt_client/issues/89> from zouri/main
```

## mqtt_client_interfaces

- No changes
