### PR TITLE
compass: 3.0.5-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1366,7 +1366,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/compass-release.git
-      version: 3.0.4-2
+      version: 3.0.5-1
     source:
       type: git
       url: https://github.com/ctu-vras/compass.git


### PR DESCRIPTION
Increasing version of package(s) in repository `compass` to `3.0.5-1`:

- upstream repository: https://github.com/ctu-vras/compass.git
- release repository: https://github.com/ros2-gbp/compass-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.4-2`

## compass_conversions

```
* Fixed build on Rolling.
* Updated readmes.
* Contributors: Martin Pecka
```

## compass_interfaces

```
* Updated readmes.
* Contributors: Martin Pecka
```

## magnetic_model

- No changes

## magnetometer_compass

```
* Fixed build on Rolling.
* Updated readmes.
* Contributors: Martin Pecka
```

## magnetometer_pipeline

```
* Updated readmes.
* Contributors: Martin Pecka
```
