### PR TITLE
resource_retriever_service: 0.0.3-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7245,7 +7245,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever_service-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `resource_retriever_service` to `0.0.3-1`:

- upstream repository: https://github.com/ros2/resource_retriever_service
- release repository: https://github.com/ros2-gbp/resource_retriever_service-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.2-1`

## resource_retriever_interfaces

- No changes

## resource_retriever_service

```
* Cleanup rclcpp resources before quitting. (#19 <https://github.com/ros2/resource_retriever_service/issues/19>) (#20 <https://github.com/ros2/resource_retriever_service/issues/20>)
* Contributors: mergify[bot]
```

## resource_retriever_service_plugin

- No changes
