### PR TITLE
Add robot_body_filter dependency to distribution.yaml

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7693,6 +7693,16 @@ repositories:
       url: https://github.com/open-planning/roboplan-ros.git
       version: main
     status: developed
+  robot_body_filter:
+    doc:
+      type: git
+      url: https://github.com/ctu-vras/robot_body_filter.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/ctu-vras/robot_body_filter.git
+      version: ros2
+    status: developed
   robot_calibration:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro.

robot_body_filter

# The source is here:

https://github.com/ctu-vras/robot_body_filter/pull/32 (PR not merged yet, but it's about to be in a while)

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
   - after the PR is merged
