### PR TITLE
Update rviz_splat source URL after org rename RVizSplat -> splat-ros

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11235,7 +11235,7 @@ repositories:
   rviz_splat:
     source:
       type: git
-      url: https://github.com/RVizSplat/RVizSplat.git
+      url: https://github.com/splat-ros/RVizSplat.git
       version: main
     status: developed
   rviz_visual_tools:

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9435,7 +9435,7 @@ repositories:
   rviz_splat:
     source:
       type: git
-      url: https://github.com/RVizSplat/RVizSplat.git
+      url: https://github.com/splat-ros/RVizSplat.git
       version: main
     status: developed
   rviz_visual_tools:

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9481,7 +9481,7 @@ repositories:
   rviz_splat:
     source:
       type: git
-      url: https://github.com/RVizSplat/RVizSplat.git
+      url: https://github.com/splat-ros/RVizSplat.git
       version: main
     status: developed
   rviz_visual_tools:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9371,7 +9371,7 @@ repositories:
   rviz_splat:
     source:
       type: git
-      url: https://github.com/RVizSplat/RVizSplat.git
+      url: https://github.com/splat-ros/RVizSplat.git
       version: main
     status: developed
   rviz_visual_tools:


### PR DESCRIPTION
Renamed our GitHub org from RVizSplat to splat-ros, so updating the rviz_splat source URL to match. 

Same change applied to rolling, kilted, jazzy, and lyrical.