### PR TITLE
ndcurves: 2.3.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6845,6 +6845,22 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: jazzy
     status: maintained
+  ndcurves:
+    doc:
+      type: git
+      url: https://github.com/loco-3d/ndcurves.git
+      version: devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/ndcurves-release.git
+      version: 2.3.0-1
+    source:
+      test_commits: false
+      type: git
+      url: https://github.com/loco-3d/ndcurves.git
+      version: devel
+    status: maintained
   nebula:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndcurves` to `2.3.0-1`:

- upstream repository: https://github.com/loco-3d/ndcurves.git
- release repository: https://github.com/ros2-gbp/ndcurves-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
