### PR TITLE
rqt_service_caller: 1.5.4-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9190,7 +9190,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_service_caller-release.git
-      version: 1.5.3-1
+      version: 1.5.4-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_service_caller` to `1.5.4-1`:

- upstream repository: https://github.com/ros-visualization/rqt_service_caller.git
- release repository: https://github.com/ros2-gbp/rqt_service_caller-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.5.3-1`

## rqt_service_caller

```
* Python3 modernization (backport #42 <https://github.com/ros-visualization/rqt_service_caller/issues/42>) (#43 <https://github.com/ros-visualization/rqt_service_caller/issues/43>)
* Contributors: mergify[bot]
```
