### PR TITLE
Add rbq_ros2 source entry (humble)

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9088,6 +9088,12 @@ repositories:
       url: https://github.com/rt-net/raspimouse_slam_navigation_ros2.git
       version: humble-devel
     status: maintained
+  rbq_ros2:
+    source:
+      type: git
+      url: https://github.com/RainbowRobotics/rbq_ros2.git
+      version: main
+    status: developed
   rc_common_msgs:
     doc:
       type: git


### PR DESCRIPTION
Adds a source-only entry for [RainbowRobotics/rbq_ros2](https://github.com/RainbowRobotics/rbq_ros2) to Humble.

The repository currently contains one package, **rbq_msgs** — ROS 2 message definitions for the RBQ quadruped robot (Rainbow Robotics).

New-package checklist:
- **License:** Apache-2.0 — `LICENSE` file present at the repo root; every `package.xml` declares `<license>Apache-2.0</license>`.
- **Public source repository:** https://github.com/RainbowRobotics/rbq_ros2
- **REP-144 naming:** `rbq_ros2` / `rbq_msgs` comply.
- **Builds on Humble:** CI in the source repo runs a minimal-environment colcon build and a bloom `rosdebian` (declared-deps-only) build — both green.

This is source-only for now; the `release:` entry will follow via bloom once the ros2-gbp release repository is set up.