### PR TITLE
mvsim: 1.4.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5296,7 +5296,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/mvsim-release.git
-      version: 1.3.0-3
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mvsim` to `1.4.0-1`:

- upstream repository: https://github.com/MRPT/mvsim.git
- release repository: https://github.com/ros2-gbp/mvsim-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.3.0-3`

## mvsim

```
* fix(ros): populate twist in /odom topic
* add custom icon
* feat(ros): add disable_sim_time_clock param to opt out of sim clock
* ci: add ubuntu-26.04 build matrix jobs (gcc, clang)
* feat(ros): use simulation time for stamps and publish /clock; show achieved real-time factor in GUI
* feat: allow sensors' GUI preview subwindow to start minimized
* fix: GNSS ROS publisher never set NavSatFix.status.status
* feat: add exactly reproducible trajectories controller for offline experiments
* feat: visualize trajectory paths in 3D GUI
* fix: avoid duplicated text when rebuilding mixed-content XML nodes
* build: auto-enable ccache when available
* fix: improve robustness of remote resource downloads
* docs: fix Lyrical arm64 binary badge URL; update ROS 2 build status and EOL distro info
* fix: XYZ wheel-corner markers must not be visible to camera/lidar sensors
* fix: robust against corrupted downloads
* fix: visual artifacts in wheel positions with custom viz
* cmake minimum version: bump to 3.22 in examples
* Add configurable maximum joystick speed via XML params
* Add agents.md file
* Contributors: Jose Luis Blanco-Claraco
```
