### PR TITLE
image_pipeline: 8.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3410,7 +3410,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 8.0.0-1
+      version: 8.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `8.0.1-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `8.0.0-1`

## camera_calibration

```
* Added flake8 and pep257 to camera calibration (#1177 <https://github.com/ros-perception/image_pipeline/issues/1177>)
* Remove Inactive Maintainer
* Contributors: Alejandro Hernández Cordero, Josh Whitley
```

## depth_image_proc

```
* Use no discard (#1176 <https://github.com/ros-perception/image_pipeline/issues/1176>)
* Use constexpr instead of inline (#1173 <https://github.com/ros-perception/image_pipeline/issues/1173>)
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Fix issue 1149 (#1152 <https://github.com/ros-perception/image_pipeline/issues/1152>)
* PointCloudXyzrgbNode can trigger a heap-buffer-overflow read in convertDepth() when image metadata and payload size diverge during a topology-transition mismatch (#1154 <https://github.com/ros-perception/image_pipeline/issues/1154>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## image_pipeline

```
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## image_proc

```
* Use no discard (#1176 <https://github.com/ros-perception/image_pipeline/issues/1176>)
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Removed the deprecated getTopicQosProfile() function (#1155 <https://github.com/ros-perception/image_pipeline/issues/1155>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## image_publisher

```
* Use std::numbers (#1171 <https://github.com/ros-perception/image_pipeline/issues/1171>)
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* Export image_publisher target (#1178 <https://github.com/ros-perception/image_pipeline/issues/1178>)
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## image_rotate

```
* Use std::numbers (#1171 <https://github.com/ros-perception/image_pipeline/issues/1171>)
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## image_view

```
* Use std::filesystem (#1174 <https://github.com/ros-perception/image_pipeline/issues/1174>)
* Use std::make_shared (#1172 <https://github.com/ros-perception/image_pipeline/issues/1172>)
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## stereo_image_proc

```
* Use no discard (#1176 <https://github.com/ros-perception/image_pipeline/issues/1176>)
* Use std::make_shared (#1172 <https://github.com/ros-perception/image_pipeline/issues/1172>)
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* Remove Inactive Maintainer
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch, Josh Whitley
```

## tracetools_image_pipeline

```
* Use lambdas, replace NULL with nullptr and std::format (#1170 <https://github.com/ros-perception/image_pipeline/issues/1170>)
* Updated CMake minimum version (#1181 <https://github.com/ros-perception/image_pipeline/issues/1181>)
* switch to C++20 (#1165 <https://github.com/ros-perception/image_pipeline/issues/1165>)
* Contributors: Alejandro Hernández Cordero, Christian Rauch
```
