### PR TITLE
libcamera: 0.7.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4086,7 +4086,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
-      version: 0.7.1-1
+      version: 0.7.2-1
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libcamera` to `0.7.2-1`:

- upstream repository: https://git.libcamera.org/libcamera/libcamera.git
- release repository: https://github.com/ros2-gbp/libcamera-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.7.1-1`
