### PR TITLE
moveit_resources: 3.2.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4942,7 +4942,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/moveit_resources-release.git
-      version: 3.1.1-3
+      version: 3.2.0-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git


### PR DESCRIPTION
Increasing version of package(s) in repository `moveit_resources` to `3.2.0-1`:

- upstream repository: https://github.com/ros-planning/moveit_resources.git
- release repository: https://github.com/ros2-gbp/moveit_resources-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.1.1-3`

## dual_arm_panda_moveit_config

- No changes

## moveit_resources

- No changes

## moveit_resources_fanuc_description

- No changes

## moveit_resources_fanuc_moveit_config

```
* Replace old gripper_controllers package with parallel_gripper_action_controller (#211 <https://github.com/ros-planning/moveit_resources/issues/211>)
* Fix chomp parameter from string to double (#208 <https://github.com/ros-planning/moveit_resources/issues/208>)
* Contributors: Marq Rasmussen, Nathan Brooks
```

## moveit_resources_panda_description

- No changes

## moveit_resources_panda_moveit_config

```
* Drop robotiq interface refs from panda_hand_controller (#215 <https://github.com/ros-planning/moveit_resources/issues/215>)
* Replace old gripper_controllers package with parallel_gripper_action_controller (#211 <https://github.com/ros-planning/moveit_resources/issues/211>)
* Fix chomp parameter from string to double (#208 <https://github.com/ros-planning/moveit_resources/issues/208>)
* Contributors: Marq Rasmussen, Nathan Brooks
```

## moveit_resources_pr2_description

- No changes
