### PR TITLE
ublox_dgnss: 0.7.6-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10592,7 +10592,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ublox_dgnss-release.git
-      version: 0.7.5-1
+      version: 0.7.6-1
     source:
       type: git
       url: https://github.com/aussierobots/ublox_dgnss.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ublox_dgnss` to `0.7.6-1`:

- upstream repository: https://github.com/aussierobots/ublox_dgnss
- release repository: https://github.com/ros2-gbp/ublox_dgnss-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.5-1`

## ntrip_client_node

```
* reverted to cmake ver 3.22 for humble
* updated min cmake version
* Contributors: Nick Hortovanyi
```

## ublox_dgnss

```
* reverted to cmake ver 3.22 for humble
* updated min cmake version
* Contributors: Nick Hortovanyi
```

## ublox_dgnss_node

```
* Fix get_package_share_directory for humble
* uncrustify formatting fix
* fix for humble based include
* added ros distro specific package share
* reverted to cmake ver 3.22 for humble
* removed deprecated calls to ament_index_cpp::get_package_share_directory()
  and replaced with ament_index_cpp::get_package_share_path() .
* updated min cmake version
* Contributors: Nick Hortovanyi
```

## ublox_nav_sat_fix_hp_node

```
* reverted to cmake ver 3.22 for humble
* updated min cmake version
* Contributors: Nick Hortovanyi
```

## ublox_ubx_interfaces

```
* reverted to cmake ver 3.22 for humble
* updated min cmake version
* Contributors: Nick Hortovanyi
```

## ublox_ubx_msgs

```
* reverted to cmake ver 3.22 for humble
* updated min cmake version
* Contributors: Nick Hortovanyi
```
