### PR TITLE
rplidar_driver: 1.4.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -10770,7 +10770,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rplidar_driver-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       type: git
       url: https://github.com/frozenreboot/rplidar_driver.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rplidar_driver` to `1.4.1-1`:

- upstream repository: https://github.com/frozenreboot/rplidar_driver.git
- release repository: https://github.com/ros2-gbp/rplidar_driver-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.4.0-1`

## rplidar_driver

```
* Fixed the Rolling build by passing the node by reference to
  ``tf2_ros::StaticTransformBroadcaster`` (NodeInterfaces API migration).
* Contributors: JWJ | frozenreboot
```
