### PR TITLE
ess_imu_driver2: 2.0.4-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2793,7 +2793,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ess_imu_driver2-release.git
-      version: 2.0.3-1
+      version: 2.0.4-1
     source:
       type: git
       url: https://github.com/cubicleguy/ess_imu_driver2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ess_imu_driver2` to `2.0.4-1`:

- upstream repository: https://github.com/cubicleguy/ess_imu_driver2.git
- release repository: https://github.com/ros2-gbp/ess_imu_driver2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.12.0`
- previous version for package: `2.0.3-1`

## ess_imu_driver2

```
* Moved sensor sampling & publishing to background thread, added G355 support
```
