### PR TITLE
py_trees_js: 0.6.7-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6427,7 +6427,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.6-3
+      version: 0.6.7-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_js` to `0.6.7-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_js.git
- release repository: https://github.com/ros2-gbp/py_trees_js-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.6-3`

## py_trees_js

```
* [infra] Fix package.xml dependencies for newer Ubuntu distros (#157 <https://github.com/splintered-reality/py_trees_js/issues/157>)
* Add resource file (#156 <https://github.com/splintered-reality/py_trees_js/issues/156>)
* Add myself to maintainers list (#154 <https://github.com/splintered-reality/py_trees_js/issues/154>)
* Contributors: Sebastian Castro
```
