### PR TITLE
sdformat_urdf: 2.1.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9584,7 +9584,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/sdformat_urdf-release.git
-      version: 2.1.0-3
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -9576,7 +9576,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/sdformat_urdf.git
-      version: rolling
+      version: lyrical
     release:
       packages:
       - sdformat_test_files
@@ -9589,7 +9589,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/sdformat_urdf.git
-      version: rolling
+      version: lyrical
     status: maintained
   sdformat_vendor:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `sdformat_urdf` to `2.1.1-1`:

- upstream repository: https://github.com/ros/sdformat_urdf.git
- release repository: https://github.com/ros2-gbp/sdformat_urdf-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.1.0-3`

## sdformat_test_files

- No changes

## sdformat_urdf

```
* Include urdf_world types in sdformat_urdf plugin (#45 <https://github.com/ros/sdformat_urdf/issues/45>) (#48 <https://github.com/ros/sdformat_urdf/issues/48>)
* Clamp urdf material rgba values to [0, 1] (#44 <https://github.com/ros/sdformat_urdf/issues/44>)
* Contributors: Rhys Mainwaring, mergify[bot]
```
