### PR TITLE
rmw_desert: 1.0.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9788,7 +9788,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_desert-release.git
-      version: 1.0.5-1
+      version: 1.0.6-1
     source:
       type: git
       url: https://github.com/signetlabdei/rmw_desert.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_desert` to `1.0.6-1`:

- upstream repository: https://github.com/signetlabdei/rmw_desert.git
- release repository: https://github.com/ros2-gbp/rmw_desert-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.5-1`

## rmw_desert

```
* Update README.md
* Add support for ROS_ALLOWED_TOPICS_CONFIG environment variable in configuration loading
* Add option to use env variable
* Contributors: Magform, dcostan
```
