### PR TITLE
class_loader: 3.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1162,7 +1162,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `class_loader` to `3.0.1-1`:

- upstream repository: https://github.com/ros/class_loader.git
- release repository: https://github.com/ros2-gbp/class_loader-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## class_loader

```
* concurrent accesses well-defined (#231 <https://github.com/ros/class_loader//issues/231>)
* Cpp20 part3 (#230 <https://github.com/ros/class_loader//issues/230>)
* Cpp20 part2 (#229 <https://github.com/ros/class_loader//issues/229>)
* Include CPP20 and related changes (#228 <https://github.com/ros/class_loader//issues/228>)
* Contributors: Alejandro Hernández Cordero
```
