### PR TITLE
py_trees_ros_tutorials: 2.5.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8661,7 +8661,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `py_trees_ros_tutorials` to `2.5.0-1`:

- upstream repository: https://github.com/splintered-reality/py_trees_ros_tutorials.git
- release repository: https://github.com/ros2-gbp/py_trees_ros_tutorials-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.0-1`

## py_trees_ros_tutorials

```
* [infra] Fix package.xml deps for Lyrical and later (#58 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/58>)
* [docs] Remove rclpy intersphinx mappings (#57 <https://github.com/splintered-reality/py_trees_ros_tutorials/issues/57>)
* Contributors: Sebastian Castro
```
