### PR TITLE
demos: 0.37.9-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1664,7 +1664,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.37.8-3
+      version: 0.37.9-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `demos` to `0.37.9-1`:

- upstream repository: https://github.com/ros2/demos.git
- release repository: https://github.com/ros2-gbp/demos-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.37.8-3`

## action_tutorials_cpp

- No changes

## action_tutorials_py

- No changes

## composition

- No changes

## demo_nodes_cpp

```
* Removed AllocatorMemoryStrategy (#784 <https://github.com/ros2/demos/issues/784>) (#790 <https://github.com/ros2/demos/issues/790>)
* Contributors: mergify[bot]
```

## demo_nodes_cpp_native

- No changes

## demo_nodes_py

- No changes

## dummy_map_server

- No changes

## dummy_robot_bringup

- No changes

## dummy_sensors

- No changes

## image_tools

```
* Update showimage.cpp removing extra std::cerr outputs (#785 <https://github.com/ros2/demos/issues/785>) (#789 <https://github.com/ros2/demos/issues/789>)
* Contributors: mergify[bot]
```

## intra_process_demo

- No changes

## lifecycle

- No changes

## lifecycle_py

- No changes

## logging_demo

- No changes

## pendulum_control

```
* fix: Removed AllocatorMemoryStrategy (#784 <https://github.com/ros2/demos/issues/784>) (#790 <https://github.com/ros2/demos/issues/790>)
* Contributors: mergify[bot]
```

## pendulum_msgs

- No changes

## quality_of_service_demo_cpp

- No changes

## quality_of_service_demo_py

- No changes

## topic_monitor

```
* Fixed topic monitor demos (#791 <https://github.com/ros2/demos/issues/791>) (#792 <https://github.com/ros2/demos/issues/792>)
* Contributors: mergify[bot]
```

## topic_statistics_demo

- No changes
