### PR TITLE
rplidar_driver: 1.4.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -8837,6 +8837,21 @@ repositories:
       url: https://github.com/AIS-Bonn/rot_conv_lib.git
       version: master
     status: maintained
+  rplidar_driver:
+    doc:
+      type: git
+      url: https://github.com/frozenreboot/rplidar_driver.git
+      version: main
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/rplidar_driver-release.git
+      version: 1.4.0-1
+    source:
+      type: git
+      url: https://github.com/frozenreboot/rplidar_driver.git
+      version: main
+    status: maintained
   rplidar_ros:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_driver` to `1.4.0-1`:

- upstream repository: https://github.com/frozenreboot/rplidar_driver.git
- release repository: https://github.com/ros2-gbp/rplidar_driver-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## rplidar_driver

```
* Raised the minimum required CMake version to 3.16 and verified builds on
  ROS 2 Jazzy and Lyrical (#38 <https://github.com/frozenreboot/rplidar_driver/issues/38>).
* Refactored the node entry point to use the rclcpp_components template macro
  and moved the node into the ``rplidar_node`` namespace (#36 <https://github.com/frozenreboot/rplidar_driver/issues/36>).
* Cleaned up package dependencies and linter configuration, fixing test
  dependency failures on the ROS build farm (#35 <https://github.com/frozenreboot/rplidar_driver/issues/35>).
* Fixed Rolling build compatibility (#33 <https://github.com/frozenreboot/rplidar_driver/issues/33>).
* Added a license audit documenting the vendored Slamtec SDK provenance for
  the first rosdistro release (#32 <https://github.com/frozenreboot/rplidar_driver/issues/32>).
* Converted the changelog to REP-132 format for catkin release tools (#31 <https://github.com/frozenreboot/rplidar_driver/issues/31>).
* Renamed the package to ``rplidar_driver`` following REP-144 naming
  guidelines (#29 <https://github.com/frozenreboot/rplidar_driver/issues/29>).
* Added GTest-based test infrastructure, including mock driver tests and
  lifecycle/publication tests (#20 <https://github.com/frozenreboot/rplidar_driver/issues/20>).
* Clarified that the ``angle_offset`` parameter is specified in radians and
  removed the corresponding launch argument in favor of YAML parameters
  (#23 <https://github.com/frozenreboot/rplidar_driver/issues/23>).
* Fixed QoS parameter inconsistency by initializing the QoS parameter and
  applying the configured policy (#15 <https://github.com/frozenreboot/rplidar_driver/issues/15>).
* Added governance documentation and an AI disclosure section for OSRF
  compliance; added Błażej Sowa as a maintainer (#34 <https://github.com/frozenreboot/rplidar_driver/issues/34>).
* Contributors: Błażej Sowa, JWJ | frozenreboot, cosmicog, wj
```
