### PR TITLE
ros2cli: 0.38.4-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -8180,7 +8180,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.38.3-2
+      version: 0.38.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros2cli` to `0.38.4-1`:

- upstream repository: https://github.com/ros2/ros2cli
- release repository: https://github.com/ros2-gbp/ros2cli-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.38.3-2`

## ros2action

- No changes

## ros2cli

```
* Enable always complete (#1190 <https://github.com/ros2/ros2cli//issues/1190>) (#1207 <https://github.com/ros2/ros2cli//issues/1207>)
* Contributors: mergify[bot]
```

## ros2cli_test_interfaces

- No changes

## ros2component

- No changes

## ros2doctor

- No changes

## ros2interface

```
* Fix ros2 interface show --no-comments leaving bare # lines (#1257 <https://github.com/ros2/ros2cli//issues/1257>) (#1259 <https://github.com/ros2/ros2cli//issues/1259>)
* Contributors: mergify[bot]
```

## ros2lifecycle

- No changes

## ros2lifecycle_test_fixtures

- No changes

## ros2multicast

- No changes

## ros2node

- No changes

## ros2param

```
* ros2param: fix parameter delete typo (use instance instead of class) (#1243 <https://github.com/ros2/ros2cli//issues/1243>) (#1251 <https://github.com/ros2/ros2cli//issues/1251>)
* Contributors: mergify[bot]
```

## ros2pkg

- No changes

## ros2run

- No changes

## ros2service

- No changes

## ros2topic

- No changes
