### PR TITLE
message_tf_frame_transformer: 1.1.3-4 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4497,7 +4497,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
-      version: 1.1.3-3
+      version: 1.1.3-4
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git


### PR DESCRIPTION
Increasing version of package(s) in repository `message_tf_frame_transformer` to `1.1.3-4`:

- upstream repository: https://github.com/ika-rwth-aachen/message_tf_frame_transformer.git
- release repository: https://github.com/ros2-gbp/message_tf_frame_transformer-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.3-3`

## message_tf_frame_transformer

```
* Merge pull request #6 <https://github.com/ika-rwth-aachen/message_tf_frame_transformer/issues/6> from ika-rwth-aachen/codex/find-common-message-packages-on-ros-index
  Remove perception_interfaces and planning_interfaces; add all geometry_msgs; improve CI
* Merge pull request #5 <https://github.com/ika-rwth-aachen/message_tf_frame_transformer/issues/5> from ika-rwth-aachen/codex/deprecate-ros-1-noetic-and-update-ros-2-support
* Merge branch 'main' into codex/deprecate-ros-1-noetic-and-update-ros-2-support
* Merge pull request #4 <https://github.com/ika-rwth-aachen/message_tf_frame_transformer/issues/4> from ika-rwth-aachen/add-ika-interfaces
  Add interfaces "perception_interfaces" and "planning_interfaces"
* Contributors: Lennart Reiher
```
