### PR TITLE
sync_tooling_msgs: 0.2.11-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9979,7 +9979,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
-      version: 0.2.10-1
+      version: 0.2.11-1
     source:
       type: git
       url: https://github.com/tier4/sync_tooling_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sync_tooling_msgs` to `0.2.11-1`:

- upstream repository: https://github.com/tier4/sync_tooling_msgs.git
- release repository: https://github.com/ros2-gbp/sync_tooling_msgs-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.10-1`

## sync_tooling_msgs

```
* build: pin grpcio-tools to match uv.lock and avoid gencode 7.x (#6 <https://github.com/tier4/sync_tooling_msgs/issues/6>)
* Contributors: Kento Yabuuchi
```
