### PR TITLE
rmw_zenoh: 0.10.5-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -7774,7 +7774,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.10.4-1
+      version: 0.10.5-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.10.5-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.10.4-1`

## rmw_zenoh_cpp

```
* Fix transient-local publishing for buffer-aware path (#1011 <https://github.com/ros2/rmw_zenoh/issues/1011>)
* fix: Fix lock order inversion / deadlock (#1010 <https://github.com/ros2/rmw_zenoh/issues/1010>)
* Add support for rosidl::Buffer-aware per-endpoint pub/sub (#987 <https://github.com/ros2/rmw_zenoh/issues/987>)
* Contributors: CY Chen, Janosch Machowinski, Yuyuan Yuan
```

## zenoh_cpp_vendor

- No changes

## zenoh_security_tools

- No changes
