### PR TITLE
clearpath_desktop: 2.9.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1546,7 +1546,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_desktop-release.git
-      version: 2.9.0-1
+      version: 2.9.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_desktop.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_desktop` to `2.9.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_desktop.git
- release repository: https://github.com/clearpath-gbp/clearpath_desktop-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.0-1`

## clearpath_config_live

- No changes

## clearpath_desktop

- No changes

## clearpath_offboard_sensors

- No changes

## clearpath_viz

```
* Added clearpath_common as dep to install all the supported RMWs. (#31 <https://github.com/clearpathrobotics/clearpath_desktop/issues/31>)
* Contributors: Tony Baltovski
```
