### PR TITLE
qt_gui_core: 3.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6640,7 +6640,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `qt_gui_core` to `3.0.2-1`:

- upstream repository: https://github.com/ros-visualization/qt_gui_core.git
- release repository: https://github.com/ros2-gbp/qt_gui_core-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.1-1`

## qt_dotgraph

- No changes

## qt_gui

- No changes

## qt_gui_app

- No changes

## qt_gui_core

- No changes

## qt_gui_cpp

```
* Fix Settings::remove() reading uninitialized bool and never invoking the proxied method (#342 <https://github.com/ros-visualization/qt_gui_core/issues/342>)
* Removed dead code (#341 <https://github.com/ros-visualization/qt_gui_core/issues/341>)
* Modernize qt_gui_cpp toward C++20 (#340 <https://github.com/ros-visualization/qt_gui_core/issues/340>)
* Use smart ptr with class loader (#339 <https://github.com/ros-visualization/qt_gui_core/issues/339>)
* Contributors: Alejandro Hernández Cordero
```

## qt_gui_py_common

- No changes
