### PR TITLE
launch: 3.9.8-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -3905,7 +3905,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.9.7-3
+      version: 3.9.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.9.8-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.9.7-3`

## launch

```
* Fix Pytest 8/9 compatibility in hooks (backport #972 <https://github.com/ros2/launch//issues/972>) (#973 <https://github.com/ros2/launch//issues/973>)
* Contributors: mergify[bot]
```

## launch_pytest

```
* Fix Pytest 8/9 compatibility in hooks (backport #972 <https://github.com/ros2/launch//issues/972>) (#973 <https://github.com/ros2/launch//issues/973>)
* Contributors: mergify[bot]
```

## launch_testing

```
* Fix Pytest 8/9 compatibility in hooks (backport #972 <https://github.com/ros2/launch//issues/972>) (#973 <https://github.com/ros2/launch//issues/973>)
* Contributors: mergify[bot]
```

## launch_testing_ament_cmake

- No changes

## launch_xml

- No changes

## launch_yaml

- No changes
