### PR TITLE
rviz: 15.0.14-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -9405,7 +9405,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 15.0.13-1
+      version: 15.0.14-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `15.0.14-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `15.0.13-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Refactor panel deletion logic in VisualizationFrame to prevent issue during bulk-clearing (backport #1789 <https://github.com/ros2/rviz/issues/1789>) (#1791 <https://github.com/ros2/rviz/issues/1791>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Use URDF visual material when it exists (#1782 <https://github.com/ros2/rviz/issues/1782>) (#1806 <https://github.com/ros2/rviz/issues/1806>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Add rendering guard for width and/or height being 0 (#1800 <https://github.com/ros2/rviz/issues/1800>) (#1802 <https://github.com/ros2/rviz/issues/1802>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_resource_interfaces

- No changes

## rviz_visual_testing_framework

- No changes
