### PR TITLE
rviz: 11.2.28-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11524,7 +11524,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.27-1
+      version: 11.2.28-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rviz` to `11.2.28-1`:

- upstream repository: https://github.com/ros2/rviz.git
- release repository: https://github.com/ros2-gbp/rviz-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `11.2.27-1`

## rviz2

- No changes

## rviz_assimp_vendor

- No changes

## rviz_common

```
* Refactor panel deletion logic in VisualizationFrame to prevent issue during bulk-clearing (backport #1789 <https://github.com/ros2/rviz/issues/1789>) (#1793 <https://github.com/ros2/rviz/issues/1793>)
* Contributors: mergify[bot]
```

## rviz_default_plugins

```
* Use URDF visual material when it exists (#1782 <https://github.com/ros2/rviz/issues/1782>) (#1808 <https://github.com/ros2/rviz/issues/1808>)
* Contributors: mergify[bot]
```

## rviz_ogre_vendor

- No changes

## rviz_rendering

```
* Add rendering guard for width and/or height being 0 (#1800 <https://github.com/ros2/rviz/issues/1800>) (#1804 <https://github.com/ros2/rviz/issues/1804>)
* Contributors: mergify[bot]
```

## rviz_rendering_tests

- No changes

## rviz_visual_testing_framework

- No changes
