### PR TITLE
Adding RAFCON to index

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8958,6 +8958,11 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.1-3
     status: maintained
+  rafcon:
+    doc:
+      type: git
+      url: https://github.com/DLR-RM/RAFCON
+      version: 2.5.0
   rai_interfaces:
     release:
       tags:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

HUMBLE

# The source is here:

https://github.com/DLR-RM/RAFCON

# Checks
 - [ ] All packages have a declared license in the package.xml
   NOTE: RAFCON comes with a license file for Eclipse Public License - v 1.0
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
