### PR TITLE
image_common: 7.0.3-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3384,7 +3384,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/image_common-release.git
-      version: 7.0.2-1
+      version: 7.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `image_common` to `7.0.3-1`:

- upstream repository: https://github.com/ros-perception/image_common
- release repository: https://github.com/ros2-gbp/image_common-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `7.0.2-1`

## camera_calibration_parsers

```
* camera_calibration_parsers: re-enable parser.py tests (#428 <https://github.com/ros-perception/image_common/issues/428>)
* Added rosdoc2 documentation to camera_info_manager_py (#404 <https://github.com/ros-perception/image_common/issues/404>)
* Compile with cpp20 (#424 <https://github.com/ros-perception/image_common/issues/424>)
* Added rosdoc2 documentation to camera_calibration_parsers (#403 <https://github.com/ros-perception/image_common/issues/403>)
* Contributors: Alejandro Hernández Cordero
```

## camera_info_manager

```
* camera_info_manager: Use string_view in URL parsing (#427 <https://github.com/ros-perception/image_common/issues/427>)
* Added rosdoc2 documentation to camera_info_manager_py (#404 <https://github.com/ros-perception/image_common/issues/404>)
* Compile with cpp20 (#424 <https://github.com/ros-perception/image_common/issues/424>)
* Added rosdoc2 documentation to camera info manager (#402 <https://github.com/ros-perception/image_common/issues/402>)
* Prevent executor race condition (#421 <https://github.com/ros-perception/image_common/issues/421>)
* Contributors: Alejandro Hernández Cordero, Michael Carroll
```

## camera_info_manager_py

```
* Type annotations for camenra_info_manager_py (#426 <https://github.com/ros-perception/image_common/issues/426>)
* Python3 modernization (#425 <https://github.com/ros-perception/image_common/issues/425>)
* Added rosdoc2 documentation to camera_info_manager_py (#404 <https://github.com/ros-perception/image_common/issues/404>)
* Contributors: Alejandro Hernández Cordero
```

## image_common

- No changes

## image_transport

```
* Added rosdoc2 documentation to camera_info_manager_py (#404 <https://github.com/ros-perception/image_common/issues/404>)
* Compile with cpp20 (#424 <https://github.com/ros-perception/image_common/issues/424>)
* Added rosdoc2 documentation to camera info manager (#402 <https://github.com/ros-perception/image_common/issues/402>)
* Contributors: Alejandro Hernández Cordero
```

## image_transport_py

```
* Compile with cpp20 (#424 <https://github.com/ros-perception/image_common/issues/424>)
* Contributors: Alejandro Hernández Cordero
```
