### PR TITLE
realtime_support: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7086,7 +7086,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/realtime_support-release.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realtime_support` to `1.0.1-1`:

- upstream repository: https://github.com/ros2/realtime_support.git
- release repository: https://github.com/ros2-gbp/realtime_support-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.0.0-1`

## rttest

```
* constrain calculate_stddev with std::ranges::input_range + std::is_arithmetic_v (#150 <https://github.com/ros2/realtime_support/issues/150>)
* replacing NULL with nullptr and atoi with from_chars (#149 <https://github.com/ros2/realtime_support/issues/149>)
* Modernize rttest and tlsf_cpp for C++20 part 2 (#148 <https://github.com/ros2/realtime_support/issues/148>)
* Modernize rttest and tlsf_cpp for C++20 (#147 <https://github.com/ros2/realtime_support/issues/147>)
* fixed page-fault accumulator and removed non-deducible converting constructor (#146 <https://github.com/ros2/realtime_support/issues/146>)
* Contributors: Alejandro Hernández Cordero
```

## tlsf_cpp

```
* replacing NULL with nullptr and atoi with from_chars (#149 <https://github.com/ros2/realtime_support/issues/149>)
* Modernize rttest and tlsf_cpp for C++20 (#147 <https://github.com/ros2/realtime_support/issues/147>)
* fixed page-fault accumulator and removed non-deducible converting constructor (#146 <https://github.com/ros2/realtime_support/issues/146>)
* Call rclcpp::shutdown at the end of the example. (#145 <https://github.com/ros2/realtime_support/issues/145>)
* Contributors: Alejandro Hernández Cordero, Chris Lalancette
```
