### PR TITLE
geometry2: 0.45.8-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2658,7 +2658,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.45.7-3
+      version: 0.45.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `geometry2` to `0.45.8-1`:

- upstream repository: https://github.com/ros2/geometry2.git
- release repository: https://github.com/ros2-gbp/geometry2-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.45.7-3`

## examples_tf2_py

- No changes

## geometry2

- No changes

## tf2

```
* Cleanup headers (#928 <https://github.com/ros2/geometry2/issues/928>) (#943 <https://github.com/ros2/geometry2/issues/943>)
* Contributors: mergify[bot]
```

## tf2_bullet

```
* Cleanup headers (#928 <https://github.com/ros2/geometry2/issues/928>) (#943 <https://github.com/ros2/geometry2/issues/943>)
* Contributors: mergify[bot]
```

## tf2_eigen

- No changes

## tf2_eigen_kdl

- No changes

## tf2_geometry_msgs

- No changes

## tf2_kdl

- No changes

## tf2_msgs

- No changes

## tf2_py

- No changes

## tf2_ros

```
* Cleanup headers (#928 <https://github.com/ros2/geometry2/issues/928>) (#943 <https://github.com/ros2/geometry2/issues/943>)
* Contributors: mergify[bot]
```

## tf2_ros_py

```
* tf2_ros_py: Make node parameter optional in TransformListener (#935 <https://github.com/ros2/geometry2/issues/935>) (#936 <https://github.com/ros2/geometry2/issues/936>)
* tf2_ros_py: Ignore ExternalShutdownException in background thread (#930 <https://github.com/ros2/geometry2/issues/930>) (#931 <https://github.com/ros2/geometry2/issues/931>)
* Contributors: mergify[bot]
```

## tf2_sensor_msgs

- No changes

## tf2_tools

- No changes
