### PR TITLE
kuka_external_control_sdk: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4880,6 +4880,14 @@ repositories:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git
       version: master
+    release:
+      packages:
+      - kuka_external_control_sdk
+      - kuka_external_control_sdk_examples
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/kroshu/kuka-external-control-sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_external_control_sdk` to `2.0.0-1`:

- upstream repository: https://github.com/kroshu/kuka-external-control-sdk.git
- release repository: https://github.com/ros2-gbp/kuka_external_control_sdk-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## kuka_external_control_sdk

```
* Remove heap allocations from XML handler
* Add external axis integration for KSS+ iiQKA OS2
* Fix propagation of Client IP and Client Port for RSI
* Add EKI support for iiQKA OS2
* Add mxAutomation as commanding protocol
```

## kuka_external_control_sdk_examples

```
* Add mxAutomation as commanding protocol
```
