### PR TITLE
fusioncore: 0.3.3-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3546,7 +3546,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/manankharwar/fusioncore-release.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       type: git
       url: https://github.com/manankharwar/fusioncore.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fusioncore` to `0.3.3-1`:

- upstream repository: https://github.com/manankharwar/fusioncore
- release repository: https://github.com/manankharwar/fusioncore-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.3.2-1`
