### PR TITLE
ur_msgs: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10680,7 +10680,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
-      version: humble
+      version: rolling
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -10689,7 +10689,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git
-      version: humble-devel
+      version: rolling-devel
     status: developed
   ur_robot_driver:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -10685,7 +10685,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_msgs-release.git
-      version: 2.5.0-2
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_msgs` to `3.0.0-1`:

- upstream repository: https://github.com/ros-industrial/ur_msgs.git
- release repository: https://github.com/ros2-gbp/ur_msgs-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.0-2`

## ur_msgs

```
* [BREAKING[ Add inertia matrix and transition_time support to set_payload service   (#42 <https://github.com/ros-industrial/ur_msgs/issues/42>)
  Replace mass/cog fields with Inertia and add transition_time in SetPayload
* Action definition for executing scripts via primary client (#45 <https://github.com/ros-industrial/ur_msgs/issues/45>)
* Increase minimum CMake version (#41 <https://github.com/ros-industrial/ur_msgs/issues/41>)
* Contributors: Felix Exner, Sergi Romero, URJala
```
