### PR TITLE
ros2cli: 0.40.8-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8178,7 +8178,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.40.7-1
+      version: 0.40.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.40.8-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.40.7-1`

## ros2action

```
* Merge pull request #1232 <https://github.com/ros2/ros2cli//issues/1232> from ros2/mergify/bp/lyrical/pr-1227
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Skyler Medeiros
```

## ros2cli

```
* Check socket is actually freed and reusable during shutdown daemon. (#1230 <https://github.com/ros2/ros2cli//issues/1230>) (#1231 <https://github.com/ros2/ros2cli//issues/1231>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

```
* Update template to use c17 and c++20 (#1221 <https://github.com/ros2/ros2cli//issues/1221>) (#1228 <https://github.com/ros2/ros2cli//issues/1228>)
* Contributors: mergify[bot]
```

## ros2component

```
* Merge pull request #1232 <https://github.com/ros2/ros2cli//issues/1232> from ros2/mergify/bp/lyrical/pr-1227
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Skyler Medeiros
```

## ros2doctor

- No changes

## ros2interface

- No changes

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

```
* Update template to use c17 and c++20 (#1221 <https://github.com/ros2/ros2cli//issues/1221>) (#1228 <https://github.com/ros2/ros2cli//issues/1228>)
* Contributors: mergify[bot]
```

## ros2multicast

- No changes

## ros2node

```
* Merge pull request #1232 <https://github.com/ros2/ros2cli//issues/1232> from ros2/mergify/bp/lyrical/pr-1227
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Skyler Medeiros
```

## ros2param

```
* ros2param: fix parameter delete typo (use instance instead of class) (#1243 <https://github.com/ros2/ros2cli//issues/1243>) (#1250 <https://github.com/ros2/ros2cli//issues/1250>)
* Contributors: mergify[bot]
```

## ros2pkg

```
* Update template to use c17 and c++20 (#1221 <https://github.com/ros2/ros2cli//issues/1221>) (#1228 <https://github.com/ros2/ros2cli//issues/1228>)
* Contributors: mergify[bot]
```

## ros2run

```
* Merge pull request #1232 <https://github.com/ros2/ros2cli//issues/1232> from ros2/mergify/bp/lyrical/pr-1227
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Skyler Medeiros
```

## ros2service

```
* Merge pull request #1246 <https://github.com/ros2/ros2cli//issues/1246> from ros2/mergify/bp/lyrical/pr-1244
* Remove fzf interactive selection for services (#1244 <https://github.com/ros2/ros2cli//issues/1244>)
* Merge pull request #1232 <https://github.com/ros2/ros2cli//issues/1232> from ros2/mergify/bp/lyrical/pr-1227
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Skyler Medeiros, Tony Najjar
```

## ros2topic

```
* Merge pull request #1232 <https://github.com/ros2/ros2cli//issues/1232> from ros2/mergify/bp/lyrical/pr-1227
* Add unit tests for sub-command tab completers (#1227 <https://github.com/ros2/ros2cli//issues/1227>)
* Contributors: MzKyle, Skyler Medeiros
```
