### PR TITLE
gps_umd: 3.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -2728,7 +2728,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/gps_umd-release.git
-      version: 3.0.0-1
+      version: 3.1.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gps_umd` to `3.1.0-1`:

- upstream repository: https://github.com/swri-robotics/gps_umd.git
- release repository: https://github.com/ros2-gbp/gps_umd-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `3.0.0-1`

## gps_msgs

- No changes

## gps_tools

- No changes

## gps_umd

- No changes

## gpsd_client

```
* Cleaning up unreachable code from include guards (#125 <https://github.com/swri-robotics/gps_umd/issues/125>)
* Added user ability to override correction source (#124 <https://github.com/swri-robotics/gps_umd/issues/124>)
  * Adding flag to override augmentation source of corrections
  * Adding parameters to readme. Also making sure the default yaml and code defaults match each other
* Implement Version Specific GPSd Parsers (#120 <https://github.com/swri-robotics/gps_umd/issues/120>)
  * Implementing parsing functionality as version specific parsers rather than conditionally compiling code.
  ---------
  Co-authored-by: DangitBen <mailto:30333928+DangitBen@users.noreply.github.com>
* Contributors: David Anthony
```
