### PR TITLE
rmw_swiftdds: 1.0.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7654,6 +7654,17 @@ repositories:
       version: rolling
     status: developed
   rmw_swiftdds:
+    doc:
+      type: git
+      url: https://github.com/greenstonesoft/rmw_swiftdds.git
+      version: rolling
+    release:
+      packages:
+      - rmw_swiftdds_cpp
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rmw_swiftdds-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/greenstonesoft/rmw_swiftdds.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_swiftdds` to `1.0.1-1`:

- upstream repository: https://github.com/greenstonesoft/rmw_swiftdds.git
- release repository: https://github.com/ros2-gbp/rmw_swiftdds-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
