### PR TITLE
move_base_flex: 1.2.1-1 in 'jazzy/distribution.yaml' [bloom]

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6160,7 +6160,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/move_base_flex-release.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `1.2.1-1`:

- upstream repository: git@github.com:naturerobots/move_base_flex.git
- release repository: https://github.com/ros2-gbp/move_base_flex-release.git
- distro file: `jazzy/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `1.2.0-1`

## mbf_abstract_core

```
* Remove ament_cmake_ros dependency
```

## mbf_abstract_nav

```
* Remove ament_cmake_ros dependency
```

## mbf_msgs

```
* Remove ament_cmake_ros dependency
```

## mbf_simple_core

```
* Remove ament_cmake_ros dependency
```

## mbf_simple_nav

```
* Remove ament_cmake_ros dependency
```

## mbf_test_utility

```
* Remove ament_cmake_ros dependency
```

## mbf_utility

```
* Remove ament_cmake_ros dependency
```

## move_base_flex

```
* Remove ament_cmake_ros dependency
```

## rviz_mbf_plugins

```
* Remove ament_cmake_ros dependency
```
