### PR TITLE
mrpt3: 3.1.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5013,7 +5013,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt3-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mrpt3` to `3.1.2-1`:

- upstream repository: https://github.com/MRPT/mrpt.git
- release repository: https://github.com/ros2-gbp/mrpt3-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.1-1`

## mrpt_apps_cli

- No changes

## mrpt_apps_gui

- No changes

## mrpt_bayes

- No changes

## mrpt_common

- No changes

## mrpt_comms

- No changes

## mrpt_config

- No changes

## mrpt_containers

- No changes

## mrpt_core

- No changes

## mrpt_data

- No changes

## mrpt_examples_cpp

- No changes

## mrpt_expr

- No changes

## mrpt_graphs

```
* Fix undefined behavior in ``connectGraphPartitions()``'s overlap check
  (dereferenced a past-the-end iterator), which could cause spurious
  assertion failures on some C++ standard library implementations.
* Fix ``CDijkstra`` not throwing ``NotConnectedGraph`` for disconnected
  graphs.
* Fix an off-by-one bug in ``CNetworkOfPoses::extractSubGraph()`` that
  excluded the highest node ID in the range.
* Increase unit test coverage.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_graphslam

- No changes

## mrpt_gui

- No changes

## mrpt_hwdrivers

- No changes

## mrpt_img

- No changes

## mrpt_imgui

- No changes

## mrpt_io

- No changes

## mrpt_kinematics

- No changes

## mrpt_libapps_cli

- No changes

## mrpt_libapps_gui

- No changes

## mrpt_maps

- No changes

## mrpt_math

```
* Fix ``nanoflann`` declared as a build-only dependency in ``package.xml``,
  which prevented it from being found by downstream packages' CMake
  configuration on ROS build farms.
* Increase unit test coverage.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_nav

- No changes

## mrpt_obs

- No changes

## mrpt_opengl

- No changes

## mrpt_poses

- No changes

## mrpt_random

- No changes

## mrpt_rtti

- No changes

## mrpt_serialization

- No changes

## mrpt_slam

- No changes

## mrpt_system

- No changes

## mrpt_tfest

```
* Fix a bug in ``se2_l2_robust()``'s point-matching RANSAC variant where a
  single rejected candidate pair could permanently exclude a valid
  correspondence from all further iterations, sometimes leaving the
  result empty.
* Increase unit test coverage.
* Contributors: Jose Luis Blanco-Claraco
```

## mrpt_topography

- No changes

## mrpt_typemeta

- No changes

## mrpt_viz

- No changes
