### PR TITLE
realsense2_camera: 4.58.3-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7235,7 +7235,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/realsense-ros-release.git
-      version: 4.58.2-1
+      version: 4.58.3-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense2_camera` to `4.58.3-1`:

- upstream repository: https://github.com/realsenseai/realsense-ros.git
- release repository: https://github.com/ros2-gbp/realsense-ros-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `4.58.2-1`

## realsense2_camera

```
* Push 4.58.3 release into ros2-master (#3540 <https://github.com/IntelRealSense/realsense-ros/issues/3540>)
* Fix image_transport::create_publisher for ROS2 Rolling (#3541 <https://github.com/IntelRealSense/realsense-ros/issues/3541>)
* Update package.xml  to version 4.58.3
* Update constants.h to version 4.58.3
* Merge master into ros2-development (4.58.2 release sync) (#3529 <https://github.com/IntelRealSense/realsense-ros/issues/3529>)
* Keep development versions after master merge (ROS 4.58.0, rgbd_plugin 0.1.0)
* Merge remote-tracking branch 'origin/ros2-master' into ros2-development
* Merge pull request #3527 <https://github.com/IntelRealSense/realsense-ros/issues/3527> from Nir-Az/fix-rosci-port-detection
  rosci: route YKUSH control through rspy hub (drop direct ykushcmd)
* rosci: skip YKUSH hub reset on first attempt to avoid ykushcmd USB-error spam
* rosci: route YKUSH control through rspy hub, drop all ykushcmd calls
* rosci: derive YKUSH port map from a single rspy query (no per-port toggling)
* Merge pull request #3526 <https://github.com/IntelRealSense/realsense-ros/issues/3526> from Nir-Az/fix-device-name-prefix-parse
  Make live-camera device-name parsing vendor-prefix-agnostic
* Address review: use NAME_LINE_VALUE_OFFSET constant instead of literal 2
* Remove Intel references from live-camera and mqtt-bridge test files
* Make live-camera device-name parsing vendor-prefix-agnostic
* Merge pull request #3524 <https://github.com/IntelRealSense/realsense-ros/issues/3524> from Nir-Az/fix-d555-name-match
  Fix D555 DDS device detection to not depend on Intel name prefix
* Merge remote-tracking branch 'origin/r/4.58.2' into ros2-master
  # Conflicts:
  #     realsense2_camera/CHANGELOG.rst
  #     realsense2_camera/CMakeLists.txt
  #     realsense2_camera_msgs/CHANGELOG.rst
  #     realsense2_description/CHANGELOG.rst
  #     realsense2_ros_mqtt_bridge/CHANGELOG.rst
* Fix D555 DDS device detection to not depend on Intel name prefix
* PR #3501 <https://github.com/IntelRealSense/realsense-ros/issues/3501> from Nir-Az: Push release 4.57.7 to master
* Merge remote-tracking branch 'origin/r/4.57.7' into ros2-master
* PR #3482 <https://github.com/IntelRealSense/realsense-ros/issues/3482> from Nir-Az: Push Release 4.57.6 to master
* Merge remote-tracking branch 'origin/r/4.57.6' into ros2-master
  # Conflicts:
  #     realsense2_camera/include/constants.h
  #     realsense2_camera/package.xml
  #     realsense2_camera_msgs/package.xml
  #     realsense2_description/package.xml
  #     realsense2_ros_mqtt_bridge/package.xml
  #     realsense2_ros_mqtt_bridge/setup.py
* Update version in constants.h
* Update CMakeLists.txt version
* Update package.xml version
* PR #3477 <https://github.com/IntelRealSense/realsense-ros/issues/3477> from Nir-Az: Push 4.57.4 release to ros2-master
* Update constants.h
* Merge remote-tracking branch 'origin/r/4.57.4' into ros2-master
  # Conflicts:
  #     README.md
  #     realsense2_camera/CHANGELOG.rst
  #     realsense2_camera/CMakeLists.txt
  #     realsense2_camera/include/constants.h
  #     realsense2_camera/package.xml
  #     realsense2_camera_msgs/CHANGELOG.rst
  #     realsense2_camera_msgs/package.xml
  #     realsense2_description/CHANGELOG.rst
  #     realsense2_description/package.xml
* 4.57.4
* changelogs updated
* Update realsense2_camera package.xml to 4.57.4
* PR #3400 <https://github.com/IntelRealSense/realsense-ros/issues/3400> from Nir-Az: Fix releases dependencies
* remove strict requirement
* PR #3374 <https://github.com/IntelRealSense/realsense-ros/issues/3374> from remibettan: kilted added to wrapper
  (cherry picked from commit 01c054b352e3b0019460347b73579726114b0404)
  # Conflicts:
  #     .github/workflows/main.yml
* PR #3399 <https://github.com/IntelRealSense/realsense-ros/issues/3399> from IntelRealSense: Push r/4.56.4 to master
* PR #3398 <https://github.com/IntelRealSense/realsense-ros/issues/3398> from ashrafk93: R/4.56.4
* 4.56.4
* bump version to 4.56.4
* PR #3329 <https://github.com/IntelRealSense/realsense-ros/issues/3329> from Nir-Az: Update version to 4.56.4
* update version to 4.56.4
* PR #3148 <https://github.com/IntelRealSense/realsense-ros/issues/3148> from SamerKhshiboun: update READMEs and CONTRIBUTING files regarding ros2-master
* update READMEs and CONTRIBUTING files regarding ros2-master
* Update CMakeLists.txt
* Contributors: Ashraf Kattoura, Nir Azkiel, Remi Bettan, Samer Khshiboun, SamerKhshiboun, remibettan
```

## realsense2_camera_msgs

```
* Push 4.58.3 release into ros2-master (#3540 <https://github.com/IntelRealSense/realsense-ros/issues/3540>)
* Update package.xml  to version 4.58.3
* Merge master into ros2-development (4.58.2 release sync) (#3529 <https://github.com/IntelRealSense/realsense-ros/issues/3529>)
* Keep development versions after master merge (ROS 4.58.0, rgbd_plugin 0.1.0)
* Merge remote-tracking branch 'origin/ros2-master' into ros2-development
* Merge remote-tracking branch 'origin/r/4.58.2' into ros2-master
  # Conflicts:
  #     realsense2_camera/CHANGELOG.rst
  #     realsense2_camera/CMakeLists.txt
  #     realsense2_camera_msgs/CHANGELOG.rst
  #     realsense2_description/CHANGELOG.rst
  #     realsense2_ros_mqtt_bridge/CHANGELOG.rst
* PR #3501 <https://github.com/IntelRealSense/realsense-ros/issues/3501> from Nir-Az: Push release 4.57.7 to master
* Merge remote-tracking branch 'origin/r/4.57.7' into ros2-master
* PR #3482 <https://github.com/IntelRealSense/realsense-ros/issues/3482> from Nir-Az: Push Release 4.57.6 to master
* Merge remote-tracking branch 'origin/r/4.57.6' into ros2-master
  # Conflicts:
  #     realsense2_camera/include/constants.h
  #     realsense2_camera/package.xml
  #     realsense2_camera_msgs/package.xml
  #     realsense2_description/package.xml
  #     realsense2_ros_mqtt_bridge/package.xml
  #     realsense2_ros_mqtt_bridge/setup.py
* Update package.xml version
* PR #3477 <https://github.com/IntelRealSense/realsense-ros/issues/3477> from Nir-Az: Push 4.57.4 release to ros2-master
* Merge remote-tracking branch 'origin/r/4.57.4' into ros2-master
  # Conflicts:
  #     README.md
  #     realsense2_camera/CHANGELOG.rst
  #     realsense2_camera/CMakeLists.txt
  #     realsense2_camera/include/constants.h
  #     realsense2_camera/package.xml
  #     realsense2_camera_msgs/CHANGELOG.rst
  #     realsense2_camera_msgs/package.xml
  #     realsense2_description/CHANGELOG.rst
  #     realsense2_description/package.xml
* 4.57.4
* changelogs updated
* Update realsense2_camera_msgs package.xml to 4.57.4
* PR #3400 <https://github.com/IntelRealSense/realsense-ros/issues/3400> from Nir-Az: Fix releases dependencies
* add missing depends
* PR #3399 <https://github.com/IntelRealSense/realsense-ros/issues/3399> from IntelRealSense: Push r/4.56.4 to master
* PR #3398 <https://github.com/IntelRealSense/realsense-ros/issues/3398> from ashrafk93: R/4.56.4
* 4.56.4
* bump version to 4.56.4
* Contributors: Ashraf Kattoura, Nir Azkiel, Remi Bettan, remibettan
```

## realsense2_description

```
* Push 4.58.3 release into ros2-master (#3540 <https://github.com/IntelRealSense/realsense-ros/issues/3540>)
* Update package.xml to version 4.58.3
* Merge master into ros2-development (4.58.2 release sync) (#3529 <https://github.com/IntelRealSense/realsense-ros/issues/3529>)
* Keep development versions after master merge (ROS 4.58.0, rgbd_plugin 0.1.0)
* Merge remote-tracking branch 'origin/ros2-master' into ros2-development
* Merge remote-tracking branch 'origin/r/4.58.2' into ros2-master
  # Conflicts:
  #     realsense2_camera/CHANGELOG.rst
  #     realsense2_camera/CMakeLists.txt
  #     realsense2_camera_msgs/CHANGELOG.rst
  #     realsense2_description/CHANGELOG.rst
  #     realsense2_ros_mqtt_bridge/CHANGELOG.rst
* PR #3501 <https://github.com/IntelRealSense/realsense-ros/issues/3501> from Nir-Az: Push release 4.57.7 to master
* Merge remote-tracking branch 'origin/r/4.57.7' into ros2-master
* PR #3482 <https://github.com/IntelRealSense/realsense-ros/issues/3482> from Nir-Az: Push Release 4.57.6 to master
* Merge remote-tracking branch 'origin/r/4.57.6' into ros2-master
  # Conflicts:
  #     realsense2_camera/include/constants.h
  #     realsense2_camera/package.xml
  #     realsense2_camera_msgs/package.xml
  #     realsense2_description/package.xml
  #     realsense2_ros_mqtt_bridge/package.xml
  #     realsense2_ros_mqtt_bridge/setup.py
* Update package.xml version
* PR #3477 <https://github.com/IntelRealSense/realsense-ros/issues/3477> from Nir-Az: Push 4.57.4 release to ros2-master
* Merge remote-tracking branch 'origin/r/4.57.4' into ros2-master
  # Conflicts:
  #     README.md
  #     realsense2_camera/CHANGELOG.rst
  #     realsense2_camera/CMakeLists.txt
  #     realsense2_camera/include/constants.h
  #     realsense2_camera/package.xml
  #     realsense2_camera_msgs/CHANGELOG.rst
  #     realsense2_camera_msgs/package.xml
  #     realsense2_description/CHANGELOG.rst
  #     realsense2_description/package.xml
* 4.57.4
* changelogs updated
* Update realsense2_camera_description package.xml to 4.57.4
* PR #3399 <https://github.com/IntelRealSense/realsense-ros/issues/3399> from IntelRealSense: Push r/4.56.4 to master
* PR #3398 <https://github.com/IntelRealSense/realsense-ros/issues/3398> from ashrafk93: R/4.56.4
* 4.56.4
* bump version to 4.56.4
* Contributors: Ashraf Kattoura, Nir Azkiel, Remi Bettan, remibettan
```
