### PR TITLE
ndcurves: 2.3.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5349,6 +5349,15 @@ repositories:
       version: rolling
     status: maintained
   ndcurves:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/ndcurves.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ndcurves-release.git
+      version: 2.3.0-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndcurves` to `2.3.0-1`:

- upstream repository: https://github.com/loco-3d/ndcurves.git
- release repository: https://github.com/ros2-gbp/ndcurves-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
