### PR TITLE
scan_2d_merger: 2.1.0-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -11521,7 +11521,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scan_2d_merger` to `2.1.0-1`:

- upstream repository: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2.git
- release repository: https://github.com/ali-pahlevani/2D_Scan_Merger_ROS2-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.0.0-1`
