### PR TITLE
rclgd: 2.1.0-3 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8827,6 +8827,16 @@ repositories:
       url: https://github.com/ros2/rclcpp.git
       version: jazzy
     status: maintained
+  rclgd:
+    release:
+      packages:
+      - colcon_rclgd
+      - rclgd
+      - rclgd_cli
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/Ozuba/rclgd-release.git
+      version: 2.1.0-3
   rclpy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rclgd` to `2.1.0-3`:

- upstream repository: https://github.com/Ozuba/rclgd.git
- release repository: https://github.com/Ozuba/rclgd-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## colcon_rclgd

```
* Initial release: colcon package identification and build task for
  build_type rclgd (Godot Engine) packages, including headless asset
  import after install
* Contributors: Miguel Oroz Zubasti
```

## rclgd

```
* Restructure into a three-package suite: rclgd (GDExtension),
  colcon_rclgd (build type) and rclgd_cli (ros2 CLI)
* Download the Godot engine at build time (SHA-512 pinned per
  architecture) and install it as lib/rclgd/godot-bin, making the
  package self-contained
* Upgrade godot-cpp and share libstdc++ across the extension boundary
* Lazy initialization architecture and runtime hardening
* Proper memory management for the shadow script registry
* Contributors: Miguel Oroz Zubasti
```

## rclgd_cli

```
* Initial release: ros2 rclgd command with create, editor, list and
  doctor verbs, plus the editor addon template
* Engine provisioning moved into the rclgd build; the former setup verb
  was removed
* Contributors: Miguel Oroz Zubasti
```
