### PR TITLE
ros-netft: 0.2.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7812,6 +7812,13 @@ repositories:
       version: ros
     status: maintained
   ros-netft:
+    release:
+      packages:
+      - netft_driver
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/netft/ros-netft-release.git
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/netft/ros-netft.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros-netft` to `0.2.1-1`:

- upstream repository: https://github.com/netft/ros-netft.git
- release repository: https://github.com/netft/ros-netft-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`
