### PR TITLE
rmw_zenoh: 0.6.7-1 in 'kilted/distribution.yaml' [bloom]

### DIFF
--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -7778,7 +7778,7 @@ repositories:
       tags:
         release: release/kilted/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_zenoh-release.git
-      version: 0.6.6-1
+      version: 0.6.7-1
     source:
       type: git
       url: https://github.com/ros2/rmw_zenoh.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rmw_zenoh` to `0.6.7-1`:

- upstream repository: https://github.com/ros2/rmw_zenoh.git
- release repository: https://github.com/ros2-gbp/rmw_zenoh-release.git
- distro file: `kilted/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.6-1`

## rmw_zenoh_cpp

```
* fix: Fix lock order inversion / deadlock (#1013 <https://github.com/ros2/rmw_zenoh/issues/1013>)
* Bump zenoh to 1.8.0 - 2nd attempt (#965 <https://github.com/ros2/rmw_zenoh/issues/965>)
* Revert 1.8.0 (#961 <https://github.com/ros2/rmw_zenoh/issues/961>)
* Don't hold both locks when processing event data (#952 <https://github.com/ros2/rmw_zenoh/issues/952>)
* fix(event): add deadline/liveliness QoS events to rmw_zenoh_cpp (#942 <https://github.com/ros2/rmw_zenoh/issues/942>)
* Bump zenoh to 1.8.0 (#939 <https://github.com/ros2/rmw_zenoh/issues/939>)
* fix: populate reception_sequence_number and advertise sequence number features (#922 <https://github.com/ros2/rmw_zenoh/issues/922>)
* finish some TODOs. (#903 <https://github.com/ros2/rmw_zenoh/issues/903>)
* feat: expose zenoh session (#899 <https://github.com/ros2/rmw_zenoh/issues/899>)
* Fix line ending in session open error message (#890 <https://github.com/ros2/rmw_zenoh/issues/890>)
* Use shared transport SHM provider instead of own instance of SHM provider (#875 <https://github.com/ros2/rmw_zenoh/issues/875>)
* Bump zenoh to 1.7.1 (#872 <https://github.com/ros2/rmw_zenoh/issues/872>)
* Fix REP url locations (#859 <https://github.com/ros2/rmw_zenoh/issues/859>)
* Restore ZENOH_CONFIG_OVERRIDE after isolation is finished (#856 <https://github.com/ros2/rmw_zenoh/issues/856>)
* Contributors: Janosch Machowinski, Yuyuan Yuan, Julien Enoch, Shane Loretz, Hervé Audren, Denis Biryukov, Tomoya Fujita, Yadunund, jordanburklund, yellowhatter, Tim Clephas, Scott K Logan, Alejandro Hernandez Cordero
```

## zenoh_cpp_vendor

```
* Bump zenoh to 1.8.0 - 2nd attempt (#965 <https://github.com/ros2/rmw_zenoh/issues/965>)
* Revert 1.8.0 (#961 <https://github.com/ros2/rmw_zenoh/issues/961>)
* Build against rust >= 1.75 for ROS Lyrical (#948 <https://github.com/ros2/rmw_zenoh/issues/948>)
* Bump zenoh to 1.8.0 (#939 <https://github.com/ros2/rmw_zenoh/issues/939>)
* Allow use of non-vendored Zenoh if present (#909 <https://github.com/ros2/rmw_zenoh/issues/909>)
* Bump zenoh to 1.7.1 (#872 <https://github.com/ros2/rmw_zenoh/issues/872>)
* Fix REP url locations (#859 <https://github.com/ros2/rmw_zenoh/issues/859>)
* Contributors: Yuyuan Yuan, Julien Enoch, Shane Loretz, Denis Biryukov, Øystein Sture, Tim Clephas, mergify[bot]
```

## zenoh_security_tools

```
* finish some TODOs. (#903 <https://github.com/ros2/rmw_zenoh/issues/903>)
* Contributors: Tomoya Fujita
```
