### PR TITLE
clearpath_config: 2.9.5-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1526,7 +1526,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.9.4-1
+      version: 2.9.5-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git


### PR DESCRIPTION
Increasing version of package(s) in repository `clearpath_config` to `2.9.5-1`:

- upstream repository: https://github.com/clearpathrobotics/clearpath_config.git
- release repository: https://github.com/clearpath-gbp/clearpath_config-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `2.9.4-1`

## clearpath_config

```
* Added support for A300 with indoor tires. (#240 <https://github.com/clearpathrobotics/clearpath_config/issues/240>)
* Bump actions/checkout from 6 to 7 (#237 <https://github.com/clearpathrobotics/clearpath_config/issues/237>)
  ...
  Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
* Contributors: Tony Baltovski, dependabot[bot]
```
