### PR TITLE
tecgihan_driver: 0.3.0-1 in 'humble/distribution.yaml' [bloom]

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -12561,7 +12561,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/tecgihan/tecgihan_driver-release.git
-      version: 0.2.0-1
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tecgihan_driver` to `0.3.0-1`:

- upstream repository: https://github.com/tecgihan/tecgihan_driver.git
- release repository: https://github.com/tecgihan/tecgihan_driver-release.git
- distro file: `humble/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.2.0-1`

## tecgihan_driver

```
Added
- Added support for DPA-06B (3axis x2 / 6axis sensor_mode).
Fixed
- Fix minor bugs in existing drivers
Contributors: Ryota Amakawa
```
