### PR TITLE
wireless: 3.0.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11279,6 +11279,24 @@ repositories:
       url: https://github.com/cyberbotics/webots_ros2.git
       version: master
     status: maintained
+  wireless:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: lyrical
+    release:
+      packages:
+      - wireless_msgs
+      - wireless_watcher
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/clearpath-gbp/wireless-release.git
+      version: 3.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/wireless.git
+      version: lyrical
+    status: maintained
   xacro:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `3.0.0-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## wireless_msgs

```
* Removed lint test and fixed deps for msgs.
* Added precommit, dependabot, CI, mergify and issue template.
* Contributors: Tony Baltovski
```

## wireless_watcher

```
* Minor linting change.
* Changed to iw from wireless-tools for Lyrical.
* Removed lint test and fixed deps for msgs.
* Added precommit, dependabot, CI, mergify and issue template.
* Contributors: Tony Baltovski
```
