### PR TITLE
libbno055_linux: 1.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5272,7 +5272,7 @@ repositories:
   libbno055_linux:
     doc:
       type: git
-      url: https://github.com/lazytatzv/bno055lib.git
+      url: https://github.com/lazytatzv/libbno055-linux
       version: main
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5272,7 +5272,7 @@ repositories:
   libbno055_linux:
     doc:
       type: git
-      url: https://github.com/lazytatzv/libbno055-linux
+      url: https://github.com/lazytatzv/libbno055-linux.git
       version: main
     release:
       tags:
@@ -5281,7 +5281,7 @@ repositories:
       version: 1.1.0-2
     source:
       type: git
-      url: https://github.com/lazytatzv/libbno055-linux
+      url: https://github.com/lazytatzv/libbno055-linux.git
       version: main
     status: developed
   libcaer_driver:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5269,6 +5269,21 @@ repositories:
       url: https://github.com/analogdevicesinc/libaditof.git
       version: main
     status: maintained
+  libbno055_linux:
+    doc:
+      type: git
+      url: https://github.com/lazytatzv/bno055lib.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/lazytatzv/libbno055_linux-release.git
+      version: 1.1.0-2
+    source:
+      type: git
+      url: https://github.com/lazytatzv/bno055lib.git
+      version: main
+    status: developed
   libcaer_driver:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5281,7 +5281,7 @@ repositories:
       version: 1.1.0-2
     source:
       type: git
-      url: https://github.com/lazytatzv/bno055lib.git
+      url: https://github.com/lazytatzv/libbno055-linux
       version: main
     status: developed
   libcaer_driver:


### PR DESCRIPTION
Increasing version of package(s) in repository `libbno055_linux` to `1.1.0-2`:

- upstream repository: git@github.com:lazytatzv/bno055lib.git
- release repository: https://github.com/lazytatzv/libbno055_linux-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
