### PR TITLE
Simplify `python3-pyqt5` dependencies in Ubuntu 26.04

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -8259,7 +8259,9 @@ python3-pyqt5:
   opensuse: [python3-qt5]
   rhel: ['python%{python3_pkgversion}-qt5-devel', 'python%{python3_pkgversion}-sip-devel', libXext-devel, redhat-rpm-config]
   slackware: [python3-PyQt5]
-  ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+  ubuntu:
+    '*': [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    resolute: [python3-pyqt5]
 python3-pyqt5.qtquick:
   debian: [python3-pyqt5.qtquick]
   ubuntu: [python3-pyqt5.qtquick]


### PR DESCRIPTION
This change is due to the unavailability of `python3-pyside2.qtsvg` and `python3-sip-dev` on Ubuntu 26.04 / resolute.

It also matches other linux distros.

I saw this in build failures for Lyrical/Rolling in the [`py_trees_ros_viewer`](https://github.com/splintered-reality/py_trees_ros_viewer) and [`py_trees_js`](https://github.com/splintered-reality/py_trees_js) repos.
