### PR TITLE
Update gstreamer1.0-plugins-good in base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1881,7 +1881,9 @@ gstreamer1.0-plugins-good:
   openembedded: [gstreamer1.0-plugins-good@openembedded-core]
   opensuse: [gstreamer-plugins-good]
   rhel: [gstreamer1-plugins-good]
-  ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
+  ubuntu:
+    '*': [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
+    resolute: [gstreamer1.0-plugins-good]
 gstreamer1.0-plugins-ugly:
   arch: [gst-plugins-ugly]
   debian: [gstreamer1.0-plugins-ugly]


### PR DESCRIPTION
Ubuntu 26.04 (resolute) updated dependencies for gstreamer1.0-plugins-good, with libgstreamer-plugins-good1.0-0 no longer in the repositories.
This causes `rosdep install` failures on up-to-date systems.
See:
- [Dependency list of Ubuntu 25.04](https://packages.ubuntu.com/questing/gstreamer1.0-plugins-good)
- [Dependency list of Ubuntu 26.04, lacking libgstreamer-plugins-good1.0-0](https://packages.ubuntu.com/resolute/gstreamer1.0-plugins-good)

These changes were tested on Ubuntu 26.04 LTS following the rosdep contribution rules.