### PR TITLE
ros-netft: add Rolling source entry

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7805,6 +7805,12 @@ repositories:
       url: https://github.com/robotraconteur/robotraconteur_companion.git
       version: ros
     status: maintained
+  ros-netft:
+    source:
+      type: git
+      url: https://github.com/han-xudong/ros-netft.git
+      version: main
+    status: maintained
   ros1_bridge:
     source:
       test_commits: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7808,7 +7808,7 @@ repositories:
   ros-netft:
     source:
       type: git
-      url: https://github.com/han-xudong/ros-netft.git
+      url: https://github.com/netft/ros-netft.git
       version: main
     status: maintained
   ros1_bridge:


### PR DESCRIPTION
Add the first Rolling source index entry for the `netft_driver` package. The public source repository supports ROS 2 Rolling on `main` and passes native build and loopback graph smoke tests.

Source release: https://github.com/netft/ros-netft/releases/tag/0.2.0
CI: https://github.com/netft/ros-netft/actions/runs/29826318562