### PR TITLE
mola: 3.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5953,7 +5953,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola-release.git
-      version: 2.9.0-1
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mola` to `3.0.0-1`:

- upstream repository: https://github.com/MOLAorg/mola.git
- release repository: https://github.com/ros2-gbp/mola-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.0-1`

## mola

- No changes

## mola_bridge_ros2

```
* chore: less verbose warning
* fix: rep105 mode made robust against lagging odom frame
* fix: replace rclcpp deprecated spin_some()
* Merge pull request #153 <https://github.com/MOLAorg/mola/issues/153> from Zeal-Robotics/fix/bridge_ros2-relocalize-frame
  fix(bridge_ros2): transform relocalization pose into reference frame
* fix(bridge_ros2): transform relocalization pose into reference frame
  The relocalization topic callback and the relocalize_near_pose service fed
  the incoming PoseWithCovarianceStamped straight to relocalize_near_pose_pdf(),
  ignoring its header.frame_id. The pose was therefore interpreted in the
  localization reference_frame regardless of the frame it was actually
  expressed in. When a tool publishes it in a different frame (e.g. RViz's
  "2D Pose Estimate" in the fixed frame) that differs from reference_frame,
  the relocalization lands in the wrong place.
  Compose reference_frame <- header.frame_id via the tf buffer before
  relocalizing, in both the topic callback and the service. The covariance is
  propagated through the rotation by CPose3DPDFGaussian::changeCoordinatesReference().
  Requests are skipped (topic) or rejected (service) when the transform is
  unavailable, instead of silently relocalizing to a wrong pose.
* fix: safer owned_rclcpp flag
* Merge pull request #150 <https://github.com/MOLAorg/mola/issues/150> from MOLAorg/fix/bridge-ros2-rclcpp-shutdown-ownership
  feat: bridge ros2 now autodetects rclpp shutdown ownership
* feat: bridge ros2 now autodetects rclpp shutdown ownership
* Merge pull request #149 <https://github.com/MOLAorg/mola/issues/149> from MOLAorg/fix/tf-listener-share-ros-node
  fix(mola_bridge_ros2): share rosNode_ with TF listener for consistent clock/use_sim_time
* fix(mola_bridge_ros2): share rosNode_ with TF listener for consistent clock/use_sim_time handling
  Pass rosNode_ to TransformListener so its /tf and /tf_static subscriptions
  share the bridge's DDS participant, clock, and use_sim_time setting.
  Without this, the default constructor creates an anonymous node that
  ignores use_sim_time -- causing subtle inconsistencies when playing bags
  with --clock. spin_thread=false avoids a redundant second spinner since
  rosNode_ is already spun by the bridge's main loop.
* Contributors: Jose Luis Blanco-Claraco, Robin Van Cauwenbergh
```

## mola_demos

```
* demos: default viz module to MolaVizImGui with per-app imgui_app_name
  Sets a unique imgui_app_name in each launch file so Dear ImGui's
  layout persistence stores a separate UI configuration per demo.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_lidar_bin_dataset

- No changes

## mola_input_rawlog

- No changes

## mola_input_rosbag2

```
* Merge pull request #176 <https://github.com/MOLAorg/mola/issues/176> from MOLAorg/fix/multi-ros-distro-build
  fix: time header field in different ros distros
* fix: time header field in different ros distros
* fix: extend optional wall-clock time source to odometry observations too
* Merge pull request #175 <https://github.com/MOLAorg/mola/issues/175> from MOLAorg/feature/rosbag2-imu-bag-recv-timestamp
  mola_input_rosbag2: opt-in per-sensor bag-recv-time timestamp override
* mola_input_rosbag2: add opt-in use_bag_recv_time_as_timestamp per-sensor flag
  Some sensor drivers (observed with an IMU driver) stamp messages using a
  monotonic/uptime clock instead of wall-clock epoch time, while other
  sensors in the same bag are correctly stamped. This desyncs the affected
  sensor from the rest and repeatedly trips the "mis-timestamped sensors"
  time reference reset in Rosbag2Dataset::next(). When set for a given
  sensor in the 'sensors' YAML list, its observations are timestamped using
  the bag's own recv/storage time instead of the message header stamp.
  Defaults to false (no behavior change).
* Merge pull request #164 <https://github.com/MOLAorg/mola/issues/164> from MOLAorg/feat/rosbag2-multifile
  feat: rosbag2 parser can open several files
* fix: clang-format brace style in for loop
  Co-Authored-By: Claude Sonnet 4.6 <mailto:noreply@anthropic.com>
* fix(rosbag2): collect topics from all bags; skip empty intermediate bags
  - Aggregate topic metadata across all bags during init instead of only
  reading from bag 0, so sensors in later bags are not silently missed.
  - Assert type consistency when the same topic appears in multiple bags.
  - Use a while loop (not if) when advancing to the next bag, so empty
  intermediate bags are skipped without calling read_next() on an
  exhausted reader.
* feat: rosbag2 parser can open several files
* feat: rosbag2 input new option 'max_duration_sec'
* Contributors: Jose Luis Blanco-Claraco
```

## mola_input_video

- No changes

## mola_kernel

```
* fix: default-dock Dataset_UI panel at top; fix Console dock on old layouts
  Add WindowDescription::dock_top_by_default so a window without a saved
  imgui.ini entry gets docked into a strip reserved at the top of the main
  window instead of floating; enabled for the per-module Dataset_UI panel.
  Also make the Console's default bottom-dock (and the new top-dock) key off
  whether that specific window has a saved imgui.ini entry, instead of whether
  the whole ini file already existed. This fixes both never docking new
  window kinds added to an already-existing layout, and splitting a stale,
  no-longer-leaf dock node once more than one default dock has been applied.
