### PR TITLE
yaets: 1.1.0-1 in 'lyrical/distribution.yaml' [bloom]

### DIFF
--- a/lyrical/distribution.yaml
+++ b/lyrical/distribution.yaml
@@ -11422,6 +11422,21 @@ repositories:
       url: https://github.com/ros/xacro.git
       version: ros2
     status: maintained
+  yaets:
+    doc:
+      type: git
+      url: https://github.com/fmrico/yaets.git
+      version: lyrical
+    release:
+      tags:
+        release: release/lyrical/{package}/{version}
+      url: https://github.com/fmrico/yaets-release.git
+      version: 1.1.0-1
+    source:
+      type: git
+      url: https://github.com/fmrico/yaets.git
+      version: lyrical
+    status: developed
   yaml_cpp_vendor:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `yaets` to `1.1.0-1`:

- upstream repository: https://github.com/fmrico/yaets.git
- release repository: https://github.com/fmrico/yaets-release.git
- distro file: `lyrical/distribution.yaml`
- bloom version: `0.14.3`
- previous version for package: `null`

## yaets

```
* Update README
* Update CI
* Contributors: Francisco Martín Rico, Francisco Miguel Moreno
```
