### PR TITLE
move_base_flex: 1.2.1-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -4872,6 +4872,21 @@ repositories:
       version: ros2
     status: developed
   move_base_flex:
+    release:
+      packages:
+      - mbf_abstract_core
+      - mbf_abstract_nav
+      - mbf_msgs
+      - mbf_simple_core
+      - mbf_simple_nav
+      - mbf_test_utility
+      - mbf_utility
+      - move_base_flex
+      - rviz_mbf_plugins
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/ros2-gbp/move_base_flex-release.git
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
Increasing version of package(s) in repository `move_base_flex` to `1.2.1-1`:

- upstream repository: git@github.com:naturerobots/move_base_flex.git
- release repository: https://github.com/ros2-gbp/move_base_flex-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## mbf_abstract_core

```
* Remove ament_cmake_ros dependency
```

## mbf_abstract_nav

```
* Remove ament_cmake_ros dependency
```

## mbf_msgs

```
* Remove ament_cmake_ros dependency
```

## mbf_simple_core

```
* Remove ament_cmake_ros dependency
```

## mbf_simple_nav

```
* Remove ament_cmake_ros dependency
```

## mbf_test_utility

```
* Remove ament_cmake_ros dependency
```

## mbf_utility

```
* Remove ament_cmake_ros dependency
```

## move_base_flex

```
* Remove ament_cmake_ros dependency
```

## rviz_mbf_plugins

```
* Remove ament_cmake_ros dependency
```
