### PR TITLE
Add python3-pyrealsense2-pip rosdep key to python.yaml

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7140,6 +7140,10 @@ python3-pyqtgraph:
   gentoo: [dev-python/pyqtgraph]
   nixos: [python3Packages.pyqtgraph]
   ubuntu: [python3-pyqtgraph]
+python3-pyrealsense2-pip:
+  '*':
+    pip:
+      packages: [pyrealsense2]
 python3-pyrender-pip:
   '*':
     pip:


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

We used to rely on `python-pyrealsense2-pip` which did indeed install Python3 version of the package, but since that's recently been deleted it would be great to have this back as a proper `python3-...` key.

## Package name:

`python3-pyrealsense2-pip` -> `pyrealsense2`

## Package Upstream Source:

https://github.com/realsenseai/librealsense

## Purpose of using this:

This makes the Python3 bindings offered by the upstream source repository via pip.

## Links to Distribution Packages

Distribution packages for `librealsense` exist, but (at least the Ubuntu one) does not include the Python wrappers.