### PR TITLE
hatchbed_common: 0.1.8-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4185,7 +4185,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/hatchbed_common-release.git
-      version: 0.1.7-1
+      version: 0.1.8-1
     source:
       type: git
       url: https://github.com/hatchbed/hatchbed_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `hatchbed_common` to `0.1.8-1`:

- upstream repository: https://github.com/hatchbed/hatchbed_common.git
- release repository: https://github.com/ros2-gbp/hatchbed_common-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.1.7-1`

## hatchbed_common

```
* Add explicit-source-location logging free functions (``logging/functions.h``): ``log_at``,
  ``debug``, ``info``, ``warn``, ``error``, ``fatal`` — each accepting ``(logger, file, func,
  line, message)`` with both ``std::string`` and ``fmt::format_string`` overloads, plus
  no-logger variants that forward to the default logger.
* Add 2D convex hull utility (``pointcloud/convex_hull_2d.hpp``): ``convexHull2D()`` computes
  the CCW convex hull of a range of 2D points using Andrew's monotone chain algorithm.
* Add ``ConvexPrism`` type and operations (``pointcloud/convex_prism.hpp``):
  ``makeConvexPrism()`` builds a prism from 3D points; ``transformConvexPrism()`` applies a
  rigid-body transform; ``padConvexPrism()`` expands the XY footprint by a margin;
  ``cropToConvexPrism()`` filters a point cloud to the prism interior.
* Add ``hasXYZFloat()`` convenience helper to ``pointcloud/point_cloud2_util.hpp``.
* Restructure ``hatchbed_common_localization`` into two focused sub-libraries:
  * ``hatchbed_common::transforms`` (``transforms/transform_util.h``,transforms/covariance_util.h, transforms/pose_buffer.h) -- frame geometry,
  covariance rotation, pose interpolation, tf_reroot and reframe_odom nodes.
  toIsometry(TransformStamped) is the canonical SE(3) conversion helper.
  
    * ``hatchbed_common::odometry`` -- odometry signal conversion and velocity muxing nodes:
      ``imu_to_twist``, ``odom_to_twist``, ``odom_tf_broadcast``, ``velocity_sensor_mux``
      (formerly ``twist_mux``).
  
* Fix build against the newer ``tf2_ros`` API.
* Contributors: Marc Alban
```