* fix: avoid enque on shutdown
* Merge branch 'feat/imviz-metric-plots' into develop
* Remove deprecated nanogui-specific VizInterface API
  create_subwindow(), enqueue_custom_nanogui_code(), subwindow_grid_layout()
  and subwindow_move_resize() have no remaining callers now that
  create_subwindow_from_description() and enqueue_custom_gui_code() cover
  their use cases on both backends.
* Merge pull request #172 <https://github.com/MOLAorg/mola/issues/172> from MOLAorg/feat/imviz-metric-plots
  feat(mola_viz_imgui): add metric time-series plot windows
* feat(mola_viz_imgui): add metric time-series plot windows
  Adds a backend-agnostic register_metric()/push_metric() API to
  VizInterface (guarded by MOLA_KERNEL_VIZ_HAS_METRICS) so any MOLA
  module can stream timestamped scalar values to live, autoscrolling
  plot windows opened from a new "Plots" menu in the mola_viz_imgui
  (ImGui/ImPlot) backend. The nanogui MolaViz backend implements the
  API as a no-op, mirroring the set_menu_bar precedent.
  The Plots menu also gives the Console window its first working
  close/reopen toggle.
  Vendors ImPlot as a submodule under mola_viz_imgui/3rdparty/implot.
* NavStateFilter: introduce optional virtual georef setter/getter
* Merge pull request #165 <https://github.com/MOLAorg/mola/issues/165> from MOLAorg/imgui-window-icon
  feat: mola viz imgui set window icon
* feat: mola viz imgui set window icon
* Merge pull request #163 <https://github.com/MOLAorg/mola/issues/163> from MOLAorg/fix/race-conditions
  fix(mola_kernel): guard RawDataSourceBase consumer list against concu…
* fix(mola_kernel): guard RawDataSourceBase consumer list against concurrent attach
  mola_launcher initializes modules in parallel threads (executor_thread), so when
  two consumers subscribe to the SAME raw_data_source (e.g. both LidarOdometry and
  a mapper module use raw_data_source: dataset_input), both call
  attachToDataConsumer() concurrently and race on the unsynchronized
  std::vector<RawDataConsumer*> push_back. This corrupted the heap and caused an
  intermittent SIGSEGV at startup (caught via coredump: _M_realloc_insert into a
  garbage pointer under RawDataSourceBase::attachToDataConsumer <- FrontEndBase::
  initialize <- MolaLauncherApp::executor_thread).
  Add a mutex guarding rdc_: lock the push_back, and snapshot the list under the
  lock in sendObservationsToFrontEnds() before dispatching (dispatch itself runs
  without the lock so onNewObservation() is not serialized). Validated: 16/16
  SharedMapOnly startups on MulRan DCC01 with two consumers, 0 crashes / 0 cores.
* Merge pull request #162 <https://github.com/MOLAorg/mola/issues/162> from MOLAorg/feat/viz-decay-lookat-frame-aware
  feat: frame-aware parentFrame for decay clouds and camera look-at
* fix: decay eviction uses per-entry container; look-at fails on missing frame
  Four reviewer findings, all confirmed valid:
  1. VizInterface.h comment: add update_viewport_look_at() to the list of APIs
  covered by MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES (it was omitted).
  2/3. Decay cloud eviction (both backends): the eviction path inside
  insert_point_cloud_with_decay() was removing the oldest cloud from the
  *current insertion's* container rather than the container that cloud was
  originally placed in.  If parentFrame ever changes between calls the wrong
  container would be used, leaking the cloud in the scene.  Fix: add a
  container member to DecayingCloud and store the owning container at insert
  time; use it at eviction time.
  4/5. Look-at frame not found (both backends): when parentFrame is non-empty but
  the frame node does not yet exist in the scene, the code was silently falling
  back to treating the raw local-frame coordinates as world-space and moving the
  camera to the wrong position.  Fix: return false so the camera is not moved
  until the frame node is present.
* feat: extend VizInterface for frame-aware decay clouds and camera look-at
  insert_point_cloud_with_decay() and update_viewport_look_at() now both
  accept an optional parentFrame argument (same semantics as the existing
  parentFrame on update_3d_object()): when non-empty, the backend looks up
  the named movable frame node and composes its current scene pose with the
  supplied point before inserting the cloud / moving the camera.  This lets
  callers (e.g. mola_lidar_odometry) pass a local-odom-frame point while
  the camera and transient clouds still end up at the correct world-space
  position when a central mapper (mola_mapper_3d) is continuously
  repositioning the frame node.
  Both backends (MolaViz / MolaVizImGuiCore) and the MolaVizImGui
  forwarder are updated.  The MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES feature
  macro already covers both new parameters; no additional macro is added.
* Merge pull request #160 <https://github.com/MOLAorg/mola/issues/160> from MOLAorg/feat/viz-with-movable-frames
  feat: viz with movable frames
* feat: viz with movable frames
* Merge pull request #159 <https://github.com/MOLAorg/mola/issues/159> from MOLAorg/feat/central-map
  feat: Add virtual interface for central keyframe map for mapper-3d
* feat: Add virtual interface for central keyframe map for mapper-3d
* Merge pull request #151 <https://github.com/MOLAorg/mola/issues/151> from MOLAorg/fix/imgui-slider
  fix: imgui slider
* fix: imgui slider
* Contributors: Jose Luis Blanco-Claraco
```

## mola_launcher

```
* Merge branch 'feat/imviz-metric-plots' into develop
* add findModulesOfType
* fix: user run-at-end functor was never called upon mola-cli dtor
* Merge pull request #152 <https://github.com/MOLAorg/mola/issues/152> from MOLAorg/feature/mola-cli-multi-yaml-cli11
  mola-cli: support multiple YAML files, switch to CLI11
