### PR TITLE
libbno055_linux: 1.1.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5269,6 +5269,19 @@ repositories:
       url: https://github.com/analogdevicesinc/libaditof.git
       version: main
     status: maintained
+  libbno055_linux:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/lazytatzv/libbno055_linux-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/lazytatzv/libbno055-linux.git
+      version: main
+    status: developed
+    status_description: Active development and maintenance of the BNO055 Linux library
+      and ROS 2 nodes.
   libcaer_driver:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5280,8 +5280,8 @@ repositories:
       url: https://github.com/lazytatzv/libbno055-linux.git
       version: main
     status: developed
-    status_description: Active development and maintenance of the BNO055 Linux library
-      and ROS 2 nodes.
+    status_description: >-
+      Active development and maintenance of the BNO055 Linux library and ROS 2 nodes.
   libcaer_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libbno055_linux` to `1.1.0-1`:

- upstream repository: git@github.com:lazytatzv/bno055lib.git
- release repository: https://github.com/lazytatzv/libbno055_linux-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
