### PR TITLE
image_pipeline: 6.0.13-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3461,7 +3461,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 6.0.12-1
+      version: 6.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `6.0.13-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `6.0.12-1`

## camera_calibration

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## depth_image_proc

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* PointCloudXyzrgbNode can trigger a heap-buffer-overflow read in convertDepth() when image metadata and payload size diverge during a topology-transition mismatch (backport #1154 <https://github.com/ros-perception/image_pipeline/issues/1154>) (#1156 <https://github.com/ros-perception/image_pipeline/issues/1156>)
* Fix issue 1149 (backport #1152 <https://github.com/ros-perception/image_pipeline/issues/1152>) (#1159 <https://github.com/ros-perception/image_pipeline/issues/1159>)
* Updated kilted CI (#1161 <https://github.com/ros-perception/image_pipeline/issues/1161>)
* PointCloudXyzrgbNode throws if resoluitions differ (backport #1148 <https://github.com/ros-perception/image_pipeline/issues/1148>) (#1150 <https://github.com/ros-perception/image_pipeline/issues/1150>)
* Contributors: Alejandro Hernández Cordero, Josh Whitley, mergify[bot]
```

## image_pipeline

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* Contributors: Josh Whitley, mergify[bot]
```

## image_proc

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* Updated kilted CI (#1161 <https://github.com/ros-perception/image_pipeline/issues/1161>)
* Contributors: Alejandro Hernández Cordero, Josh Whitley, mergify[bot]
```

## image_publisher

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* Contributors: Josh Whitley, mergify[bot]
```

## image_rotate

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* Contributors: Josh Whitley, mergify[bot]
```

## image_view

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* Contributors: Josh Whitley, mergify[bot]
```

## stereo_image_proc

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Remove Inactive Maintainer
* Contributors: Josh Whitley, mergify[bot]
```

## tracetools_image_pipeline

```
* Updated CMake minimum version (backport #1181 <https://github.com/ros-perception/image_pipeline/issues/1181>) (#1191 <https://github.com/ros-perception/image_pipeline/issues/1191>)
* Contributors: mergify[bot]
```
