### PR TITLE
mola_imu_preintegration: 1.17.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6011,7 +6011,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
-      version: 1.17.0-1
+      version: 1.17.1-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_imu_preintegration.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola_imu_preintegration` to `1.17.1-1`:

- upstream repository: https://github.com/MOLAorg/mola_imu_preintegration.git
- release repository: https://github.com/ros2-gbp/mola_imu_preintegration-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.17.0-1`

## mola_imu_preintegration

```
* Merge pull request #10 <https://github.com/MOLAorg/mola_imu_preintegration/issues/10> from MOLAorg/fix/imu-transformer-near-duplicate-timestamp-dt
  fix: guard against near-zero dt in ImuTransformer angular-accel finite difference
* style: clang-format fix
* fix: guard against near-zero dt in ImuTransformer angular-accel finite difference
  Some IMU drivers (e.g. the Hesai built-in IMU) emit consecutive messages with
  near-duplicate timestamps a few microseconds apart. Dividing the finite-
  difference angular-acceleration term by such a near-zero dt amplified an
  otherwise negligible angular-velocity delta into a huge spurious lever-arm
  correction, corrupting the transformed acceleration for that sample.
  Reproduced end-to-end: ImuInitialCalibrator's pitch/roll came out ~33 deg off
  on a dataset where the true tilt (per the bag's own static transforms) is
  ~2 deg, with about a third of samples in the calibration window affected.
  Widen the existing fallback-rate guard to treat any dt at or below 1 ms the
  same as the dt<=0 case. Add a regression test.
* Contributors: Jose Luis Blanco-Claraco
```
