### PR TITLE
NavMap: 0.4.0-3 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -12,6 +12,27 @@ release_platforms:
   ubuntu:
   - resolute
 repositories:
+  NavMap:
+    doc:
+      type: git
+      url: https://github.com/EasyNavigation/NavMap.git
+      version: lyrical
+    release:
+      packages:
+      - navmap_core
+      - navmap_examples
+      - navmap_ros
+      - navmap_ros_interfaces
+      - navmap_rviz_plugin
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/EasyNavigation/NavMap-release.git
+      version: 0.4.0-3
+    source:
+      type: git
+      url: https://github.com/EasyNavigation/NavMap.git
+      version: lyrical
+    status: developed
   SMACC2:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `NavMap` to `0.4.0-3`:

- upstream repository: https://github.com/EasyNavigation/NavMap.git
- release repository: https://github.com/EasyNavigation/NavMap-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## navmap_core

```
* Speedup the navcel location
* Sppedup the navcel location
* Cleanup unused headers
* Fix potential linker error and warning
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## navmap_examples

```
* Cleanup unused headers
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## navmap_ros

```
* Cleanup unused headers
* Occupancy works
* Add occupancy grid constants
* Fix surface creation from points
* Remove unused field
* Remove some comments
* Final working version
* Acelerated respecting floors
* Working slow with many points
* Initial working version
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```

## navmap_ros_interfaces

```
* Merge branch 'rolling' into kilted
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico
```

## navmap_rviz_plugin

```
* Cleanup unused headers
* NavMap Goal Pose
* Occupancy works
* FREE_SPACE as white
* Merge branch 'jazzy' into rolling
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```
