### PR TITLE
mqtt_client: 2.4.2-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5026,7 +5026,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
-      version: 2.4.1-4
+      version: 2.4.2-2
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.4.2-2`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ros2-gbp/mqtt_client-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.1-4`

## mqtt_client

```
* Merge pull request #96 <https://github.com/ika-rwth-aachen/mqtt_client/issues/96> from Eternal-Robotics/eternal/v2.4.1
* Merge pull request #93 <https://github.com/ika-rwth-aachen/mqtt_client/issues/93> from nim65s/main
* Merge pull request #94 <https://github.com/ika-rwth-aachen/mqtt_client/issues/94> from nim65s/ament_target_dependencies
* Merge pull request #91 <https://github.com/ika-rwth-aachen/mqtt_client/issues/91> from martfra/main
* Merge pull request #89 <https://github.com/ika-rwth-aachen/mqtt_client/issues/89> from zouri/main
```

## mqtt_client_interfaces

- No changes
