### PR TITLE
Mark dynamixel_hardware end-of-life in all distros

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2545,7 +2545,8 @@ repositories:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: humble
-    status: developed
+    status: end-of-life
+    status_description: Use dynamixel_hardware_interface; see https://github.com/dynamixel-community/dynamixel_hardware
   dynamixel_hardware_interface:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2476,7 +2476,8 @@ repositories:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: jazzy
-    status: developed
+    status: end-of-life
+    status_description: Use dynamixel_hardware_interface; see https://github.com/dynamixel-community/dynamixel_hardware
   dynamixel_hardware_interface:
     doc:
       type: git

--- a/kilted/distribution.yaml
+++ b/kilted/distribution.yaml
@@ -1726,7 +1726,8 @@ repositories:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: rolling
-    status: developed
+    status: end-of-life
+    status_description: Use dynamixel_hardware_interface; see https://github.com/dynamixel-community/dynamixel_hardware
   dynamixel_hardware_interface:
     doc:
       type: git

--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -1782,7 +1782,8 @@ repositories:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: rolling
-    status: developed
+    status: end-of-life
+    status_description: Use dynamixel_hardware_interface; see https://github.com/dynamixel-community/dynamixel_hardware
   dynamixel_hardware_interface:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1746,7 +1746,8 @@ repositories:
       type: git
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: rolling
-    status: developed
+    status: end-of-life
+    status_description: Use dynamixel_hardware_interface; see https://github.com/dynamixel-community/dynamixel_hardware
   dynamixel_hardware_interface:
     doc:
       type: git


### PR DESCRIPTION
Marks `dynamixel_hardware` end-of-life in humble, jazzy, kilted, lyrical, and rolling.

The package is deprecated in favor of ROBOTIS's officially maintained [`dynamixel_hardware_interface`](https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface), which fills the same role, is released for every distro `dynamixel_hardware` targets, and is the hardware layer behind ROBOTIS's own OpenManipulator-X, OMY, and AI Worker products. A [migration guide](https://github.com/dynamixel-community/dynamixel_hardware/blob/rolling/docs/migration_to_dynamixel_hardware_interface.md) has been published covering the URDF conversion, complete parameter and interface mapping tables, and the capabilities that do not carry over.

I am the maintainer of `dynamixel_hardware`. The upstream repository already carries the deprecation notice, and it will be archived read-only once this merges.

The `release:` entries are deliberately left untouched so that existing binaries keep installing for current users. Only `status` changes, plus a new `status_description`.
