### PR TITLE
Change multisensor_calibration version and status in Jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6440,7 +6440,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git
-      version: main
+      version: jazzy
     release:
       packages:
       - multisensor_calibration
@@ -6453,8 +6453,8 @@ repositories:
     source:
       type: git
       url: https://github.com/FraunhoferIOSB/multisensor_calibration.git
-      version: main
-    status: maintained
+      version: jazzy
+    status: developed
   mvsim:
     doc:
       type: git


### PR DESCRIPTION
Hi,

I want to update the Jazzy version of our packages, since we are not going to keep adding features for jazzy we created a new Jazzy branch.

Thanks

## Package name:

multisensor_calibration

## Package Upstream Source:

[https://github.com/FraunhoferIOSB/multisensor_calibration](https://github.com/FraunhoferIOSB/multisensor_calibration)


Jazzy
