### PR TITLE
rqt_graph: 2.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8899,7 +8899,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `2.0.2-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.1-1`

## rqt_graph

```
* f-string, super() and python3 modernizations (#121 <https://github.com/ros-visualization/rqt_graph/issues/121>)
* Removed Python2 references and Qt6 fixes (#120 <https://github.com/ros-visualization/rqt_graph/issues/120>)
* Contributors: Alejandro Hernández Cordero
```
