### PR TITLE
rqt_graph: 1.8.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8989,7 +8989,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_graph-release.git
-      version: 1.8.4-1
+      version: 1.8.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_graph` to `1.8.5-1`:

- upstream repository: https://github.com/ros-visualization/rqt_graph.git
- release repository: https://github.com/ros2-gbp/rqt_graph-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.8.4-1`

## rqt_graph

```
* f-string, super() and python3 modernizations (backport #121 <https://github.com/ros-visualization/rqt_graph/issues/121>) (#122 <https://github.com/ros-visualization/rqt_graph/issues/122>)
* Contributors: mergify[bot]
```
