### PR TITLE
resource_retriever_service: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7167,7 +7167,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever_service-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever_service` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/resource_retriever_service
- release repository: https://github.com/ros2-gbp/resource_retriever_service-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## resource_retriever_interfaces

- No changes

## resource_retriever_service

```
* Cleanup rclcpp resources before quitting. (#19 <https://github.com/ros2/resource_retriever_service/issues/19>)
* Contributors: Chris Lalancette
```

## resource_retriever_service_plugin

```
* Include missing headers (#21 <https://github.com/ros2/resource_retriever_service/issues/21>)
* Contributors: Alejandro Hernández Cordero
```
