### PR TITLE
Adding libqtgui key for Jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6853,7 +6853,7 @@ libqtgui:
   ubuntu:
     '*': [libqt6gui6]
     'focal': null
-    'jammy': null
+    'jammy': [libqt5gui5]
     'noble': [libqt5gui5t64]
 libqtgui4:
   debian: [libqtgui4]


### PR DESCRIPTION
Adds a Qt5 package for libqtgui for `jammy` to go with the other distros.
