### PR TITLE
launch: 3.8.8-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -3900,7 +3900,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.8.7-1
+      version: 3.8.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `launch` to `3.8.8-1`:

- upstream repository: https://github.com/ros2/launch.git
- release repository: https://github.com/ros2-gbp/launch-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.8.7-1`

## launch

```
* Correct typos (backport #961 <https://github.com/ros2/launch//issues/961>) (#962 <https://github.com/ros2/launch//issues/962>)
* Contributors: mergify[bot]
```

## launch_pytest

```
* Backport #949 <https://github.com/ros2/launch//issues/949> (#966 <https://github.com/ros2/launch//issues/966>)
* Contributors: Tim Clephas
```

## launch_testing

```
* Correct typos (backport #961 <https://github.com/ros2/launch//issues/961>) (#962 <https://github.com/ros2/launch//issues/962>)
* Contributors: mergify[bot]
```

## launch_testing_ament_cmake

- No changes

## launch_xml

```
* Correct typos (backport #961 <https://github.com/ros2/launch//issues/961>) (#962 <https://github.com/ros2/launch//issues/962>)
* Contributors: mergify[bot]
```

## launch_yaml

```
* Correct typos (backport #961 <https://github.com/ros2/launch//issues/961>) (#962 <https://github.com/ros2/launch//issues/962>)
* Contributors: mergify[bot]
```
