### PR TITLE
unique_identifier_msgs: 2.7.1-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -10693,7 +10693,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
-      version: 2.7.0-2
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `unique_identifier_msgs` to `2.7.1-1`:

- upstream repository: https://github.com/ros2/unique_identifier_msgs.git
- release repository: https://github.com/ros2-gbp/unique_identifier_msgs-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.7.0-2`

## unique_identifier_msgs

```
* fix cmake deprecation (#33 <https://github.com/ros2/unique_identifier_msgs/issues/33>) (#34 <https://github.com/ros2/unique_identifier_msgs/issues/34>)
* Remove CODEOWNERS and mirror-rolling-to-master workflow. (#31 <https://github.com/ros2/unique_identifier_msgs/issues/31>)
* Contributors: Chris Lalancette, mergify[bot]
```
