### PR TITLE
image_pipeline: 7.1.7-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3450,7 +3450,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 7.1.6-1
+      version: 7.1.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `7.1.7-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.1.6-1`

## camera_calibration

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## depth_image_proc

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* Fix issue 1149 (backport #1152 <https://github.com/ros-perception/image_pipeline/issues/1152>) (#1163 <https://github.com/ros-perception/image_pipeline/issues/1163>)
* PointCloudXyzrgbNode can trigger a heap-buffer-overflow read in convertDepth() when image metadata and payload size diverge during a topology-transition mismatch (backport #1154 <https://github.com/ros-perception/image_pipeline/issues/1154>) (#1162 <https://github.com/ros-perception/image_pipeline/issues/1162>)
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## image_pipeline

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## image_proc

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## image_publisher

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## image_rotate

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## image_view

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## stereo_image_proc

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* Remove Inactive Maintainer
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: Josh Whitley, mergify[bot]
```

## tracetools_image_pipeline

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1190 <https://github.com/ros-perception/image_pipeline/issues/1190>)
* switch to C++20 (backport #1165 <https://github.com/ros-perception/image_pipeline/issues/1165>) (#1169 <https://github.com/ros-perception/image_pipeline/issues/1169>)
* Contributors: mergify[bot]
```
