### PR TITLE
pybulletfleet: add Jazzy source entry

### DIFF
--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8301,6 +8301,16 @@ repositories:
       url: https://github.com/ros2/pybind11_vendor.git
       version: jazzy
     status: maintained
+  pybulletfleet:
+    doc:
+      type: git
+      url: https://github.com/yuokamoto/PyBulletFleet.git
+      version: release/jazzy-0.1.0
+    source:
+      type: git
+      url: https://github.com/yuokamoto/PyBulletFleet.git
+      version: release/jazzy-0.1.0
+    status: developed
   pymoveit2:
     doc:
       type: git


### PR DESCRIPTION
 # Please Add This Package to be indexed in the rosdistro.

  Jazzy

  # The source is here:

  https://github.com/yuokamoto/PyBulletFleet.git

  This repository provides the following ROS 2 packages:

  - `pybullet_fleet_msgs`
  - `pybullet_fleet_ros`
  - `pybullet_fleet_rmf`

  PyBulletFleet provides a PyBullet-based multi-robot fleet
  simulation bridge for ROS 2, including an RMF adapter
  integration.

  # Checks
  - [x] All packages have a declared license in the package.xml
  - [x] This repository has a LICENSE file
  - [x] This package is expected to build on the submitted
  rosdistro