### PR TITLE
ros2_control: 5.16.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7914,7 +7914,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 5.15.0-1
+      version: 5.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2_control` to `5.16.0-1`:

- upstream repository: https://github.com/ros-controls/ros2_control.git
- release repository: https://github.com/ros2-gbp/ros2_control-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `5.15.0-1`

## controller_interface

```
* Migrate hardware components to new handle API (#2987 <https://github.com/ros-controls/ros2_control/issues/2987>) (#3186 <https://github.com/ros-controls/ros2_control/issues/3186>)
* Contributors: mergify[bot]
```

## controller_manager

```
* Fix the initialization of the parsed resource managers (#3346 <https://github.com/ros-controls/ros2_control/issues/3346>) (#3460 <https://github.com/ros-controls/ros2_control/issues/3460>)
* Migrate hardware components to new handle API (#2987 <https://github.com/ros-controls/ros2_control/issues/2987>) (#3186 <https://github.com/ros-controls/ros2_control/issues/3186>)
* Make sleep in ros2_control node optional (#3213 <https://github.com/ros-controls/ros2_control/issues/3213>) (#3453 <https://github.com/ros-controls/ros2_control/issues/3453>)
* Contributors: mergify[bot]
```

## controller_manager_msgs

- No changes

## hardware_interface

```
* Fix the initialization of the parsed resource managers (#3346 <https://github.com/ros-controls/ros2_control/issues/3346>) (#3460 <https://github.com/ros-controls/ros2_control/issues/3460>)
* Migrate hardware components to new handle API (#2987 <https://github.com/ros-controls/ros2_control/issues/2987>) (#3186 <https://github.com/ros-controls/ros2_control/issues/3186>)
* Contributors: mergify[bot]
```

## hardware_interface_testing

```
* Migrate hardware components to new handle API (#2987 <https://github.com/ros-controls/ros2_control/issues/2987>) (#3186 <https://github.com/ros-controls/ros2_control/issues/3186>)
* Contributors: mergify[bot]
```

## joint_limits

```
* Fix joint limits namespace wording (#3445 <https://github.com/ros-controls/ros2_control/issues/3445>) (#3448 <https://github.com/ros-controls/ros2_control/issues/3448>)
* Contributors: mergify[bot]
```

## ros2_control

- No changes

## ros2_control_test_assets

- No changes

## ros2controlcli

- No changes

## rqt_controller_manager

- No changes

## transmission_interface

- No changes
