### PR TITLE
mapoi: 0.6.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5457,6 +5457,24 @@ repositories:
       url: https://github.com/Neargye/magic_enum.git
       version: master
     status: maintained
+  mapoi:
+    release:
+      packages:
+      - mapoi
+      - mapoi_interfaces
+      - mapoi_rviz_plugins
+      - mapoi_server
+      - mapoi_turtlebot3_example
+      - mapoi_webui
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/shimz-robotics/mapoi-release.git
+      version: 0.6.0-1
+    source:
+      type: git
+      url: https://github.com/shimz-robotics/mapoi.git
+      version: main
+    status: developed
   mapviz:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mapoi` to `0.6.0-1`:

- upstream repository: https://github.com/shimz-robotics/mapoi.git
- release repository: https://github.com/shimz-robotics/mapoi-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mapoi

```
* Add the repository ``LICENSE`` alongside ``package.xml``, so the bloom-generated release artifacts (source archive / deb) for the metapackage bundle the license text like the other packages already did (#395).
```

## mapoi_interfaces

```
* No changes for this package in this release.
```

## mapoi_rviz_plugins

```
* Add Undo/Redo to ``PoiEditorPanel`` via ``QUndoStack``, covering row add/copy/delete, cell edits, and row reordering (Ctrl+Z / Ctrl+Shift+Z, shortcuts scoped to panel focus) (#407).
* Add Undo/Redo buttons to the PoiEditor toolbar, enabled via ``canUndoChanged`` / ``canRedoChanged``, since the Ctrl+Z-only shortcut from #407 gave no visible affordance (#435).
* Add an unsaved-edit guard to ``PoiEditorPanel``: track a dirty flag from cell edits/row add/delete/reorder, confirm before an external ``mapoi/config_path`` update discards them, and warn before ``Save`` overwrites content that changed on disk since load (#399).
* Add a POI name search filter to the PoiEditor table (case-insensitive substring match via ``setRowHidden``, combinable with the existing tag filter) (#405).
* Add Nav/Loc backend connection status badges to ``MapoiPanel``, derived from ``NavigationBackendStatus`` / ``LocalizationBackendStatus`` liveliness and ``reason`` (#400).
* Surface operation failures and successful initial-pose requests as a transient UI notice instead of RCLCPP-log-only feedback, covering ``request_initial_pose`` reject/timeout and ``get_route_pois`` failure (#401).
* Show route-driving progress in ``MapoiPanel`` by subscribing to ``mapoi/events`` and displaying the passed POI name with an ``n/total`` count (#406).
* Show a transient notice for commands rejected while navigating by subscribing to the existing ``mapoi/nav/command_rejected`` topic, auto-clearing after 5 s (#398).
* Keep the ``Route progress: —`` / ``Notice: —`` / ``Nav status: —`` idle placeholders permanently visible instead of blank labels, via new ``SetRouteProgressIdle`` / ``SetNoticeIdle`` / ``SetNavStatusIdle`` helpers (#451).
* Translate the ``MapoiPanel`` UI strings (buttons, labels, status messages) and the few remaining Japanese PoiEditor strings (two ``ValidatePois`` messages, the name-filter placeholder) from Japanese to English, matching the already-English WebUI (#431).
* Fix an uninitialized ``is_table_color_`` bool in ``PoiEditorPanel`` that could read as true when the mapoi service is unavailable, and add a bounds check on the ``shadow_`` write in ``TableChanged`` to prevent an out-of-bounds vector write (#432).
* Guard ``YAML::LoadFile`` in ``SaveButton`` against an unreadable or malformed map file, which previously threw uncaught and crashed RViz (#429).
* Validate the RViz Fixed Frame in ``PoiPoseCallback`` (Set Mapoi Pose) and reject the pose with a warning dialog unless the frame is ``map``, preventing a Fixed-Frame-relative pose from being saved as a map-frame POI (#430).
* Fix ``PoiPoseCallback`` writing the Set Mapoi Pose result into the hardcoded column index ``2`` instead of ``kColPose``, which corrupted the tolerance cell and left the pose cell unchanged (#427).
* Add a timeout to eight ``spin_until_future_complete`` service calls in the panel and editor that could previously hang the UI thread indefinitely (#404).
* Extend the unsaved-edit confirmation guard to tag filter changes, which previously discarded edits (and cleared the undo stack) on any filter change, even reselecting the same tag (#428).
* Clear a cell's green edited-mark once Undo restores its value to the ``clean_texts_`` baseline (last full rebuild / save), instead of leaving it marked as changed (#445).
* Fix New/Copy inserting rows at the logical index instead of the visually selected position after a drag reorder, using ``visualIndex`` / ``moveSection`` to insert under the selected row (#434).
* Remove the ``PoiTable`` header's sort indicator, which implied an active ascending sort that was never actually enabled (#433).
* Add a bottom vertical spacer to ``mapoi_panel.ui`` to absorb excess dock height instead of stretching the gaps between status labels (#446).
* Add a path+mtime content-diff guard to ``ConfigPathCallback`` in both panels (mirroring ``mapoi_rviz2_publisher``'s dedup), skipping the blocking service re-fetch and full rebuild when a re-published ``mapoi/config_path`` is unchanged (#403).
* Split ``mapoi_panel.cpp`` and ``poi_editor.cpp`` into per-responsibility translation units (``mapoi_panel_nav_control.cpp`` / ``mapoi_panel_backend_status.cpp`` / ``mapoi_panel_config.cpp`` / ``mapoi_panel_nav_status.cpp`` / ``poi_editor_tags.cpp`` / ``poi_editor_save.cpp`` / ``poi_editor_display_settings.cpp``) and convert ``calcYaw`` / ``join`` / ``SplitSentence`` into free functions in ``poi_editor_helpers.hpp``; internal refactor, no behavior change (#397).
```

## mapoi_server

```
* ``mapoi_rviz2_publisher``: rebuild the marker arrays only when the underlying data changed (POIs, routes, highlights, display parameters), republishing the cached arrays with a refreshed stamp on unchanged ticks — the 1 Hz republish itself is kept so late-joining ``volatile`` subscribers still receive markers — and skip the tick entirely while both marker topics have zero subscribers (#402).
```

## mapoi_turtlebot3_example

```
* No changes for this package in this release.
```

## mapoi_webui

```
* Flip the UI toggle (☰) ``aria-pressed`` semantics so the button lights up (blue) while the UI panel is shown, matching the lock button's "on by default" look (#449).
* Vendor Leaflet under ``web/vendor/leaflet/`` and serve it from a new ``/vendor/<path>`` static route instead of loading it from the ``unpkg.com`` CDN, so the WebUI works fully offline (#394).
* Add a Help overlay (``?`` button / modal, also opened with the ``?`` key) listing shortcuts and map/edit/save/POI-list/Navigation usage; Escape closes it with top priority over other shortcuts, and while it is open all other owned shortcuts are disabled to prevent accidental actions behind the modal (#391).
* Add ``L`` / ``U`` single-key shortcuts to toggle POI position-drag lock and UI panel visibility, driving the existing toggle buttons through a single code path; modifier combinations (e.g. ``Ctrl+L``) and key repeat are ignored (#390).
* Add a name search box to the POI list: case-insensitive substring match on ``poi.name``, filtering the list only (map markers and the current selection are unaffected) (#383).
* Pan the map to the selected POI when it is picked from the POI list (or Navigation dropdown) and falls outside the current viewport; selections originating from a map click are never panned since the clicked POI is already visible (#382).
* Warn on tab close / reload / navigation via ``beforeunload`` when a POI/route/tag editor is dirty or has an open edit form, reusing the same blocker definition as the SSE reload guard (#380).
* Show a world-coordinate readout (``x: ..., y: ...``, formatted to the POI YAML's decimal precision) that follows the mouse over the map and hides on ``mouseout`` or non-finite coordinates (#381).
* Skip the SSE-triggered full reload when a tab's own Save round-trips back to it: ``config_changed`` payloads now carry a ``config_version`` (sha256), and the frontend treats a matching version as self-originated, avoiding the undo-history and map-viewport reset that a spurious reload used to cause; a "Saved" toast (shown on a successful ``Ctrl+S`` save) now gives the save-confirmation feedback that the reload flicker previously provided (#384).
* Add ``Ctrl+S`` / ``Cmd+S`` to save all dirty editors, committing an open edit form first (via its OK-equivalent validation) before saving; shows a "No unsaved changes" toast when there is nothing to save, and ignores key repeat and re-entry while a save is in flight (#375).
* Add a ``Delete`` key shortcut to remove the selected POI, with no confirmation dialog — the deletion only touches the working copy and is undoable with ``Ctrl+Z``, so an undo-hint toast is shown instead; ignored while an input is focused or a route/POI form is open (#374).
* Guard the SSE ``config_changed`` full reload against silently discarding a dirty tab's unsaved edits and undo history: reload is now held and offered as an OK/Cancel choice (load latest vs. keep editing) whenever a POI/route/tag editor is dirty or has an open edit form (#373).
```
