### PR TITLE
Adding DendROS to documentation index for jazzy

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2258,6 +2258,16 @@ repositories:
       url: https://github.com/ros2/demos.git
       version: jazzy
     status: developed
+  dendros:
+    doc:
+      type: git
+      url: https://github.com/mlisi1/DendROS.git
+      version: main
+    source:
+      type: git
+      url: https://github.com/mlisi1/DendROS.git
+      version: main
+    status: developed
   depth_obstacle_detect_ros:
     doc:
       type: git


### PR DESCRIPTION
<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

  # Please Add This Package to be indexed in the rosdistro.

  Jazzy

  # The source is here:

  https://github.com/mlisi1/DendROS

  # Checks
   - [x] All packages have a declared license in the package.xml
   - [x] This repository has a LICENSE file
   - [ ] This package is expected to build on the submitted rosdistro

  # Note

  `dendros` is a shell wrapper around ros2 CLI,  providing per-node
  colorized output, crash alerts, and colorized CLI tooling (topic/service/action/param
  listings). It has no compiled code or ROS nodes, so it is not colcon-buildable — this
  PR adds `source`/`doc` indexing only, no `release` entry.