* feat(mola_launcher): support multiple YAML config files in mola-cli, switch CLI parsing to CLI11
  mola-cli now accepts one or more YAML config files as positional arguments;
  each file keeps its existing self-contained modules: structure and all of
  them are merged into a single running system, in the order given.
  Also replaces the TCLAP-based CLI parsing in mola-cli and mola-yaml-parser
  with CLI11 (libcli11-dev), updating CMakeLists.txt and package.xml
  accordingly.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_metric_maps

```
* fix: dont crash on empty maps
* feat: --unify-all flag for mm-kf-regroup
* fix(mola_metric_maps): don't restore stale icp_search_kfs cache from serialized maps
  icp_search_kfs was serialized purely for post-mortem debugging, but
  serializeFrom() restored it straight into the live cache. Since
  icp_search_submap (the actual prepared search structure it gates) is
  never serialized, this let icp_get_prepared_as_global()'s already-up-to-date
  fast path skip rebuilding the submap whenever the freshly computed
  active-keyframe selection happened to coincide with the stale, reloaded
  set. The next nn_search_cov2cov() call would then fail its
  'icp_get_prepared_as_global() first' assertion. Reproduced reliably when
  chaining multi-session/multi-robot maps (loading a previously saved map
  as the starting point for a new robot/session).
* fix: sort by indices to avoid gcc warnings on ABI changes
* chore: tune default island param
* debug: add env-gated point-density match-stats trace
  Adds MOLA_KEYFRAME_MAP_DEBUG_MATCH_STATS (off by default), counting per-call
  accepted / no-candidate-in-range / rejected-by-view-filter totals in
  nn_search_cov2cov_approximate(). Used to diagnose a localization stall on a
  real dataset: distinguishes a genuine point-density gap in the map (points
  with no nearby candidate) from a view-direction-filter rejection or a
  keyframe-selection problem, which look identical from the ICP goodness
  trace alone.
* fix(mola_metric_maps): bound island-merge distance; never starve the diverse KF slot
  Address CodeRabbit review on #174 <https://github.com/MOLAorg/mola/issues/174> plus a second, distinct tracking-loss
  mode found during full-bag testing:
  - regroupKeyframes(): cap island absorption distance at
  extent_factor * (seed radii sum) so a tiny cluster is not glued to a
  spatially disjoint neighbor merely because it's the "nearest" one
  left; islands beyond that bound stay standalone.
  - icp_get_prepared_as_global(): the diverse-keyframe slot's distance
  limit (3x the nearest primary candidate) could reject every other
  candidate when a map has only a handful of large super-keyframes,
  leaving that slot empty and ICP running against a single keyframe.
  At the edge of that keyframe's own coverage this can permanently
  stall tracking (quality stuck just under threshold, no fallback).
  Now falls back to the best-diversity candidate regardless of
  distance rather than leaving the slot unfilled.
* fix(mola_metric_maps): density-aware nearest-keyframe selection + island merging in regroup
  A sparse, under-merged keyframe (e.g. a leftover cluster from
  regroupKeyframes()) could outrank a much better-populated keyframe in
  icp_get_prepared_as_global()'s proximity search purely because its pose
  happened to be closer, starving ICP of real geometry and causing
  localization to get stuck with zero correspondences.
  - KeyframePointCloudMap: add a distance penalty for keyframes below
  density_penalty_min_points, so sparse candidates no longer win over
  well-populated ones just by pose proximity.
  - regroupKeyframes(): absorb clusters below island_merge_fraction of the
  largest cluster's point count into their nearest neighbor instead of
  emitting them as standalone, near-empty super-keyframes.
  - mm-kf-regroup: expose --island-merge-fraction.
  - Adds env-gated debug traces (MOLA_KEYFRAME_MAP_DEBUG_ACTIVE_KFS,
  MOLA_KEYFRAME_MAP_DEBUG_DUMP_KFS_ON_LOAD) used to diagnose this.
* Merge pull request #173 <https://github.com/MOLAorg/mola/issues/173> from MOLAorg/perf/mm-kf-regroup-tbb-parallel-superkf
  mm-kf-regroup: parallelize super-keyframe cloud building with TBB
* mm-kf-regroup: parallelize super-keyframe cloud building with TBB
  Building each super-keyframe's merged/decimated point cloud in
  regroupKeyframes() was the most expensive step but ran single-threaded.
  Clusters are independent, so parallelize with tbb::parallel_for
  (gated by MOLA_METRIC_MAPS_USE_TBB, already a mola_metric_maps
  dependency), falling back to a serial loop when TBB is unavailable.
* better defaults for regroup KF algorithm
* feat: mm-kf-bake-kdtrees sets approximate cov by default
* Merge pull request #171 <https://github.com/MOLAorg/mola/issues/171> from MOLAorg/feat/keyframe-map-persist-covariances-local-tree
  feat(mola_metric_maps): persist per-KF covariances + query baked local KD-tree in approximate cov2cov
* fix(mola_metric_maps): handle v3 in serializeFrom + clang-format
  - Add case 3: to KeyframePointCloudMap::serializeFrom(): serializeGetVersion()
  returns 3, so v3 maps (with baked covariances) were hitting
  MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION on load and never reaching the new
  covariance-read block. (CodeRabbit)
  - Apply clang-format-14 to the changed files (CI clang-format-check).
* feat(mola_metric_maps): persist per-KF covariances and query baked local KD-tree in approximate cov2cov
  Two changes that make localization-only startup with a baked .mm actually
  fast, eliminating the occasional multi-second stalls seen when a fresh
  keyframe first enters the active set:
  A) approximate_cov now queries each active keyframe's own LOCAL-frame cloud
  and KD-tree directly (kf.pointcloud(), the one baked by mm-kf-bake-kdtrees).
  The query point is transformed into each KF's local frame before the lookup
  and the match composed back to global for the pairing. A KD-tree's structure
  is invariant under the rigid KF pose, so this avoids ever materializing a
  per-KF global-frame cloud or rebuilding a KD-tree on it. Previously the baked
  (local) index never touched this hot path, which used a separate global-frame
  tree rebuilt from scratch on first activation. Also robust to online KF pose
  nudges (LIO gravity-tilt correction), which no longer invalidate a global cloud.
  B) New serialize_covariances creationOption: bakes each keyframe's per-point
  local covariances into the .mm (map serialization bumped to v3), so the
  plane-regularized K-NN + SVD pass is not repeated on load. This is the single
  most expensive part of warming a keyframe and needs no special MRPT API, so it
  works on any build (unlike serialize_kdtrees). The cheap per-pose global
  rotation is still done at runtime.
  mm-kf-bake-kdtrees now bakes both KD-trees and covariances by default
  (--no-kdtrees / --no-covariances to select, --disable to strip both).
  Adds a round-trip test asserting a covariance-baked map yields byte-identical
  cov2cov pairings (points + cov_inv) to a runtime-computed one.
* Merge pull request #169 <https://github.com/MOLAorg/mola/issues/169> from MOLAorg/feat/keyframe-map-approximate-cov2cov
  feat(mola_metric_maps): approximate cov2cov mode for KeyframePointCloudMap
* fix(mola_metric_maps): tolerate concurrent KF eviction in approximate cov2cov
  nn_search_cov2cov_approximate() looked up each active KF id via
  keyframes_.at(), which throws std::out_of_range if the KF was evicted
  by a concurrent insertObservation() (remove_frames_farther_than)
  between the earlier icp_get_prepared_as_global() snapshot and this
  call. The exact (merged-submap) path is immune since it deep-copies
  points at prepare time; the approximate path intentionally keeps live
  references into keyframes_ instead, so it needs to check existence.
  Found by CodeRabbit review on MOLAorg/mola#169 <https://github.com/MOLAorg/mola/issues/169>.
* feat(mola_metric_maps): approximate cov2cov mode for KeyframePointCloudMap
  Add TCreationOptions::approximate_cov: when enabled, nn_search_cov2cov()
  skips building the merged, multi-keyframe submap in
  icp_get_prepared_as_global() and instead queries each active keyframe's
  own already-cached KD-tree and per-point covariances directly (N
  per-KF KD-tree lookups instead of one on a merged cloud). This trades
  covariance exactness (estimated only from within-KF neighbors) for
  speed (no merge/KD-tree rebuild), and is opt-in (default false,
  unchanged exact behavior).
* fix: stable re-coloring
* Merge pull request #168 <https://github.com/MOLAorg/mola/issues/168> from MOLAorg/feat/kf-viz-color-by-kf
  feat(mola_metric_maps): debug env var to color each keyframe distinctly
* feat(mola_metric_maps): debug env var to color each keyframe distinctly
  Add MOLA_KEYFRAME_MAP_VIZ_COLOR_BY_KF: when set, KeyframePointCloudMap
  renders every keyframe with a single, distinct color (golden-ratio hue
  spacing) so regrouped super-keyframes / clusters are easy to tell apart
  visually while debugging.
  KeyFrame::getViz() gains an optional overrideColor argument; the override
  path paints all points uniformly and is not cached, so toggling the env
  var takes effect on the next render.
* Merge pull request #167 <https://github.com/MOLAorg/mola/issues/167> from MOLAorg/feat/keyframe-map-regroup-and-kdtree-persist
  Keyframe map regrouping + optional KD-tree persistence (localization-only speedups)
* address review: clearer error when --layer is not present in the map
* address review: shared CLI helper, unsupported-build warning, decimation test
  - Extract the duplicated plugin-load / map-load / KeyframePointCloudMap-layer
  iteration logic of the two CLI tools into a shared apps/kf_cli_utils.h.
  - mm-kf-bake-kdtrees now warns when built against an MRPT lacking the KD-tree
  save/load index API (baking would silently be a no-op otherwise).
  - Add a regroup test exercising merge_decimate_voxel > 0: the duplicated points
  collapse and the per-point view-direction fields survive decimation (verified
  via the cov-to-cov view filter).
* feat(mola_metric_maps): keyframe regrouping + optional kd-tree persistence
  Two offline optimizations of a KeyframePointCloudMap layer for fast
  localization-only operation:
  - regroupKeyframes() + mm-kf-regroup CLI: group many small keyframes into
  fewer, larger, deliberately-overlapping "super-keyframes" so the ICP active
  set stays size 1 (no per-scan keyframe switching). Graph-theoretic: keyframe
  adjacency graph with voxel Jaccard-min overlap edge weights, greedy
  overlapping set-cover clustering auto-sized from each keyframe bounding box,
  merged clouds voxel-decimated (view-direction fields carried).
  - serialize_kdtrees creationOption + mm-kf-bake-kdtrees CLI: cache each
  keyframe's per-cloud 3D KD-tree index inside the .mm so it is not rebuilt on
  every load. Bumps map serialization to v2 (self-describing per-KF flag byte +
  KD-tree blob). Requires the MRPT KD-tree save/load index API, feature-detected
  via MRPT_HAS_KDTREE_SAVE_LOAD_INDEX; when absent the option is a no-op on write
  and readers skip any stored blob, so .mm files stay interoperable across MRPT
  builds.
  Adds unit tests (regroup reduction/coverage/roundtrip, kd-tree serialization
  roundtrip) and updates agents.md.
* docs: clarify clouds are deskwed
* remove not used macros
* Add mm2ini/ini2mm CLI tools to export/import metric map layer options (#158 <https://github.com/MOLAorg/mola/issues/158>)
  * Add mm2ini/ini2mm CLI tools to export/import metric map layer options
  mm2ini exports the CLoadableOptions (creation/insertion/likelihood/render
  options) of every layer in a .mm file to a human-editable .ini file;
  ini2mm applies such a file back, overwriting only the options sections
  present in it while leaving map data untouched. Supported layer classes
  are identified via dynamic_cast in OptionsIniIO.h, covering this
  library's own map types plus basic mrpt::maps classes (CPointsMap and
  derivatives, COccupancyGridMap2D).
  Also works around a few known dumpToTextStream()/loadFromConfigFile()
  inconsistencies in upstream MRPT (COccupancyGridMap2D's
  horizontalTolerance unit mismatch, rayTracing_decimation being write-only,
  and bare Y/N booleans) without requiring any MRPT changes.
  Adds test-options-ini-io.cpp, which builds a synthetic in-memory
  CSimpleMap and round-trips the options of all 7 supported classes.
  * Add MapOptionsCapable interface for generic, safe creation-options handling
  Introduces mola::MapOptionsCapable, a mixin interface implemented by all
  map classes in this library, with two methods:
  - optionsByName(): lists every CLoadableOptions group by name, so callers
  (e.g. OptionsIniIO/mm2ini/ini2mm) no longer need per-class knowledge of
  which option structs a map defines.
  - trySetCreationOptions(): applies new creation options (e.g. voxel/grid
  size) only if doing so doesn't require discarding the map's current
  contents; otherwise returns false and leaves the map untouched.
  NDT, HashedVoxelPointCloud, SparseVoxelPointCloud and SparseTreesPointCloud
  gain a real TCreationOptions (their voxel/grid size, previously only a
  constructor argument), kept in sync with the internal structure via
  setVoxelProperties()/setGridProperties(). KeyframePointCloudMap's existing
  TCreationOptions are pure runtime thresholds, so it always accepts changes.
  OptionsIniIO.cpp's five near-duplicate per-class dynamic_cast blocks
  collapse into one generic path for any MapOptionsCapable map, keeping a
  dynamic_cast fallback only for classes outside this library
  (mrpt::maps::CPointsMap, COccupancyGridMap2D). ini2mm now reports rejected
  creation-option changes explicitly instead of a generic warning.
  * Rename MapOptionsCapable to OptionsCapable
  * Fix critical data-wipe bug and stale-cache issue found by CodeRabbit
  - NDT/HashedVoxelPointCloud/SparseVoxelPointCloud/SparseTreesPointCloud's
  trySetCreationOptions() called setVoxelProperties()/setGridProperties()
  unconditionally, which clears the map -- so re-applying an unchanged
  voxel/grid size (e.g. a routine ini2mm run that doesn't touch that field)
  silently wiped all map contents. Now only called when the value actually
  changes.
  - KeyframePointCloudMap::trySetCreationOptions() updated the top-level
  creationOptions but left already-inserted KeyFrames with their own
  cached k_correspondences_for_cov/min_correspondences_for_cov/
  max_distance_for_cov (frozen at insertion time for lazy per-point
  covariance computation), so existing keyframes kept using stale values.
  Added KeyFrame::updateCovarianceParams() and propagate the new values to
  every existing keyframe, under state_mtx_ like other mutators.
  - Added regression tests for both: re-applying an unchanged voxel_size on
  a non-empty map must be a no-op (not a wipe), and clarified the
  agents.md wording on which classes implement OptionsCapable.
* Merge pull request #157 <https://github.com/MOLAorg/mola/issues/157> from MOLAorg/fix/keyframemap-view-vector-rotation
  Fix view-direction vector frame mismatch in KeyframePointCloudMap
* Fix compat shim: real if constexpr discarding requires a template
  The previous compat shim used if constexpr inside a non-template member
  function (updatePointsGlobal). Per the standard, if constexpr only skips
  type-checking the untaken branch inside a template -- in ordinary code
  both branches are fully compiled. Against a real old mp2p_icp checkout
  (2.9.0, lacking rotateViewDirectionFields()), this made the discarded
  "call the real helper" branch resolve to our own ellipsis fallback and
  try to pass CPointsMap by value through it, which is ill-formed since
  CPointsMap's copy constructor is deleted -- a hard build failure caught
  by CI (x86_64 / humble stable job on PR #157 <https://github.com/MOLAorg/mola/issues/157>).
  Fix: move the dispatch into a small template function
  (rotateViewDirectionFieldsOrFallback<Pts, Pose>), and factor the legacy
  rotation loop into its own function (rotateViewDirectionFieldsLegacy) so
  it isn't duplicated between the "header missing" and "header present but
  function missing" cases. With a genuine template parameter, if constexpr
  now actually discards the untaken branch without instantiating it.
  Verified: rebuilt and ran mola_metric_maps' full test suite (12/12 pass)
  against the real (new) mp2p_icp, and syntax-checked the file with
  -fsyntax-only against a hand-crafted header lacking
  rotateViewDirectionFields() to confirm the fallback path compiles too.
* Keep building against older mp2p_icp checkouts lacking rotateViewDirectionFields()
  Detect the helper's availability purely in C++ via a SFINAE trait (the
  containing header predates the function, so __has_include() alone can't
  tell old and new mp2p_icp_map apart) and fall back to the original
  open-coded rotation loop when it's absent. MRPT_TODO marks the fallback
  for removal once the minimum required mp2p_icp_map version provides the
  helper (MOLAorg/mp2p_icp#70 <https://github.com/MOLAorg/mp2p_icp/issues/70>).
* Fix view-direction vector frame mismatch in KeyframePointCloudMap
  KeyFrame::updatePointsGlobal() rotated a keyframe's view_x/y/z vectors to
  the global frame assuming they were stored in the local KF frame, but
  mp2p_icp_filters::FilterMerge was leaving them in the global frame after
  inserting into a KeyframePointCloudMap, causing a double rotation that
  made the cov-to-cov view-angle pairing filter reject valid pairs as the
  keyframe heading diverged from the map's build-time reference.
  Replaces the open-coded rotation loop with the new shared
  mp2p_icp::rotateViewDirectionFields() helper (also used by the FilterMerge
  fix in MOLAorg/mp2p_icp#70 <https://github.com/MOLAorg/mp2p_icp/issues/70>), documents the local-KF-frame contract in
  KeyframePointCloudMap.h, and adds a heading-sweep regression test.
* Merge pull request #156 <https://github.com/MOLAorg/mola/issues/156> from MOLAorg/feat/cov-viz
  feat: add debug viz of map covariances
* feat: add debug viz of map covariances
* Merge pull request #155 <https://github.com/MOLAorg/mola/issues/155> from MOLAorg/fix/more-robust-kf-map-covariances
  fix: more robust KF map convariances
* fix: more robust KF map convariances
* docs(mola_metric_maps): expand class-level Doxygen and complete README
  - HashedVoxelPointCloud: document SSO, robin_map backend, global ID packing
  - SparseVoxelPointCloud: document two-level hierarchy, voxel-mean ICP option
  - NDT: document dual-interface design (point-to-point vs. point-to-plane)
  - KeyframePointCloudMap: full description of keyframe storage, ICP integration,
  and implemented interfaces
  - FixedDenseGrid3D: document calloc rationale, cell layout, trivially-copyable
  requirement
  - index3d_t / index3d_hash: document coordinate range, hash algorithm reference,
  dual-role as hash and comparator
  - OccGrid: mark as experimental/incomplete (likelihood cache not populated)
  - SparseTreesPointCloud: document per-block KD-tree design; mark as experimental
  - README: replace two-class stub with full table of all classes, including
  production vs. experimental status
* fix KeyframePointCloudMap::boundingBox() using TOrientedBox for correct AABB
  The previous implementation called TBoundingBox::compose(pose), which only
  transforms the two diagonal corners (min/max), giving an incorrect result
  under rotation. Replace with TOrientedBoxf::getAxisAlignedBox(), which
  transforms all 8 corners before taking the envelope.
* Contributors: Jose Luis Blanco-Claraco
```

