### PR TITLE
py_trees_ros_interfaces: 2.1.2-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -6615,7 +6615,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
-      version: 2.1.1-2
+      version: 2.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_interfaces` to `2.1.2-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_interfaces
- release repository: https://github.com/ros2-gbp/py_trees_ros_interfaces-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.1-2`

## py_trees_ros_interfaces

```
* Add generic COMPOSITE enum in Behaviour message type (#16 <https://github.com/splintered-reality/py_trees_ros_interfaces/issues/16>)
* Add myself to package maintainers (#15 <https://github.com/splintered-reality/py_trees_ros_interfaces/issues/15>)
* add ROS 2 Kilted to README (#14 <https://github.com/splintered-reality/py_trees_ros_interfaces/issues/14>)
* Update README to latest ROS versions (#13 <https://github.com/splintered-reality/py_trees_ros_interfaces/issues/13>)
* Contributors: Sebastian Castro
```
