### PR TITLE
ros2cli: 0.41.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8086,7 +8086,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.41.0-1
+      version: 0.41.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.41.1-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.41.0-1`

## ros2action

```
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle
```

## ros2cli

```
* Allow configuring the daemon inactivity timeout (#1240 <https://github.com/ros2/ros2cli//issues/1240>)
* ros2daemon also uses node logger to store log in the file system. (#1237 <https://github.com/ros2/ros2cli//issues/1237>)
* Check socket is actually freed and reusable during shutdown daemon. (#1230 <https://github.com/ros2/ros2cli//issues/1230>)
* Contributors: Abderahmane BENALI, Tomoya Fujita
```

## ros2cli_test_interfaces

- No changes

## ros2component

```
* add "--log-level" option for "ros2 component load" (#1212 <https://github.com/ros2/ros2cli//issues/1212>)
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Peng Wang
```

## ros2doctor

- No changes

## ros2interface

```
* Fix ros2 interface show --no-comments leaving bare # lines (#1257 <https://github.com/ros2/ros2cli//issues/1257>)
* Contributors: FAN YUCHEN
```

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

```
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle
```

## ros2param

```
* ros2param: fix parameter delete typo (use instance instead of class) (#1243 <https://github.com/ros2/ros2cli//issues/1243>)
* Contributors: longway
```

## ros2pkg

- No changes

## ros2run

```
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle
```

## ros2service

```
* Remove fzf interactive selection for services (#1244 <https://github.com/ros2/ros2cli//issues/1244>)
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Tony Najjar
```

## ros2topic

```
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle
```
