### PR TITLE
move_base_flex to lyrical

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4851,6 +4851,12 @@ repositories:
       url: https://github.com/IMRCLab/motion_capture_tracking.git
       version: ros2
     status: developed
+  move_base_flex:
+    source:
+      type: git
+      url: https://github.com/naturerobots/move_base_flex.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

lyrical

# The source is here:

https://github.com/naturerobots/move_base_flex

# Checks
 - [X] All packages have a declared license in the package.xml
 - [X] This repository has a LICENSE file
 - [X] This package is expected to build on the submitted rosdistro
