### PR TITLE
mujoco_vendor: 0.0.9-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -5235,7 +5235,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/mujoco_vendor-release.git
-      version: 0.0.8-2
+      version: 0.0.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/mujoco_vendor.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mujoco_vendor` to `0.0.9-1`:

- upstream repository: https://github.com/pal-robotics/mujoco_vendor.git
- release repository: https://github.com/ros2-gbp/mujoco_vendor-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.0.8-2`

## mujoco_vendor

```
* Export simulate, lodepng, and path variables for downstream packages (#10 <https://github.com/pal-robotics/mujoco_vendor/issues/10>)
* Add support for the AMENT_VENDOR_POLICY variable to support unvendoring (#9 <https://github.com/pal-robotics/mujoco_vendor/issues/9>)
* Contributors: Erik Holum, Silvio Traversaro
```
