### PR TITLE
robot_localization: 3.10.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7740,7 +7740,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.10.0-3
+      version: 3.10.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_localization` to `3.10.1-1`:

- upstream repository: https://github.com/cra-ros-pkg/robot_localization.git
- release repository: https://github.com/ros2-gbp/robot_localization-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.10.0-3`

## robot_localization

```
* Fixing Rolling API changes (#973 <https://github.com/cra-ros-pkg/robot_localization/issues/973>)
* Fixing rosdoc (#970 <https://github.com/cra-ros-pkg/robot_localization/issues/970>)
  * Fixing rosdoc
* move conf.py to subfolder so that rosdoc2 works (#969 <https://github.com/cra-ros-pkg/robot_localization/issues/969>)
* Adding publishing of an REP-105 compliant ECEF transform (#948 <https://github.com/cra-ros-pkg/robot_localization/issues/948>)
  * Adding publishing of an REP-105 compliant ECEF transform
* Fix negative time crashes in Rolling (port of #954 <https://github.com/cra-ros-pkg/robot_localization/issues/954>) (#964 <https://github.com/cra-ros-pkg/robot_localization/issues/964>)
  * Fix additional negative time issues in ROS Kilted
  The previous fix (e992754) addressed some Time constructor calls but
  missed additional code paths:
  1. getFilteredAccelMessage(): Removed redundant rclcpp::Time() wrapper
  around filter_.getLastMeasurementTime() which already returns an
  rclcpp::Time with RCL_ROS_TIME clock type. Now matches the pattern
  used in getFilteredOdometryMessage().
  2. preparePose(): Added RCL_ROS_TIME clock type to Time constructor
  calls for lookupTransformSafe(), matching the pattern used in
  navsat_transform.cpp from commit e992754.
  These paths are only exercised with specific configurations (e.g.,
  acceleration output enabled, certain frame transform setups), which
  is why they weren't caught in the original fix.
  * Fix negative time crash in periodicUpdate clearExpiredHistory
  Guard against subtracting history_length_ from last_measurement_time
  when last_measurement_time is smaller, which results in negative time
  and throws an exception in rclcpp::Time.
  This occurs during simulation startup when the filter has received
  measurements but hasn't been running long enough for history_length_
  (default 0.5s) to have elapsed.
  * Address PR review feedback
  - Revert unintentional removal of rclcpp::Time cast in getFilteredAccelMessage
  - Add clarifying comment for negative time point prevention check
  ---------
  Co-authored-by: Jay Herpin <jherpin@metalsharkboats.com>
* Implement Lifecycle Node Support for EKF and UKF nodes (#959 <https://github.com/cra-ros-pkg/robot_localization/issues/959>)
  * Implement Lifecycle Node Support for EKF and UKF nodes
* Ignoring vscode
* Fix discrepancy between tf and odometry/filtered when world_frame is set to map_frame (#939 <https://github.com/cra-ros-pkg/robot_localization/issues/939>)
  * Improve baselink odom transform lookup
  * New transform_timeout_odom_bl parameter and documentation (#939 <https://github.com/cra-ros-pkg/robot_localization/issues/939>)
* bugfix: imu linear acceleration gravity removal with rotated IMU (#946 <https://github.com/cra-ros-pkg/robot_localization/issues/946>)
  * bugfix: gravity vector rotated to target_grame (was IMU frame) prior to removal from acc_tmp.
  ---------
  Co-authored-by: Haoguang YANG <mailto:yang1510@purdue.edu>
* Fixing angular acceleration initialisation (#945 <https://github.com/cra-ros-pkg/robot_localization/issues/945>)
* Contributors: Boopesh, Jay Herpin, Jonas Otto, Manuel Wopfner, Steve Macenski, Sybren Kappert, Tom Moore
```
