### PR TITLE
dynamixel_hardware: 0.6.1-2 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1777,7 +1777,7 @@ repositories:
       tags:
         release: release/lyrical/{package}/{version}
       url: https://github.com/ros2-gbp/dynamixel_hardware-release.git
-      version: 0.6.0-3
+      version: 0.6.1-2
     source:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git


### PR DESCRIPTION
Increasing version of package(s) in repository `dynamixel_hardware` to `0.6.1-2`:

- upstream repository: https://github.com/dynamixel-community/dynamixel_hardware.git
- release repository: https://github.com/ros2-gbp/dynamixel_hardware-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `0.6.0-3`

## dynamixel_hardware

```
* Link namespaced CMake targets instead of ament_target_dependencies
* Update the deprecated on_init function to use new parameter type (#108 <https://github.com/dynamixel-community/dynamixel_hardware/issues/108>)
* Contributors: Yutaka Kondo, Zheng Qu
```
