### PR TITLE
resource_retriever: 3.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7142,7 +7142,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.10.0-1
+      version: 3.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever` to `3.10.1-1`:

- upstream repository: https://github.com/ros/resource_retriever.git
- release repository: https://github.com/ros2-gbp/resource_retriever-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.10.0-1`

## resource_retriever

```
* Updated to cpp20 (#123 <https://github.com/ros/resource_retriever/issues/123>)
* Update cmake_minimum_required version and package version (#124 <https://github.com/ros/resource_retriever/issues/124>)
* Contributors: Alejandro Hernández Cordero
```
