### PR TITLE
Update dependencies for Ubuntu Jammy to libqt5 packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6866,7 +6866,7 @@ libqtcore:
   ubuntu:
     '*': [libqt6core6t64]
     focal: null
-    jammy: [libqt5core]
+    jammy: [libqt5core5a]
     noble: [libqt5core5t64]
 libqtgui:
   alpine: [qt6-qtbase]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6949,7 +6949,7 @@ libqtwidgets:
   ubuntu:
     '*': [libqt6widgets6]
     'focal': null
-    'jammy': [libqt5widgets]
+    'jammy': [libqt5widgets5]
     'noble': [libqt5widgets5t64]
 libqwt-qt5-dev:
   arch: [qwt]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6866,7 +6866,7 @@ libqtcore:
   ubuntu:
     '*': [libqt6core6t64]
     focal: null
-    jammy: null
+    jammy: [libqt5core]
     noble: [libqt5core5t64]
 libqtgui:
   alpine: [qt6-qtbase]
@@ -6926,7 +6926,7 @@ libqtsvg:
   ubuntu:
     '*': [libqt6svg6]
     'focal': null
-    'jammy': null
+    'jammy': [libqt5svg5]
     'noble': [libqt5svg5]
     'resolute': [libqt6svg6, qt6-svg-plugins]
 libqtwebkit-dev:
@@ -6949,7 +6949,7 @@ libqtwidgets:
   ubuntu:
     '*': [libqt6widgets6]
     'focal': null
-    'jammy': null
+    'jammy': [libqt5widgets]
     'noble': [libqt5widgets5t64]
 libqwt-qt5-dev:
   arch: [qwt]
@@ -9555,7 +9555,7 @@ qt-svg-dev:
   ubuntu:
     '*': [qt6-svg-dev]
     'focal': null
-    'jammy': null
+    'jammy': [libqt5svg5-dev]
     'noble': [libqt5svg5-dev]
 qt4-dev-tools:
   debian: [qt4-dev-tools]


### PR DESCRIPTION
I'm trying to catch the remaining generic Qt dependencies that specify Qt6 correctly and Qt5 for `noble` but not `jammy`. I think this is the last of them.
