### PR TITLE
move_base_flex: 1.2.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6255,7 +6255,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/move_base_flex-release.git
-      version: 1.0.5-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `1.2.0-1`:

- upstream repository: git@github.com:naturerobots/move_base_flex.git
- release repository: https://github.com/ros2-gbp/move_base_flex-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.5-1`

## mbf_abstract_core

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## mbf_abstract_nav

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## mbf_msgs

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## mbf_simple_core

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## mbf_simple_nav

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## mbf_test_utility

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## mbf_utility

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## move_base_flex

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```

## rviz_mbf_plugins

```
* ROS 2 Lyrical Compatibility
* Non-blocking RobotInfo for faster control cycles
```
