### PR TITLE
scan_2d_merger: 2.1.0-2 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11696,7 +11696,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release.git
-      version: 2.0.0-3
+      version: 2.1.0-2
     source:
       type: git
       url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_2d_merger` to `2.1.0-2`:

- upstream repository: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git
- release repository: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-3`
