### PR TITLE
mqtt_client: 2.5.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6346,7 +6346,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mqtt_client-release.git
-      version: 2.4.2-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/mqtt_client.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_client` to `2.5.0-1`:

- upstream repository: https://github.com/ika-rwth-aachen/mqtt_client.git
- release repository: https://github.com/ros2-gbp/mqtt_client-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.4.2-1`

## mqtt_client

```
* Merge pull request #95 <https://github.com/ika-rwth-aachen/mqtt_client/issues/95> from Pumpkin-Engineering/json-message-bridge
  JSON message bridging
```

## mqtt_client_interfaces

- No changes
