### PR TITLE
tecgihan_driver: 0.2.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11978,7 +11978,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/tecgihan/tecgihan_driver-release.git
-      version: 0.1.2-1
+      version: 0.2.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tecgihan_driver` to `0.2.0-1`:

- upstream repository: https://github.com/tecgihan/tecgihan_driver.git
- release repository: https://github.com/tecgihan/tecgihan_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.2-1`

## tecgihan_driver

```
Added
- Added support for IMS-SD.
Fixed
- Fixed a bug causing errors on redundant rclpy.shutdown() calls in DMA03Publisher.main()
Contributors: Ryota Amakawa
```
