### PR TITLE
gz_common_vendor: 0.4.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2888,7 +2888,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_common_vendor-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gz_common_vendor` to `0.4.1-1`:

- upstream repository: https://github.com/gazebo-release/gz_common_vendor.git
- release repository: https://github.com/ros2-gbp/gz_common_vendor-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.4.0-1`

## gz_common_vendor

```
* Bump version to 7.3.0 (#28 <https://github.com/gazebo-release/gz_common_vendor/issues/28>)
* Contributors: Addisu Z. Taddese
```
