### PR TITLE
clearpath_nav2_demos: 2.8.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1580,7 +1580,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
-      version: 2.8.0-1
+      version: 2.8.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_nav2_demos.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_nav2_demos` to `2.8.1-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_nav2_demos.git
- release repository: https://github.com/clearpath-gbp/clearpath_nav2_demos-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.8.0-1`

## clearpath_nav2_demos

```
* Tuned slam_toolbox defaults: increase throttling, map update interval, and minimum travel thresholds. (#42 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/42>)
* Fixed global costmap rolling window and collision monitor tuning. (#40 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/40>)
* Remaped /tf and /tf_static into robot namespace in nav2.launch.py. (#38 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/38>)
* Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image. (#36 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/36>)
* Added mergify and auto-label. (#34 <https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/34>)
* Contributors: Tony Baltovski
```
