### PR TITLE
rviz: 16.0.2-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9332,7 +9332,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 16.0.1-1
+      version: 16.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `16.0.2-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `16.0.1-1`

## rviz2

```
* use C++ 20 in default. (#1810 <https://github.com/ros2/rviz/issues/1810>)
* Contributors: Tomoya Fujita
```

## rviz_common

```
* SelectionHandler::registerHandle() handle null pointer (#1710 <https://github.com/ros2/rviz/issues/1710>)
* Modernize rviz_common to C++20 (#1787 <https://github.com/ros2/rviz/issues/1787>)
* Refactor panel deletion logic in VisualizationFrame to prevent issues during bulk-clearing (#1789 <https://github.com/ros2/rviz/issues/1789>)
* Contributors: Alejandro Hernández Cordero, Tony Najjar
```

## rviz_default_plugins

```
* use C++ 20 in default. (#1810 <https://github.com/ros2/rviz/issues/1810>)
* Clean up rviz_default_plugins CMakeLists.txt by removing unused libraries (#1785 <https://github.com/ros2/rviz/issues/1785>)
* Use URDF visual material when it exists (#1782 <https://github.com/ros2/rviz/issues/1782>)
* Implement destructor for PointCloud2TransportDisplay to unsubscribe on destruction (#1788 <https://github.com/ros2/rviz/issues/1788>)
* Contributors: Alejandro Hernández Cordero, Tomoya Fujita, Tony Najjar, mosfet80
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* use C++ 20 in default. (#1810 <https://github.com/ros2/rviz/issues/1810>)
* Add rendering guard for width and/or height being 0 (#1800 <https://github.com/ros2/rviz/issues/1800>)
* Contributors: Tomoya Fujita, Tony Najjar
```

## rviz_rendering_tests

```
* use C++ 20 in default. (#1810 <https://github.com/ros2/rviz/issues/1810>)
* Contributors: Tomoya Fujita
```

## rviz_visual_testing_framework

```
* use C++ 20 in default. (#1810 <https://github.com/ros2/rviz/issues/1810>)
* Contributors: Tomoya Fujita
```
