### PR TITLE
kuka_drivers: 2.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4870,6 +4870,26 @@ repositories:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git
       version: master
+    release:
+      packages:
+      - fri_configuration_controller
+      - fri_state_broadcaster
+      - joint_group_impedance_controller
+      - kuka_control_mode_handler
+      - kuka_controllers
+      - kuka_driver_interfaces
+      - kuka_drivers
+      - kuka_drivers_core
+      - kuka_event_broadcaster
+      - kuka_iiqka_eac_driver
+      - kuka_kss_message_handler
+      - kuka_rsi_driver
+      - kuka_rsi_simulator
+      - kuka_sunrise_fri_driver
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/kuka_drivers-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/kroshu/kuka_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_drivers` to `2.0.0-1`:

- upstream repository: https://github.com/kroshu/kuka_drivers.git
- release repository: https://github.com/ros2-gbp/kuka_drivers-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## fri_configuration_controller

```
* Add mxAutomation support
```

## fri_state_broadcaster

```
* Add mxAutomation support
```

## joint_group_impedance_controller

```
* Add commanded_position interface to joint_group_impedance_controller
```

## kuka_control_mode_handler

```
* Add mxAutomation support and refactor
```

## kuka_controllers

```
* Add mxAutomation support
```

## kuka_driver_interfaces

```
* Add mxAutomation support
```

## kuka_drivers

```
* Add mxAutomation support
```

## kuka_drivers_core

```
* Synchronize update rate of controller manager
* Add option to lock memory of control loop
```

## kuka_event_broadcaster

```
* Add mxAutomation support
```

## kuka_iiqka_eac_driver

```
* Add option to lock memory
```

## kuka_kss_message_handler

```
* Add mxAutomation support
```

## kuka_rsi_driver

```
* Synchronize update rate of controller manager
* Add option to lock memory
* Change model verification to only consider payload, reach and type
* Scheduling diagnostics
* Add external axis support
* Make CPU affinities and realtime thread priority configurable
* Add mxAutomation support
* [Fix] Deactivate plain RSI driver in case of an error
```

## kuka_rsi_simulator

```
* Add external axis support
```

## kuka_sunrise_fri_driver

```
* Added synchronus cycle time change
* Synchronize update rate of controller manager
* Add option to lock memory
```
