### PR TITLE
Add robstride_ros2 source entry to supported ROS 2 distributions

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10095,6 +10095,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur_companion.git
       version: ros
     status: maintained
+  robstride_ros2:
+    source:
+      type: git
+      url: https://github.com/s2015-turtle/robstride_ros2.git
+      version: main
+    status: maintained
   ros1_bridge:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -9672,6 +9672,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur_companion.git
       version: ros
     status: maintained
+  robstride_ros2:
+    source:
+      type: git
+      url: https://github.com/s2015-turtle/robstride_ros2.git
+      version: main
+    status: maintained
   ros1_bridge:
     source:
       test_commits: false

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7872,6 +7872,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur_companion.git
       version: ros
     status: maintained
+  robstride_ros2:
+    source:
+      type: git
+      url: https://github.com/s2015-turtle/robstride_ros2.git
+      version: main
+    status: maintained
   ros1_bridge:
     source:
       test_commits: false

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7862,6 +7862,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur_companion.git
       version: ros
     status: maintained
+  robstride_ros2:
+    source:
+      type: git
+      url: https://github.com/s2015-turtle/robstride_ros2.git
+      version: main
+    status: maintained
   ros1_bridge:
     source:
       test_commits: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7805,6 +7805,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur_companion.git
       version: ros
     status: maintained
+  robstride_ros2:
+    source:
+      type: git
+      url: https://github.com/s2015-turtle/robstride_ros2.git
+      version: main
+    status: maintained
   ros1_bridge:
     source:
       test_commits: false


### PR DESCRIPTION
## Summary

Add the `robstride_ros2` source repository to the supported ROS 2 distributions.

`robstride_ros2` is an unofficial, community-maintained ROS 2 integration for
RobStride actuators. It uses the RobStride private CAN protocol through
`ros2_socketcan` and provides position, velocity, and effort command interfaces
through `ros2_control`.

The repository contains four ROS packages with separated responsibilities:

- `robstride_driver`: protocol, CAN transport, feedback, and motor lifecycle
- `robstride_ros2_control`: `ros2_control` hardware component and plugin registration
- `robstride_examples`: example Xacro, controller configuration, and launch files
- `robstride_ros2`: aggregate package for installing the complete integration

The existing plugin identifier `robstride_ros2/RobStrideSystem` is retained for
robot-description compatibility.

## Package review information

- Public source repository: https://github.com/s2015-turtle/robstride_ros2
- Packages: `robstride_driver`, `robstride_ros2_control`, `robstride_examples`, `robstride_ros2`
- License: MIT, with matching `LICENSE` and `package.xml` files in every package
- Maintainer: yamato (`ykturtler@outlook.com`)
- ROS distributions: Humble, Jazzy, Kilted, Lyrical, Rolling
- Source branch: `main`
- CI: https://github.com/s2015-turtle/robstride_ros2/actions/runs/29822952749

The repository and package names do not currently conflict with another
RobStride entry in rosdistro. The README identifies the project as unofficial
and references the vendor's public product documentation used to validate the
protocol profiles.

## Validation

- Upstream CI builds and tests all four packages on Humble, Jazzy, Kilted,
  Lyrical, and Rolling
- Installed example resources and Xacro files are validated in CI
- `rosdistro_reformat -n index.yaml`
- `git diff --check`
