### PR TITLE
Add rosmon2 source entry

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -8744,6 +8744,12 @@ repositories:
       url: https://github.com/Tonywelte/rosidlcpp.git
       version: rolling
     status: developed
+  rosmon2:
+    source:
+      type: git
+      url: https://github.com/GibsonHu/rosmon2.git
+      version: main
+    status: developed
   rospy_message_converter:
     doc:
       type: git


### PR DESCRIPTION
# Please Add This Package to be indexed in the rosdistro

rosmon2

# The source is here

https://github.com/GibsonHu/rosmon2

`rosmon2` is a ROS 2 terminal launcher and process monitor with an optional MCP server for inspecting and controlling named launch sessions.

This source-only entry requests the required package-name and source review for ROS 2 Rolling. A release entry will be generated by Bloom after the release repository is approved.

# Checks

- [x] All packages declare `BSD-3-Clause` in `package.xml`.
- [x] The source repository contains a `LICENSE` file.
- [x] The package builds and tests successfully.
- [x] `rosdep check --from-paths . --ignore-src --rosdistro rolling --os=ubuntu:noble` reports all dependencies satisfied.
