### PR TITLE
Add Fedora 43 to Lyrical distribution list

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -5,6 +5,8 @@
 release_platforms:
   debian:
   - trixie
+  fedora:
+  - '43'
   rhel:
   - '10'
   ubuntu:


### PR DESCRIPTION
RHEL 10 is already listed for Lyrical, which uses the dynamic RPM generator in Bloom. Unlike traditional platforms, adding more platforms that use the dynamic RPM generator doesn't result in additional work during Bloom generation, so there is almost no cost to listing Fedora here. However, listing it here is necessary to build packages on the ROS buildfarm.

Fedora 43 is EOL in December. There's some work we need to land to support Fedora 44, but I'm optimistic that we'll transition to Fedora 44 for Lyrical soon.

Fedora support in ROS 2 is maintained by the community and not the ROS PMC.