### PR TITLE
Add python3-torchvision-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10141,6 +10141,10 @@ python3-torchvision:
     '*': [python3-torchvision]
     bionic: null
     focal: null
+python3-torchvision-pip:
+  '*':
+    pip:
+      packages: [torchvision]
 python3-tornado:
   arch: [python-tornado]
   debian: [python3-tornado]


### PR DESCRIPTION
Similar to: https://github.com/ros/rosdistro/pull/37485

Apt version is only availble for humble

Skipping all hyperlink searches as this is a pip target I guess?

Was flagged here: https://github.com/mgonzs13/yolo_ros/pull/120

