### PR TITLE
sbg_driver: 3.4.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9469,6 +9469,11 @@ repositories:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9553,7 +9553,7 @@ repositories:
     release:
       tags:
         release: release/rolling/{package}/{version}
-      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      url: https://github.com/ros2-gbp/sbg_ros2-release.git
       version: 3.4.0-1
     source:
       test_pull_requests: true

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -9550,6 +9550,11 @@ repositories:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros2.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/SBG-Systems/sbg_ros2-release.git
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sbg_driver` to `3.4.0-1`:

- upstream repository: https://github.com/SBG-Systems/sbg_ros2.git
- release repository: https://github.com/SBG-Systems/sbg_ros2-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## sbg_driver

```
* Use std::this_thread::sleep_for in log replay
* Enable MSVC math constants
* Proper integration of imu_short and remove dynamic tf-broadcaster for static transform
* Add sensor fusion integration section to README
* Document GNSS antenna and INS reference points in messages
* Fix use_enu handling of body-frame EKF outputs
* Fix body frame convention comments in IMU and Mag messages
* Fix wrapAnglePi returning out-of-range or reflected angles
* Add gps_frame_id parameter to fix GPS message frame ID
* Revert "Fix transformations to use correct parents and children frames"
* Use target_link_libraries instead of ament_target_dependencies to comply with new CMake standard
* Fix ECEF prime vertical radius to use e^2
* Fix month and day reading from wrong parameter key
* FEAT: Better rollover handling to avoid issues with late sensor messages
* Contributors: Braden Meyers, Fabian Freihube, Guido Linden, Samuel TOLEDANO, Tobias Fischer, michaelschleiss
```
