### PR TITLE
libbno055_linux: 1.2.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5283,7 +5283,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/lazytatzv/libbno055_linux-release.git
-      version: 1.2.0-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/lazytatzv/libbno055-linux.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libbno055_linux` to `1.2.3-1`:

- upstream repository: git@github.com:lazytatzv/bno055lib.git
- release repository: https://github.com/lazytatzv/libbno055_linux-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.0-1`
