### PR TITLE
rviz: 14.1.23-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11215,7 +11215,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.22-1
+      version: 14.1.23-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `14.1.23-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `14.1.22-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Refactor panel deletion logic in VisualizationFrame to prevent issue during bulk-clearing (backport #1789 <https://github.com/ros2/rviz/issues/1789>) (#1792 <https://github.com/ros2/rviz/issues/1792>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Use URDF visual material when it exists (#1782 <https://github.com/ros2/rviz/issues/1782>) (#1807 <https://github.com/ros2/rviz/issues/1807>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Add rendering guard for width and/or height being 0 (#1800 <https://github.com/ros2/rviz/issues/1800>) (#1803 <https://github.com/ros2/rviz/issues/1803>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