## mola_msgs

- No changes

## mola_pose_list

- No changes

## mola_relocalization

- No changes

## mola_traj_tools

- No changes

## mola_viz

```
* Merge branch 'feat/imviz-metric-plots' into develop
* Remove deprecated nanogui-specific VizInterface API
  create_subwindow(), enqueue_custom_nanogui_code(), subwindow_grid_layout()
  and subwindow_move_resize() have no remaining callers now that
  create_subwindow_from_description() and enqueue_custom_gui_code() cover
  their use cases on both backends.
* Merge pull request #172 <https://github.com/MOLAorg/mola/issues/172> from MOLAorg/feat/imviz-metric-plots
  feat(mola_viz_imgui): add metric time-series plot windows
* feat(mola_viz_imgui): add metric time-series plot windows
  Adds a backend-agnostic register_metric()/push_metric() API to
  VizInterface (guarded by MOLA_KERNEL_VIZ_HAS_METRICS) so any MOLA
  module can stream timestamped scalar values to live, autoscrolling
  plot windows opened from a new "Plots" menu in the mola_viz_imgui
  (ImGui/ImPlot) backend. The nanogui MolaViz backend implements the
  API as a no-op, mirroring the set_menu_bar precedent.
  The Plots menu also gives the Console window its first working
  close/reopen toggle.
  Vendors ImPlot as a submodule under mola_viz_imgui/3rdparty/implot.
* Merge pull request #165 <https://github.com/MOLAorg/mola/issues/165> from MOLAorg/imgui-window-icon
  feat: mola viz imgui set window icon
* feat: mola viz imgui set window icon
* Merge pull request #162 <https://github.com/MOLAorg/mola/issues/162> from MOLAorg/feat/viz-decay-lookat-frame-aware
  feat: frame-aware parentFrame for decay clouds and camera look-at
* fix: decay eviction uses per-entry container; look-at fails on missing frame
  Four reviewer findings, all confirmed valid:
  1. VizInterface.h comment: add update_viewport_look_at() to the list of APIs
  covered by MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES (it was omitted).
  2/3. Decay cloud eviction (both backends): the eviction path inside
  insert_point_cloud_with_decay() was removing the oldest cloud from the
  *current insertion's* container rather than the container that cloud was
  originally placed in.  If parentFrame ever changes between calls the wrong
  container would be used, leaking the cloud in the scene.  Fix: add a
  container member to DecayingCloud and store the owning container at insert
  time; use it at eviction time.
  4/5. Look-at frame not found (both backends): when parentFrame is non-empty but
  the frame node does not yet exist in the scene, the code was silently falling
  back to treating the raw local-frame coordinates as world-space and moving the
  camera to the wrong position.  Fix: return false so the camera is not moved
  until the frame node is present.
* feat: extend VizInterface for frame-aware decay clouds and camera look-at
  insert_point_cloud_with_decay() and update_viewport_look_at() now both
  accept an optional parentFrame argument (same semantics as the existing
  parentFrame on update_3d_object()): when non-empty, the backend looks up
  the named movable frame node and composes its current scene pose with the
  supplied point before inserting the cloud / moving the camera.  This lets
  callers (e.g. mola_lidar_odometry) pass a local-odom-frame point while
  the camera and transient clouds still end up at the correct world-space
  position when a central mapper (mola_mapper_3d) is continuously
  repositioning the frame node.
  Both backends (MolaViz / MolaVizImGuiCore) and the MolaVizImGui
  forwarder are updated.  The MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES feature
  macro already covers both new parameters; no additional macro is added.
* Merge pull request #160 <https://github.com/MOLAorg/mola/issues/160> from MOLAorg/feat/viz-with-movable-frames
  feat: viz with movable frames
* feat: viz with movable frames
* Merge pull request #151 <https://github.com/MOLAorg/mola/issues/151> from MOLAorg/fix/imgui-slider
  fix: imgui slider
* fix: imgui slider
* Merge pull request #146 <https://github.com/MOLAorg/mola/issues/146> from MOLAorg/fix-upgrade-points-classes
  fix: upgrade not to use deprecated mrpt2 point cloud classes
* fix: upgrade not to use deprecated mrpt2 point cloud classes
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_viz_imgui

```
* fix format
* feat: remove the obsolete text messages overlay mechanism in mola_viz_imgui (superseded by console subwindow)
* fix: default-dock Dataset_UI panel at top; fix Console dock on old layouts
  Add WindowDescription::dock_top_by_default so a window without a saved
  imgui.ini entry gets docked into a strip reserved at the top of the main
  window instead of floating; enabled for the per-module Dataset_UI panel.
  Also make the Console's default bottom-dock (and the new top-dock) key off
  whether that specific window has a saved imgui.ini entry, instead of whether
  the whole ini file already existed. This fixes both never docking new
  window kinds added to an already-existing layout, and splitting a stale,
  no-longer-leaf dock node once more than one default dock has been applied.
