### PR TITLE
Adding qt-base-dev key for jammy

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9516,7 +9516,7 @@ qt-base-dev:
   ubuntu:
     '*': [qt6-base-dev]
     'focal': null
-    'jammy': null
+    'jammy': [qtbase5-dev]
     'noble': [qtbase5-dev]
 qt-svg-dev:
   alpine: [qt6-qtsvg-dev]


### PR DESCRIPTION
Adds missing key for `qt-base-dev` for `jammy` so that packages can correctly pick up the Qt5 or Qt6 version of this package, depending on which distro they are running.
