### PR TITLE
python_qt_binding: 2.5.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -6659,7 +6659,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 2.5.4-3
+      version: 2.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `python_qt_binding` to `2.5.5-1`:

- upstream repository: https://github.com/ros-visualization/python_qt_binding.git
- release repository: https://github.com/ros2-gbp/python_qt_binding-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.5.4-3`

## python_qt_binding

```
* Removed Python2 references (#163 <https://github.com/ros-visualization/python_qt_binding/issues/163>) (#164 <https://github.com/ros-visualization/python_qt_binding/issues/164>)
* Contributors: mergify[bot]
```
