### PR TITLE
ur_robot_driver: 7.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10707,7 +10707,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 6.0.0-1
+      version: 7.0.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `7.0.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.0-1`

## ur

```
* Update minimum CMake version to 3.28.3 (#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>)
* Contributors: Felix Exner
```

## ur_calibration

```
* Update minimum CMake version to 3.28.3 (#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>)
* Contributors: Felix Exner
```

## ur_controllers

```
* Allow setting payload inertia matrix via set_payload service   (#1808 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1808>)
* Allow updating robot gravity (#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>)
* Use a realtime_tools::RealtimePublisher for publishing the state (#1822 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1822>)
* Make GPIO controller publishers realtime safe (#1807 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1807>)
* Update minimum CMake version to 3.28.3 (#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>)
* Contributors: AdamPettinger, Felix Exner, Hasan Amin, Sergi Romero
```

## ur_dashboard_msgs

```
* Update safety status msg with new IO plane stop (#1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>)
* Update minimum CMake version to 3.28.3 (#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>)
* Contributors: Felix Exner, Mads Holm Peters
```

## ur_moveit_config

```
* Update minimum CMake version to 3.28.3 (#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>)
* Contributors: Felix Exner
```

## ur_robot_driver

```
* Allow setting payload inertia matrix via set_payload service   (#1808 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1808>)
* Migrate Urscript interface to primary client (#1833 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1833>)
* Remove controller switch to passthrough controller (#1857 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1857>)
* Replace linking to moprim controller my using its include directories (#1853 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1853>)
* Update model test (#1848 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1848>)
* Allow updating robot gravity (#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>)
* [tests] Fix shadowed function arg (#1835 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1835>)
* Explicitly send MODE_STOPPED when returning control to the robot (#1678 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1678>)
* Update minimum CMake version to 3.28.3 (#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>)
* Fix whitespace error introduced earlier (#1805 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1805>)
* Clarify effort control limitations in URSim (#1800 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1800>)
* Fail example move on error (#1795 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1795>)
* Contributors: AdamPettinger, Felix Exner, Sergi Romero, URJala
```