### PR TITLE
perception_pcl: 2.10.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6015,7 +6015,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/perception_pcl-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl` to `2.10.0-1`:

- upstream repository: https://github.com/ros-perception/perception_pcl.git
- release repository: https://github.com/ros2-gbp/perception_pcl-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.0-1`

## pcl_conversions

- No changes

## pcl_ros

```
* fix(pcl_ros): preserve all fields in combined_pointcloud_to_pcd
* Replace exceptions with the base tf2::TransformException (#532 <https://github.com/ros-perception/perception_pcl/issues/532>)
* Contributors: Alireza Moayyedi, Jion Kubo
```

## perception_pcl

- No changes