* fix: dont use deprecated mrpt2.x point cloud classes
* feat: autodock log window; update menu item names
* transparent icon
* Merge branch 'feat/imviz-metric-plots' into develop
* Remove deprecated nanogui-specific VizInterface API
  create_subwindow(), enqueue_custom_nanogui_code(), subwindow_grid_layout()
  and subwindow_move_resize() have no remaining callers now that
  create_subwindow_from_description() and enqueue_custom_gui_code() cover
  their use cases on both backends.
* Merge pull request #172 <https://github.com/MOLAorg/mola/issues/172> from MOLAorg/feat/imviz-metric-plots
  feat(mola_viz_imgui): add metric time-series plot windows
* fix: load params from yaml
* feat(mola_viz_imgui): add metric time-series plot windows
  Adds a backend-agnostic register_metric()/push_metric() API to
  VizInterface (guarded by MOLA_KERNEL_VIZ_HAS_METRICS) so any MOLA
  module can stream timestamped scalar values to live, autoscrolling
  plot windows opened from a new "Plots" menu in the mola_viz_imgui
  (ImGui/ImPlot) backend. The nanogui MolaViz backend implements the
  API as a no-op, mirroring the set_menu_bar precedent.
  The Plots menu also gives the Console window its first working
  close/reopen toggle.
  Vendors ImPlot as a submodule under mola_viz_imgui/3rdparty/implot.
