### PR TITLE
rviz_satellite: 4.3.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9356,6 +9356,11 @@ repositories:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git
       version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rviz_satellite-release.git
+      version: 4.3.1-1
     source:
       type: git
       url: https://github.com/nobleo/rviz_satellite.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz_satellite` to `4.3.1-1`:

- upstream repository: https://github.com/nobleo/rviz_satellite.git
- release repository: https://github.com/ros2-gbp/rviz_satellite-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## rviz_satellite

```
* rviz switched to Qt6
  https://github.com/ros2/rviz/pull/1635
* CI and formatting using pre-commit
* Update demo.rviz Object URI
* Contributors: Tim Clephas, psmh13
```
