### PR TITLE
opennav_following: 1.0.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -7389,6 +7389,21 @@ repositories:
       url: https://github.com/ros-event-camera/openeb_vendor.git
       version: release
     status: developed
+  opennav_following:
+    doc:
+      type: git
+      url: https://github.com/marcospontoexe/opennav_following.git
+      version: master
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/marcospontoexe/opennav_following.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/marcospontoexe/opennav_following.git
+      version: master
+    status: developed
   openni2_camera:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `opennav_following` to `1.0.0-1`:

- upstream repository: https://github.com/marcospontoexe/opennav_following.git
- release repository: https://github.com/marcospontoexe/opennav_following.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.13.0`
- previous version for package: `null`
