### PR TITLE
Index gb_robot_models package in all mantained ROS distros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3701,6 +3701,12 @@ repositories:
       url: https://github.com/nlamprian/gazebo_video_monitors.git
       version: ros2
     status: maintained
+  gb_robot_models:
+    source:
+      type: git
+      url: https://github.com/gbionics/gb-robot-models.git
+      version: main
+    status: maintained
   generate_parameter_library:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -3533,6 +3533,12 @@ repositories:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
       version: 3.8.0-1
+  gb_robot_models:
+    source:
+      type: git
+      url: https://github.com/gbionics/gb-robot-models.git
+      version: main
+    status: maintained
   generate_parameter_library:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -2638,6 +2638,12 @@ repositories:
       url: https://github.com/ros-sports/game_controller_spl.git
       version: rolling
     status: developed
+  gb_robot_models:
+    source:
+      type: git
+      url: https://github.com/gbionics/gb-robot-models.git
+      version: main
+    status: maintained
   generate_parameter_library:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2581,6 +2581,12 @@ repositories:
       url: https://github.com/ros-sports/game_controller_spl.git
       version: rolling
     status: developed
+  gb_robot_models:
+    source:
+      type: git
+      url: https://github.com/gbionics/gb-robot-models.git
+      version: main
+    status: maintained
   generate_parameter_library:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2556,6 +2556,12 @@ repositories:
       url: https://github.com/ros-sports/game_controller_spl.git
       version: rolling
     status: developed
+  gb_robot_models:
+    source:
+      type: git
+      url: https://github.com/gbionics/gb-robot-models.git
+      version: main
+    status: maintained
   generate_parameter_library:
     doc:
       type: git


### PR DESCRIPTION
As a first step for packaging [gb-robot-models](github.com/gbionics/gb-robot-models) in the ros build farm, this PR index the `gb_robot_models`  package on all mantained ROS distro.

# Please Add This Package to be indexed in the rosdistro.

humble, kilted, jazzy, lyrical, rolling

# The source is here:

https://github.com/gbionics/gb-robot-models

# Checks
 - [x] All packages have a declared license in the package.xml
 - [x] This repository has a LICENSE file
 - [x] This package is expected to build on the submitted rosdistro