* Merge pull request #170 <https://github.com/MOLAorg/mola/issues/170> from MOLAorg/fix/console-log-window-hardening
  fix(mola_viz_imgui): Console log window perf/config follow-ups
* fix(mola_viz_imgui): Console log window perf/config follow-ups
  - Default the pipeline-wide log capture level to INFO instead of DEBUG:
  capturing DEBUG from every module forced every MRPT_LOG_DEBUG_STREAM()
  callsite in the whole pipeline to always format its message just to feed
  the sink, even though the UI hid Debug entries by default anyway. Now
  runtime-adjustable from a new "Capture" combo in the Console toolbar
  (with a tooltip explaining it's distinct from the Levels display filter),
  and re-applied to already-hooked modules on every discovery tick so a
  runtime change takes effect immediately.
  - Avoid a full deque-of-strings copy under ConsoleLogSink's mutex on every
  rendered frame: added a lock-free version() counter (bumped on
  push()/clear()) so the Console window only re-snapshots when the sink
  actually changed, instead of unconditionally at up to target_fps_ Hz --
  that copy was contending with module threads trying to push() new lines.
  See MRPT/mrpt#1375 <https://github.com/MRPT/mrpt/issues/1375> for a related fix in COutputLogger itself (an
  unsynchronized concurrent access to its callback list, triggered by this
  window's pattern of registering a callback on an already-running module
  from the GUI thread).
