### PR TITLE
ament_package: 0.19.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -368,7 +368,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_package-release.git
-      version: 0.19.0-1
+      version: 0.19.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ament_package` to `0.19.1-1`:

- upstream repository: https://github.com/ament/ament_package.git
- release repository: https://github.com/ros2-gbp/ament_package-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.19.0-1`

## ament_package

```
* type annotations (#167 <https://github.com/ament/ament_package/issues/167>)
* Tests coverage (#166 <https://github.com/ament/ament_package/issues/166>)
* Python 3 modernization (#165 <https://github.com/ament/ament_package/issues/165>)
* Contributors: Alejandro Hernández Cordero
```
