### PR TITLE
py_trees: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8597,7 +8597,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees` to `2.5.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees.git
- release repository: https://github.com/ros2-gbp/py_trees-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.0-1`

## py_trees

```
* [ports] Improve handling of decorator nodes in XML parser (#498 <https://github.com/splintered-reality/py_trees/issues/498>)
* [ports] Add tests for including subtrees in other files (#500 <https://github.com/splintered-reality/py_trees/issues/500>)
* [ports] Convert constructor kwargs to types defined in parent classes (#496 <https://github.com/splintered-reality/py_trees/issues/496>)
* [infra] Update lock file to use Python 3.10 (#501 <https://github.com/splintered-reality/py_trees/issues/501>)
* [infra] Fix colcon build (at the expense of specifying requires-python) (#497 <https://github.com/splintered-reality/py_trees/issues/497>)
* [infra] Use old setuptools license definition in pyproject.toml to make ROS buildfarm happy
* [infra] Modernize dev environment to use uv, ruff, and ty (#495 <https://github.com/splintered-reality/py_trees/issues/495>)
* [ports] Add auto registration of PortsMixin classes (#493 <https://github.com/splintered-reality/py_trees/issues/493>)
* [ports] Split list/tuple value strings based on comma or semicolon (#494 <https://github.com/splintered-reality/py_trees/issues/494>)
* [behaviours] Add input/output ports and XML parser (#487 <https://github.com/splintered-reality/py_trees/issues/487>)
* Contributors: Jennifer Buehler, Sebastian Castro
```