* fix(mola_viz_imgui): sensor Hz readout underestimates real rate
  show_common_sensor_info() is invoked once per GUI frame, not once per
  new observation, since render_sensor_windows() redraws the last-seen
  observation every frame while waiting for the next one. The Hz
  low-pass filter was treating each of those repeat-frame calls (same
  timestamp, At=0) as a genuine 0 Hz sample, dragging the running
  estimate well below the sensor's real rate. Now the filter is only
  updated when the timestamp actually advances.
* Merge pull request #166 <https://github.com/MOLAorg/mola/issues/166> from MOLAorg/feat/console-log-window
  feat: add auto-exposed Console log window to MolaVizImGui
* fix: address coderabbitai review on Console log window
  - ConsoleLogSink::push() now also evicts entries past window_seconds,
  not just past max_entries, so the rolling buffer honors both bounds
  as documented.
  - Track the Console source filter by name instead of combo index: the
  underlying source set is sorted and its order shifts as new modules
  register, so an index alone could silently start pointing at a
  different module. The combo index is now re-derived from the stored
  name each frame.
  - agents.md: clarify that the Console subwindow was added after v2.6,
  not as part of it.
* feat: add auto-exposed Console log window to MolaVizImGui
  Aggregates mrpt-logger output from all running ExecutableBase modules
  into a dockable, filterable "Console" subwindow (level/source/text
  filters, color-by-level, Save-to-file), gated by a console_enabled
  param. Capture is done via logRegisterCallback() into a thread-safe
  rolling buffer bounded by entry count and age.
