### PR TITLE
rviz_satellite: 4.3.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9421,8 +9421,8 @@ repositories:
     release:
       tags:
         release: release/kilted/{package}/{version}
-      url: https://github.com/nobleo/rviz_satellite-release.git
-      version: 4.3.0-1
+      url: https://github.com/ros2-gbp/rviz_satellite-release.git
+      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.3.1-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/ros2-gbp/rviz_satellite-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.3.0-1`

## rviz_satellite

```
* rviz switched to Qt6
  https://github.com/ros2/rviz/pull/1635
* CI and formatting using pre-commit
* Update demo.rviz Object URI
* Contributors: Tim Clephas, psmh13
```
