### PR TITLE
fusioncore: 0.3.2-1 in 'jazzy/distribution.yaml'

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3473,7 +3473,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fusioncore` to `0.3.2-1`:

- compass_msgs
- fusioncore_core
- fusioncore_datasets
- fusioncore_gazebo
- fusioncore_ros
- fusioncore_ublox