### PR TITLE
wireless: 3.0.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11301,7 +11301,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/clearpath-gbp/wireless-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/wireless.git


### PR DESCRIPTION
Increasing version of package(s) in repository `wireless` to `3.0.1-1`:

- upstream repository: https://github.com/clearpathrobotics/wireless.git
- release repository: https://github.com/clearpath-gbp/wireless-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## wireless_msgs

- No changes

## wireless_watcher

```
* Added the dormant state as still being connected. (#31 <https://github.com/clearpathrobotics/wireless/issues/31>)
* Contributors: Tony Baltovski
```
