### PR TITLE
mapviz: 3.1.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4274,7 +4274,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mapviz-release.git
-      version: 2.6.5-1
+      version: 3.1.0-1
     source:
       type: git
       url: https://github.com/swri-robotics/mapviz.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapviz` to `3.1.0-1`:

- upstream repository: https://github.com/swri-robotics/mapviz.git
- release repository: https://github.com/ros2-gbp/mapviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.6.5-1`

## mapviz

```
* Dual Support for Qt5 and Qt6 (#873 <https://github.com/swri-robotics/mapviz/issues/873>)
  Adding support for building against both Qt5 and Qt6
* Remove config panel pin check (#883 <https://github.com/swri-robotics/mapviz/issues/883>)
* Add persistent config dock size; Move config toggle button (#881 <https://github.com/swri-robotics/mapviz/issues/881>)
* Plugin panel eliding (#880 <https://github.com/swri-robotics/mapviz/issues/880>)
* Adjust UI element size properties to work for higher resolutions/scaling (#879 <https://github.com/swri-robotics/mapviz/issues/879>)
  * Update button/text/space fields to work better for a variety of display resolutions and scalings
  * Fix spinboxes for 1080p
* Contributors: Alex Youngs, David Anthony
```

## mapviz_interfaces

- No changes

## mapviz_plugins

```
* Dual Support for Qt5 and Qt6 (#873 <https://github.com/swri-robotics/mapviz/issues/873>)
  Adding support for building against both Qt5 and Qt6
* Robot Model Plugin (#882 <https://github.com/swri-robotics/mapviz/issues/882>)
* Adjust UI element size properties to work for higher resolutions/scaling (#879 <https://github.com/swri-robotics/mapviz/issues/879>)
  * Update button/text/space fields to work better for a variety of display resolutions and scalings
  * Fix spinboxes for 1080p
* Contributors: Alex Youngs, David Anthony
```

## multires_image

```
* Dual Support for Qt5 and Qt6 (#873 <https://github.com/swri-robotics/mapviz/issues/873>)
  Adding support for building against both Qt5 and Qt6
* Adjust UI element size properties to work for higher resolutions/scaling (#879 <https://github.com/swri-robotics/mapviz/issues/879>)
  * Update button/text/space fields to work better for a variety of display resolutions and scalings
  * Fix spinboxes for 1080p
* Fixed bad initial path import (#878 <https://github.com/swri-robotics/mapviz/issues/878>)
  Co-authored-by: David Anthony <mailto:djanthony@gmail.com>
* Contributors: Alex Youngs, David Anthony
```

## tile_map

```
* Dual Support for Qt5 and Qt6 (#873 <https://github.com/swri-robotics/mapviz/issues/873>)
  Adding support for building against both Qt5 and Qt6
* Adjust UI element size properties to work for higher resolutions/scaling (#879 <https://github.com/swri-robotics/mapviz/issues/879>)
  * Update button/text/space fields to work better for a variety of display resolutions and scalings
  * Fix spinboxes for 1080p
* Tilemap Plugin Peformance/Stability Improvements (#877 <https://github.com/swri-robotics/mapviz/issues/877>)
* Contributors: Alex Youngs, David Anthony
```
