### PR TITLE
rko_lio: 0.3.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7279,7 +7279,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rko_lio-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/PRBonn/rko_lio.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rko_lio` to `0.3.1-1`:

- upstream repository: https://github.com/PRBonn/rko_lio.git
- release repository: https://github.com/ros2-gbp/rko_lio-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.0-1`

## rko_lio

```
* ros: fix rolling compat break, plus a bunch of deprecation warnings (#149 <https://github.com/PRBonn/rko_lio/issues/149>)
  add a ros nightly image based weekly ci job so i have my own signal of api changes upstream
* py: improve raw dataloader and remove open3d as a dep (#148 <https://github.com/PRBonn/rko_lio/issues/148>)
```
