### PR TITLE
libbno055_linux: 1.4.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -4062,6 +4062,20 @@ repositories:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
       version: foxy-devel
+  libbno055_linux:
+    doc:
+      type: git
+      url: https://github.com/lazytatzv/libbno055-linux.git
+      version: main
+    release:
+      tags:
+        release: release/kilted/{package}/{version}
+      url: https://github.com/lazytatzv/libbno055_linux-release.git
+      version: 1.4.3-1
+    source:
+      type: git
+      url: https://github.com/lazytatzv/libbno055-linux.git
+      version: main
   libcaer_driver:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libbno055_linux` to `1.4.3-1`:

- upstream repository: https://github.com/lazytatzv/libbno055-linux.git
- release repository: https://github.com/lazytatzv/libbno055_linux-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
