### PR TITLE
rqt_tf_tree: 1.1.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9255,7 +9255,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_tf_tree.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rqt_tf_tree` to `1.1.1-1`:

- upstream repository: https://github.com/ros-visualization/rqt_tf_tree.git
- release repository: https://github.com/ros2-gbp/rqt_tf_tree-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.0-1`

## rqt_tf_tree

```
* Add missing dependency on tf2_ros_py (#63 <https://github.com/ros-visualization/rqt_tf_tree/issues/63>)
* Replace SafeLoader monkey-patch with dedicated YAML loader subclass (#56 <https://github.com/ros-visualization/rqt_tf_tree/issues/56>)
* Replace SafeLoader monkey-patch with dedicated YAML loader subclass
* Contributors: Arne Hitzmann, Rafal Gorecki, Tim Clephas
```
