### PR TITLE
wireless: 1.1.6-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -14279,7 +14279,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 1.1.5-2
+      version: 1.1.6-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `1.1.6-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.5-2`

## wireless_msgs

```
* Removed lint test and fixed deps for msgs.
* Added precommit, dependabot, CI, mergify and issue template.
* Contributors: Tony Baltovski
```

## wireless_watcher

```
* Added the dormant state as still being connected. (#30 <https://github.com/clearpathrobotics/wireless/issues/30>)
* Removed lint test and fixed deps for msgs.
* Added precommit, dependabot, CI, mergify and issue template.
* Contributors: Tony Baltovski
```
