### PR TITLE
kuka_robot_descriptions: 1.1.2-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4986,7 +4986,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/kuka_robot_descriptions-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/kroshu/kuka_robot_descriptions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `kuka_robot_descriptions` to `1.1.2-1`:

- upstream repository: https://github.com/kroshu/kuka_robot_descriptions.git
- release repository: https://github.com/ros2-gbp/kuka_robot_descriptions-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.1.1-1`

## kuka_agilus_support

- No changes

## kuka_cybertech_support

- No changes

## kuka_fortec_support

- No changes

## kuka_gazebo

```
* Fix kuka_gazebo binary package build
```

## kuka_iontec_support

- No changes

## kuka_kl_support

- No changes

## kuka_kr_moveit_config

- No changes

## kuka_lbr_iisy_moveit_config

- No changes

## kuka_lbr_iisy_support

- No changes

## kuka_lbr_iiwa_moveit_config

- No changes

## kuka_lbr_iiwa_support

- No changes

## kuka_mock_hardware_interface

- No changes

## kuka_quantec_support

- No changes

## kuka_resources

- No changes

## kuka_robot_descriptions

- No changes
