### PR TITLE
Add back pymavlink as python3-pymavlink-pip

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6923,6 +6923,16 @@ python3-pymap3d:
     '*': [python3-pymap3d]
     bionic: null
     focal: null
+python3-pymavlink-pip:
+  debian:
+    pip:
+      packages: [pymavlink]
+  fedora:
+    pip:
+      packages: [pymavlink]
+  ubuntu:
+    pip:
+      packages: [pymavlink]
 python3-pymesh2-pip:
   debian:
     pip:


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.  Pymavlink was in rosdistro until 5 days ago when it was removed as part of a removal of python2 packages. Pymavlink does not support python2 anymore (as can be seen on their [PyPi page](https://pypi.org/project/pymavlink/)). I believe it was mistakenly removed because its name was `python-pymavlink` due to the package being supported for 12 years and the name never being updated or a new rule added after the package started supporting python3. Could you please add it back under the updated name.

## Package name:

pymavlink

## Package Upstream Source:

https://github.com/ArduPilot/pymavlink

## Purpose of using this:

This repository is used to send messages with the mavlink protocol. Mavlink messages are used to communicate between drones and control stations to be able to send commands to the drone and read information from the drone.

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://pypi.org/project/pymavlink/
- Ubuntu: https://packages.ubuntu.com/
  - https://pypi.org/project/pymavlink/
- Fedora: https://packages.fedoraproject.org/
  - https://pypi.org/project/pymavlink/
