### PR TITLE
add jskeus-dev key

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2607,6 +2607,10 @@ jskeus:
   debian: [jskeus]
   ubuntu:
     jammy: [jskeus]
+jskeus-dev:
+  debian: [jskeus-dev]
+  ubuntu:
+    jammy: [jskeus-dev]
 julius-voxforge:
   fedora: [julius-voxforge]
   ubuntu: [julius-voxforge]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

jskeus-dev

## Package Upstream Source:

https://github.com/euslisp/euslisp

## Purpose of using this:

This dependency is being used for releasing our package https://github.com/jsk-ros-pkg/jsk_roseus/pull/761

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/sid/jskeus-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/jskeus-dev
