### PR TITLE
roboplan: 0.5.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7735,6 +7735,7 @@ repositories:
     release:
       packages:
       - roboplan
+      - roboplan_cartesian_planning
       - roboplan_example_models
       - roboplan_examples
       - roboplan_oink
@@ -7744,7 +7745,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/roboplan-release.git
-      version: 0.4.0-1
+      version: 0.5.0-1
     source:
       type: git
       url: https://github.com/open-planning/roboplan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `roboplan` to `0.5.0-1`:

- upstream repository: https://github.com/open-planning/roboplan.git
- release repository: https://github.com/ros2-gbp/roboplan-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-1`

## roboplan

```
* Add unit tests for roboplan_simple_ik package (#257 <https://github.com/open-planning/roboplan/issues/257>)
* Cartesian path planner (#240 <https://github.com/open-planning/roboplan/issues/240>)
* Make ConfigurationTask runtime tunable and add AccelerationLimit (#250 <https://github.com/open-planning/roboplan/issues/250>)
* Add broadphase culling to collision checking and self-collision barrier (#254 <https://github.com/open-planning/roboplan/issues/254>)
* Add clang-tidy (#182 <https://github.com/open-planning/roboplan/issues/182>)
* Store list of link names in group info (#253 <https://github.com/open-planning/roboplan/issues/253>)
* Add RRT* and fast-return mode (#246 <https://github.com/open-planning/roboplan/issues/246>)
* add base frame support to Jacobian (#238 <https://github.com/open-planning/roboplan/issues/238>)
* Allow overriding joint position limits in YAML config (#242 <https://github.com/open-planning/roboplan/issues/242>)
* support accel + jerk limits in urdf>=1.2  (#235 <https://github.com/open-planning/roboplan/issues/235>)
* Speed up path shortcutting (#236 <https://github.com/open-planning/roboplan/issues/236>)
* Speed up collision checking and RRT (#232 <https://github.com/open-planning/roboplan/issues/232>)
* Minor improvements to SimpleIK and forward kinematics (#231 <https://github.com/open-planning/roboplan/issues/231>)
* Scene parsing and joint configuration clamping improvements (#228 <https://github.com/open-planning/roboplan/issues/228>)
* Contributors: Erik Holum, Muslim Alaran, Sebastian Castro, Sebastian Jahr
```

## roboplan_cartesian_planning

```
* Add pixi Support for osx-arm64 and missing docs pages (#248 <https://github.com/open-planning/roboplan/issues/248>)
* Cartesian path planner (#240 <https://github.com/open-planning/roboplan/issues/240>)
* Contributors: Erik Holum, Sebastian Castro
```

## roboplan_example_models

```
* Add pixi Support for osx-arm64 and missing docs pages (#248 <https://github.com/open-planning/roboplan/issues/248>)
* Make ConfigurationTask runtime tunable and add AccelerationLimit (#250 <https://github.com/open-planning/roboplan/issues/250>)
* Add clang-tidy (#182 <https://github.com/open-planning/roboplan/issues/182>)
* Store list of link names in group info (#253 <https://github.com/open-planning/roboplan/issues/253>)
* Add Reachback mobile manipulator model (#227 <https://github.com/open-planning/roboplan/issues/227>)
* Contributors: Erik Holum, Sebastian Castro, Sebastian Jahr, Stephanie Eng
```

## roboplan_examples

```
* Fix OInK instability with failures to converge (#256 <https://github.com/open-planning/roboplan/issues/256>)
* Cartesian path planner (#240 <https://github.com/open-planning/roboplan/issues/240>)
* Make ConfigurationTask runtime tunable and add AccelerationLimit (#250 <https://github.com/open-planning/roboplan/issues/250>)
* Add broadphase culling to collision checking and self-collision barrier (#254 <https://github.com/open-planning/roboplan/issues/254>)
* Add RRT* and fast-return mode (#246 <https://github.com/open-planning/roboplan/issues/246>)
* add base frame support to Jacobian (#238 <https://github.com/open-planning/roboplan/issues/238>)
* Speed up path shortcutting (#236 <https://github.com/open-planning/roboplan/issues/236>)
* Fix the example IK python script (#233 <https://github.com/open-planning/roboplan/issues/233>)
* Add Reachback mobile manipulator model (#227 <https://github.com/open-planning/roboplan/issues/227>)
* Contributors: Erik Holum, Muslim Alaran, Sebastian Castro, Stephanie Eng
```

## roboplan_oink

```
* Fix OInK instability with failures to converge (#256 <https://github.com/open-planning/roboplan/issues/256>)
* Cartesian path planner (#240 <https://github.com/open-planning/roboplan/issues/240>)
* Make ConfigurationTask runtime tunable and add AccelerationLimit (#250 <https://github.com/open-planning/roboplan/issues/250>)
* Add broadphase culling to collision checking and self-collision barrier (#254 <https://github.com/open-planning/roboplan/issues/254>)
* Add clang-tidy (#182 <https://github.com/open-planning/roboplan/issues/182>)
* add base frame support to Jacobian (#238 <https://github.com/open-planning/roboplan/issues/238>)
* Contributors: Muslim Alaran, Sebastian Castro, Sebastian Jahr
```

## roboplan_rrt

```
* Add unit tests for roboplan_simple_ik package (#257 <https://github.com/open-planning/roboplan/issues/257>)
* Cartesian path planner (#240 <https://github.com/open-planning/roboplan/issues/240>)
* Add clang-tidy (#182 <https://github.com/open-planning/roboplan/issues/182>)
* Store list of link names in group info (#253 <https://github.com/open-planning/roboplan/issues/253>)
* Fix RRT connect tree joining for RRT* (#252 <https://github.com/open-planning/roboplan/issues/252>)
* Add RRT* and fast-return mode (#246 <https://github.com/open-planning/roboplan/issues/246>)
* Speed up collision checking and RRT (#232 <https://github.com/open-planning/roboplan/issues/232>)
* Scene parsing and joint configuration clamping improvements (#228 <https://github.com/open-planning/roboplan/issues/228>)
* Contributors: Erik Holum, Sebastian Castro, Sebastian Jahr
```

## roboplan_simple_ik

```
* Add unit tests for roboplan_simple_ik package (#257 <https://github.com/open-planning/roboplan/issues/257>)
* Store list of link names in group info (#253 <https://github.com/open-planning/roboplan/issues/253>)
* Speed up collision checking and RRT (#232 <https://github.com/open-planning/roboplan/issues/232>)
* Fix the example IK python script (#233 <https://github.com/open-planning/roboplan/issues/233>)
* Minor improvements to SimpleIK and forward kinematics (#231 <https://github.com/open-planning/roboplan/issues/231>)
* Contributors: Erik Holum, Sebastian Castro
```

## roboplan_toppra

```
* Add pixi Support for osx-arm64 and missing docs pages (#248 <https://github.com/open-planning/roboplan/issues/248>)
* Cartesian path planner (#240 <https://github.com/open-planning/roboplan/issues/240>)
* Add clang-tidy (#182 <https://github.com/open-planning/roboplan/issues/182>)
* Speed up collision checking and RRT (#232 <https://github.com/open-planning/roboplan/issues/232>)
* Contributors: Erik Holum, Sebastian Castro, Sebastian Jahr
```