* Merge pull request #165 <https://github.com/MOLAorg/mola/issues/165> from MOLAorg/imgui-window-icon
  feat: mola viz imgui set window icon
* feat: mola viz imgui set window icon
* Merge pull request #162 <https://github.com/MOLAorg/mola/issues/162> from MOLAorg/feat/viz-decay-lookat-frame-aware
  feat: frame-aware parentFrame for decay clouds and camera look-at
* fix: decay eviction uses per-entry container; look-at fails on missing frame
  Four reviewer findings, all confirmed valid:
  1. VizInterface.h comment: add update_viewport_look_at() to the list of APIs
  covered by MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES (it was omitted).
  2/3. Decay cloud eviction (both backends): the eviction path inside
  insert_point_cloud_with_decay() was removing the oldest cloud from the
  *current insertion's* container rather than the container that cloud was
  originally placed in.  If parentFrame ever changes between calls the wrong
  container would be used, leaking the cloud in the scene.  Fix: add a
  container member to DecayingCloud and store the owning container at insert
  time; use it at eviction time.
  4/5. Look-at frame not found (both backends): when parentFrame is non-empty but
  the frame node does not yet exist in the scene, the code was silently falling
  back to treating the raw local-frame coordinates as world-space and moving the
  camera to the wrong position.  Fix: return false so the camera is not moved
  until the frame node is present.
* feat: extend VizInterface for frame-aware decay clouds and camera look-at
  insert_point_cloud_with_decay() and update_viewport_look_at() now both
  accept an optional parentFrame argument (same semantics as the existing
  parentFrame on update_3d_object()): when non-empty, the backend looks up
  the named movable frame node and composes its current scene pose with the
  supplied point before inserting the cloud / moving the camera.  This lets
  callers (e.g. mola_lidar_odometry) pass a local-odom-frame point while
  the camera and transient clouds still end up at the correct world-space
  position when a central mapper (mola_mapper_3d) is continuously
  repositioning the frame node.
  Both backends (MolaViz / MolaVizImGuiCore) and the MolaVizImGui
  forwarder are updated.  The MOLA_KERNEL_VIZ_HAS_MOVABLE_FRAMES feature
  macro already covers both new parameters; no additional macro is added.
* Merge pull request #160 <https://github.com/MOLAorg/mola/issues/160> from MOLAorg/feat/viz-with-movable-frames
  feat: viz with movable frames
* feat: viz with movable frames
* feat: imgui now has a clear all method
* Merge pull request #151 <https://github.com/MOLAorg/mola/issues/151> from MOLAorg/fix/imgui-slider
  fix: imgui slider
* fix: imgui slider
* fix docs
* Merge pull request #148 <https://github.com/MOLAorg/mola/issues/148> from MOLAorg/refactor/imgui
  refactor: split into MolaVizImGuiCore and MolaVizImGui to enable 3rdparty GUIs
* fix(mola_viz_imgui): address review findings in ImGui viz backend
  - Move widget state from process-global statics to per-instance members
  - Tab-qualify widget context so same-labeled widgets across tabs don't collide
  - Persist sub-window open flag so closing sticks across frames
  - Clamp negative decay_time_seconds to avoid size_t wraparound
  - Guard null dynamic_pointer_cast in update_3d_object / clear_all_point_clouds_with_decay
  - Drain pending GUI tasks in shutdown_for_embed (broken_promise instead of hang)
  - Stop leaking GLFW/ImGui backend headers from the public header; forward-declare GLFWwindow
* refactor: split into MolaVizImGuiCore and MolaVizImGui to enable 3rdparty GUIs
* Contributors: Jose Luis Blanco Claraco, Jose Luis Blanco-Claraco
```

## mola_yaml

```
* docs: list all debug/trace env variables
* Merge pull request #161 <https://github.com/MOLAorg/mola/issues/161> from MOLAorg/feat/yaml-import-override
  feat(mola_yaml): $import map directive for base-file + overrides
* feat(mola_yaml): add $import map directive for base-file + overrides
  A map with an $import key (a path, or a sequence of paths) is replaced by
  the deep-merge of the imported file(s) with the map's remaining keys overlaid
  on top, so sibling entries OVERRIDE the imported base (nested maps merge
  deeply; scalars/sequences replace). This complements $include{} (which
  replaces a whole node) and lets near-identical launch files share a common
  params block while tweaking just a few values, instead of duplicating it.
  - Resolved in the same first pass as $include{}, reusing its path
  pre-processing, relative-path resolution and circular-reference detection.
  - Unit tests: single import, multi-file sequence (later file wins), sibling
  override including deep-nested, load_yaml_file path, and missing-file throw.
  - Docs: new section + processing-order table row in the SLAM config format.
* Contributors: Jose Luis Blanco-Claraco
```
