### PR TITLE
rmw_zenoh: 0.12.0-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7689,7 +7689,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.11.0-1
+      version: 0.12.0-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.12.0-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.11.0-1`

## rmw_zenoh_cpp

```
* return early with a zero-initialized array. (#1012 <https://github.com/ros2/rmw_zenoh/issues/1012>)
* Fix transient-local publishing for buffer-aware path (#1009 <https://github.com/ros2/rmw_zenoh/issues/1009>)
* Make use of ServiceData::is_shutdown() when possible (#997 <https://github.com/ros2/rmw_zenoh/issues/997>)
* Fix lock order inversion in rmw_wait (#1005 <https://github.com/ros2/rmw_zenoh/issues/1005>)
* fix(publisher): unify publisher ownership to fix debug-mode crash (#990 <https://github.com/ros2/rmw_zenoh/issues/990>)
* use C++ 20 in default. (#1006 <https://github.com/ros2/rmw_zenoh/issues/1006>)
* Fix deadlock between wait_set condition_mutex and entity-specific mutexes (#992 <https://github.com/ros2/rmw_zenoh/issues/992>)
* Add support for rosidl::Buffer-aware per-endpoint pub/sub (#930 <https://github.com/ros2/rmw_zenoh/issues/930>)
* Contributors: Alejandro Hernandez Cordero, CY Chen, Janosch Machowinski, Patrick Roncagliolo, Tomoya Fujita, Yuyuan Yuan, Yadunund
```

## zenoh_cpp_vendor

```
* use C++ 20 in default. (#1006 <https://github.com/ros2/rmw_zenoh/issues/1006>)
* Contributors: Alejandro Hernandez Cordero, Tomoya Fujita
```

## zenoh_security_tools

```
* publish-deny topic correctly denied (#1007 <https://github.com/ros2/rmw_zenoh/issues/1007>)
* use C++ 20 in default. (#1006 <https://github.com/ros2/rmw_zenoh/issues/1006>)
* Contributors: Alejandro Hernandez Cordero, Tomoya Fujita
```
