### PR TITLE
py_trees_ros: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8062,7 +8062,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros` to `2.5.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros
- release repository: https://github.com/ros2-gbp/py_trees_ros-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.0-1`

## py_trees_ros

```
* [trees] Provide option to shutdown tree without destroying node (#253 <https://github.com/splintered-reality/py_trees_ros/issues/253>)
* [code] It's vs its correctness, remove typing.Optional (#252 <https://github.com/splintered-reality/py_trees_ros/issues/252>)
* [conversions] Include COMPOSITE enum in behaviour to ROS Message conversions (#251 <https://github.com/splintered-reality/py_trees_ros/issues/251>)
* [trees] Always publish snapshot on setup() calls (#250 <https://github.com/splintered-reality/py_trees_ros/issues/250>)
* [trees] Allow setup() method to be called multiple times per tree (#249 <https://github.com/splintered-reality/py_trees_ros/issues/249>)
* [docs] Add service_clients module to docs (#246 <https://github.com/splintered-reality/py_trees_ros/issues/246>)
* [docs] Remove rclpy intersphinx mapping (#244 <https://github.com/splintered-reality/py_trees_ros/issues/244>)
* Contributors: Sebastian Castro
```
