### PR TITLE
Fix python3-pyudev entry for NixOS

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7580,7 +7580,7 @@ python3-pyudev:
   debian: [python3-pyudev]
   fedora: [python3-pyudev]
   gentoo: [dev-python/pyudev]
-  nixos: [pythonPackages.pyudev]
+  nixos: [python3Packages.pyudev]
   openembedded: [python3-pyudev@meta-python]
   ubuntu: [python3-pyudev]
 python3-pyvista-pip:


### PR DESCRIPTION
[nix-ros-overlay](https://github.com/lopsided98/nix-ros-overlay) has python3Packages aliased to pythonPackages. We [want to remove that alias](https://github.com/lopsided98/nix-ros-overlay/pull/856) and this entry would be broken by that. Let's use the non-aliased attribute name here.
