### PR TITLE
Add libargparse-dev

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2812,7 +2812,6 @@ libargparse-dev:
   debian: [libargparse-dev]
   fedora: [argparse-devel]
   gentoo: [dev-cpp/argparse]
-  macports: [argparse]
   nixos: [argparse]
   ubuntu: [libargparse-dev]
 libargtable2-dev:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2807,6 +2807,14 @@ libapache2-mod-python:
   debian: [libapache2-mod-python]
   gentoo: [www-apache/mod_python]
   ubuntu: [libapache2-mod-python]
+libargparse-dev:
+  arch: [argparse]
+  debian: [libargparse-dev]
+  fedora: [argparse-devel]
+  gentoo: [dev-cpp/argparse]
+  macports: [argparse]
+  nixos: [argparse]
+  ubuntu: [libargparse-dev]
 libargtable2-dev:
   arch: [argtable]
   debian: [libargtable2-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2809,11 +2809,16 @@ libapache2-mod-python:
   ubuntu: [libapache2-mod-python]
 libargparse-dev:
   arch: [argparse]
-  debian: [libargparse-dev]
+  debian:
+    '*': [libargparse-dev]
+    bookworm: null
   fedora: [argparse-devel]
   gentoo: [dev-cpp/argparse]
   nixos: [argparse]
-  ubuntu: [libargparse-dev]
+  ubuntu:
+    '*': [libargparse-dev]
+    focal: null
+    jammy: null
 libargtable2-dev:
   arch: [argtable]
   debian: [libargtable2-dev]


### PR DESCRIPTION
<!-- Thank you for contributing a change to the rosdistro. There are two primary types of submissions.
Please select the appropriate template from below: ROSDEP_RULE_TEMPLATE or DOC_INDEX_TEMPLATE

If you're making a new release with bloom please use bloom to create the pull request automatically (except for the naming review request which must be made manually).
If you've already run the release bloom has a `--pull-request-only` option you can use.-->

<!-- ROSDEP_RULE_TEMPLATE: Submitter Please review the contributing guidelines: https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md -->

Please add the following dependency to the rosdep database.

## Package name:

libargparse-dev

## Package Upstream Source:

https://github.com/p-ranav/argparse

## Purpose of using this:

This package is very convenient to create CLI tools.

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/trixie/libargparse-dev
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/noble/libargparse-dev
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/argparse/argparse-devel/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/any/argparse/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/dev-cpp/argparse
- macOS: https://formulae.brew.sh/
  - https://formulae.brew.sh/formula/argparse
- Alpine: https://pkgs.alpinelinux.org/packages
  - not available
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=26.05&query=argparse#show=argparse
- openSUSE: https://software.opensuse.org/package/
  - not available
- rhel: https://rhel.pkgs.org/
  - not available
