### PR TITLE
ros2_helper: 0.1.3-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9784,6 +9784,21 @@ repositories:
       url: https://github.com/nobleo/ros2_fmt_logger.git
       version: main
     status: developed
+  ros2_helper:
+    doc:
+      type: git
+      url: https://github.com/codevilot/ros2-helper.git
+      version: main
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/codevilot/ros2-helper-release.git
+      version: 0.1.3-1
+    source:
+      type: git
+      url: https://github.com/codevilot/ros2-helper.git
+      version: main
+    status: maintained
   ros2_kortex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository ros2_helper to 0.1.3-1:

Note: the upstream package version is 0.1.3. The -1 suffix is the Debian release increment used by rosdistro/bloom, not part of the upstream release tag or user-facing release version.

- upstream repository: https://github.com/codevilot/ros2-helper.git
- release repository: https://github.com/codevilot/ros2-helper-release.git
- distro file: jazzy/distribution.yaml
- bloom-generated release: ros2_helper 0.1.3-1
- bloom version: 0.14.3

This adds ros2_helper as a new Jazzy release.