### PR TITLE
Adding libqtopengl key for Jammy.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6859,7 +6859,7 @@ libqtopengl:
   ubuntu:
     '*': [libqt6opengl6]
     'focal': null
-    'jammy': null
+    'jammy': [libqt5opengl5]
     'noble': [libqt5opengl5t64]
 libqtsvg:
   alpine: [qt6-qtsvg]


### PR DESCRIPTION
Defines a key to install this Qt OpenGL module for Jammy/Humble.
