### PR TITLE
py_trees_ros_viewer: 0.3.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6564,7 +6564,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
-      version: 0.2.5-4
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_viewer` to `0.3.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_viewer
- release repository: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.5-4`

## py_trees_ros_viewer

```
* [code] Handle SIGTERM using on_shutdown function (#56 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/56>)
* [code] Add purple color for user-defined composites (#48 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/48>)
* [code] Improve behavior around hanging with too much blackboard data or too many disconnects/reconnects (#55 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/55>)
* [code] Clear snapshot timeline on reconnect (#54 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/54>)
* [infra] Temporarily exclude python3-pyqt5 dep on Lyrical and Rolling (#53 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/53>)
* [infra] Fix package.xml dependencies for newer Ubuntu distros (#52 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/52>)
* Allow reconnecting to snapshot streams on backend restart (#51 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/51>)
* Add resource file (#50 <https://github.com/splintered-reality/py_trees_ros_viewer/issues/50>)
* Fix small typo in README
* Contributors: Jorge Santos Simón, Sebastian Castro
```
