### PR TITLE
dynamixel_hardware: 0.6.1-1 in 'rolling/distribution.yaml' [bloom]

### DIFF
--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1741,6 +1741,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
+      version: 0.6.1-1
     source:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware` to `0.6.1-1`:

- upstream repository: https://github.com/dynamixel-community/dynamixel_hardware.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware-release.git
- distro file: `rolling/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## dynamixel_hardware

```
* Link namespaced CMake targets instead of ament_target_dependencies
* Update the deprecated on_init function to use new parameter type (#108 <https://github.com/dynamixel-community/dynamixel_hardware/issues/108>)
* Contributors: Yutaka Kondo, Zheng Qu
```
