### PR TITLE
added RAFCON in distribution.yaml

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8438,6 +8438,11 @@ repositories:
       url: https://github.com/ros2-gbp/radar_msgs-release.git
       version: 0.2.2-4
     status: maintained
+  rafcon:
+    doc:
+      type: git
+      url: https://github.com/DLR-RM/RAFCON.git
+      version: 2.5.0
   rai_interfaces:
     release:
       tags:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

JAZZY and HUMBLE

# The source is here:

https://github.com/DLR-RM/RAFCON.git

# Checks
 - [ ] All packages have a declared license in the package.xml
   NOTE: RAFCON in itself is independent from ROS2 but can (and should) be used complementary. Therefore, it does not have a `package.xml`.
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
