### PR TITLE
sdformat_urdf: 3.0.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9475,7 +9475,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 2.1.0-2
+      version: 3.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `3.0.0-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.0-2`

## sdformat_test_files

- No changes

## sdformat_urdf

```
* Include urdf_world types in sdformat_urdf plugin (#45 <https://github.com/ros/sdformat_urdf/issues/45>)
* Clamp urdf material rgba values to [0, 1] (#44 <https://github.com/ros/sdformat_urdf/issues/44>)
* Contributors: Rhys Mainwaring, Tobias Fischer
```
