### PR TITLE
ros_snapd_interfaces: 0.0.1-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10617,6 +10617,11 @@ repositories:
       type: git
       url: https://github.com/canonical/ros_snapd_interfaces.git
       version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_snapd_interfaces-release.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/canonical/ros_snapd_interfaces.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_snapd_interfaces` to `0.0.1-1`:

- upstream repository: https://github.com/canonical/ros_snapd_interfaces.git
- release repository: https://github.com/ros2-gbp/ros_snapd_interfaces-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## ros_snapd_interfaces

```
* Update README.md
* update README
* add CMakeLists and package.xml
* Update srv/SnapdList.srv
* Update README.md
* add service definition
* Initial commit
* Contributors: Guillaume Beuzeboc, Guillaumebeuzeboc
```
