### PR TITLE
image_pipeline: 5.0.13-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4495,7 +4495,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/image_pipeline-release.git
-      version: 5.0.12-1
+      version: 5.0.13-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_pipeline` to `5.0.13-1`:

- upstream repository: https://github.com/ros-perception/image_pipeline.git
- release repository: https://github.com/ros2-gbp/image_pipeline-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.0.12-1`

## camera_calibration

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## depth_image_proc

```
* Remove Inactive Maintainer
* PointCloudXyzrgbNode can trigger a heap-buffer-overflow read in convertDepth() when image metadata and payload size diverge during a topology-transition mismatch (backport #1154 <https://github.com/ros-perception/image_pipeline/issues/1154>) (#1157 <https://github.com/ros-perception/image_pipeline/issues/1157>)
* Fix issue 1149 (backport #1152 <https://github.com/ros-perception/image_pipeline/issues/1152>) (#1160 <https://github.com/ros-perception/image_pipeline/issues/1160>)
* PointCloudXyzrgbNode throws if resoluitions differ (backport #1148 <https://github.com/ros-perception/image_pipeline/issues/1148>) (#1151 <https://github.com/ros-perception/image_pipeline/issues/1151>)
* Contributors: Josh Whitley, mergify[bot]
```

## image_pipeline

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## image_proc

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## image_publisher

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## image_rotate

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## image_view

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## stereo_image_proc

```
* Remove Inactive Maintainer
* Contributors: Josh Whitley
```

## tracetools_image_pipeline

- No changes
