### PR TITLE
rviz: 15.2.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9442,7 +9442,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.2.4-1
+      version: 15.2.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.2.5-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.2.4-1`

## rviz2

- No changes

## rviz_common

```
* Refactor panel deletion logic in VisualizationFrame to prevent issues during bulk-clearing (#1789 <https://github.com/ros2/rviz/issues/1789>) (#1790 <https://github.com/ros2/rviz/issues/1790>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Use URDF visual material when it exists (#1782 <https://github.com/ros2/rviz/issues/1782>) (#1805 <https://github.com/ros2/rviz/issues/1805>)
* Implement destructor for PointCloud2TransportDisplay to unsubscribe on destruction (#1788 <https://github.com/ros2/rviz/issues/1788>) (#1794 <https://github.com/ros2/rviz/issues/1794>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Add rendering guard for width and/or height being 0 (#1800 <https://github.com/ros2/rviz/issues/1800>) (#1801 <https://github.com/ros2/rviz/issues/1801>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
