### PR TITLE
ndcurves: 2.3.0-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5491,6 +5491,22 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: kilted
     status: maintained
+  ndcurves:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/ndcurves.git
+      version: devel
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/ros2-gbp/ndcurves-release.git
+      version: 2.3.0-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/loco-3d/ndcurves.git
+      version: devel
+    status: maintained
   neo_nav2_bringup:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `ndcurves` to `2.3.0-1`:

- upstream repository: https://github.com/loco-3d/ndcurves.git
- release repository: https://github.com/ros2-gbp/ndcurves-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
