### PR TITLE
Index osqp_eigen package in all mantained ROS distros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7681,6 +7681,12 @@ repositories:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
       version: 9.9.0-7
+  osqp_eigen:
+    source:
+      type: git
+      url: https://github.com/robotology/osqp-eigen.git
+      version: master
+    status: maintained
   osqp_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7464,6 +7464,12 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
       version: 9.9.0-6
+  osqp_eigen:
+    source:
+      type: git
+      url: https://github.com/robotology/osqp-eigen.git
+      version: master
+    status: maintained
   osqp_vendor:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5949,6 +5949,12 @@ repositories:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
       version: 9.9.0-10
+  osqp_eigen:
+    source:
+      type: git
+      url: https://github.com/robotology/osqp-eigen.git
+      version: master
+    status: maintained
   osqp_vendor:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5882,6 +5882,12 @@ repositories:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
       version: 9.9.0-11
+  osqp_eigen:
+    source:
+      type: git
+      url: https://github.com/robotology/osqp-eigen.git
+      version: master
+    status: maintained
   osqp_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5806,6 +5806,12 @@ repositories:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ortools_vendor-release.git
       version: 9.9.0-10
+  osqp_eigen:
+    source:
+      type: git
+      url: https://github.com/robotology/osqp-eigen.git
+      version: master
+    status: maintained
   osqp_vendor:
     doc:
       type: git


### PR DESCRIPTION
As a first step for packaging [osqp-eigen](github.com/gbionics/osqp-eigen) in the ros build farm, this PR index the `osqp_eigen`  package on all mantained ROS distro.

# Please Add This Package to be indexed in the rosdistro.

humble, kilted, jazzy, lyrical, rolling

# The source is here:

https://github.com/gbionics/osqp-eigen

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro
