### PR TITLE
ur_robot_driver: 4.8.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10747,7 +10747,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 4.6.0-1
+      version: 4.8.0-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ur_robot_driver` to `4.8.0-1`:

- upstream repository: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
- release repository: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `4.6.0-1`

## ur

- No changes

## ur_calibration

- No changes

## ur_controllers

```
* Allow updating robot gravity (backport #1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>) (#1846 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1846>)
* Use a realtime_tools::RealtimePublisher for publishing the state (backport #1822 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1822>) (#1825 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1825>)
* Make GPIO controller publishers realtime safe (backport #1807 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1807>) (#1828 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1828>)
* Contributors: Felix Exner, mergify[bot]
```

## ur_dashboard_msgs

```
* Update safety status msg with new IO plane stop (backport #1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>) (#1820 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1820>)
* Contributors: Felix Exner, mergify[bot]
```

## ur_moveit_config

- No changes

## ur_robot_driver

```
* Migrate Urscript interface to primary client (backport #1833 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1833>) (#1867 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1867>)
* Remove controller switch to passthrough controller (backport #1857 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1857>) (#1862 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1862>)
* Update model test (backport #1848 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1848>) (#1855 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1855>)
* Replace linking to moprim controller my using its include directories (backport #1853 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1853>) (#1856 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1856>)
* Allow updating robot gravity (backport #1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>) (#1846 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1846>)
* [tests] Fix shadowed function arg (backport #1835 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1835>) (#1844 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1844>)
* Explicitly send MODE_STOPPED when returning control to the robot (backport #1678 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1678>) (#1832 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1832>)
* Clarify effort control limitations in URSim (backport #1800 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1800>) (#1804 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1804>)
* Fail example move on error (backport #1795 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1795>) (#1798 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1798>)
* Contributors: Felix Exner, mergify[bot]
```
