### PR TITLE
[openembedded] libpcre is moved from openembedded-core to meta-ros-common

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8884,7 +8884,7 @@ pcre:
   gentoo: [dev-libs/libpcre]
   macports: [pcre]
   nixos: [pcre]
-  openembedded: [libpcre@openembedded-core]
+  openembedded: [libpcre@meta-ros-common]
   rhel: [pcre-devel]
   ubuntu: [libpcre3-dev]
 pcre-dev:


### PR DESCRIPTION
The recipe libpcre is replaced by libpcre2 in openembedded-core

see: https://github.com/ros/meta-ros/commit/b3a4f6c47974231c54bd2c53a3fbbb97375c5e42

@robwoolley: could you review please.  Tested with `python3 -m rosdep_repo_check`